### PR TITLE
Add .deepsource.toml

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,21 @@
+version = 1
+
+test_patterns = [
+  '**/*_test.go',
+]
+
+exclude_patterns = [
+  'vendor/**',
+]
+
+[[ analyzers ]]
+  name = 'go'
+  enabled = true
+  
+  [analyzers.meta]
+    import_path = "github.com/convox/convox"
+    
+
+[[ analyzers ]]
+  name = 'docker'
+  enabled = true


### PR DESCRIPTION
This adds a customized `.deepsource.toml` file for the repository with proper test and exclude patterns. More information can be found in the [docs](https://deepsource.io/docs/analyzers/go.html).

Upon merging this, the analysis would start running on the repo, and the dashboard would be visible here: [deepsource.io/gh/convox/convox](deepsource.io/gh/convox/convox).