### PR TITLE
Decrease interval in which fluentd scan for logfiles to watch

### DIFF
--- a/terraform/fluentd/k8s/containers.conf
+++ b/terraform/fluentd/k8s/containers.conf
@@ -7,6 +7,7 @@
 	tag container.*
 	read_from_head true
 	follow_inodes true
+	refresh_interval 1
 	<parse>
 		@type multi_format
 		<pattern>


### PR DESCRIPTION
Fluentd has a default [refresh_interval](https://docs.fluentd.org/input/tail#refresh_interval) of 60 seconds and when we have short lived workloads on the cluster fluentd might skip sending the logs to cloudwatch(if a job runs for 10 seconds, fluentd might no be able to find the container logs file if it gets deleted before the new refresh cycle)

I'm settings it to 1 second to make sure it captures all logs. Tested in a cluster with 30 workloads generating logs and didn't notice any performance degradation. Resources consumption also didn't change.