### PR TITLE
Add template to new Pull Requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+### What is the feature/fix?
+
+** Describe the task and what is the goal for it. **
+** Describe the bug and the solution. **
+** Any additional information **
+
+### Does it has a breaking change?
+
+** Describe the changes and if it has any breaking changes in any feature **
+
+### How to use/test it?
+
+** Describe how to test or use the feature **
+
+### Checklist
+- [ ] New coverage tests
+- [ ] Unit tests passing
+- [ ] E2E tests passing
+- [ ] E2E downgrade/update test passing
+- [ ] Documentation updated
+- [ ] No warnings or errors on Deepsource/Codecov


### PR DESCRIPTION
Adds a template to new PRs, the goal is to be more straightforward and concise with the changes, fixes, and features in new PRs. Improve overall communication.