### PR TITLE
Build the binary as statically linked

### DIFF
--- a/cmd/convox/Makefile
+++ b/cmd/convox/Makefile
@@ -7,12 +7,10 @@ all: build
 
 build:
 	mkdir pkg/
-	export CGO_ENABLED=0
-	env GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version=$(VERSION) -X main.image=$(IMAGE)" -o pkg/convox-linux-amd64
-	env GOOS=linux GOARCH=arm64 go build -ldflags "-X main.version=$(VERSION) -X main.image=$(IMAGE)" -o pkg/convox-linux-arm64
-	env GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.version=$(VERSION) -X main.image=$(IMAGE)" -o pkg/convox-darwin-amd64
-	env GOOS=darwin GOARCH=arm64 go build -ldflags "-X main.version=$(VERSION) -X main.image=$(IMAGE)" -o pkg/convox-darwin-arm64
-
+	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version=$(VERSION) -X main.image=$(IMAGE)" -o pkg/convox-linux-amd64
+	env CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "-X main.version=$(VERSION) -X main.image=$(IMAGE)" -o pkg/convox-linux-arm64
+	env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.version=$(VERSION) -X main.image=$(IMAGE)" -o pkg/convox-darwin-amd64
+	env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags "-X main.version=$(VERSION) -X main.image=$(IMAGE)" -o pkg/convox-darwin-arm64
 
 clean:
 	rm -f pkg/convox-*


### PR DESCRIPTION
The binary was not being built as statically linked but as dynamically linked.
This was causing errors on Alpine.