### PR TITLE
Node group should be able to scale in non HA mode

### DIFF
--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -111,7 +111,7 @@ resource "aws_eks_node_group" "cluster" {
   scaling_config {
     desired_size = 1
     min_size     = 1
-    max_size     = var.high_availability ? 100 : 3
+    max_size     = 100
   }
 
   lifecycle {


### PR DESCRIPTION
Just like v2, even when in non-HA mode, the node group should still be able to scale to accommodate whatever workloads are being scheduled.