### PR TITLE
Create E2E test for canceling apps deployment

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -116,6 +116,8 @@ convox deploy -a httpd
 
 # test apps cancel
 echo "FOO=not-bar" | convox env set -a httpd
+
+cp Dockerfile Dockerfile.original # copy current Dockerfile
 echo "COPY new-feature.html /usr/local/apache2/htdocs/index.html" >> Dockerfile
 echo "ENTRYPOINT sleep 60 && httpd-foreground" >> Dockerfile
 nohup convox deploy & # run deploy on background
@@ -133,7 +135,6 @@ done
 
 echo "app is updating will cancel in 10 secs"
 sleep 10
-# kill $!
 
 convox apps cancel -a httpd | grep "OK"
 echo "app deployment canceled"
@@ -144,6 +145,8 @@ echo "still returning the right content"
 
 convox env -a httpd | grep "FOO" | grep "not-bar"
 echo "env var is correctly set"
+
+mv Dockerfile.original Dockerfile # replace the Dockerfile with the original copy
 
 # timers
 sleep 30

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -118,7 +118,7 @@ convox deploy -a httpd
 echo "FOO=not-bar" | convox env set -a httpd
 echo "COPY new-feature.html /usr/local/apache2/htdocs/index.html" >> Dockerfile
 echo "ENTRYPOINT sleep 60 && httpd-foreground" >> Dockerfile
-convox deploy & # run deploy on background
+nohup convox deploy & # run deploy on background
 
 i=0
 while [ "$(convox apps info -a httpd | grep updating | wc -l)" != "1" ]
@@ -131,18 +131,18 @@ do
   sleep 1
 done
 
-echo "app is updating will cancel in 5 secs"
-sleep 5
-kill $!
+echo "app is updating will cancel in 10 secs"
+sleep 10
+# kill $!
 
-convox apps cancel -a httpd | grep "Rewriting last active release... OK"
+convox apps cancel -a httpd | grep "OK"
 echo "app deployment canceled"
 
 endpoint=$(convox api get /apps/httpd/services | jq -r '.[] | select(.name == "web") | .domain')
 fetch https://$endpoint | grep "It works"
 echo "still returning the right content"
 
-convox env -a httpd | grep FOO=not-bar
+convox env -a httpd | grep "FOO" | grep "not-bar"
 echo "env var is correctly set"
 
 # timers

--- a/examples/httpd/new-feature.html
+++ b/examples/httpd/new-feature.html
@@ -1,0 +1,7 @@
+<html>
+
+<!-- used for apps cancel test -->
+
+<body>New feature added!</body>
+
+</html>


### PR DESCRIPTION
It will run `convox deploy` and when the app is set as _updating_ it will cancel the deployment. After completion, it will test if the deployment was canceled (the new feature should not be released) and if the env vars are still set.