### PR TITLE
aws: fix eks perm for elb

### DIFF
--- a/terraform/cluster/aws/iam.tf
+++ b/terraform/cluster/aws/iam.tf
@@ -35,10 +35,6 @@ data "aws_iam_policy_document" "assume_eks" {
   }
 }
 
-data "aws_iam_policy_document" "assume_elb" {
-
-}
-
 resource "aws_iam_role" "cluster" {
   assume_role_policy = data.aws_iam_policy_document.assume_eks.json
   name               = "${var.name}-cluster"

--- a/terraform/cluster/aws/iam.tf
+++ b/terraform/cluster/aws/iam.tf
@@ -24,6 +24,19 @@ data "aws_iam_policy_document" "assume_eks" {
       identifiers = ["eks.amazonaws.com"]
     }
   }
+  
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["elasticloadbalancing.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "assume_elb" {
+
 }
 
 resource "aws_iam_role" "cluster" {
@@ -35,6 +48,11 @@ resource "aws_iam_role" "cluster" {
 resource "aws_iam_role_policy_attachment" "cluster_eks_cluster" {
   role       = aws_iam_role.cluster.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_eks_service" {
+  role       = aws_iam_role.cluster.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
 }
 
 resource "aws_iam_role_policy_attachment" "cluster_eks_service" {

--- a/terraform/cluster/aws/iam.tf
+++ b/terraform/cluster/aws/iam.tf
@@ -55,11 +55,6 @@ resource "aws_iam_role_policy_attachment" "cluster_eks_service" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
 }
 
-resource "aws_iam_role_policy_attachment" "cluster_eks_service" {
-  role       = aws_iam_role.cluster.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
-}
-
 resource "aws_iam_role" "nodes" {
   assume_role_policy = data.aws_iam_policy_document.assume_ec2.json
   name               = "${var.name}-nodes"

--- a/terraform/cluster/aws/iam.tf
+++ b/terraform/cluster/aws/iam.tf
@@ -24,15 +24,6 @@ data "aws_iam_policy_document" "assume_eks" {
       identifiers = ["eks.amazonaws.com"]
     }
   }
-  
-  statement {
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["elasticloadbalancing.amazonaws.com"]
-    }
-  }
 }
 
 resource "aws_iam_role" "cluster" {
@@ -49,6 +40,11 @@ resource "aws_iam_role_policy_attachment" "cluster_eks_cluster" {
 resource "aws_iam_role_policy_attachment" "cluster_eks_service" {
   role       = aws_iam_role.cluster.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_ec2_readonly" {
+  role       = aws_iam_role.cluster.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess"
 }
 
 resource "aws_iam_role" "nodes" {


### PR DESCRIPTION
@ddollar fixes the issue described here: https://medium.com/faun/aws-eks-the-role-is-not-authorized-to-perform-ec2-describeaccountattributes-error-1c6474781b84 which has been reported a few times by people with fresh AWS accounts