### PR TITLE
Change EBS CSI Driver image for arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: golang-1.16
         uses: actions/setup-go@v3
         with:

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -152,7 +152,7 @@ module "ebs_csi_driver_controller" {
   version = "3.3.1"
 
   ebs_csi_controller_image                   = "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver"
-  ebs_csi_driver_version                     = var.arm_type ? "v1.9.0-linux-arm64-amazon" : "v1.9.0"
+  ebs_csi_driver_version                     = "v1.9.0"
   ebs_csi_controller_role_name               = "convox-ebs-csi-driver-controller"
   ebs_csi_controller_role_policy_name_prefix = "convox-ebs-csi-driver-policy"
   oidc_url                                   = aws_iam_openid_connect_provider.cluster.url

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -144,6 +144,10 @@ resource "aws_launch_template" "cluster" {
 }
 
 module "ebs_csi_driver_controller" {
+  depends_on = [
+    null_resource.wait_k8s_api
+  ]
+
   source  = "DrFaust92/ebs-csi-driver/kubernetes"
   version = "3.3.1"
 
@@ -155,7 +159,15 @@ module "ebs_csi_driver_controller" {
 }
 
 resource "kubernetes_storage_class" "default" {
+  depends_on = [
+    null_resource.wait_k8s_api
+  ]
+
   metadata {
+    labels = {
+      "ebs_driver_name" = module.ebs_csi_driver_controller.ebs_csi_driver_name
+    }
+
     name = "gp3"
     annotations = {
       "storageclass.kubernetes.io/is-default-class" = "true"
@@ -171,6 +183,10 @@ resource "kubernetes_storage_class" "default" {
 }
 
 resource "kubernetes_annotations" "gp2" {
+  depends_on = [
+    kubernetes_storage_class.default
+  ]
+
   api_version = "storage.k8s.io/v1"
   kind        = "StorageClass"
 

--- a/terraform/cluster/aws/outputs.tf
+++ b/terraform/cluster/aws/outputs.tf
@@ -3,6 +3,10 @@ output "ca" {
   value      = base64decode(aws_eks_cluster.cluster.certificate_authority.0.data)
 }
 
+output "ebs_csi_driver_name" {
+  value = module.ebs_csi_driver_controller.ebs_csi_driver_name
+}
+
 output "endpoint" {
   depends_on = [aws_eks_node_group.cluster]
   value      = aws_eks_cluster.cluster.endpoint

--- a/terraform/rack/aws/variables.tf
+++ b/terraform/rack/aws/variables.tf
@@ -10,6 +10,10 @@ variable "docker_hub_password" {
   default = ""
 }
 
+variable "ebs_csi_driver_name" {
+  type = string
+}
+
 variable "high_availability" {
   default = true
 }

--- a/terraform/router/aws/outputs.tf
+++ b/terraform/router/aws/outputs.tf
@@ -1,3 +1,3 @@
 output "endpoint" {
-  value = data.http.alias.body
+  value = data.http.alias.response_body
 }

--- a/terraform/router/azure/outputs.tf
+++ b/terraform/router/azure/outputs.tf
@@ -1,3 +1,3 @@
 output "endpoint" {
-  value = data.http.alias.body
+  value = data.http.alias.response_body
 }

--- a/terraform/router/do/outputs.tf
+++ b/terraform/router/do/outputs.tf
@@ -1,3 +1,3 @@
 output "endpoint" {
-  value = data.http.alias.body
+  value = data.http.alias.response_body
 }

--- a/terraform/router/gcp/outputs.tf
+++ b/terraform/router/gcp/outputs.tf
@@ -1,3 +1,3 @@
 output "endpoint" {
-  value = data.http.alias.body
+  value = data.http.alias.response_body
 }

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -25,7 +25,7 @@ locals {
   // var.node_type can be assigned a comma separated list of instance types
   node_type = split(",", var.node_type)[0]
   arm_type  = substr(local.node_type, 0, 2) == "a1" || substr(local.node_type, 0, 3) == "c6g" || substr(local.node_type, 0, 3) == "c7g" || substr(local.node_type, 0, 3) == "m6g" || substr(local.node_type, 0, 3) == "r6g" || substr(local.node_type, 0, 3) == "t4g"
-  current   = jsondecode(data.http.releases.body).tag_name
+  current   = jsondecode(data.http.releases.response_body).tag_name
   gpu_type  = substr(local.node_type, 0, 1) == "g" || substr(local.node_type, 0, 1) == "p"
   image     = var.image
   release   = local.arm_type ? format("%s-%s", coalesce(var.release, local.current), "arm64") : coalesce(var.release, local.current)

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -91,4 +91,5 @@ module "rack" {
   release             = local.release
   subnets             = module.cluster.subnets
   whitelist           = split(",", var.whitelist)
+  ebs_csi_driver_name = module.cluster.ebs_csi_driver_name
 }

--- a/terraform/system/azure/main.tf
+++ b/terraform/system/azure/main.tf
@@ -15,7 +15,7 @@ data "http" "releases" {
 }
 
 locals {
-  current = jsondecode(data.http.releases.body).tag_name
+  current = jsondecode(data.http.releases.response_body).tag_name
   release = coalesce(var.release, local.current)
 }
 
@@ -50,7 +50,7 @@ module "rack" {
 
   cluster        = module.cluster.id
   docker_hub_username = var.docker_hub_username
-  docker_hub_password = var.docker_hub_password  
+  docker_hub_password = var.docker_hub_password
   image          = var.image
   name           = var.name
   region         = var.region

--- a/terraform/system/do/main.tf
+++ b/terraform/system/do/main.tf
@@ -15,7 +15,7 @@ data "http" "releases" {
 }
 
 locals {
-  current = jsondecode(data.http.releases.body).tag_name
+  current = jsondecode(data.http.releases.response_body).tag_name
   release = coalesce(var.release, local.current)
 }
 

--- a/terraform/system/gcp/main.tf
+++ b/terraform/system/gcp/main.tf
@@ -20,7 +20,7 @@ data "http" "releases" {
 }
 
 locals {
-  current = jsondecode(data.http.releases.body).tag_name
+  current = jsondecode(data.http.releases.response_body).tag_name
   release = coalesce(var.release, local.current)
 }
 

--- a/terraform/system/local/main.tf
+++ b/terraform/system/local/main.tf
@@ -4,7 +4,7 @@ data "http" "releases" {
 
 locals {
   arm_type = module.platform.arch == "arm64"
-  current = jsondecode(data.http.releases.body).tag_name
+  current = jsondecode(data.http.releases.response_body).tag_name
   release = local.arm_type ? format("%s-%s", coalesce(var.release, local.current), "arm64") : coalesce(var.release, local.current)
 }
 

--- a/terraform/system/metal/main.tf
+++ b/terraform/system/metal/main.tf
@@ -3,7 +3,7 @@ data "http" "releases" {
 }
 
 locals {
-  current = jsondecode(data.http.releases.body).tag_name
+  current = jsondecode(data.http.releases.response_body).tag_name
   release = coalesce(var.release, local.current)
 }
 


### PR DESCRIPTION
The arm64 image was deleted, and the image on `v1.9.0` is multi-arch.

https://github.com/kubernetes-sigs/aws-ebs-csi-driver/issues/1315

Also fixes:

- Release notes;
- remove deprecation warning;
- `proxy_protocol` and ebs csi driver installation.