### PR TITLE
Update k8s version

### DIFF
--- a/ci/dependencies.sh
+++ b/ci/dependencies.sh
@@ -14,3 +14,6 @@ curl -Ls https://storage.googleapis.com/kubernetes-release/release/v1.13.0/bin/l
 # install terraform
 curl -L https://releases.hashicorp.com/terraform/0.13.2/terraform_0.13.2_linux_amd64.zip -o terraform.zip && \
 	unzip terraform.zip -d /tmp && sudo mv /tmp/terraform /usr/bin/terraform && rm terraform.zip
+
+# install latest aws cli
+pip install --upgrade awscli

--- a/terraform/cluster/aws/variables.tf
+++ b/terraform/cluster/aws/variables.tf
@@ -6,8 +6,9 @@ variable "cidr" {
   default = "10.1.0.0/16"
 }
 
-variable "kubernetes_version" {
-  default = "1.13"
+variable "k8s_version" {
+  type = string
+  default = "1.18"
 }
 
 variable "name" {

--- a/terraform/cluster/azure/main.tf
+++ b/terraform/cluster/azure/main.tf
@@ -1,6 +1,6 @@
 data "azurerm_kubernetes_service_versions" "available" {
   location       = var.region
-  version_prefix = "1.17."
+  version_prefix = "${var.k8s_version}."
 }
 
 resource "random_string" "suffix" {

--- a/terraform/cluster/azure/variables.tf
+++ b/terraform/cluster/azure/variables.tf
@@ -1,3 +1,8 @@
+variable "k8s_version" {
+  type = string
+  default = "1.18"
+}
+
 variable "name" {
   type = string
 }

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -5,9 +5,13 @@ provider "aws" {
 provider "kubernetes" {
   cluster_ca_certificate = module.cluster.ca
   host                   = module.cluster.endpoint
-  token                  = data.aws_eks_cluster_auth.cluster.token
 
   load_config_file = false
+  exec {
+    api_version = "client.authentication.k8s.io/v1alpha1"
+    args        = ["eks", "get-token", "--cluster-name", var.name]
+    command     = "aws"
+  }
 }
 
 data "aws_eks_cluster_auth" "cluster" {
@@ -32,6 +36,7 @@ module "cluster" {
 
   availability_zones = var.availability_zones
   cidr               = var.cidr
+  k8s_version        = var.k8s_version
   name               = var.name
   node_disk          = var.node_disk
   node_type          = var.node_type

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -28,6 +28,11 @@ variable "image" {
   default = "convox/convox"
 }
 
+variable "k8s_version" {
+  type = string
+  default = "1.18"
+}
+
 variable "name" {
   type = string
 }

--- a/terraform/system/azure/main.tf
+++ b/terraform/system/azure/main.tf
@@ -34,6 +34,7 @@ module "cluster" {
     azurerm = azurerm
   }
 
+  k8s_version    = var.k8s_version
   name           = var.name
   node_type      = var.node_type
   region         = var.region

--- a/terraform/system/azure/variables.tf
+++ b/terraform/system/azure/variables.tf
@@ -10,6 +10,11 @@ variable "image" {
   default = "convox/convox"
 }
 
+variable "k8s_version" {
+  type = string
+  default = "1.18"
+}
+
 variable "name" {
   type = string
 }


### PR DESCRIPTION
This updates `k8s` version to `1.18` in `aws` and `azure`. do is already pinned to 1.20 and gcp auto update between versions so it's not pinned.

I'm wrapping up tests but merging will require some coordination so let's wait a bit.