### PR TITLE
When canceling an app update, rewrite the last active release on top

### DIFF
--- a/pkg/cli/apps.go
+++ b/pkg/cli/apps.go
@@ -109,12 +109,32 @@ func Apps(rack sdk.Interface, c *stdcli.Context) error {
 }
 
 func AppsCancel(rack sdk.Interface, c *stdcli.Context) error {
-	app := coalesce(c.Arg(0), app(c))
+	aname := coalesce(c.Arg(0), app(c))
 
-	c.Startf("Cancelling deployment of <app>%s</app>", app)
+	c.Startf("Cancelling deployment of <app>%s</app>", aname)
 
-	if err := rack.AppCancel(app); err != nil {
+	if err := rack.AppCancel(aname); err != nil {
 		return err
+	}
+
+	app, err := rack.AppGet(aname)
+	if err != nil {
+		return err
+	}
+
+	c.Writef("Rewriting last active release")
+
+	rs, err := rack.ReleaseList(app.Name, structs.ReleaseListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, r := range rs {
+		if app.Release == r.Id {
+			_, err := rack.ReleaseCreate(app.Name, structs.ReleaseCreateOptions{Build: &r.Build, Description: &r.Description, Env: &r.Env})
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	return c.OK()

--- a/pkg/cli/apps.go
+++ b/pkg/cli/apps.go
@@ -122,7 +122,7 @@ func AppsCancel(rack sdk.Interface, c *stdcli.Context) error {
 		return err
 	}
 
-	c.Writef("Rewriting last active release")
+	c.Writef("Rewriting last active release... ")
 
 	rs, err := rack.ReleaseList(app.Name, structs.ReleaseListOptions{})
 	if err != nil {
@@ -134,6 +134,7 @@ func AppsCancel(rack sdk.Interface, c *stdcli.Context) error {
 			if err != nil {
 				return err
 			}
+			break
 		}
 	}
 

--- a/pkg/cli/fixtures_test.go
+++ b/pkg/cli/fixtures_test.go
@@ -237,6 +237,10 @@ func fxRelease3() *structs.Release {
 	}
 }
 
+func fxReleaseList() structs.Releases {
+	return structs.Releases{*fxRelease(), *fxRelease2(), *fxRelease3()}
+}
+
 func fxResource() *structs.Resource {
 	return &structs.Resource{
 		Name:       "resource1",


### PR DESCRIPTION
When canceling an app update, rewrite the last active release on top of the canceled one.