### PR TITLE
Fix gcp rack instalation. Pin k8s version

### DIFF
--- a/terraform/cluster/gcp/main.tf
+++ b/terraform/cluster/gcp/main.tf
@@ -16,8 +16,10 @@ resource "google_container_cluster" "rack" {
   initial_node_count       = 1
 
   release_channel {
-    channel = "REGULAR"
+    channel = "UNSPECIFIED"
   }
+
+  min_master_version = "1.21.13-gke.900"
 
   workload_identity_config {
     workload_pool = "${data.google_project.current.project_id}.svc.id.goog"


### PR DESCRIPTION
After fixing the subnet quota problem I noticed that the GCP installation is still failing because the minimum version on the `REGULAR` release channel is 1.22 - which deprecated some API objects that we still use.

I changed the version to be statically managed so we guarantee it won't be automatically updated to 1.22 