### PR TITLE
Update convox-yml.md

### DIFF
--- a/docs/configuration/convox-yml.md
+++ b/docs/configuration/convox-yml.md
@@ -51,7 +51,7 @@ order: 1
         image: awesome/metrics
     timers:
       cleanup:
-        schedule: "0 3 * * ? *"
+        schedule: "0 3 * * * *"
         command: bin/cleanup
         service: worker
 
@@ -107,7 +107,7 @@ that run periodically on a set interval.
 
     timers:
       cleanup:
-        schedule: "0 3 * * ? *"
+        schedule: "0 3 * * * *"
         command: bin/cleanup
         service: worker
 


### PR DESCRIPTION
It seems, at least for AWS racks, that the schedule syntax can't have `?`'s in it anymore even though it's in the example:

```
2020-05-20T14:24:33Z service/build/build-v945j ERROR: validation errors:
2020-05-20T14:24:33Z service/build/build-v945j timer cleanup invalid, schedule cannot contain ?
2020-05-20T14:24:33Z service/build/build-v945j ERROR: validation errors:
2020-05-20T14:24:33Z service/build/build-v945j timer cleanup invalid, schedule cannot contain ?
```