### PR TITLE
Fix for CLI rack update command

### DIFF
--- a/pkg/rack/console.go
+++ b/pkg/rack/console.go
@@ -256,11 +256,20 @@ func (c Console) UpdateVersion(version string) error {
 }
 
 func isSkippingMinor(currentVersion, version string) error {
-	cmv, err := strconv.Atoi(strings.Split(currentVersion, ".")[1])
+	splittedCurrent := strings.Split(currentVersion, ".")
+	if len(splittedCurrent) <= 1 {
+		return nil
+	}
+	cmv, err := strconv.Atoi(splittedCurrent[1])
 	if err != nil {
 		return err
 	}
-	mv, err := strconv.Atoi(strings.Split(version, ".")[1])
+
+	splittedVersion := strings.Split(version, ".")
+	if len(splittedVersion) <= 1 {
+		return nil
+	}
+	mv, err := strconv.Atoi(splittedVersion[1])
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Using a non-standard 3.X.X version breaks the CLI. It will try to split the numbers but will return an empty slice. Trying to access index 1 breaks the CLI.

Example: with a CLI on 3.5.3 and try to update to [gp3-default](https://github.com/convox/convox/releases/tag/gp3-default).