### PR TITLE
Use launch template to use gp3

### DIFF
--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -97,12 +97,16 @@ resource "aws_eks_node_group" "cluster" {
   ami_type        = var.gpu_type ? "AL2_x86_64_GPU" : var.arm_type ? "AL2_ARM_64" : "AL2_x86_64"
   capacity_type   = var.node_capacity_type
   cluster_name    = aws_eks_cluster.cluster.name
-  disk_size       = random_id.node_group.keepers.node_disk
   instance_types  = split(",", random_id.node_group.keepers.node_type)
   node_group_name = "${var.name}-${local.availability_zones[count.index]}-${random_id.node_group.hex}"
   node_role_arn   = random_id.node_group.keepers.role_arn
   subnet_ids      = [var.private ? aws_subnet.private[count.index].id : aws_subnet.public[count.index].id]
   version         = var.k8s_version
+
+  launch_template {
+    id = aws_launch_template.cluster.id
+    version = "$Latest"
+  }
 
   scaling_config {
     desired_size = 1
@@ -127,4 +131,14 @@ resource "local_file" "kubeconfig" {
     cluster  = aws_eks_cluster.cluster.id
     endpoint = aws_eks_cluster.cluster.endpoint
   })
+}
+
+resource "aws_launch_template" "cluster" {
+  block_device_mappings {
+    device_name = "/dev/xvda"
+    ebs {
+      volume_type = "gp3"
+      volume_size = random_id.node_group.keepers.node_disk
+    }
+  }
 }


### PR DESCRIPTION
Using a launch template, the EKS cluster nodes will use the gp3.

[Still testing]