### PR TITLE
rack: Add arbitrary security context to allow for token reads

### DIFF
--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -88,6 +88,8 @@ spec:
       {{ if .Service.Agent.Enabled }}
       hostNetwork: true
       {{ end }}
+      securityContext:
+         fsGroup: 65534
       serviceAccountName: {{.Service.Name}}
       shareProcessNamespace: {{.Service.Init}}
       terminationGracePeriodSeconds: {{$.Service.Termination.Grace}}

--- a/provider/k8s/testdata/release-basic-app.yml
+++ b/provider/k8s/testdata/release-basic-app.yml
@@ -745,6 +745,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/convox
           name: ca
+      securityContext:
+         fsGroup: 65534
       serviceAccountName: deployment
       shareProcessNamespace: true
       terminationGracePeriodSeconds: 30
@@ -859,6 +861,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/convox
           name: ca
+      securityContext:
+         fsGroup: 65534
       serviceAccountName: singleton
       shareProcessNamespace: true
       terminationGracePeriodSeconds: 30
@@ -1006,6 +1010,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/convox
           name: ca
+      securityContext:
+         fsGroup: 65534
       serviceAccountName: web
       shareProcessNamespace: true
       terminationGracePeriodSeconds: 30
@@ -1178,6 +1184,8 @@ spec:
         volumeMounts:
         - mountPath: /etc/convox
           name: ca
+      securityContext:
+         fsGroup: 65534
       serviceAccountName: web2
       shareProcessNamespace: true
       terminationGracePeriodSeconds: 30


### PR DESCRIPTION
This will need a little bit of testing, but should solve https://github.com/aws/amazon-eks-pod-identity-webhook/issues/8