### PR TITLE
docs: clarify where `convox run` processes are run

### DIFF
--- a/docs/management/run.md
+++ b/docs/management/run.md
@@ -6,7 +6,7 @@ for starting a shell for debugging purposes or running administrative commands s
 ## Spawning a new Process
 
 Using `convox run` will start a new [Process](../reference/primitives/app/process.md) of the specified
-[Service](../reference/primitives/app/service.md) on a Convox node and run your command inside the new Process.
+[Service](../reference/primitives/app/service.md) on your current Rack and run your command inside the new Process.
 
 ### Running Interactively
 

--- a/docs/management/run.md
+++ b/docs/management/run.md
@@ -6,7 +6,7 @@ for starting a shell for debugging purposes or running administrative commands s
 ## Spawning a new Process
 
 Using `convox run` will start a new [Process](../reference/primitives/app/process.md) of the specified
-[Service](../reference/primitives/app/service.md) and run your command inside the new Process.
+[Service](../reference/primitives/app/service.md) on a Convox node and run your command inside the new Process.
 
 ### Running Interactively
 


### PR DESCRIPTION
It wasn't entirely clear to me whether `convox run` would run the command on the user's local machine using the Convox release's build's image, or on one of their Convox pods. Even digging into the link to the process page (https://docs.convox.com/reference/primitives/app/process) doesn't easily answer the question.

Add a quick note mentioning that the process is run remotely.