### PR TITLE
Add local Kubernetes version to Known Issues

### DIFF
--- a/docs/help/known-issues.md
+++ b/docs/help/known-issues.md
@@ -15,4 +15,9 @@ url: /help/known-issues
   created for the Rack that are left behind in an "available" state.
   [aws/amazon-vpc-cni-k8s#608](https://github.com/aws/amazon-vpc-cni-k8s/issues/608)
   * Update:  We have provided a fix for this issue that extends the delete operation timeout 
-    for public and private subnets.  
+    for public and private subnets.
+    
+### Local
+
+ * Kubernetes >= 1.22 is not supported as it deprecated an Ingress resource name which Convox uses. We are going to deploy a fix, but meanwhile the workaround is to run version <= 1.21. Convox automatically uses a compatible version in remote racks, but you must ensure that you're running <= 1.21 locally.
+   * macOS: Docker Desktop does not allow you to specify the Kubernetes version. The latest Docker Desktop version with Kubernetes <= 1.21 is [Docker Desktop 4.2.0](https://docs.docker.com/desktop/mac/release-notes/#docker-desktop-420) and there are alternatives such as [minikube](https://minikube.sigs.k8s.io/docs/).

--- a/docs/help/known-issues.md
+++ b/docs/help/known-issues.md
@@ -20,4 +20,4 @@ url: /help/known-issues
 ### Local
 
  * Kubernetes >= 1.22 is not supported as it deprecated an Ingress resource name which Convox uses. We are going to deploy a fix, but meanwhile the workaround is to run version <= 1.21. Convox automatically uses a compatible version in remote racks, but you must ensure that you're running <= 1.21 locally.
-   * macOS: Docker Desktop does not allow you to specify the Kubernetes version. The latest Docker Desktop version with Kubernetes <= 1.21 is [Docker Desktop 4.2.0](https://docs.docker.com/desktop/mac/release-notes/#docker-desktop-420) and there are alternatives such as [minikube](https://minikube.sigs.k8s.io/docs/).
+ * macOS: Docker Desktop does not allow you to specify the Kubernetes version. The latest Docker Desktop version with Kubernetes <= 1.21 is [Docker Desktop 4.2.0](https://docs.docker.com/desktop/mac/release-notes/#docker-desktop-420) and there are alternatives such as [minikube](https://minikube.sigs.k8s.io/docs/).

--- a/docs/installation/development-rack/macos.md
+++ b/docs/installation/development-rack/macos.md
@@ -16,7 +16,7 @@ url: /installation/development-rack/macos
 - Drag the CPU slider to the halfway point
 - Drag the Memory slider to at least 8GB
 - Go to the Kubernetes tab
-- Enable Kubernetes
+- Enable Kubernetes(there is a known bug when using Kubernetes 1.22+. Please refer to [known-issues](/help/known-issues))
 
 ### Terraform
 


### PR DESCRIPTION
Docker Desktop defaults to the latest Kubernetes version which prevents new local racks from being created. Mentioning this here, and it should probably also be cross-referenced in https://github.com/convox/convox/blob/master/docs/installation/development-rack/macos.md.