### PR TITLE
k8s: allow console/export in resource overlays

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,10 @@ compress: $(binaries)
 	upx-ucl -1 $^
 
 dev:
+	test -n "$(IMAGE)" # IMAGE
 	test -n "$(RACK)" # RACK
-	docker build --target development -t convox/convox:master .
-	docker push convox/convox:master
+	docker build --target development -t $(IMAGE) .
+	docker push $(IMAGE)
 	$(call restart,$(RACK)-system,deployment/api)
 	$(call restart,$(RACK)-system,deployment/atom)
 	$(call restart,$(RACK)-system,deployment/resolver)


### PR DESCRIPTION
This change allows `convox resources console` and `convox resources export/import` to work even when you are using a `RESOURCE_URL` environment variable to overlay/override the default container-based resources.