### PR TITLE
Feat-306: Update AWS eks to 1.21

### DIFF
--- a/terraform/cluster/aws/variables.tf
+++ b/terraform/cluster/aws/variables.tf
@@ -24,7 +24,7 @@ variable "internet_gateway_id" {
 
 variable "k8s_version" {
   type = string
-  default = "1.18"
+  default = "1.21"
 }
 
 variable "name" {

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -38,7 +38,7 @@ variable "internet_gateway_id" {
 
 variable "k8s_version" {
   type = string
-  default = "1.20"
+  default = "1.21"
 }
 
 variable "name" {


### PR DESCRIPTION
https://github.com/convox/issues-private/issues/306

Able to launch rack with eks version 1.21

![Screenshot from 2022-08-04 21-51-13](https://user-images.githubusercontent.com/12232198/183127437-698f0c82-f622-4fa3-a673-ab283f870cd3.png)

