### PR TITLE
Update Nginx controller to 1.3.0

### DIFF
--- a/provider/gcp/ingress.go
+++ b/provider/gcp/ingress.go
@@ -9,5 +9,5 @@ func (p *Provider) IngressAnnotations(app string) (map[string]string, error) {
 }
 
 func (p *Provider) IngressClass() string {
-	return "convox"
+	return "nginx"
 }

--- a/provider/k8s/template/app/ingress.yml.tmpl
+++ b/provider/k8s/template/app/ingress.yml.tmpl
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   namespace: {{.Namespace}}
@@ -7,7 +7,6 @@ metadata:
     alb.ingress.kubernetes.io/scheme: internet-facing
     convox.com/backend-protocol: "{{.Service.Port.Scheme}}"
     convox.com/idles: "{{.Idles}}"
-    kubernetes.io/ingress-class: "{{.Class}}"
     nginx.ingress.kubernetes.io/backend-protocol: "{{.Service.Port.Scheme}}"
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "{{.Service.Timeout}}"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "{{.Service.Timeout}}"
@@ -34,6 +33,7 @@ metadata:
     system: convox
     type: service
 spec:
+  ingressClassName: "{{.Class}}"
   tls:
   - hosts:
     - {{ safe .Host }}
@@ -50,13 +50,18 @@ spec:
       http:
         paths:
         - backend:
-            serviceName: {{.Service.Name}}
-            servicePort: {{.Service.Port.Port}}
+            service:
+              name: {{.Service.Name}}
+              port:
+                number: {{.Service.Port.Port}}
+          pathType: ImplementationSpecific
     {{ range .Service.Domains }}
     - host: {{ safe . }}
       http:
         paths:
         - backend:
-            serviceName: {{$.Service.Name}}
-            servicePort: {{$.Service.Port.Port}}
+            service:
+              name: {{$.Service.Name}}
+              port:
+                number: {{$.Service.Port.Port}}
     {{ end }}

--- a/provider/k8s/testdata/release-basic-app.yml
+++ b/provider/k8s/testdata/release-basic-app.yml
@@ -53,7 +53,7 @@ spec:
     type: service
   type: LoadBalancer
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -61,7 +61,6 @@ metadata:
     ann1: val1
     convox.com/backend-protocol: http
     convox.com/idles: "false"
-    kubernetes.io/ingress-class: ""
     nginx.ingress.kubernetes.io/backend-protocol: http
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "60"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
@@ -84,19 +83,23 @@ metadata:
   name: web
   namespace: rack1-app1
 spec:
+  ingressClassName: ""
   rules:
   - host: service.host
     http:
       paths:
       - backend:
-          serviceName: web
-          servicePort: 5000
+          service:
+            name: web
+            port:
+              number: 5000
+        pathType: ImplementationSpecific
   tls:
   - hosts:
     - service.host
     secretName: cert-web
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -104,7 +107,6 @@ metadata:
     ann1: val1
     convox.com/backend-protocol: http
     convox.com/idles: "false"
-    kubernetes.io/ingress-class: ""
     nginx.ingress.kubernetes.io/backend-protocol: http
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "60"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
@@ -126,13 +128,17 @@ metadata:
   name: web2
   namespace: rack1-app1
 spec:
+  ingressClassName: ""
   rules:
   - host: service.host
     http:
       paths:
       - backend:
-          serviceName: web2
-          servicePort: 5000
+          service:
+            name: web2
+            port:
+              number: 5000
+        pathType: ImplementationSpecific
   tls:
   - hosts:
     - service.host

--- a/terraform/rack/do/registry.tf
+++ b/terraform/rack/do/registry.tf
@@ -175,7 +175,8 @@ resource "kubernetes_ingress" "registry" {
     name      = "registry"
 
     annotations = {
-      "cert-manager.io/cluster-issuer" : "letsencrypt"
+      "cert-manager.io/cluster-issuer" = "letsencrypt"
+      "kubernetes.io/ingress.class"    = "nginx"
     }
 
     labels = {
@@ -204,4 +205,3 @@ resource "kubernetes_ingress" "registry" {
     }
   }
 }
-

--- a/terraform/router/local/main.tf
+++ b/terraform/router/local/main.tf
@@ -12,7 +12,7 @@ module "nginx" {
     kubernetes = kubernetes
   }
 
-  nginx_image        = "quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.26.1"
+  nginx_image        = var.nginx_image
   nginx_user         = "33"
   namespace          = var.namespace
   rack               = var.name

--- a/terraform/router/local/variables.tf
+++ b/terraform/router/local/variables.tf
@@ -13,3 +13,8 @@ variable "platform" {
 variable "release" {
   type = string
 }
+
+variable "nginx_image" {
+  type = string
+  default = "registry.k8s.io/ingress-nginx/controller:v1.3.0@sha256:d1707ca76d3b044ab8a28277a2466a02100ee9f58a86af1535a3edf9323ea1b5"
+}

--- a/terraform/router/nginx/main.tf
+++ b/terraform/router/nginx/main.tf
@@ -231,6 +231,7 @@ resource "kubernetes_deployment" "ingress-nginx" {
           image = var.nginx_image
           args = [
             "/nginx-ingress-controller",
+            "--watch-ingress-without-class=true",
             "--configmap=$(POD_NAMESPACE)/nginx-configuration",
             "--tcp-services-configmap=$(POD_NAMESPACE)/tcp-services",
             "--udp-services-configmap=$(POD_NAMESPACE)/udp-services",

--- a/terraform/router/nginx/variables.tf
+++ b/terraform/router/nginx/variables.tf
@@ -1,6 +1,6 @@
 variable "nginx_image" {
   type = string
-  default = "k8s.gcr.io/ingress-nginx/controller:v0.46.0@sha256:52f0058bed0a17ab0fb35628ba97e8d52b5d32299fbc03cc0f6c7b9ff036b61a"
+  default = "registry.k8s.io/ingress-nginx/controller:v1.3.0@sha256:d1707ca76d3b044ab8a28277a2466a02100ee9f58a86af1535a3edf9323ea1b5"
 }
 
 variable "nginx_user" {


### PR DESCRIPTION
### What is the feature/fix?

Update the nginx ingress controller to 1.3.0, see https://github.com/convox/convox/pull/472. 
Include a tag to watch ingresses without class for old apps. When the app is deployed, it will include it.

### Does it has a breaking change?

No, old apps are still compatible and new apps will be compatible with old racks (if a downgrade is necessary).

### How to use/test it?

1. Install a rack setting release as [nginx-update-130-rc](https://github.com/convox/convox/releases/tag/nginx-update-130-rc). 
2. Create and deploy a new app. 
3. Get access to Kubernetes 
4. Search for the apps ingress `kubectl get ingress web -n dev-v3-nodejs -o yaml`
5. Under spec, it must have the `ingressClassName` as `nginx`:

```
[...]
spec:
  ingressClassName: nginx
  rules:
  - host: xxxx
[...]
```

### Checklist
- [x] New coverage tests 
**don't need, it's just a lib update**
- [x] Unit tests passing
- [x] E2E tests passing
- [x] E2E downgrade/update test passing
- [x] Documentation updated
- [x] No warnings or errors on Deepsource/Codecov
