### PR TITLE
Update k8s terraform provider and increase eks api ready wait time

### DIFF
--- a/terraform/api/aws/versions.tf
+++ b/terraform/api/aws/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/api/azure/versions.tf
+++ b/terraform/api/azure/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
     random = {
       source = "hashicorp/random"

--- a/terraform/api/do/versions.tf
+++ b/terraform/api/do/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
     random = {
       source = "hashicorp/random"

--- a/terraform/api/gcp/versions.tf
+++ b/terraform/api/gcp/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
     random = {
       source = "hashicorp/random"

--- a/terraform/api/k8s/atom.tf
+++ b/terraform/api/k8s/atom.tf
@@ -107,7 +107,7 @@ resource "kubernetes_deployment" "atom" {
           image_pull_policy  = "IfNotPresent"
 
           resources {
-            requests {
+            requests = {
               cpu    = "32m"
               memory = "32Mi"
             }

--- a/terraform/api/k8s/versions.tf
+++ b/terraform/api/k8s/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/api/local/versions.tf
+++ b/terraform/api/local/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/api/metal/versions.tf
+++ b/terraform/api/metal/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/cluster/aws/autoscaler.tf
+++ b/terraform/cluster/aws/autoscaler.tf
@@ -286,12 +286,12 @@ resource "kubernetes_deployment" "autoscaler" {
           ]
 
           resources {
-            limits {
+            limits = {
               cpu    = "100m"
               memory = "300Mi"
             }
 
-            requests {
+            requests = {
               cpu    = "100m"
               memory = "300Mi"
             }

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -2,7 +2,6 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(aws_eks_cluster.cluster.certificate_authority.0.data)
   host                   = aws_eks_cluster.cluster.endpoint
 
-  load_config_file = false
   exec {
     api_version = "client.authentication.k8s.io/v1alpha1"
     args        = ["eks", "get-token", "--cluster-name", var.name]
@@ -41,7 +40,7 @@ resource "null_resource" "delay_cluster" {
 // https://github.com/terraform-aws-modules/terraform-aws-eks/issues/621
 resource "null_resource" "wait_k8s_api" {
   provisioner "local-exec" {
-    command = "sleep 60"
+    command = "sleep 120"
   }
 
   depends_on = [

--- a/terraform/cluster/aws/versions.tf
+++ b/terraform/cluster/aws/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/terraform/cluster/gcp/main.tf
+++ b/terraform/cluster/gcp/main.tf
@@ -97,8 +97,6 @@ resource "local_file" "kubeconfig" {
 provider "kubernetes" {
   alias = "direct"
 
-  load_config_file = false
-
   host                   = "https://${google_container_cluster.rack.endpoint}"
   token                  = data.google_client_config.current.access_token
   cluster_ca_certificate = base64decode(google_container_cluster.rack.master_auth.0.cluster_ca_certificate)

--- a/terraform/elasticsearch/k8s/main.tf
+++ b/terraform/elasticsearch/k8s/main.tf
@@ -129,7 +129,7 @@ resource "kubernetes_stateful_set" "elasticsearch" {
           }
 
           resources {
-            requests {
+            requests = {
               memory = "1Gi"
             }
           }

--- a/terraform/elasticsearch/k8s/versions.tf
+++ b/terraform/elasticsearch/k8s/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/fluentd/aws/versions.tf
+++ b/terraform/fluentd/aws/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/fluentd/elasticsearch/versions.tf
+++ b/terraform/fluentd/elasticsearch/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/fluentd/k8s/main.tf
+++ b/terraform/fluentd/k8s/main.tf
@@ -131,11 +131,11 @@ resource "kubernetes_daemonset" "fluentd" {
           }
 
           resources {
-            limits {
+            limits = {
               memory = "200Mi"
             }
 
-            requests {
+            requests = {
               cpu    = "100m"
               memory = "200Mi"
             }

--- a/terraform/fluentd/k8s/versions.tf
+++ b/terraform/fluentd/k8s/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/metrics/k8s/versions.tf
+++ b/terraform/metrics/k8s/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/rack/aws/versions.tf
+++ b/terraform/rack/aws/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/rack/azure/versions.tf
+++ b/terraform/rack/azure/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/rack/do/versions.tf
+++ b/terraform/rack/do/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
     random = {
       source = "hashicorp/random"

--- a/terraform/rack/gcp/versions.tf
+++ b/terraform/rack/gcp/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/rack/k8s/versions.tf
+++ b/terraform/rack/k8s/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/rack/local/versions.tf
+++ b/terraform/rack/local/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
     random = {
       source = "hashicorp/random"

--- a/terraform/rack/metal/versions.tf
+++ b/terraform/rack/metal/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
     random = {
       source = "hashicorp/random"

--- a/terraform/resolver/aws/versions.tf
+++ b/terraform/resolver/aws/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/resolver/azure/versions.tf
+++ b/terraform/resolver/azure/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/resolver/do/versions.tf
+++ b/terraform/resolver/do/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
 }

--- a/terraform/resolver/gcp/versions.tf
+++ b/terraform/resolver/gcp/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/resolver/k8s/main.tf
+++ b/terraform/resolver/k8s/main.tf
@@ -161,7 +161,7 @@ resource "kubernetes_deployment" "resolver" {
           }
 
           resources {
-            requests {
+            requests = {
               cpu    = "64m"
               memory = "64Mi"
             }

--- a/terraform/resolver/k8s/versions.tf
+++ b/terraform/resolver/k8s/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/resolver/local/versions.tf
+++ b/terraform/resolver/local/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/resolver/metal/versions.tf
+++ b/terraform/resolver/metal/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/router/aws/main.tf
+++ b/terraform/router/aws/main.tf
@@ -58,5 +58,5 @@ resource "kubernetes_service" "router" {
 }
 
 data "http" "alias" {
-  url = "https://alias.convox.com/alias/${length(kubernetes_service.router.load_balancer_ingress) > 0 ? kubernetes_service.router.load_balancer_ingress.0.hostname : ""}"
+  url = "https://alias.convox.com/alias/${length(kubernetes_service.router.status.0.load_balancer.0.ingress) > 0 ? kubernetes_service.router.status.0.load_balancer.0.ingress.0.hostname : ""}"
 }

--- a/terraform/router/aws/versions.tf
+++ b/terraform/router/aws/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/router/azure/main.tf
+++ b/terraform/router/azure/main.tf
@@ -50,5 +50,5 @@ resource "kubernetes_service" "router" {
 }
 
 data "http" "alias" {
-  url = "https://alias.convox.com/alias/${length(kubernetes_service.router.load_balancer_ingress) > 0 ? kubernetes_service.router.load_balancer_ingress.0.ip : ""}"
+  url = "https://alias.convox.com/alias/${length(kubernetes_service.router.status.0.load_balancer.0.ingress) > 0 ? kubernetes_service.router.status.0.load_balancer.0.ingress.0.ip : ""}"
 }

--- a/terraform/router/azure/versions.tf
+++ b/terraform/router/azure/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/router/do/main.tf
+++ b/terraform/router/do/main.tf
@@ -52,5 +52,5 @@ resource "kubernetes_service" "router" {
 }
 
 data "http" "alias" {
-  url = "https://alias.convox.com/alias/${length(kubernetes_service.router.load_balancer_ingress) > 0 ? kubernetes_service.router.load_balancer_ingress.0.ip : ""}"
+  url = "https://alias.convox.com/alias/${length(kubernetes_service.router.status.0.load_balancer.0.ingress) > 0 ? kubernetes_service.router.status.0.load_balancer.0.ingress.0.ip : ""}"
 }

--- a/terraform/router/do/versions.tf
+++ b/terraform/router/do/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
 }

--- a/terraform/router/gcp/main.tf
+++ b/terraform/router/gcp/main.tf
@@ -46,5 +46,5 @@ resource "kubernetes_service" "router" {
 }
 
 data "http" "alias" {
-  url = "https://alias.convox.com/alias/${length(kubernetes_service.router.load_balancer_ingress) > 0 ? kubernetes_service.router.load_balancer_ingress.0.ip : ""}"
+  url = "https://alias.convox.com/alias/${length(kubernetes_service.router.status.0.load_balancer.0.ingress) > 0 ? kubernetes_service.router.status.0.load_balancer.0.ingress.0.ip : ""}"
 }

--- a/terraform/router/gcp/versions.tf
+++ b/terraform/router/gcp/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/router/local/versions.tf
+++ b/terraform/router/local/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/terraform/router/metal/versions.tf
+++ b/terraform/router/metal/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/router/nginx/main.tf
+++ b/terraform/router/nginx/main.tf
@@ -232,7 +232,7 @@ resource "kubernetes_deployment" "ingress-nginx" {
           }
 
           resources {
-            requests {
+            requests = {
               cpu    = "100m"
               memory = "90Mi"
             }

--- a/terraform/router/nginx/versions.tf
+++ b/terraform/router/nginx/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -6,7 +6,6 @@ provider "kubernetes" {
   cluster_ca_certificate = module.cluster.ca
   host                   = module.cluster.endpoint
 
-  load_config_file = false
   exec {
     api_version = "client.authentication.k8s.io/v1alpha1"
     args        = ["eks", "get-token", "--cluster-name", var.name]

--- a/terraform/system/aws/versions.tf
+++ b/terraform/system/aws/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/system/azure/main.tf
+++ b/terraform/system/azure/main.tf
@@ -8,7 +8,6 @@ provider "kubernetes" {
   cluster_ca_certificate = module.cluster.ca
   host                   = module.cluster.endpoint
 
-  load_config_file = false
 }
 
 data "http" "releases" {

--- a/terraform/system/azure/versions.tf
+++ b/terraform/system/azure/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/system/do/main.tf
+++ b/terraform/system/do/main.tf
@@ -8,7 +8,6 @@ provider "kubernetes" {
   host                   = module.cluster.endpoint
   token                  = module.cluster.token
 
-  load_config_file = false
 }
 
 data "http" "releases" {

--- a/terraform/system/do/versions.tf
+++ b/terraform/system/do/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
 }

--- a/terraform/system/gcp/main.tf
+++ b/terraform/system/gcp/main.tf
@@ -9,7 +9,6 @@ provider "kubernetes" {
   cluster_ca_certificate = module.cluster.ca
   host                   = module.cluster.endpoint
 
-  load_config_file = false
 }
 
 module "project" {

--- a/terraform/system/gcp/versions.tf
+++ b/terraform/system/gcp/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/system/local/versions.tf
+++ b/terraform/system/local/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/system/metal/versions.tf
+++ b/terraform/system/metal/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11"
+      version = "~> 2.9.0"
     }
   }
   required_version = ">= 0.12"


### PR DESCRIPTION
E2E tests are looking more stable with these changes.

- increase delay time waiting for EKS API to be ready
- bump the kubernetes terraform provider 