### PR TITLE
aws: pass through source ip information in custom balancers

### DIFF
--- a/provider/k8s/template/app/balancer.yml.tmpl
+++ b/provider/k8s/template/app/balancer.yml.tmpl
@@ -5,6 +5,7 @@ metadata:
   name: balancer-{{.Balancer.Name}}
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   labels:
     balancer: {{.Balancer.Name}}
     service: {{.Balancer.Service}}


### PR DESCRIPTION
Currently there's no way to get the client IP for a custom balancer. [Docs here suggest](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html#proxy-protocol) that the NLB will pass the correct source IP when using instances as targets, unlike the currently-used classic ELB which would require enabling the proxy protocol.

> If you specify targets by instance ID, the source IP addresses provided to your applications are the client IP addresses. However, if you prefer, you can enable proxy protocol and get the client IP addresses from the proxy protocol header.

