### PR TITLE
rack: Skip invalid parameters on import

### DIFF
--- a/provider/k8s/app.go
+++ b/provider/k8s/app.go
@@ -281,7 +281,7 @@ func (p *Provider) appParametersUpdate(a *structs.App, params map[string]string)
 		}
 	}
 
-	fmt.Print("Skipping invalid parameters: %s ...", strings.Join(invalidParameters, ", "))
+	fmt.Printf("Skipping invalid parameters: %s ...", strings.Join(invalidParameters, ", "))
 
 	return nil
 }

--- a/provider/k8s/app.go
+++ b/provider/k8s/app.go
@@ -281,7 +281,7 @@ func (p *Provider) appParametersUpdate(a *structs.App, params map[string]string)
 		}
 	}
 
-	fmt.Print("Skipping invalid parameters: %s ...", strings.join(invalidParameters, ", ")
+	fmt.Print("Skipping invalid parameters: %s ...", strings.Join(invalidParameters, ", "))
 
 	return nil
 }

--- a/provider/k8s/app.go
+++ b/provider/k8s/app.go
@@ -272,13 +272,16 @@ func (p *Provider) appNameValidate(name string) error {
 func (p *Provider) appParametersUpdate(a *structs.App, params map[string]string) error {
 	defs := p.Engine.AppParameters()
 
+	var invalidParameters []string
 	for k, v := range params {
 		if _, ok := defs[k]; !ok {
-			return errors.WithStack(fmt.Errorf("invalid parameter: %s", k))
+			invalidParameters = append(invalidParameters, k)
+		} else {
+			a.Parameters[k] = v
 		}
-
-		a.Parameters[k] = v
 	}
+
+	fmt.Print("Skipping invalid parameters: %s ...", strings.join(invalidParameters, ", ")
 
 	return nil
 }

--- a/provider/k8s/app.go
+++ b/provider/k8s/app.go
@@ -272,16 +272,16 @@ func (p *Provider) appNameValidate(name string) error {
 func (p *Provider) appParametersUpdate(a *structs.App, params map[string]string) error {
 	defs := p.Engine.AppParameters()
 
-	var invalidParameters []string
+	var redundantParameters []string
 	for k, v := range params {
 		if _, ok := defs[k]; !ok {
-			invalidParameters = append(invalidParameters, k)
+			redundantParameters = append(redundantParameters, k)
 		} else {
 			a.Parameters[k] = v
 		}
 	}
 
-	fmt.Printf("Skipping invalid parameters: %s ...", strings.Join(invalidParameters, ", "))
+	fmt.Printf("Skipping redundant parameters: %s ...", strings.Join(redundantParameters, ", "))
 
 	return nil
 }


### PR DESCRIPTION
Exporting an App from v2 and importing to v3 will cause errors due to the lack of matching (or any) app params on v3.  Instead we can skip over them during Import.