### PR TITLE
AWS is using six required fields in cron

### DIFF
--- a/docs/reference/primitives/app/timer.md
+++ b/docs/reference/primitives/app/timer.md
@@ -28,12 +28,12 @@ A Timer is defined in [`convox.yml`](../../../configuration/convox-yml.md).
 Cron expressions use the following format. All times are UTC.
 
 ```
-.----------------- minute (0 - 59)
-|  .-------------- hour (0 - 23)
-|  |  .----------- day-of-month (1 - 31)
-|  |  |  .-------- month (1 - 12) OR JAN,FEB,MAR,APR ...
-|  |  |  |  .----- day-of-week (0 - 6) OR SUN,MON,TUE,WED,THU,FRI,SAT
-|  |  |  |  |  .-- year
+.------------------ minute (0 - 59)
+|  .--------------- hour (0 - 23)
+|  |  .------------ day-of-month (1 - 31)
+|  |  |  .--------- month (1 - 12) OR JAN,FEB,MAR,APR ...
+|  |  |  |  .------ day-of-week (0 - 6) OR SUN,MON,TUE,WED,THU,FRI,SAT
+|  |  |  |  |  .--- year (1970 – 2199)
 |  |  |  |  |  |
 *  *  *  *  *  *
 ```

--- a/docs/reference/primitives/app/timer.md
+++ b/docs/reference/primitives/app/timer.md
@@ -12,7 +12,7 @@ A Timer is defined in [`convox.yml`](../../../configuration/convox-yml.md).
     timers:
       cleanup:
         command: bin/cleanup
-        schedule: "0 3 * * *"
+        schedule: "0 3 * * * *"
         service: worker
 
 ### Attributes
@@ -33,8 +33,9 @@ Cron expressions use the following format. All times are UTC.
 |  |  .----------- day-of-month (1 - 31)
 |  |  |  .-------- month (1 - 12) OR JAN,FEB,MAR,APR ...
 |  |  |  |  .----- day-of-week (0 - 6) OR SUN,MON,TUE,WED,THU,FRI,SAT
-|  |  |  |  |
-*  *  *  *  *
+|  |  |  |  |  .-- year
+|  |  |  |  |  |
+*  *  *  *  *  *
 ```
 
 ### Using a Template Service
@@ -54,7 +55,7 @@ template [Service](service.md) for your Timers.
     timers:
       cleanup:
         command: bin/cleanup
-        schedule: "*/2 * * * *"
+        schedule: "*/2 * * * * *"
         service: jobs
 
 On this [App](..) the `jobs` [Service](service.md) is scaled to zero and not running any durable


### PR DESCRIPTION
"Cron expressions have six required fields, which are separated by white space." https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#CronExpressions