### PR TITLE
AWS - Add proxy protocol parameter (client's real source ip)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
           - job: aws-existing-vpc
             provider: aws
             rack_params: "vpc_id=vpc-0f18b6d1265717215 internet_gateway_id=igw-01c3d338eecec02a1 cidr=172.0.0.0/16"
-            suffix: existing-vpc
+            suffix: evpc
           - job: do
             provider: do
           - job: gcp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,11 +109,12 @@ jobs:
             provider: aws
           - job: aws-arm64
             provider: aws
-            rack_params: "node_type=t4g.small"
+            rack_params: "node_type=t4g.small proxy_protocol=true"
             suffix: arm64
           - job: aws-existing-vpc
             provider: aws
             rack_params: "vpc_id=vpc-0f18b6d1265717215 internet_gateway_id=igw-01c3d338eecec02a1 cidr=172.0.0.0/16"
+            suffix: existing-vpc
           - job: do
             provider: do
           - job: gcp

--- a/ci/secrets.sh
+++ b/ci/secrets.sh
@@ -7,7 +7,7 @@ export_secret() {
 case "$PROVIDER" in
 aws)
   export_secret AWS_ACCESS_KEY_ID
-  export_secret AWS_REGION # we also want to export AWS_REGION for the aws cli config
+  export_secret AWS_REGION AWS_DEFAULT_REGION # we also want to export AWS_DEFAULT_REGION for the aws cli config
   export_secret AWS_REGION REGION
   export_secret AWS_SECRET_ACCESS_KEY
   ;;

--- a/ci/secrets.sh
+++ b/ci/secrets.sh
@@ -8,6 +8,7 @@ case "$PROVIDER" in
 aws)
   export_secret AWS_ACCESS_KEY_ID
   export_secret AWS_REGION REGION
+  export_secret AWS_REGION # we also want to export AWS_REGION for the aws cli config
   export_secret AWS_SECRET_ACCESS_KEY
   ;;
 azure)

--- a/ci/secrets.sh
+++ b/ci/secrets.sh
@@ -7,8 +7,8 @@ export_secret() {
 case "$PROVIDER" in
 aws)
   export_secret AWS_ACCESS_KEY_ID
-  export_secret AWS_REGION REGION
   export_secret AWS_REGION # we also want to export AWS_REGION for the aws cli config
+  export_secret AWS_REGION REGION
   export_secret AWS_SECRET_ACCESS_KEY
   ;;
 azure)

--- a/docs/installation/production-rack/aws.md
+++ b/docs/installation/production-rack/aws.md
@@ -54,6 +54,7 @@ The following environment variables are required:
 | **node_disk**            | **20**                 | Node disk size in GB                                                                                           |
 | **node_type**            | **t3.small**           | Node instance type. You can also pass a comma separated list of instance types                                 |
 | **private**              | **true**               | Put nodes in private subnets behind NAT gateways                                                               |
+| **proxy_protocol**       | **true**               | Enable proxy protocol. With this parameter set, the client source ip will be available in the request header `x-forwarded-for` key. **Requires 5 - 10 minutes downtime**.          |
 | **region**               | **us-east-1**          | AWS Region                                                                                                     |
 | **syslog**               |                        | Forward logs to a syslog endpoint (e.g. **tcp+tls://example.org:1234**)                                        |
 | **vpc_id** *             |                        | Use an existing VPC for cluster creation. Make sure to also pass the **cidr** block and **internet_gateway_id**|

--- a/docs/management/cli-rack-management.md
+++ b/docs/management/cli-rack-management.md
@@ -46,10 +46,12 @@ The parameters available for your Rack depend on the underlying cloud provider.
 | **node_type**                    | **t3.small**    |
 | **region**                       | **us-east-1**   |
 | **high_availability** *          | **true**        |
-| **vpc_id** **                    |                 |
+| **proxy_protocol** *             | **false**       |
+| **vpc_id** ***                   |                 |
 
 \* Parameter cannot be changed after rack creation
-\*\* To avoid CIDR block collision with existing VPC subnets, please add a new CIDR block to your VPC to separate rack resources. Also, remember to pass the **internet_gateway_id** attached to the VPC. If the VPC doesn't have an IG attached, the rack installation will create one automatically, which will also be destroyed if you delete the rack.
+\*\* Setting **proxy_protocol** in an existing rack will require a 5 - 10 minutes downtime window.
+\*\*\* To avoid CIDR block collision with existing VPC subnets, please add a new CIDR block to your VPC to separate rack resources. Also, remember to pass the **internet_gateway_id** attached to the VPC. If the VPC doesn't have an IG attached, the rack installation will create one automatically, which will also be destroyed if you delete the rack.
 
 &nbsp;
 

--- a/terraform/rack/aws/main.tf
+++ b/terraform/rack/aws/main.tf
@@ -72,6 +72,7 @@ module "router" {
   namespace         = module.k8s.namespace
   oidc_arn          = var.oidc_arn
   oidc_sub          = var.oidc_sub
+  proxy_protocol    = var.proxy_protocol
   release           = var.release
   whitelist         = var.whitelist
 }

--- a/terraform/rack/aws/variables.tf
+++ b/terraform/rack/aws/variables.tf
@@ -34,6 +34,10 @@ variable "oidc_sub" {
   type = string
 }
 
+variable "proxy_protocol" {
+  default = false
+}
+
 variable "release" {
   type = string
 }

--- a/terraform/router/aws/main.tf
+++ b/terraform/router/aws/main.tf
@@ -15,11 +15,28 @@ module "nginx" {
     kubernetes = kubernetes
   }
 
+  cloud_provider = "aws"
   namespace      = var.namespace
   proxy_protocol = var.proxy_protocol
   rack           = var.name
   replicas_max   = var.high_availability ? 10 : 1
   replicas_min   = var.high_availability ? 2 : 1
+}
+
+resource "kubernetes_config_map" "nginx-configuration" {
+  metadata {
+    namespace = var.namespace
+    name      = "nginx-configuration"
+  }
+
+  data = {
+    "proxy-body-size"    = "0"
+    "use-proxy-protocol" = var.proxy_protocol ? "true" : "false"
+  }
+
+  depends_on = [
+    null_resource.set_proxy_protocol
+  ]
 }
 
 resource "null_resource" "set_proxy_protocol" {

--- a/terraform/router/aws/proxy-protocol.sh
+++ b/terraform/router/aws/proxy-protocol.sh
@@ -2,10 +2,36 @@
 
 set -e
 
+if [ ! -x "$(which jq)" ]
+then
+    echo "missing jq binary"
+    exit 1
+fi
+
+if [ ! -x "$(which aws)" ]
+then
+    echo "missing aws cli"
+    exit 1
+fi
+
+if [ ! -x "$(which tr)" ]
+then
+    echo "missing tr binary"
+    exit 1
+fi
+
 sleep 5 # make sure the load-balancer and target groups associated with the router service were already created 
 
-tgroups=$(aws resourcegroupstaggingapi get-resources --tag-filters "Key=kubernetes.io/service-name,Values=$1-system/router" --resource-type-filters "elasticloadbalancing:targetgroup" | jq -r "[.ResourceTagMappingList[] | .ResourceARN] | @sh" | tr -d \')
+target_groups=$(aws resourcegroupstaggingapi get-resources --tag-filters "Key=kubernetes.io/service-name,Values=$1-system/router" --resource-type-filters "elasticloadbalancing:targetgroup")
 
-for group in $tgroups; do
+target_groups=$(echo $target_groups | jq -r "[.ResourceTagMappingList[] | .ResourceARN] | @sh" | tr -d \')
+
+if [ -z "$target_groups" ]
+then
+  echo "router for rack $1 not found"
+  exit 1
+fi
+
+for group in $target_groups; do
     aws elbv2 modify-target-group-attributes --target-group-arn $group --attributes Key=proxy_protocol_v2.enabled,Value=$2 > /dev/null
 done

--- a/terraform/router/aws/proxy-protocol.sh
+++ b/terraform/router/aws/proxy-protocol.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+sleep 5 # make sure the load-balancer and target groups associated with the router service were already created 
+
+tgroups=$(aws resourcegroupstaggingapi get-resources --tag-filters "Key=kubernetes.io/service-name,Values=$1-system/router" --resource-type-filters "elasticloadbalancing:targetgroup" | jq -r "[.ResourceTagMappingList[] | .ResourceARN] | @sh" | tr -d \')
+
+for group in $tgroups; do
+    aws elbv2 modify-target-group-attributes --target-group-arn $group --attributes Key=proxy_protocol_v2.enabled,Value=$2 > /dev/null
+done

--- a/terraform/router/aws/variables.tf
+++ b/terraform/router/aws/variables.tf
@@ -26,6 +26,10 @@ variable "oidc_sub" {
   type = string
 }
 
+variable "proxy_protocol" {
+  default = false
+}
+
 variable "release" {
   type = string
 }

--- a/terraform/router/nginx/main.tf
+++ b/terraform/router/nginx/main.tf
@@ -5,8 +5,8 @@ resource "kubernetes_config_map" "nginx-configuration" {
   }
 
   data = {
-    "proxy-body-size" = "0"
-    # "use-proxy-protocol" = "true"
+    "proxy-body-size"    = "0"
+    "use-proxy-protocol" = var.proxy_protocol ? "true" : "false"
   }
 }
 
@@ -167,12 +167,13 @@ resource "kubernetes_deployment" "ingress-nginx" {
     template {
       metadata {
         labels = {
-          app     = "system"
-          name    = "ingress-nginx"
-          rack    = var.rack
-          system  = "convox"
-          service = "ingress-nginx"
-          type    = "service"
+          app            = "system"
+          name           = "ingress-nginx"
+          rack           = var.rack
+          system         = "convox"
+          service        = "ingress-nginx"
+          type           = "service"
+          proxy_protocol = var.proxy_protocol
         }
       }
 

--- a/terraform/router/nginx/main.tf
+++ b/terraform/router/nginx/main.tf
@@ -1,4 +1,5 @@
 resource "kubernetes_config_map" "nginx-configuration" {
+  count = var.cloud_provider == "aws" ? 0 : 1
   metadata {
     namespace = var.namespace
     name      = "nginx-configuration"

--- a/terraform/router/nginx/variables.tf
+++ b/terraform/router/nginx/variables.tf
@@ -12,6 +12,10 @@ variable "namespace" {
   type = string
 }
 
+variable "proxy_protocol" {
+  default = false
+}
+
 variable "rack" {
   type = string
 }

--- a/terraform/router/nginx/variables.tf
+++ b/terraform/router/nginx/variables.tf
@@ -16,6 +16,10 @@ variable "proxy_protocol" {
   default = false
 }
 
+variable "cloud_provider" {
+  default = ""
+}
+
 variable "rack" {
   type = string
 }

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -87,6 +87,7 @@ module "rack" {
   name                = var.name
   oidc_arn            = module.cluster.oidc_arn
   oidc_sub            = module.cluster.oidc_sub
+  proxy_protocol      = var.proxy_protocol
   release             = local.release
   subnets             = module.cluster.subnets
   whitelist           = split(",", var.whitelist)

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -61,6 +61,10 @@ variable "private" {
   default = true
 }
 
+variable "proxy_protocol" {
+  default = false
+}
+
 variable "release" {
   default = ""
 }


### PR DESCRIPTION
Adds a new parameter for AWS racks to enable [proxy protocol ](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html#proxy-protocol).
With the protocol enabled, convox apps will be able to get the client source IP using the `x-forwarded-for` header key.

The parameter will toggle proxy protocol on/off in the NLB and Nginx Deployment.
Changing the parameter will require a 5 - 10 minutes Downtime which is the time needed for the NLB to start sending the proxy protocol header and Nginx restarting with the new config and be able to parse the header.