### PR TITLE
aws: adding a timeout to subnet deletes.

### DIFF
--- a/docs/help/known-issues.md
+++ b/docs/help/known-issues.md
@@ -7,4 +7,6 @@
 * EKS Node groups currently leak ENIs when they are being destroyed. This may cause failures when
   uninstalling AWS Racks. To work around this issue you must manually delete the ENIs in the VPC
   created for the Rack that are left behind in an "available" state.
-  [aws/amazon-vpc-cni-k8s#608](https://github.com/aws/amazon-vpc-cni-k8s/issues/608) 
+  [aws/amazon-vpc-cni-k8s#608](https://github.com/aws/amazon-vpc-cni-k8s/issues/608)
+  * Update:  We have provided a fix for this issue that extends the delete operation timeout 
+    for public and private subnets.  

--- a/terraform/cluster/aws/network.tf
+++ b/terraform/cluster/aws/network.tf
@@ -41,6 +41,10 @@ resource "aws_subnet" "public" {
     "kubernetes.io/cluster/${var.name}" : "shared"
     "kubernetes.io/role/elb" : ""
   })
+
+  timeouts {
+    delete = "6h"
+  }
 }
 
 resource "aws_route_table" "public" {
@@ -80,6 +84,10 @@ resource "aws_subnet" "private" {
     "kubernetes.io/cluster/${var.name}" : "shared"
     "kubernetes.io/role/internal-elb" : ""
   })
+
+  timeouts {
+    delete = "6h"
+  }
 }
 
 resource "aws_eip" "nat" {


### PR DESCRIPTION
To prevent the `timeout while waiting for state to become 'destroyed'` error that occurs when deleting racks, I've added a 6-hr timeout value for the deletion of private and public subnets.

Signed-off-by: Jay Clark <jay@convox.com>