### PR TITLE
manifest: add conversion for ? in timer syntax for v2 compatibility

### DIFF
--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -272,6 +272,26 @@ func TestManifestLoad(t *testing.T) {
 				Sticky: false,
 			},
 		},
+		Timers: manifest.Timers{
+			manifest.Timer{
+				Command:  "bin/alpha",
+				Name:     "alpha",
+				Schedule: "*/1 * * * *",
+				Service:  "api",
+			},
+			manifest.Timer{
+				Command:  "bin/bravo",
+				Name:     "bravo",
+				Schedule: "*/1 * * * *",
+				Service:  "api",
+			},
+			manifest.Timer{
+				Command:  "bin/charlie",
+				Name:     "charlie",
+				Schedule: "*/1 * * * *",
+				Service:  "api",
+			},
+		},
 	}
 
 	attrs := []string{
@@ -359,6 +379,19 @@ func TestManifestLoad(t *testing.T) {
 		"services.scaler.scale.targets.custom.AWS/SQS/ApproximateNumberOfMessagesVisible.value",
 		"services.scaler.scale.targets.memory",
 		"services.scaler.scale.targets.requests",
+		"timers",
+		"timers.alpha",
+		"timers.alpha.command",
+		"timers.alpha.schedule",
+		"timers.alpha.service",
+		"timers.bravo",
+		"timers.bravo.command",
+		"timers.bravo.schedule",
+		"timers.bravo.service",
+		"timers.charlie",
+		"timers.charlie.command",
+		"timers.charlie.schedule",
+		"timers.charlie.service",
 	}
 
 	env := map[string]string{"FOO": "bar", "SECRET": "shh", "OTHERGLOBAL": "test"}
@@ -501,7 +534,6 @@ func TestManifestValidate(t *testing.T) {
 		"service serviceF references a resource that does not exist: foo",
 		"timer name timer_1 invalid, must contain only lowercase alphanumeric and dashes",
 		"timer timer_1 references a service that does not exist: someservice",
-		"timer timer_1 invalid, schedule cannot contain ?",
 	}
 
 	require.EqualError(t, err, fmt.Sprintf("validation errors:\n%s", strings.Join(errors, "\n")))

--- a/pkg/manifest/testdata/full.yml
+++ b/pkg/manifest/testdata/full.yml
@@ -90,3 +90,16 @@ services:
       - 5000/udp
       - 5001
       - 5002/tcp
+timers:
+  alpha:
+    command: bin/alpha
+    service: api
+    schedule: "*/1 * * * ? *"
+  bravo:
+    command: bin/bravo
+    service: api
+    schedule: "*/1 * * * ?"
+  charlie:
+    command: bin/charlie
+    service: api
+    schedule: "*/1 * * * *"

--- a/pkg/manifest/timer.go
+++ b/pkg/manifest/timer.go
@@ -1,10 +1,5 @@
 package manifest
 
-import (
-	"fmt"
-	"strings"
-)
-
 type Timer struct {
 	Name string `yaml:"-"`
 
@@ -14,17 +9,6 @@ type Timer struct {
 }
 
 type Timers []Timer
-
-func (t Timer) Cron() (string, error) {
-	switch len(strings.Split(t.Schedule, " ")) {
-	case 5:
-		return fmt.Sprintf("%s *", t.Schedule), nil
-	case 6:
-		return t.Schedule, nil
-	default:
-		return "", fmt.Errorf("invalid schedule expression: %s", t.Schedule)
-	}
-}
 
 func (t Timer) GetName() string {
 	return t.Name


### PR DESCRIPTION
Allows for backwards compatibility of timer syntax from v2.

V2 allowed 5 or 6 fields for cron syntax and required one field to be a `?`. This is no longer the case for the Kubernetes-standard cron syntax in v3. This change allows the old syntax to work as intended.