### PR TITLE
Install EBS CSI and enable gp3 by default

### DIFF
--- a/terraform/api/aws/s3.tf
+++ b/terraform/api/aws/s3.tf
@@ -8,7 +8,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "storage" {
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm     = "aws:kms"
+      sse_algorithm = "aws:kms"
     }
   }
 }

--- a/terraform/api/aws/s3.tf
+++ b/terraform/api/aws/s3.tf
@@ -1,4 +1,4 @@
-resource "aws_s3_bucket" "storage" {
+resource "aws_s3_bucket" "storage" { # skipcq: TF-AWS017, TF-AWS002, TF-AWS077
   bucket_prefix = "${var.name}-storage-"
   force_destroy = true
 }

--- a/terraform/api/aws/s3.tf
+++ b/terraform/api/aws/s3.tf
@@ -1,13 +1,19 @@
 resource "aws_s3_bucket" "storage" {
-  acl           = "private"
   bucket_prefix = "${var.name}-storage-"
   force_destroy = true
+}
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "aws:kms"
-      }
+resource "aws_s3_bucket_server_side_encryption_configuration" "storage" {
+  bucket = aws_s3_bucket.storage.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
     }
   }
+}
+
+resource "aws_s3_bucket_acl" "storage" {
+  bucket = aws_s3_bucket.storage.bucket
+  acl    = "private"
 }

--- a/terraform/api/aws/versions.tf
+++ b/terraform/api/aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.33"
+      version = "4.22.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/terraform/api/aws/versions.tf
+++ b/terraform/api/aws/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/api/azure/versions.tf
+++ b/terraform/api/azure/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
     random = {
       source = "hashicorp/random"

--- a/terraform/api/do/versions.tf
+++ b/terraform/api/do/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
     random = {
       source = "hashicorp/random"

--- a/terraform/api/gcp/versions.tf
+++ b/terraform/api/gcp/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
     random = {
       source = "hashicorp/random"

--- a/terraform/api/k8s/versions.tf
+++ b/terraform/api/k8s/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/api/local/versions.tf
+++ b/terraform/api/local/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/api/metal/versions.tf
+++ b/terraform/api/metal/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -98,7 +98,7 @@ resource "aws_eks_node_group" "cluster" {
   capacity_type   = var.node_capacity_type
   cluster_name    = aws_eks_cluster.cluster.name
   instance_types  = split(",", random_id.node_group.keepers.node_type)
-  node_group_name = "${var.name}-${local.availability_zones[count.index]}-${random_id.node_group.hex}"
+  node_group_name = "${var.name}-${local.availability_zones[count.index]}-${count.index}${random_id.node_group.hex}"
   node_role_arn   = random_id.node_group.keepers.role_arn
   subnet_ids      = [var.private ? aws_subnet.private[count.index].id : aws_subnet.public[count.index].id]
   version         = var.k8s_version

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -147,6 +147,8 @@ module "ebs_csi_driver_controller" {
   source  = "DrFaust92/ebs-csi-driver/kubernetes"
   version = "3.3.1"
 
+  ebs_csi_controller_image                   = "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver"
+  ebs_csi_driver_version                     = var.arm_type ? "v1.9.0-linux-arm64-amazon" : "v1.9.0"
   ebs_csi_controller_role_name               = "convox-ebs-csi-driver-controller"
   ebs_csi_controller_role_policy_name_prefix = "convox-ebs-csi-driver-policy"
   oidc_url                                   = aws_iam_openid_connect_provider.cluster.url

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -160,7 +160,7 @@ resource "kubernetes_storage_class" "default" {
     }
   }
 
-  storage_provisioner    = "kubernetes.io/aws-ebs"
+  storage_provisioner    = "ebs.csi.aws.com"
   volume_binding_mode    = "WaitForFirstConsumer"
   allow_volume_expansion = false
   parameters = {

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -164,7 +164,7 @@ resource "kubernetes_storage_class" "default" {
 
   storage_provisioner    = "ebs.csi.aws.com"
   volume_binding_mode    = "WaitForFirstConsumer"
-  allow_volume_expansion = false
+  allow_volume_expansion = true
   parameters = {
     type = "gp3"
   }

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -142,3 +142,28 @@ resource "aws_launch_template" "cluster" {
     }
   }
 }
+
+module "ebs_csi_driver_controller" {
+  source  = "DrFaust92/ebs-csi-driver/kubernetes"
+  version = "3.3.1"
+
+  ebs_csi_controller_role_name               = "convox-ebs-csi-driver-controller"
+  ebs_csi_controller_role_policy_name_prefix = "convox-ebs-csi-driver-policy"
+  oidc_url                                   = aws_iam_openid_connect_provider.cluster.url
+}
+
+resource "kubernetes_storage_class" "default" {
+  metadata {
+    name = "gp3"
+    annotations = {
+      "storageclass.kubernetes.io/is-default-class" = "true"
+    }
+  }
+
+  storage_provisioner    = "kubernetes.io/aws-ebs"
+  volume_binding_mode    = "WaitForFirstConsumer"
+  allow_volume_expansion = false
+  parameters = {
+    type = "gp3"
+  }
+}

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -167,3 +167,18 @@ resource "kubernetes_storage_class" "default" {
     type = "gp3"
   }
 }
+
+resource "kubernetes_annotations" "gp2" {
+  api_version = "storage.k8s.io/v1"
+  kind        = "StorageClass"
+
+  metadata {
+    name = "gp2"
+  }
+
+  annotations = {
+    "storageclass.kubernetes.io/is-default-class" = "false"
+  }
+
+  force = true
+}

--- a/terraform/cluster/aws/versions.tf
+++ b/terraform/cluster/aws/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/terraform/cluster/aws/versions.tf
+++ b/terraform/cluster/aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.33"
+      version = "4.22.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/terraform/elasticsearch/k8s/versions.tf
+++ b/terraform/elasticsearch/k8s/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/fluentd/aws/versions.tf
+++ b/terraform/fluentd/aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.33"
+      version = "4.22.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/terraform/fluentd/aws/versions.tf
+++ b/terraform/fluentd/aws/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/fluentd/elasticsearch/versions.tf
+++ b/terraform/fluentd/elasticsearch/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/fluentd/k8s/versions.tf
+++ b/terraform/fluentd/k8s/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/metrics/k8s/versions.tf
+++ b/terraform/metrics/k8s/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/rack/aws/versions.tf
+++ b/terraform/rack/aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.33"
+      version = "4.22.0"
     }
     external = {
       source  = "hashicorp/external"

--- a/terraform/rack/aws/versions.tf
+++ b/terraform/rack/aws/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/rack/azure/versions.tf
+++ b/terraform/rack/azure/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/rack/do/versions.tf
+++ b/terraform/rack/do/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
     random = {
       source = "hashicorp/random"

--- a/terraform/rack/gcp/versions.tf
+++ b/terraform/rack/gcp/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/rack/k8s/versions.tf
+++ b/terraform/rack/k8s/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/rack/local/versions.tf
+++ b/terraform/rack/local/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
     random = {
       source = "hashicorp/random"

--- a/terraform/rack/metal/versions.tf
+++ b/terraform/rack/metal/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
     random = {
       source = "hashicorp/random"

--- a/terraform/resolver/aws/versions.tf
+++ b/terraform/resolver/aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.33"
+      version = "4.22.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/terraform/resolver/aws/versions.tf
+++ b/terraform/resolver/aws/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/resolver/azure/versions.tf
+++ b/terraform/resolver/azure/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/resolver/do/versions.tf
+++ b/terraform/resolver/do/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
 }

--- a/terraform/resolver/gcp/versions.tf
+++ b/terraform/resolver/gcp/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/resolver/k8s/versions.tf
+++ b/terraform/resolver/k8s/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/resolver/local/versions.tf
+++ b/terraform/resolver/local/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/resolver/metal/versions.tf
+++ b/terraform/resolver/metal/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/router/aws/versions.tf
+++ b/terraform/router/aws/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/router/aws/versions.tf
+++ b/terraform/router/aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.33"
+      version = "4.22.0"
     }
     http = {
       source  = "hashicorp/http"

--- a/terraform/router/azure/versions.tf
+++ b/terraform/router/azure/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/router/do/versions.tf
+++ b/terraform/router/do/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
 }

--- a/terraform/router/gcp/versions.tf
+++ b/terraform/router/gcp/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/router/local/versions.tf
+++ b/terraform/router/local/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/terraform/router/metal/versions.tf
+++ b/terraform/router/metal/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/router/nginx/versions.tf
+++ b/terraform/router/nginx/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/system/aws/versions.tf
+++ b/terraform/system/aws/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/system/aws/versions.tf
+++ b/terraform/system/aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.33"
+      version = "4.22.0"
     }
     http = {
       source  = "hashicorp/http"

--- a/terraform/system/azure/versions.tf
+++ b/terraform/system/azure/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/system/do/versions.tf
+++ b/terraform/system/do/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
 }

--- a/terraform/system/gcp/versions.tf
+++ b/terraform/system/gcp/versions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/system/local/versions.tf
+++ b/terraform/system/local/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
   required_version = ">= 0.12"

--- a/terraform/system/metal/versions.tf
+++ b/terraform/system/metal/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.9.0"
+      version = "~> 2.10.0"
     }
   }
   required_version = ">= 0.12"


### PR DESCRIPTION
Installing the EBS CSI Driver Controller, we will be able to deploy volumes using gp3 instead of the default (in-tree) gp2.