### PR TITLE
docs: adding 18.04 support clause.

### DIFF
--- a/docs/installation/development-rack/ubuntu.md
+++ b/docs/installation/development-rack/ubuntu.md
@@ -2,6 +2,8 @@
 
 ## Initial Setup
 
+> **_NOTE:_**:  Currently, we guarantee support for Ubuntu up to version 18.04. Newer versions of Ubuntu have yet to be fully supported.
+
 ### Docker
 
     $ sudo apt install docker.io

--- a/docs/installation/development-rack/ubuntu.md
+++ b/docs/installation/development-rack/ubuntu.md
@@ -2,7 +2,7 @@
 
 ## Initial Setup
 
-> **_NOTE:_**:  Currently, we guarantee support for Ubuntu up to version 18.04. Newer versions of Ubuntu have yet to be fully supported.
+> **_NOTE:_**:  Currently, we guarantee support for Ubuntu up to version 18.04. Though newer versions of Ubuntu have yet to be fully supported, we are actively working on support for Ubuntu version 20.04.
 
 ### Docker
 


### PR DESCRIPTION
Addresses: https://trello.com/c/R2uNQERm

Adding the Ubuntu 18.04 support clause to the documentation.



