### PR TITLE
docs: proper resource type in redis documentation

### DIFF
--- a/docs/reference/primitives/app/resource/redis.md
+++ b/docs/reference/primitives/app/resource/redis.md
@@ -18,6 +18,6 @@ A Redis Resource can have the following options configured for it (default value
 
     resources:
       main:
-        type: memcached
+        type: redis
         options:
           version: 4.0.10


### PR DESCRIPTION
Hey guys, I've just noticed what seems to be a copy-paste error in the Redis options section. Cheers ✌️