### PR TITLE
aws: enable spot instance types

### DIFF
--- a/pkg/cli/fixtures_test.go
+++ b/pkg/cli/fixtures_test.go
@@ -126,6 +126,7 @@ func fxInstance() *structs.Instance {
 		PublicIp:  "public",
 		Status:    "status",
 		Started:   time.Now().UTC().Add(-48 * time.Hour),
+		Type:      "type1",
 	}
 }
 

--- a/pkg/cli/instances.go
+++ b/pkg/cli/instances.go
@@ -39,10 +39,10 @@ func Instances(rack sdk.Interface, c *stdcli.Context) error {
 		return err
 	}
 
-	t := c.Table("ID", "STATUS", "STARTED", "PS", "CPU", "MEM", "PUBLIC", "PRIVATE")
+	t := c.Table("ID", "TYPE", "STATUS", "STARTED", "PS", "CPU", "MEM", "PUBLIC", "PRIVATE")
 
 	for _, i := range is {
-		t.AddRow(i.Id, i.Status, common.Ago(i.Started), fmt.Sprintf("%d", i.Processes), common.Percent(i.Cpu), common.Percent(i.Memory), i.PublicIp, i.PrivateIp)
+		t.AddRow(i.Id, i.Type, i.Status, common.Ago(i.Started), fmt.Sprintf("%d", i.Processes), common.Percent(i.Cpu), common.Percent(i.Memory), i.PublicIp, i.PrivateIp)
 	}
 
 	return t.Print()

--- a/pkg/cli/instances_test.go
+++ b/pkg/cli/instances_test.go
@@ -19,9 +19,9 @@ func TestInstances(t *testing.T) {
 		require.Equal(t, 0, res.Code)
 		res.RequireStderr(t, []string{""})
 		res.RequireStdout(t, []string{
-			"ID         STATUS  STARTED     PS  CPU     MEM     PUBLIC  PRIVATE",
-			"instance1  status  2 days ago  3   42.30%  71.80%  public  private",
-			"instance1  status  2 days ago  3   42.30%  71.80%  public  private",
+			"ID         TYPE   STATUS  STARTED     PS  CPU     MEM     PUBLIC  PRIVATE",
+			"instance1  type1  status  2 days ago  3   42.30%  71.80%  public  private",
+			"instance1  type1  status  2 days ago  3   42.30%  71.80%  public  private",
 		})
 	})
 }

--- a/pkg/structs/instance.go
+++ b/pkg/structs/instance.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/fsouza/go-dockerclient"
+	docker "github.com/fsouza/go-dockerclient"
 )
 
 type Instance struct {
@@ -18,6 +18,7 @@ type Instance struct {
 	PublicIp  string    `json:"public-ip"`
 	Status    string    `json:"status"`
 	Started   time.Time `json:"started"`
+	Type      string    `json:"type"`
 }
 
 type Instances []Instance

--- a/provider/k8s/instance.go
+++ b/provider/k8s/instance.go
@@ -62,6 +62,7 @@ func (p *Provider) InstanceList() (structs.Instances, error) {
 			PublicIp:  public,
 			Started:   n.CreationTimestamp.Time,
 			Status:    status,
+			Type:      n.ObjectMeta.Labels["node.kubernetes.io/instance-type"],
 		})
 	}
 

--- a/terraform/api/aws/versions.tf
+++ b/terraform/api/aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.49"
+      version = "~> 3.30"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/terraform/cluster/aws/variables.tf
+++ b/terraform/cluster/aws/variables.tf
@@ -21,3 +21,7 @@ variable "node_type" {
 variable "private" {
   default = true
 }
+
+variable "spot_types" {
+  default = ""
+}

--- a/terraform/cluster/aws/versions.tf
+++ b/terraform/cluster/aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.49"
+      version = "~> 3.30"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/terraform/fluentd/aws/versions.tf
+++ b/terraform/fluentd/aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.49"
+      version = "~> 3.30"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/terraform/rack/aws/versions.tf
+++ b/terraform/rack/aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.49"
+      version = "~> 3.30"
     }
     external = {
       source  = "hashicorp/external"

--- a/terraform/resolver/aws/versions.tf
+++ b/terraform/resolver/aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.49"
+      version = "~> 3.30"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/terraform/router/aws/versions.tf
+++ b/terraform/router/aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.49"
+      version = "~> 3.30"
     }
     http = {
       source  = "hashicorp/http"

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -30,11 +30,12 @@ module "cluster" {
     aws = aws
   }
 
-  cidr      = var.cidr
-  name      = var.name
-  node_disk = var.node_disk
-  node_type = var.node_type
-  private   = var.private
+  cidr       = var.cidr
+  name       = var.name
+  node_disk  = var.node_disk
+  node_type  = var.node_type
+  private    = var.private
+  spot_types = var.spot_types
 }
 
 module "fluentd" {

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -26,6 +26,10 @@ variable "region" {
   default = "us-east-1"
 }
 
+variable "spot_types" {
+  default = ""
+}
+
 variable "syslog" {
   default = ""
 }

--- a/terraform/system/aws/versions.tf
+++ b/terraform/system/aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 2.49"
+      version = "~> 3.30"
     }
     http = {
       source  = "hashicorp/http"


### PR DESCRIPTION
Adds a new parameter to AWS racks: `spot_types`

Set this parameter to one or more instance types to enable spot instances in your Rack.

The Rack will still run a minimum of 3 on demand instances (one in each AZ) to keep a bare minimum of infrastructure running should all spots disappear.

Note: Because AWS managed node groups currently require a minimum of one instance setting the `spot_types` parameter will cause your instance to have a minimum of 6 instances (3 on-demand, 3 spot)