### PR TITLE
Include the arm64 on CLI installation

### DIFF
--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -23,24 +23,49 @@ We recommend you follow these tutorials in this order:
 
 ## Create a free Convox account
 
-To create a Convox account simply signup [here](https://console.convox.com/signup). We recommend using your company email address if you have one, and using your actual company name as the organization name. You can invite your colleagues to the organization later. 
+To create a Convox account simply signup [here](https://console.convox.com/signup). We recommend using your company email address if you have one, and using your actual company name as the organization name. You can invite your colleagues to the organization later.
 
 ## Install the Convox CLI and Login
 
 To install the Convox CLI follow the instructions for your operating system:
 
-### macOS
-```html
-    $ curl -L https://github.com/convox/convox/releases/latest/download/convox-macos -o /tmp/convox
-    $ sudo mv /tmp/convox /usr/local/bin/convox
-    $ sudo chmod 755 /usr/local/bin/convox
-```
+
 ### Linux
+
+#### x86_64 / amd64
+
 ```html
     $ curl -L https://github.com/convox/convox/releases/latest/download/convox-linux -o /tmp/convox
     $ sudo mv /tmp/convox /usr/local/bin/convox
     $ sudo chmod 755 /usr/local/bin/convox
 ```
+
+#### arm64
+
+```html
+    $ curl -L https://github.com/convox/convox/releases/latest/download/convox-linux-arm64 -o /tmp/convox
+    $ sudo mv /tmp/convox /usr/local/bin/convox
+    $ sudo chmod 755 /usr/local/bin/convox
+```
+
+### macOS
+
+#### x86_64 / amd64
+
+```html
+    $ curl -L https://github.com/convox/convox/releases/latest/download/convox-macos -o /tmp/convox
+    $ sudo mv /tmp/convox /usr/local/bin/convox
+    $ sudo chmod 755 /usr/local/bin/convox
+```
+
+#### arm64
+
+```html
+    $ curl -L https://github.com/convox/convox/releases/latest/download/convox-macos-arm64 -o /tmp/convox
+    $ sudo mv /tmp/convox /usr/local/bin/convox
+    $ sudo chmod 755 /usr/local/bin/convox
+```
+
 Once you have installed the CLI you can login to your Convox account by copying the login command from the web console
 
 ![CLI Login](/images/documentation/getting-started/introduction/CLI_tutorial_login.png)
@@ -155,7 +180,7 @@ to instead say:
 
 `res.end('Hello World!\nI\'m: ' ...`
 
-and then save the file. 
+and then save the file.
 
 Now, you can re-deploy the app by once again running the deploy command.
 ```html
@@ -171,14 +196,14 @@ One of the great features of Convox is nearly instantaneous rollbacks. Convox pe
 ```html
     $ convox releases
     ID           STATUS  BUILD        CREATED        DESCRIPTION
-    RSBSSIPZIEF  active  BUTQJQRIWUZ  2 minutes ago  
-    RYCWZIXLKQT          BVXIJQDCELS  30 minutes ago     
+    RSBSSIPZIEF  active  BUTQJQRIWUZ  2 minutes ago
+    RYCWZIXLKQT          BVXIJQDCELS  30 minutes ago
 ```
 You can now rollback to your previous release with `convox releases rollback`
 ```html
     $ convox releases rollback RYCWZIXLKQT
     Rolling back to RYCWZIXLKQT... OK, RSPAOICEBER
-    Promoting RSPAOICEBER... 
+    Promoting RSPAOICEBER...
     ...
 ```
 Once the rollback is complete, refresh your browser and you should see the `Hello World!` message has been reverted to `Hello Convox!`

--- a/docs/installation/cli.md
+++ b/docs/installation/cli.md
@@ -7,14 +7,37 @@ url: /installation/cli
 # Command Line Interface
 
 ## Linux
+
+### x86_64 / amd64
+
 ```html
     $ curl -L https://github.com/convox/convox/releases/latest/download/convox-linux -o /tmp/convox
     $ sudo mv /tmp/convox /usr/local/bin/convox
     $ sudo chmod 755 /usr/local/bin/convox
 ```
+
+### arm64
+
+```html
+    $ curl -L https://github.com/convox/convox/releases/latest/download/convox-linux-arm64 -o /tmp/convox
+    $ sudo mv /tmp/convox /usr/local/bin/convox
+    $ sudo chmod 755 /usr/local/bin/convox
+```
+
 ## macOS
+
+### x86_64 / amd64
+
 ```html
     $ curl -L https://github.com/convox/convox/releases/latest/download/convox-macos -o /tmp/convox
+    $ sudo mv /tmp/convox /usr/local/bin/convox
+    $ sudo chmod 755 /usr/local/bin/convox
+```
+
+### arm64
+
+```html
+    $ curl -L https://github.com/convox/convox/releases/latest/download/convox-macos-arm64 -o /tmp/convox
     $ sudo mv /tmp/convox /usr/local/bin/convox
     $ sudo chmod 755 /usr/local/bin/convox
 ```

--- a/docs/installation/development-rack/macos.md
+++ b/docs/installation/development-rack/macos.md
@@ -23,11 +23,23 @@ url: /installation/development-rack/macos
 - Install [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html)
 
 ### Convox CLI
+
+#### x86_64 / amd64
+
 ```html
     $ curl -L https://github.com/convox/convox/releases/latest/download/convox-macos -o /tmp/convox
     $ sudo mv /tmp/convox /usr/local/bin/convox
     $ sudo chmod 755 /usr/local/bin/convox
 ```
+
+#### arm64
+
+```html
+    $ curl -L https://github.com/convox/convox/releases/latest/download/convox-macos-arm64 -o /tmp/convox
+    $ sudo mv /tmp/convox /usr/local/bin/convox
+    $ sudo chmod 755 /usr/local/bin/convox
+```
+
 ## Installation
 
 > Make sure that your `kubectl` points at your local docker setup.  Ensure that if your `KUBECONFIG` env var is set, it is pointing at a config file that contains your desktop context.  By default, your local context will be installed into `~/.kube/config`.

--- a/docs/installation/development-rack/ubuntu.md
+++ b/docs/installation/development-rack/ubuntu.md
@@ -61,11 +61,23 @@ Now, the Kubernetes steps below should work as expected.
 - Install [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html)
 
 ### Convox CLI
+
+### x86_64 / amd64
+
 ```html
     $ curl -L https://github.com/convox/convox/releases/latest/download/convox-linux -o /tmp/convox
     $ sudo mv /tmp/convox /usr/local/bin/convox
     $ sudo chmod 755 /usr/local/bin/convox
 ```
+
+### arm64
+
+```html
+    $ curl -L https://github.com/convox/convox/releases/latest/download/convox-linux-arm64 -o /tmp/convox
+    $ sudo mv /tmp/convox /usr/local/bin/convox
+    $ sudo chmod 755 /usr/local/bin/convox
+```
+
 ## Installation
 
 > Make sure that your `kubectl` points at your local microk8s setup.  Ensure that if your `KUBECONFIG` env var is set, it is pointing at a config file that contains your local context.  By default as per the above instructions, your local config will be copied into `~/.kube/config`.
@@ -75,7 +87,7 @@ Install a local Rack named `dev`.
     $ convox rack install local dev
 ```
 
---- 
+---
 
 ### Tips for Ubuntu 20.04 Users
 


### PR DESCRIPTION
Includes option to install arm64 for Apple's new processor.

![image](https://user-images.githubusercontent.com/8239709/146612677-a37969a8-48e8-4f17-969c-0f8f1a2da5d0.png)
