### PR TITLE
terraform: pin kubernetes to avoid broken release

### DIFF
--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -11,7 +11,7 @@ provider "http" {
 }
 
 provider "kubernetes" {
-  version = "~> 1.10"
+  version = "~> 1.10.0"
 
   cluster_ca_certificate = module.cluster.ca
   host                   = module.cluster.endpoint

--- a/terraform/system/azure/main.tf
+++ b/terraform/system/azure/main.tf
@@ -7,7 +7,7 @@ provider "http" {
 }
 
 provider "kubernetes" {
-  version = "~> 1.10"
+  version = "~> 1.10.0"
 
   client_certificate     = module.cluster.client_certificate
   client_key             = module.cluster.client_key

--- a/terraform/system/do/main.tf
+++ b/terraform/system/do/main.tf
@@ -11,7 +11,7 @@ provider "http" {
 }
 
 provider "kubernetes" {
-  version = "~> 1.10"
+  version = "~> 1.10.0"
 
   cluster_ca_certificate = module.cluster.ca
   host                   = module.cluster.endpoint

--- a/terraform/system/gcp/main.tf
+++ b/terraform/system/gcp/main.tf
@@ -21,7 +21,7 @@ provider "http" {
 }
 
 provider "kubernetes" {
-  version = "~> 1.10"
+  version = "~> 1.10.0"
 
   client_certificate     = module.cluster.client_certificate
   client_key             = module.cluster.client_key

--- a/terraform/system/local/main.tf
+++ b/terraform/system/local/main.tf
@@ -7,7 +7,7 @@ provider "http" {
 }
 
 provider "kubernetes" {
-  version = "~> 1.10"
+  version = "~> 1.10.0"
 }
 
 data "http" "releases" {


### PR DESCRIPTION
See terraform-providers/terraform-provider-kubernetes#759

New version of Kubernetes provider breaks during plan when the Kubernetes cluster itself will be created by a child module.