### PR TITLE
[Bugfix] update nginx ingress class name in gcp

### DIFF
--- a/provider/gcp/ingress.go
+++ b/provider/gcp/ingress.go
@@ -9,5 +9,5 @@ func (p *Provider) IngressAnnotations(app string) (map[string]string, error) {
 }
 
 func (p *Provider) IngressClass() string {
-	return "convox"
+	return "nginx"
 }


### PR DESCRIPTION
Fix this error on ingress controller: `"Ignoring ingress because of error while validating ingress class" ingress="localhost-gcp-httpd/web" error="no object matching key \"convox\" in local store"`