### PR TITLE
add `--name` flag to `convox rack install local` development installation tutorial

### DIFF
--- a/docs/installation/development-rack/macos.md
+++ b/docs/installation/development-rack/macos.md
@@ -26,7 +26,7 @@
 
 Install a local Rack named `dev`.
 
-    $ convox rack install local dev
+    $ convox rack install local --name dev
 
 ## DNS Setup
 


### PR DESCRIPTION
I looks like the CLI for `convo rack install` was updated, so that the `dev` argument needs to be specified with `--name`