### PR TITLE
Add new rack sync cli command to force syncing the v2 racks API url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage.txt
 terraform.tfvars
 terraform/platform/convox.platform
 .DS_Store
+.vscode/

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -77,6 +77,11 @@ func init() {
 		Validate: stdcli.Args(0),
 	})
 
+	register("rack sync", "sync v2 rack API url", RackSync, stdcli.CommandOptions{
+		Flags:    []stdcli.Flag{flagRack},
+		Validate: stdcli.Args(0),
+	})
+
 	registerWithoutProvider("rack uninstall", "uninstall a rack", RackUninstall, stdcli.CommandOptions{
 		Usage:    "<name>",
 		Validate: stdcli.Args(1),
@@ -86,11 +91,6 @@ func init() {
 		Flags:    []stdcli.Flag{flagRack},
 		Usage:    "[version]",
 		Validate: stdcli.ArgsMax(1),
-	})
-
-	register("rack sync", "sync v2 rack API url", RackSync, stdcli.CommandOptions{
-		Flags:    []stdcli.Flag{flagRack},
-		Validate: stdcli.Args(0),
 	})
 }
 
@@ -391,34 +391,6 @@ func RackScale(rack sdk.Interface, c *stdcli.Context) error {
 	return i.Print()
 }
 
-func RackUninstall(_ sdk.Interface, c *stdcli.Context) error {
-	name := c.Arg(0)
-
-	r, err := rack.Match(c, name)
-	if err != nil {
-		return err
-	}
-
-	if err := r.Uninstall(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func RackUpdate(_ sdk.Interface, c *stdcli.Context) error {
-	r, err := rack.Current(c)
-	if err != nil {
-		return err
-	}
-
-	if err := r.UpdateVersion(c.Arg(0)); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func RackSync(_ sdk.Interface, c *stdcli.Context) error {
 	r, err := rack.Current(c)
 	if err != nil {
@@ -451,4 +423,32 @@ func RackSync(_ sdk.Interface, c *stdcli.Context) error {
 	}
 
 	return fmt.Errorf("sync is only supported for console managed v2 racks")
+}
+
+func RackUninstall(_ sdk.Interface, c *stdcli.Context) error {
+	name := c.Arg(0)
+
+	r, err := rack.Match(c, name)
+	if err != nil {
+		return err
+	}
+
+	if err := r.Uninstall(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func RackUpdate(_ sdk.Interface, c *stdcli.Context) error {
+	r, err := rack.Current(c)
+	if err != nil {
+		return err
+	}
+
+	if err := r.UpdateVersion(c.Arg(0)); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/console/rack.go
+++ b/pkg/console/rack.go
@@ -62,6 +62,10 @@ func (c *Client) RackGet(name string) (*Rack, error) {
 	return &r, nil
 }
 
+func (c *Client) RackSync(name string) error {
+	return c.Post(fmt.Sprintf("/racks/%s/sync", name), stdsdk.RequestOptions{}, nil)
+}
+
 func (c *Client) RackList() (Racks, error) {
 	var rs Racks
 

--- a/pkg/rack/console.go
+++ b/pkg/rack/console.go
@@ -160,6 +160,14 @@ func (c Console) Status() string {
 	return c.status
 }
 
+func (c Console) Sync() error {
+	cc, err := c.client()
+	if err != nil {
+		return err
+	}
+	return cc.RackSync(c.name)
+}
+
 func (c Console) Uninstall() error {
 	return fmt.Errorf("console uninstall not yet supported")
 }
@@ -205,14 +213,6 @@ func (c Console) updateParamsDirect(params map[string]string) error {
 	}
 
 	return nil
-}
-
-func (c Console) Sync() error {
-	cc, err := c.client()
-	if err != nil {
-		return err
-	}
-	return cc.RackSync(c.name)
 }
 
 func (c Console) UpdateVersion(version string) error {

--- a/pkg/rack/console.go
+++ b/pkg/rack/console.go
@@ -207,6 +207,14 @@ func (c Console) updateParamsDirect(params map[string]string) error {
 	return nil
 }
 
+func (c Console) Sync() error {
+	cc, err := c.client()
+	if err != nil {
+		return err
+	}
+	return cc.RackSync(c.name)
+}
+
 func (c Console) UpdateVersion(version string) error {
 	cu, err := c.consoleUpdateSupported()
 	if err != nil {
@@ -215,7 +223,6 @@ func (c Console) UpdateVersion(version string) error {
 	if !cu {
 		return c.updateVersionDirect(version)
 	}
-	
 	cc, err := c.client()
 	if err != nil {
 		return err

--- a/pkg/rack/direct.go
+++ b/pkg/rack/direct.go
@@ -131,6 +131,10 @@ func (d Direct) UpdateVersion(version string) error {
 	return nil
 }
 
+func (d Direct) Sync() error {
+	return fmt.Errorf("sync is only supported for console managed v2 racks")
+}
+
 func (d Direct) latest() (string, error) {
 	s, err := d.client.SystemGet()
 	if err != nil {

--- a/pkg/rack/direct.go
+++ b/pkg/rack/direct.go
@@ -85,6 +85,10 @@ func (d Direct) Status() string {
 	return d.status
 }
 
+func (d Direct) Sync() error {
+	return fmt.Errorf("sync is only supported for console managed v2 racks")
+}
+
 func (d Direct) Uninstall() error {
 	return fmt.Errorf("uninstall not supported with RACK_URL")
 }
@@ -129,10 +133,6 @@ func (d Direct) UpdateVersion(version string) error {
 	}
 
 	return nil
-}
-
-func (d Direct) Sync() error {
-	return fmt.Errorf("sync is only supported for console managed v2 racks")
 }
 
 func (d Direct) latest() (string, error) {

--- a/pkg/rack/rack.go
+++ b/pkg/rack/rack.go
@@ -36,6 +36,7 @@ type Rack interface {
 	Uninstall() error
 	UpdateParams(map[string]string) error
 	UpdateVersion(string) error
+	Sync() error
 }
 
 func Create(c *stdcli.Context, name string, md *Metadata) (Rack, error) {

--- a/pkg/rack/terraform.go
+++ b/pkg/rack/terraform.go
@@ -171,6 +171,10 @@ func (t Terraform) Delete() error {
 	return nil
 }
 
+func (t Terraform) Sync() error {
+	return fmt.Errorf("sync is only supported for console managed v2 racks")
+}
+
 func (t Terraform) Endpoint() (*url.URL, error) {
 	return url.Parse(t.endpoint)
 }

--- a/pkg/rack/terraform.go
+++ b/pkg/rack/terraform.go
@@ -171,10 +171,6 @@ func (t Terraform) Delete() error {
 	return nil
 }
 
-func (t Terraform) Sync() error {
-	return fmt.Errorf("sync is only supported for console managed v2 racks")
-}
-
 func (t Terraform) Endpoint() (*url.URL, error) {
 	return url.Parse(t.endpoint)
 }
@@ -247,6 +243,10 @@ func (Terraform) Remote() bool {
 
 func (t Terraform) Status() string {
 	return t.status
+}
+
+func (t Terraform) Sync() error {
+	return fmt.Errorf("sync is only supported for console managed v2 racks")
 }
 
 func (t Terraform) Uninstall() error {

--- a/pkg/rack/test.go
+++ b/pkg/rack/test.go
@@ -31,6 +31,10 @@ func (t Test) Delete() error {
 	return nil
 }
 
+func (t Test) Sync() error {
+	return nil
+}
+
 func (t Test) Endpoint() (*url.URL, error) {
 	return url.Parse("https://foo:bar@example.org")
 }


### PR DESCRIPTION
New cli command `convox rack sync` to prepare for the v2 Classic x ALB migration.

This command allow users to manually sync the rack API URL. Ref https://github.com/convox/console/pull/222