### PR TITLE
Add AWS spot  instances support

### DIFF
--- a/docs/installation/production-rack/aws.md
+++ b/docs/installation/production-rack/aws.md
@@ -43,13 +43,15 @@ The following environment variables are required:
 ```
 ### Available Parameters
 
-| Name                   | Default         | Description                                                                                |
-| -----------------------| ----------------|--------------------------------------------------------------------------------------------|
-| **availability_zones** |                 | Specify a list of AZ names (minimum 3) to override the random automatic selection from AWS |
-| **cidr**               | **10.1.0.0/16** | CIDR range for VPC                                                                         |
-| **idle_timeout**       | **3600**        | Idle timeout value (in seconds) for the Rack Load Balancer                                 |
-| **node_disk**          | **20**          | Node disk size in GB                                                                       |
-| **node_type**          | **t3.small**    | Node instance type. You can also pass a comma separated list of instance types             |
-| **private**            | **true**        | Put nodes in private subnets behind NAT gateways                                           |
-| **region**             | **us-east-1**   | AWS Region                                                                                 |
-| **syslog**             |                 | Forward logs to a syslog endpoint (e.g. **tcp+tls://example.org:1234**)                    |
+| Name                   | Default                | Description                                                                                       |
+| -----------------------|------------------------|---------------------------------------------------------------------------------------------------|
+| **availability_zones** |                        | Specify a list of AZ names (minimum 3) to override the random automatic selection from AWS        |
+| **cidr**               | **10.1.0.0/16**        | CIDR range for VPC                                                                                |
+| **high_availability**  | **true**               | Setting this to "false" will create a cluster with less reduntant resources for cost optimization |
+| **idle_timeout**       | **3600**               | Idle timeout value (in seconds) for the Rack Load Balancer                                        |
+| **node_capacity_type** | **on_demand**          | Can be either "on_demand" or "spot". Spot will use AWS spot instances for the cluster nodes       |
+| **node_disk**          | **20**                 | Node disk size in GB                                                                              |
+| **node_type**          | **t3.small**           | Node instance type. You can also pass a comma separated list of instance types                    |
+| **private**            | **true**               | Put nodes in private subnets behind NAT gateways                                                  |
+| **region**             | **us-east-1**          | AWS Region                                                                                        |
+| **syslog**             |                        | Forward logs to a syslog endpoint (e.g. **tcp+tls://example.org:1234**)                           |

--- a/docs/installation/production-rack/aws.md
+++ b/docs/installation/production-rack/aws.md
@@ -43,13 +43,13 @@ The following environment variables are required:
 ```
 ### Available Parameters
 
-| Name                 | Default       | Description                                                                                |
-| -------------------- | ------------- | ------------------------------------------------------------------------------------------ |
-| **availability_zones** |               | Specify a list of AZ names (minimum 3) to override the random automatic selection from AWS |
+| Name                   | Default         | Description                                                                                |
+| -----------------------| ----------------|--------------------------------------------------------------------------------------------|
+| **availability_zones** |                 | Specify a list of AZ names (minimum 3) to override the random automatic selection from AWS |
 | **cidr**               | **10.1.0.0/16** | CIDR range for VPC                                                                         |
 | **idle_timeout**       | **3600**        | Idle timeout value (in seconds) for the Rack Load Balancer                                 |
 | **node_disk**          | **20**          | Node disk size in GB                                                                       |
-| **node_type**          | **t3.small**    | Node instance type                                                                         |
+| **node_type**          | **t3.small**    | Node instance type. You can also pass a comma separated list of instance types             |
 | **private**            | **true**        | Put nodes in private subnets behind NAT gateways                                           |
 | **region**             | **us-east-1**   | AWS Region                                                                                 |
-| **syslog**             |               | Forward logs to a syslog endpoint (e.g. **tcp+tls://example.org:1234**)                      |
+| **syslog**             |                 | Forward logs to a syslog endpoint (e.g. **tcp+tls://example.org:1234**)                    |

--- a/docs/management/cli-rack-management.md
+++ b/docs/management/cli-rack-management.md
@@ -37,13 +37,14 @@ The parameters available for your Rack depend on the underlying cloud provider.
 
 ### Amazon Web Services
 
-| Name                    | Default         |
-|-------------------------|-----------------|
-| **cidr**                | **10.1.0.0/16** |
-| **node_disk**           | **20**          |
-| **node_type**           | **t3.small**    |
-| **region**              | **us-east-1**   |
-| **high_availability** * | **true**        |
+| Name                             | Default         |
+|----------------------------------|-----------------|
+| **cidr**                         | **10.1.0.0/16** |
+| **node_capacity_type**           | **on_demand**   |
+| **node_disk**                    | **20**          |
+| **node_type**                    | **t3.small**    |
+| **region**                       | **us-east-1**   |
+| **high_availability** *          | **true**        |
 
 \* Parameter cannot be changed after rack creation
 

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -79,10 +79,11 @@ resource "random_id" "node_group" {
   byte_length = 8
 
   keepers = {
-    node_disk = var.node_disk
-    node_type = var.node_type
-    private   = var.private
-    role_arn  = replace(aws_iam_role.nodes.arn, "role/convox/", "role/") # eks barfs on roles with paths
+    node_capacity_type = var.node_capacity_type
+    node_disk          = var.node_disk
+    node_type          = var.node_type
+    private            = var.private
+    role_arn           = replace(aws_iam_role.nodes.arn, "role/convox/", "role/") # eks barfs on roles with paths
   }
 }
 

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -95,9 +95,10 @@ resource "aws_eks_node_group" "cluster" {
   count = var.high_availability ? 3 : 1
 
   ami_type        = var.gpu_type ? "AL2_x86_64_GPU" : var.arm_type ? "AL2_ARM_64" : "AL2_x86_64"
+  capacity_type   = var.node_capacity_type
   cluster_name    = aws_eks_cluster.cluster.name
   disk_size       = random_id.node_group.keepers.node_disk
-  instance_types  = [random_id.node_group.keepers.node_type]
+  instance_types  = split(",", random_id.node_group.keepers.node_type)
   node_group_name = "${var.name}-${local.availability_zones[count.index]}-${random_id.node_group.hex}"
   node_role_arn   = random_id.node_group.keepers.role_arn
   subnet_ids      = [var.private ? aws_subnet.private[count.index].id : aws_subnet.public[count.index].id]

--- a/terraform/cluster/aws/variables.tf
+++ b/terraform/cluster/aws/variables.tf
@@ -27,6 +27,10 @@ variable "name" {
   type = string
 }
 
+variable "node_capacity_type" {
+  default = "ON_DEMAND"
+}
+
 variable "node_disk" {
   default = 20
 }

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -46,7 +46,7 @@ module "cluster" {
   high_availability  = var.high_availability
   k8s_version        = var.k8s_version
   name               = var.name
-  node_capacity_type = var.node_capacity_type
+  node_capacity_type = upper(var.node_capacity_type)
   node_disk          = var.node_disk
   node_type          = var.node_type
   private            = var.private

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -42,7 +42,7 @@ variable "name" {
 }
 
 variable "node_capacity_type" {
-  default = "ON_DEMAND"
+  default = "on_demand"
 }
 
 variable "node_disk" {

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -41,6 +41,10 @@ variable "name" {
   type = string
 }
 
+variable "node_capacity_type" {
+  default = "ON_DEMAND"
+}
+
 variable "node_disk" {
   default = 20
 }


### PR DESCRIPTION
Adds the necessary parameters to enable the creation of racks with spot instances.
I also changed `node_type` to accept a comma-separated list of instance types since AWS recommends specifying multiple instance types when using spot instances
