### PR TITLE
Prevent skip minor on update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage.txt
 terraform.tfvars
 terraform/platform/convox.platform
 .DS_Store
+cmd/convox/convox

--- a/pkg/rack/terraform.go
+++ b/pkg/rack/terraform.go
@@ -405,7 +405,6 @@ func (t Terraform) update(release string, vars map[string]string) error {
 		release = v
 
 	}
-	fmt.Println("current version: ", currentVersion)
 
 	if vars == nil {
 		vars = map[string]string{}

--- a/pkg/rack/terraform.go
+++ b/pkg/rack/terraform.go
@@ -297,6 +297,20 @@ func (t Terraform) UpdateParams(params map[string]string) error {
 }
 
 func (t Terraform) UpdateVersion(version string) error {
+	if version != "" {
+		r, err := t.Client()
+		if err != nil {
+			return err
+		}
+		s, err := r.SystemGet()
+		if err != nil {
+			return err
+		}
+		if err := isSkippingMinor(s.Version, version); err != nil {
+			return err
+		}
+	}
+
 	vars, err := t.vars()
 	if err != nil {
 		return err
@@ -391,6 +405,7 @@ func (t Terraform) update(release string, vars map[string]string) error {
 		release = v
 
 	}
+	fmt.Println("current version: ", currentVersion)
 
 	if vars == nil {
 		vars = map[string]string{}


### PR DESCRIPTION
It will receive an error if tries to skip one minor version (e.g. 3.5.X to 3.7.X) and will ask to update to the next minor release (e.g. 3.6.X) first.