### PR TITLE
docs: ca trust command backwards compatibility

### DIFF
--- a/docs/installation/development-rack/macos.md
+++ b/docs/installation/development-rack/macos.md
@@ -42,5 +42,5 @@ you can trust the Rack's CA certificate.
 
 This certificate is generated on your local machine and is unique to your Rack.
 
-    $ kubectl get secret/ca -n dev-system -o jsonpath="{.data.tls\.crt}" | base64 -d > /tmp/ca
+    $ kubectl get secret/ca -n dev-system -o jsonpath="{.data.tls\.crt}" | base64 --decode > /tmp/ca
     $ sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /tmp/ca


### PR DESCRIPTION
On macos, `base64` decode is `-D` not `-d`. Just changed it to cross-platform and more clear `--decode`.