### PR TITLE
k8s: manual control over deployment parameters

### DIFF
--- a/docs/reference/primitives/app/service.md
+++ b/docs/reference/primitives/app/service.md
@@ -25,6 +25,9 @@ services:
       manifest: Dockerfile
       path: .
     command: bin/web
+    deployment:
+      minimum: 25
+      maximum: 100
     domain: ${WEB_HOST}
     drain: 10
     environment:
@@ -53,24 +56,25 @@ services:
     test: make test
 ```
 
-| Attribute     | Type       | Default             | Description                                                                                                                         |
-| ------------- | ---------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Attribute     | Type       | Default             | Description                                                                                                                                |
+| ------------- | ---------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | `agent`       | boolean    | false               | Set to `true` to declare this Service as an [Agent](../../../configuration/agents.md)                                                      |
-| `build`       | string/map | .                   | Build definition (see below)                                                                                                        |
-| `command`     | string     | `CMD` of Dockerfile | The command to run to start a [Process](process.md) for this Service                                                                |
-| `domain`      | string     |                     | A custom domain(s) (comma separated) to route to this Service                                                                       |
-| `drain`       | number     |                     | The number of seconds to wait for connections to drain when terminating a [Process](process.md) of this Service                     |
-| `environment` | list       |                     | A list of environment variables (with optional defaults) to populate from the [Release](release.md) environment                     |
-| `health`      | string/map | /                   | Health check definition (see below)                                                                                                 |
-| `image`       | string     |                     | An external Docker image to use for this Service (supercedes `build`)                                                               |
-| `internal`    | boolean    | false               | Set to `true` to make this Service only accessible inside the Rack                                                                  |
+| `build`       | string/map | .                   | Build definition (see below)                                                                                                               |
+| `command`     | string     | `CMD` of Dockerfile | The command to run to start a [Process](process.md) for this Service                                                                       |
+| `deployment`  | map        |                     | Manual control over deployment parameters                                                                                                  |
+| `domain`      | string     |                     | A custom domain(s) (comma separated) to route to this Service                                                                              |
+| `drain`       | number     |                     | The number of seconds to wait for connections to drain when terminating a [Process](process.md) of this Service                            |
+| `environment` | list       |                     | A list of environment variables (with optional defaults) to populate from the [Release](release.md) environment                            |
+| `health`      | string/map | /                   | Health check definition (see below)                                                                                                        |
+| `image`       | string     |                     | An external Docker image to use for this Service (supercedes `build`)                                                                      |
+| `internal`    | boolean    | false               | Set to `true` to make this Service only accessible inside the Rack                                                                         |
 | `port`        | string     |                     | The port that the default Rack balancer will use to [route incoming traffic](../../../configuration/load-balancers.md)                     |
 | `ports`       | list       |                     | A list of ports available for internal [service discovery](../../../configuration/service-discovery.md) or custom [Balancers](balancer.md) |
-| `privileged`  | boolean    | true                | Set to `false` to prevent [Processes](process.md) of this Service from running as root inside their container                       |
-| `scale`       | map        | 1                   | Define scaling parameters (see below)                                                                                               |
-| `singleton`   | boolean    | false               | Set to `true` to prevent extra [Processes](process.md) of this Service from being started during deployments                        |
-| `sticky`      | boolean    | false               | Set to `true` to enable sticky sessions                                                      |
-| `test`        | string     |                     | A command to run to test this Service when running `convox test`                                                                    |
+| `privileged`  | boolean    | true                | Set to `false` to prevent [Processes](process.md) of this Service from running as root inside their container                              |
+| `scale`       | map        | 1                   | Define scaling parameters (see below)                                                                                                      |
+| `singleton`   | boolean    | false               | Set to `true` to prevent extra [Processes](process.md) of this Service from being started during deployments                               |
+| `sticky`      | boolean    | false               | Set to `true` to enable sticky sessions                                                                                                    |
+| `test`        | string     |                     | A command to run to test this Service when running `convox test`                                                                           |
 
 > Environment variables **must** be declared to be populated for a Service.
 
@@ -82,6 +86,13 @@ services:
 | `path`     | string | .          | The path (relative to `convox.yml`) to build for this Service |
 
 > Specifying `build` as a string will set the `path` and leave the other values as defaults.
+
+### deployment
+
+| Attribute | Type   | Default | Description                                                                      |
+| --------- | ------ | ------- | -------------------------------------------------------------------------------- |
+| `maximum` | number | 200     | The maximum percentage of Processes to allow during rolling deploys              |
+| `minimum` | number | 50      | The minimum percentage of healthy Processes to keep alive during rolling deploys |
 
 ### health
 

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -87,6 +87,22 @@ func (m *Manifest) ApplyDefaults() error {
 			m.Services[i].Build.Manifest = "Dockerfile"
 		}
 
+		if !m.AttributeExists(fmt.Sprintf("services.%s.deployment.maximum", s.Name)) {
+			if s.Agent.Enabled || s.Singleton {
+				m.Services[i].Deployment.Maximum = 100
+			} else {
+				m.Services[i].Deployment.Maximum = 200
+			}
+		}
+
+		if !m.AttributeExists(fmt.Sprintf("services.%s.deployment.minimum", s.Name)) {
+			if s.Agent.Enabled || s.Singleton {
+				m.Services[i].Deployment.Minimum = 0
+			} else {
+				m.Services[i].Deployment.Minimum = 50
+			}
+		}
+
 		if s.Drain == 0 {
 			m.Services[i].Drain = 30
 		}

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -55,6 +55,10 @@ func TestManifestLoad(t *testing.T) {
 					Path:     "api",
 				},
 				Command: "",
+				Deployment: manifest.ServiceDeployment{
+					Minimum: 25,
+					Maximum: 110,
+				},
 				Domains: []string{"foo.example.org"},
 				Drain:   30,
 				Environment: []string{
@@ -86,6 +90,10 @@ func TestManifestLoad(t *testing.T) {
 			manifest.Service{
 				Name:    "proxy",
 				Command: "bash",
+				Deployment: manifest.ServiceDeployment{
+					Minimum: 50,
+					Maximum: 200,
+				},
 				Domains: []string{"bar.example.org", "*.example.org"},
 				Drain:   30,
 				Health: manifest.ServiceHealth{
@@ -114,6 +122,10 @@ func TestManifestLoad(t *testing.T) {
 					Path:     ".",
 				},
 				Command: "foo",
+				Deployment: manifest.ServiceDeployment{
+					Minimum: 0,
+					Maximum: 100,
+				},
 				Domains: []string{"baz.example.org", "qux.example.org"},
 				Drain:   60,
 				Health: manifest.ServiceHealth{
@@ -139,7 +151,11 @@ func TestManifestLoad(t *testing.T) {
 					Path:     ".",
 				},
 				Command: "",
-				Drain:   30,
+				Deployment: manifest.ServiceDeployment{
+					Minimum: 50,
+					Maximum: 200,
+				},
+				Drain: 30,
 				Health: manifest.ServiceHealth{
 					Grace:    5,
 					Interval: 5,
@@ -161,7 +177,11 @@ func TestManifestLoad(t *testing.T) {
 					Path:     ".",
 				},
 				Command: "",
-				Drain:   30,
+				Deployment: manifest.ServiceDeployment{
+					Minimum: 50,
+					Maximum: 200,
+				},
+				Drain: 30,
 				Health: manifest.ServiceHealth{
 					Grace:    5,
 					Interval: 5,
@@ -193,6 +213,10 @@ func TestManifestLoad(t *testing.T) {
 			manifest.Service{
 				Name:    "inherit",
 				Command: "inherit",
+				Deployment: manifest.ServiceDeployment{
+					Minimum: 50,
+					Maximum: 200,
+				},
 				Domains: []string{"bar.example.org", "*.example.org"},
 				Drain:   30,
 				Health: manifest.ServiceHealth{
@@ -222,6 +246,10 @@ func TestManifestLoad(t *testing.T) {
 				Build: manifest.ServiceBuild{
 					Manifest: "Dockerfile",
 					Path:     ".",
+				},
+				Deployment: manifest.ServiceDeployment{
+					Minimum: 0,
+					Maximum: 100,
 				},
 				Drain: 30,
 				Health: manifest.ServiceHealth{
@@ -271,6 +299,9 @@ func TestManifestLoad(t *testing.T) {
 		"services.api.build",
 		"services.api.build.manifest",
 		"services.api.build.path",
+		"services.api.deployment",
+		"services.api.deployment.maximum",
+		"services.api.deployment.minimum",
 		"services.api.domain",
 		"services.api.environment",
 		"services.api.health",
@@ -369,6 +400,10 @@ func TestManifestLoadSimple(t *testing.T) {
 					Manifest: "Dockerfile",
 					Path:     ".",
 				},
+				Deployment: manifest.ServiceDeployment{
+					Minimum: 50,
+					Maximum: 200,
+				},
 				Drain: 30,
 				Environment: manifest.Environment{
 					"REQUIRED",
@@ -458,6 +493,10 @@ func TestManifestValidate(t *testing.T) {
 
 	errors := []string{
 		"resource name 1resource invalid, must contain only lowercase alphanumeric and dashes",
+		"service deployment-invalid-low deployment minimum can not be less than 0",
+		"service deployment-invalid-low deployment maximum can not be less than 100",
+		"service deployment-invalid-high deployment minimum can not be greater than 100",
+		"service deployment-invalid-high deployment maximum can not be greater than 200",
 		"service name serviceF invalid, must contain only lowercase alphanumeric and dashes",
 		"service serviceF references a resource that does not exist: foo",
 		"timer name timer_1 invalid, must contain only lowercase alphanumeric and dashes",

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -13,6 +13,7 @@ type Service struct {
 	Agent       ServiceAgent          `yaml:"agent,omitempty"`
 	Build       ServiceBuild          `yaml:"build,omitempty"`
 	Command     string                `yaml:"command,omitempty"`
+	Deployment  ServiceDeployment     `yaml:"deployment,omitempty"`
 	Domains     ServiceDomains        `yaml:"domain,omitempty"`
 	Drain       int                   `yaml:"drain,omitempty"`
 	Environment Environment           `yaml:"environment,omitempty"`
@@ -41,6 +42,11 @@ type ServiceBuild struct {
 	Args     []string `yaml:"args,omitempty"`
 	Manifest string   `yaml:"manifest,omitempty"`
 	Path     string   `yaml:"path,omitempty"`
+}
+
+type ServiceDeployment struct {
+	Maximum int `yaml:"maximum,omitempty"`
+	Minimum int `yaml:"minimum,omitempty"`
 }
 
 type ServiceDomains []string

--- a/pkg/manifest/testdata/full.yml
+++ b/pkg/manifest/testdata/full.yml
@@ -22,6 +22,9 @@ services:
     build:
       manifest: Dockerfile2
       path: api
+    deployment:
+      minimum: 25
+      maximum: 110
     domain: foo.example.org
     environment:
       - DEFAULT=test

--- a/pkg/manifest/testdata/validate.yml
+++ b/pkg/manifest/testdata/validate.yml
@@ -2,6 +2,14 @@ resources:
   1resource:
     type: postgres
 services:
+  deployment-invalid-low:
+    deployment:
+      minimum: -1
+      maximum: 99
+  deployment-invalid-high:
+    deployment:
+      minimum: 101
+      maximum: 201
   serviceF:
     build: .
     resources:

--- a/pkg/manifest/validate.go
+++ b/pkg/manifest/validate.go
@@ -61,6 +61,22 @@ func (m *Manifest) validateServices() []error {
 			errs = append(errs, fmt.Errorf("service name %s invalid, %s", s.Name, ValidNameDescription))
 		}
 
+		if s.Deployment.Minimum < 0 {
+			errs = append(errs, fmt.Errorf("service %s deployment minimum can not be less than 0", s.Name))
+		}
+
+		if s.Deployment.Minimum > 100 {
+			errs = append(errs, fmt.Errorf("service %s deployment minimum can not be greater than 100", s.Name))
+		}
+
+		if s.Deployment.Maximum < 100 {
+			errs = append(errs, fmt.Errorf("service %s deployment maximum can not be less than 100", s.Name))
+		}
+
+		if s.Deployment.Maximum > 200 {
+			errs = append(errs, fmt.Errorf("service %s deployment maximum can not be greater than 200", s.Name))
+		}
+
 		for _, r := range s.ResourceMap() {
 			if _, err := m.Resource(r.Name); err != nil {
 				if strings.HasPrefix(err.Error(), "no such resource") {

--- a/provider/k8s/release.go
+++ b/provider/k8s/release.go
@@ -414,13 +414,8 @@ func (p *Provider) releaseTemplateServices(a *structs.App, e structs.Environment
 	}
 
 	for _, s := range ss {
-		min := 50
-		max := 200
-
-		if s.Agent.Enabled || s.Singleton {
-			min = 0
-			max = 100
-		}
+		min := s.Deployment.Minimum
+		max := s.Deployment.Maximum
 
 		if opts.Min != nil {
 			min = *opts.Min
@@ -440,7 +435,7 @@ func (p *Provider) releaseTemplateServices(a *structs.App, e structs.Environment
 		params := map[string]interface{}{
 			"App":            a,
 			"Environment":    env,
-			"MaxSurge":       max,
+			"MaxSurge":       max - 100,
 			"MaxUnavailable": 100 - min,
 			"Namespace":      p.AppNamespace(a.Name),
 			"Password":       p.Password,

--- a/provider/k8s/testdata/release-basic-app.yml
+++ b/provider/k8s/testdata/release-basic-app.yml
@@ -418,6 +418,327 @@ data:
   BUILD_DESCRIPTION: ""
   FOO: YmFy
   FOUR_URL: ""
+  RACK: cmFjazE=
+  RACK_URL: aHR0cHM6Ly9jb252b3g6QGFwaS5uczEuc3ZjLmNsdXN0ZXIubG9jYWw6NTQ0Mw==
+  RELEASE: UkVMRUFTRTI=
+  SERVICE: YWdlbnQ=
+  THREE_URL: dmFsdWU=
+kind: Secret
+metadata:
+  labels:
+    app: app1
+    provider: k8s
+    rack: rack1
+    release: release2
+    service: agent
+    system: convox
+    type: env
+  name: env-agent
+  namespace: rack1-app1
+type: Opaque
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations: null
+  labels:
+    app: app1
+    provider: k8s
+    rack: rack1
+    release: release2
+    service: agent
+    system: convox
+    type: service
+  name: agent
+  namespace: rack1-app1
+spec:
+  minReadySeconds: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: app1
+      rack: rack1
+      service: agent
+      system: convox
+  template:
+    metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      labels:
+        app: app1
+        name: agent
+        rack: rack1
+        release: RELEASE2
+        service: agent
+        system: convox
+        type: service
+    spec:
+      containers:
+      - env:
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        envFrom:
+        - secretRef:
+            name: env-agent
+        image: repo1:agent.build1
+        imagePullPolicy: IfNotPresent
+        name: main
+        ports:
+        - containerPort: 8125
+          hostPort: 8125
+          name: port-8125
+          protocol: UDP
+        - containerPort: 8126
+          hostPort: 8126
+          name: port-8126
+          protocol: TCP
+        resources:
+          limits:
+            memory: 512Mi
+          requests:
+            cpu: 256m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /etc/convox
+          name: ca
+      hostNetwork: true
+      shareProcessNamespace: true
+      volumes:
+      - configMap:
+          name: ca
+          optional: true
+        name: ca
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    convox.com/alias: agent.app1.rack1.local
+  labels:
+    app: app1
+    provider: k8s
+    rack: rack1
+    release: release2
+    service: agent
+    system: convox
+  name: agent
+  namespace: rack1-app1
+spec:
+  ports:
+  - name: port-8125
+    port: 8125
+    protocol: UDP
+    targetPort: 8125
+  - name: port-8126
+    port: 8126
+    protocol: TCP
+    targetPort: 8126
+  selector:
+    service: agent
+    type: service
+  type: ClusterIP
+---
+apiVersion: v1
+data:
+  APP: YXBwMQ==
+  BUILD: QlVJTEQx
+  BUILD_DESCRIPTION: ""
+  FOO: YmFy
+  FOUR_URL: ""
+  RACK: cmFjazE=
+  RACK_URL: aHR0cHM6Ly9jb252b3g6QGFwaS5uczEuc3ZjLmNsdXN0ZXIubG9jYWw6NTQ0Mw==
+  RELEASE: UkVMRUFTRTI=
+  SERVICE: ZGVwbG95bWVudA==
+  THREE_URL: dmFsdWU=
+kind: Secret
+metadata:
+  labels:
+    app: app1
+    provider: k8s
+    rack: rack1
+    release: release2
+    service: deployment
+    system: convox
+    type: env
+  name: env-deployment
+  namespace: rack1-app1
+type: Opaque
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    atom.conditions: Available=True,Progressing=True/NewReplicaSetAvailable
+  labels:
+    app: app1
+    provider: k8s
+    rack: rack1
+    release: release2
+    service: deployment
+    system: convox
+    type: service
+  name: deployment
+  namespace: rack1-app1
+spec:
+  minReadySeconds: 1
+  replicas: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: app1
+      rack: rack1
+      service: deployment
+      system: convox
+  strategy:
+    rollingUpdate:
+      maxSurge: 10%
+      maxUnavailable: 75%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: app1
+        name: deployment
+        rack: rack1
+        release: RELEASE2
+        service: deployment
+        system: convox
+        type: service
+    spec:
+      containers:
+      - env:
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        envFrom:
+        - secretRef:
+            name: env-deployment
+        image: repo1:deployment.build1
+        imagePullPolicy: IfNotPresent
+        name: main
+        ports: null
+        resources:
+          limits:
+            memory: 512Mi
+          requests:
+            cpu: 256m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /etc/convox
+          name: ca
+      shareProcessNamespace: true
+      volumes:
+      - configMap:
+          name: ca
+          optional: true
+        name: ca
+---
+apiVersion: v1
+data:
+  APP: YXBwMQ==
+  BUILD: QlVJTEQx
+  BUILD_DESCRIPTION: ""
+  FOO: YmFy
+  FOUR_URL: ""
+  RACK: cmFjazE=
+  RACK_URL: aHR0cHM6Ly9jb252b3g6QGFwaS5uczEuc3ZjLmNsdXN0ZXIubG9jYWw6NTQ0Mw==
+  RELEASE: UkVMRUFTRTI=
+  SERVICE: c2luZ2xldG9u
+  THREE_URL: dmFsdWU=
+kind: Secret
+metadata:
+  labels:
+    app: app1
+    provider: k8s
+    rack: rack1
+    release: release2
+    service: singleton
+    system: convox
+    type: env
+  name: env-singleton
+  namespace: rack1-app1
+type: Opaque
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    atom.conditions: Available=True,Progressing=True/NewReplicaSetAvailable
+  labels:
+    app: app1
+    provider: k8s
+    rack: rack1
+    release: release2
+    service: singleton
+    system: convox
+    type: service
+  name: singleton
+  namespace: rack1-app1
+spec:
+  minReadySeconds: 1
+  replicas: 1
+  revisionHistoryLimit: 1
+  selector:
+    matchLabels:
+      app: app1
+      rack: rack1
+      service: singleton
+      system: convox
+  strategy:
+    rollingUpdate:
+      maxSurge: 0%
+      maxUnavailable: 100%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: app1
+        name: singleton
+        rack: rack1
+        release: RELEASE2
+        service: singleton
+        system: convox
+        type: service
+    spec:
+      containers:
+      - env:
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        envFrom:
+        - secretRef:
+            name: env-singleton
+        image: repo1:singleton.build1
+        imagePullPolicy: IfNotPresent
+        name: main
+        ports: null
+        resources:
+          limits:
+            memory: 512Mi
+          requests:
+            cpu: 256m
+            memory: 512Mi
+        volumeMounts:
+        - mountPath: /etc/convox
+          name: ca
+      shareProcessNamespace: true
+      volumes:
+      - configMap:
+          name: ca
+          optional: true
+        name: ca
+---
+apiVersion: v1
+data:
+  APP: YXBwMQ==
+  BUILD: QlVJTEQx
+  BUILD_DESCRIPTION: ""
+  FOO: YmFy
+  FOUR_URL: ""
   PORT: NTAwMA==
   RACK: cmFjazE=
   RACK_URL: aHR0cHM6Ly9jb252b3g6QGFwaS5uczEuc3ZjLmNsdXN0ZXIubG9jYWw6NTQ0Mw==
@@ -465,7 +786,7 @@ spec:
       system: convox
   strategy:
     rollingUpdate:
-      maxSurge: 200%
+      maxSurge: 100%
       maxUnavailable: 50%
     type: RollingUpdate
   template:

--- a/provider/k8s/testdata/release-basic.yml
+++ b/provider/k8s/testdata/release-basic.yml
@@ -23,6 +23,20 @@ manifest:
         - two:OTHER_URL
         - three
         - four
+    deployment:
+      build: .
+      deployment:
+        minimum: 25
+        maximum: 110
+    agent:
+      agent: true
+      build: .
+      ports:
+        - 8125/udp
+        - 8126
+    singleton:
+      build: .
+      singleton: true
   timers:
     test:
       command: bin/test


### PR DESCRIPTION
Adds new attributes to `convox.yml` to allow for manual control of deployment minimum/maximum percent of Processes to run during rolling deploys:

    services:
      web:
        deployment:
          minimum: 50
          maximum: 100