### PR TITLE
Creating a new app use an empty Atom CRD

### DIFF
--- a/pkg/atom/templates/crd.yml.tmpl
+++ b/pkg/atom/templates/crd.yml.tmpl
@@ -18,10 +18,13 @@ spec:
           properties:
             started:
               type: string
+              nullable: true
             status:
               type: string
+              nullable: true
             spec:
               type: object
+              nullable: true
               properties:
                 conditions:
                   type: array


### PR DESCRIPTION
When upgrading from 3.5.7 to 3.6.0 and trying to create a new app, the CLI tried to create an empty resource using Atom CRD.