### PR TITLE
docs: fixed incorrect reference to "memcached"

### DIFF
--- a/docs/reference/primitives/app/resource/postgres.md
+++ b/docs/reference/primitives/app/resource/postgres.md
@@ -18,7 +18,7 @@ A Postgres Resource can have the following options configured for it (default va
 
     resources:
       main:
-        type: memcached
+        type: postgres
         options:
           version: 10.5
           storage: 10


### PR DESCRIPTION
The memcached literal was incorrectly carried over into the Postgres resource documentation. This PR fixes this.