### PR TITLE
Fix fluentd skipping to send some logs to cloudwatch

### DIFF
--- a/terraform/fluentd/aws/main.tf
+++ b/terraform/fluentd/aws/main.tf
@@ -16,7 +16,7 @@ module "k8s" {
   }
 
   cluster   = var.cluster
-  image     = "convox/fluentd:1.7.1"
+  image     = "convox/fluentd:1.13"
   namespace = var.namespace
   rack      = var.rack
 

--- a/terraform/fluentd/k8s/containers.conf
+++ b/terraform/fluentd/k8s/containers.conf
@@ -5,7 +5,8 @@
 	exclude_path ["/var/log/containers/cloudwatch-agent*", "/var/log/containers/fluentd*"]
 	pos_file /var/log/fluentd-containers.log.pos
 	tag container.*
-	read_from_head false
+	read_from_head true
+	follow_inodes true
 	<parse>
 		@type multi_format
 		<pattern>


### PR DESCRIPTION
# Description

This PR make sure to always read log files from head to prevent `fluentd` to skip sending initial logs to cloudwatch.