### PR TITLE
k8s: use docker buildkit for remote build cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.13 AS development
 
 RUN apt-get update && apt-get -y install default-mysql-client postgresql-client redis-tools telnet
 
-RUN curl -s https://download.docker.com/linux/static/stable/x86_64/docker-18.03.1-ce.tgz | \
+RUN curl -s https://download.docker.com/linux/static/stable/x86_64/docker-19.03.9.tgz | \
   tar -C /usr/bin --strip-components 1 -xz
 
 RUN curl -Ls https://storage.googleapis.com/kubernetes-release/release/v1.17.3/bin/linux/amd64/kubectl -o /usr/bin/kubectl && \

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -14,6 +14,7 @@ var (
 	flagApp         string
 	flagAuth        string
 	flagCache       string
+	flagCacheFrom   string
 	flagDevelopment string
 	flagEnvWrapper  string
 	flagGeneration  string
@@ -44,6 +45,7 @@ func execute() error {
 	fs.StringVar(&flagApp, "app", "example", "app name")
 	fs.StringVar(&flagAuth, "auth", "", "docker auth data (json)")
 	fs.StringVar(&flagCache, "cache", "true", "use docker cache")
+	fs.StringVar(&flagCacheFrom, "cache-from", "", "use a registry image as a cache source")
 	fs.StringVar(&flagDevelopment, "development", "false", "create a development build")
 	fs.StringVar(&flagEnvWrapper, "env-wrapper", "false", "wrap with convox-env")
 	fs.StringVar(&flagGeneration, "generation", "", "app generation")
@@ -64,6 +66,10 @@ func execute() error {
 
 	if v := os.Getenv("BUILD_AUTH"); v != "" {
 		flagAuth = v
+	}
+
+	if v := os.Getenv("BUILD_CACHE_FROM"); v != "" {
+		flagCacheFrom = v
 	}
 
 	if v := os.Getenv("BUILD_DEVELOPMENT"); v != "" {
@@ -102,6 +108,7 @@ func execute() error {
 		App:         flagApp,
 		Auth:        flagAuth,
 		Cache:       flagCache == "true",
+		CacheFrom:   flagCacheFrom,
 		Development: flagDevelopment == "true",
 		EnvWrapper:  flagEnvWrapper == "true",
 		Generation:  flagGeneration,

--- a/pkg/build/build_test.go
+++ b/pkg/build/build_test.go
@@ -37,7 +37,7 @@ func TestBuildGeneration2(t *testing.T) {
 		require.NoError(t, err)
 		p.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{*fxRelease()}, nil)
 		p.On("ReleaseGet", "app1", "release1").Return(fxRelease(), nil)
-		e.On("Run", mock.Anything, "docker", "build", "-t", "e00bc968ebe3f5b4c934a1f3c00fcfba74384f944f6f9fa2ba819445", "-f", "Dockerfile", "--network", "host", ".").Return(nil).Run(func(args mock.Arguments) {
+		e.On("Run", mock.Anything, "docker", "build", "-t", "e00bc968ebe3f5b4c934a1f3c00fcfba74384f944f6f9fa2ba819445", "-f", "Dockerfile", "--network", "host", "--build-arg", "BUILDKIT_INLINE_CACHE=1", ".").Return(nil).Run(func(args mock.Arguments) {
 			fmt.Fprintf(args.Get(0).(io.Writer), "build1\nbuild2\n")
 		})
 		e.On("Execute", "docker", "inspect", "e00bc968ebe3f5b4c934a1f3c00fcfba74384f944f6f9fa2ba819445", "--format", "{{json .Config.Entrypoint}}").Return([]byte("[]"), nil)
@@ -102,7 +102,7 @@ func TestBuildGeneration2Development(t *testing.T) {
 		require.NoError(t, err)
 		p.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{*fxRelease()}, nil)
 		p.On("ReleaseGet", "app1", "release1").Return(fxRelease(), nil)
-		e.On("Run", mock.Anything, "docker", "build", "-t", "e00bc968ebe3f5b4c934a1f3c00fcfba74384f944f6f9fa2ba819445", "-f", "Dockerfile", "--network", "host", "--target", "development", ".").Return(nil).Run(func(args mock.Arguments) {
+		e.On("Run", mock.Anything, "docker", "build", "-t", "e00bc968ebe3f5b4c934a1f3c00fcfba74384f944f6f9fa2ba819445", "-f", "Dockerfile", "--network", "host", "--build-arg", "BUILDKIT_INLINE_CACHE=1", "--target", "development", ".").Return(nil).Run(func(args mock.Arguments) {
 			fmt.Fprintf(args.Get(0).(io.Writer), "build1\nbuild2\n")
 		})
 		e.On("Execute", "docker", "inspect", "e00bc968ebe3f5b4c934a1f3c00fcfba74384f944f6f9fa2ba819445", "--format", "{{json .Config.Entrypoint}}").Return([]byte("[]"), nil)
@@ -162,7 +162,7 @@ func TestBuildGeneration2Entrypoint(t *testing.T) {
 		require.NoError(t, err)
 		p.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{*fxRelease()}, nil)
 		p.On("ReleaseGet", "app1", "release1").Return(fxRelease(), nil)
-		e.On("Run", mock.Anything, "docker", "build", "-t", "e00bc968ebe3f5b4c934a1f3c00fcfba74384f944f6f9fa2ba819445", "-f", "Dockerfile", "--network", "host", ".").Return(nil).Run(func(args mock.Arguments) {
+		e.On("Run", mock.Anything, "docker", "build", "-t", "e00bc968ebe3f5b4c934a1f3c00fcfba74384f944f6f9fa2ba819445", "-f", "Dockerfile", "--network", "host", "--build-arg", "BUILDKIT_INLINE_CACHE=1", ".").Return(nil).Run(func(args mock.Arguments) {
 			fmt.Fprintf(args.Get(0).(io.Writer), "build1\nbuild2\n")
 		})
 		e.On("Execute", "docker", "inspect", "e00bc968ebe3f5b4c934a1f3c00fcfba74384f944f6f9fa2ba819445", "--format", "{{json .Config.Entrypoint}}").Return([]byte("[\"bin/entry\"]"), nil)
@@ -280,7 +280,7 @@ func TestBuildGeneration2Options(t *testing.T) {
 		// p.On("BuildUpdate", "app1", "build1", structs.BuildUpdateOptions{Manifest: options.String(string(mdata))}).Return(fxBuildStarted(), nil).Once()
 		p.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{*fxRelease()}, nil)
 		p.On("ReleaseGet", "app1", "release1").Return(fxRelease(), nil)
-		e.On("Run", mock.Anything, "docker", "build", "--no-cache", "-t", "c67c8080ff5483672fe18cfb54f4710ddcc920b3575810ad05dbe1a4", "-f", "Dockerfile2", "--network", "host", "--build-arg", "FOO=bar", ".").Return(nil).Run(func(args mock.Arguments) {
+		e.On("Run", mock.Anything, "docker", "build", "--no-cache", "-t", "c67c8080ff5483672fe18cfb54f4710ddcc920b3575810ad05dbe1a4", "-f", "Dockerfile2", "--network", "host", "--build-arg", "BUILDKIT_INLINE_CACHE=1", "--build-arg", "FOO=bar", ".").Return(nil).Run(func(args mock.Arguments) {
 			fmt.Fprintf(args.Get(0).(io.Writer), "build1\nbuild2\n")
 		})
 		e.On("Execute", "docker", "inspect", "c67c8080ff5483672fe18cfb54f4710ddcc920b3575810ad05dbe1a4", "--format", "{{json .Config.Entrypoint}}").Return([]byte("[]"), nil)
@@ -294,7 +294,7 @@ func TestBuildGeneration2Options(t *testing.T) {
 		p.On("ObjectStore", "app1", "build/build1/logs", mock.Anything, structs.ObjectStoreOptions{}).Return(fxObject(), nil).Run(func(args mock.Arguments) {
 			data, err := ioutil.ReadAll(args.Get(2).(io.Reader))
 			require.NoError(t, err)
-			require.Equal(t, "Authenticating host1: login-success\nBuilding: .\nbuild1\nbuild2\nRunning: docker tag c67c8080ff5483672fe18cfb54f4710ddcc920b3575810ad05dbe1a4 rack1/app1:web.build1\nInjecting: convox-env\nRunning: docker tag rack1/app1:web.build1 push1:web.build1\nRunning: docker push push1:web.build1\n", string(data))
+			require.Equal(t, "Authenticating host1: OK\nBuilding: .\nbuild1\nbuild2\nRunning: docker tag c67c8080ff5483672fe18cfb54f4710ddcc920b3575810ad05dbe1a4 rack1/app1:web.build1\nInjecting: convox-env\nRunning: docker tag rack1/app1:web.build1 push1:web.build1\nRunning: docker push push1:web.build1\n", string(data))
 		})
 		p.On("BuildUpdate", "app1", "build1", mock.Anything).Return(fxBuildStarted(), nil).Run(func(args mock.Arguments) {
 			opts := args.Get(2).(structs.BuildUpdateOptions)
@@ -316,7 +316,7 @@ func TestBuildGeneration2Options(t *testing.T) {
 
 		require.Equal(t,
 			[]string{
-				"Authenticating host1: login-success",
+				"Authenticating host1: OK",
 				"Building: .",
 				"build1",
 				"build2",

--- a/provider/k8s/build.go
+++ b/provider/k8s/build.go
@@ -58,6 +58,13 @@ func (p *Provider) BuildCreate(app, url string, opts structs.BuildCreateOptions)
 		"RACK_URL":          fmt.Sprintf("https://convox:%s@api.%s.svc.cluster.local:5443", p.Password, p.Namespace),
 	}
 
+	r, err := common.ReleaseLatest(p, app)
+	if err != nil {
+		return nil, err
+	}
+
+	env["BUILD_CACHE_FROM"] = r.Build
+
 	repo, _, err := p.Engine.RepositoryHost(app)
 	if err != nil {
 		return nil, errors.WithStack(err)


### PR DESCRIPTION
Uses Docker's buildkit to enable a build cache stored in the registry.

The builder then uses this stored build cache to allow for cached build without needing to pin to a specific instance.