### PR TITLE
docs: missed options

### DIFF
--- a/docs/reference/cli/start.md
+++ b/docs/reference/cli/start.md
@@ -6,7 +6,11 @@ Start an application for local development
 
 ### Usage
 
-    convox start [service] [service...]
+    convox start [service] [service...] [options]
+
+### Options
+
+    -m <file.yml> allows to specify an alternative manifest file (convox.yml by default)
 
 ### Examples
 


### PR DESCRIPTION
i spent some time realizing how to specify an alternative yml manifest file. there is such option, but it is not documented. after a number of failures i found `-m` works, so i want to share my solution with others.

feel free to add the missing parts.