### PR TITLE
Preparation for k8s 1.22 update

### DIFF
--- a/terraform/api/aws/main.tf
+++ b/terraform/api/aws/main.tf
@@ -29,7 +29,6 @@ module "k8s" {
     "cert-manager.io/cluster-issuer" = "letsencrypt"
     "eks.amazonaws.com/role-arn"     = aws_iam_role.api.arn
     "iam.amazonaws.com/role"         = aws_iam_role.api.arn
-    "kubernetes.io/ingress.class"    = "nginx"
   }
 
   env = {

--- a/terraform/api/do/main.tf
+++ b/terraform/api/do/main.tf
@@ -49,7 +49,6 @@ module "k8s" {
 
   annotations = {
     "cert-manager.io/cluster-issuer" = "letsencrypt"
-    "kubernetes.io/ingress.class"    = "nginx"
   }
 
   env = {

--- a/terraform/api/k8s/main.tf
+++ b/terraform/api/k8s/main.tf
@@ -289,6 +289,7 @@ resource "kubernetes_ingress_v1" "api" {
   }
 
   spec {
+    ingress_class_name = "nginx"
     tls {
       hosts       = ["api.${var.domain}"]
       secret_name = "api-certificate"
@@ -302,7 +303,9 @@ resource "kubernetes_ingress_v1" "api" {
           backend {
             service {
               name = kubernetes_service.api.metadata.0.name
-              port = 5443
+              port {
+                number = 5443
+              }
             }
           }
         }
@@ -329,6 +332,7 @@ resource "kubernetes_ingress_v1" "kubernetes" {
   }
 
   spec {
+    ingress_class_name = "nginx"
     tls {
       hosts       = ["api.${var.domain}"]
       secret_name = "api-certificate"
@@ -344,7 +348,9 @@ resource "kubernetes_ingress_v1" "kubernetes" {
           backend {
             service {
               name = kubernetes_service.api.metadata.0.name
-              port = 8001
+              port {
+                number = 8001
+              }
             }
           }
         }

--- a/terraform/api/k8s/main.tf
+++ b/terraform/api/k8s/main.tf
@@ -268,7 +268,7 @@ resource "kubernetes_service" "api" {
   }
 }
 
-resource "kubernetes_ingress" "api" {
+resource "kubernetes_ingress_v1" "api" {
   wait_for_load_balancer = true
 
   metadata {
@@ -300,8 +300,10 @@ resource "kubernetes_ingress" "api" {
       http {
         path {
           backend {
-            service_name = kubernetes_service.api.metadata.0.name
-            service_port = 5443
+            service {
+              name = kubernetes_service.api.metadata.0.name
+              port = 5443
+            }
           }
         }
       }
@@ -309,7 +311,7 @@ resource "kubernetes_ingress" "api" {
   }
 }
 
-resource "kubernetes_ingress" "kubernetes" {
+resource "kubernetes_ingress_v1" "kubernetes" {
   wait_for_load_balancer = true
 
   metadata {
@@ -340,8 +342,10 @@ resource "kubernetes_ingress" "kubernetes" {
           path = "/kubernetes/.*"
 
           backend {
-            service_name = kubernetes_service.api.metadata.0.name
-            service_port = 8001
+            service {
+              name = kubernetes_service.api.metadata.0.name
+              port = 8001
+            }
           }
         }
       }

--- a/terraform/api/local/main.tf
+++ b/terraform/api/local/main.tf
@@ -25,7 +25,6 @@ module "k8s" {
   annotations = {
     "cert-manager.io/cluster-issuer" = "self-signed"
     "convox.com/idles"               = "true"
-    "kubernetes.io/ingress.class"    = "nginx"
   }
 
   env = {

--- a/terraform/api/metal/main.tf
+++ b/terraform/api/metal/main.tf
@@ -46,7 +46,6 @@ module "k8s" {
 
   annotations = {
     "cert-manager.io/cluster-issuer" = "self-signed"
-    "kubernetes.io/ingress.class"    = "nginx"
   }
 
   env = {

--- a/terraform/cluster/aws/kubeconfig.tpl
+++ b/terraform/cluster/aws/kubeconfig.tpl
@@ -16,7 +16,7 @@ users:
 - name: aws
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
+      apiVersion: client.authentication.k8s.io/v1
       command: aws
       args:
         - "eks"

--- a/terraform/metrics/k8s/main.tf
+++ b/terraform/metrics/k8s/main.tf
@@ -95,7 +95,7 @@ resource "kubernetes_service_account" "metrics" {
   }
 }
 
-resource "kubernetes_api_service_v1" "metrics" {
+resource "kubernetes_api_service" "metrics" {
   metadata {
     name = "v1beta1.metrics.k8s.io"
   }

--- a/terraform/metrics/k8s/main.tf
+++ b/terraform/metrics/k8s/main.tf
@@ -59,7 +59,13 @@ resource "kubernetes_cluster_role" "resource" {
 
   rule {
     api_groups = [""]
-    resources  = ["pods", "nodes", "nodes/stats", "namespaces"]
+    resources  = ["nodes/metrics"]
+    verbs      = ["get"]
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["pods", "nodes"]
     verbs      = ["get", "list", "watch"]
   }
 }
@@ -89,7 +95,7 @@ resource "kubernetes_service_account" "metrics" {
   }
 }
 
-resource "kubernetes_api_service" "metrics" {
+resource "kubernetes_api_service_v1" "metrics" {
   metadata {
     name = "v1beta1.metrics.k8s.io"
   }
@@ -140,8 +146,26 @@ resource "kubernetes_deployment" "metrics" {
 
         container {
           name              = "metrics-server"
-          image             = "k8s.gcr.io/metrics-server/metrics-server:v0.3.7"
+          image             = "k8s.gcr.io/metrics-server/metrics-server:v0.6.1"
           image_pull_policy = "IfNotPresent"
+          args = [
+            "--cert-dir=/tmp",
+            "--secure-port=10250",
+            "--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname",
+            "--kubelet-use-node-status-port",
+            "--metric-resolution=15s"
+          ]
+
+          security_context {
+            run_as_non_root            = true
+            run_as_user                = 1000
+          }
+
+          port {
+            name           = "https"
+            container_port = 10250
+            protocol       = "TCP"
+          }
 
           volume_mount {
             name       = "tmp-dir"
@@ -177,7 +201,7 @@ resource "kubernetes_service" "metrics" {
     port {
       port        = 443
       protocol    = "TCP"
-      target_port = 443
+      target_port = "https"
     }
   }
 }

--- a/terraform/rack/do/registry.tf
+++ b/terraform/rack/do/registry.tf
@@ -167,7 +167,7 @@ resource "kubernetes_service" "registry" {
     }
   }
 }
-resource "kubernetes_ingress" "registry" {
+resource "kubernetes_ingress_v1" "registry" {
   wait_for_load_balancer = true
 
   metadata {
@@ -176,7 +176,6 @@ resource "kubernetes_ingress" "registry" {
 
     annotations = {
       "cert-manager.io/cluster-issuer" = "letsencrypt"
-      "kubernetes.io/ingress.class"    = "nginx"
     }
 
     labels = {
@@ -186,6 +185,7 @@ resource "kubernetes_ingress" "registry" {
   }
 
   spec {
+    ingress_class_name = "nginx"
     tls {
       hosts       = ["registry.${module.router.endpoint}"]
       secret_name = "registry-certificate"
@@ -197,8 +197,12 @@ resource "kubernetes_ingress" "registry" {
       http {
         path {
           backend {
-            service_name = kubernetes_service.registry.metadata.0.name
-            service_port = 80
+            service {
+              name = kubernetes_service.registry.metadata.0.name
+              port {
+                number = 80
+              }
+            }
           }
         }
       }

--- a/terraform/rack/local/registry.tf
+++ b/terraform/rack/local/registry.tf
@@ -156,7 +156,9 @@ resource "kubernetes_ingress_v1" "registry" {
           backend {
             service {
               name = kubernetes_service.registry.metadata.0.name
-              port = 80
+              port {
+                number = 80
+              }
             }
           }
         }

--- a/terraform/rack/local/registry.tf
+++ b/terraform/rack/local/registry.tf
@@ -123,7 +123,7 @@ resource "kubernetes_service" "registry" {
   }
 }
 
-resource "kubernetes_ingress" "registry" {
+resource "kubernetes_ingress_v1" "registry" {
   wait_for_load_balancer = true
 
   metadata {
@@ -133,7 +133,6 @@ resource "kubernetes_ingress" "registry" {
     annotations = {
       "cert-manager.io/cluster-issuer" = "self-signed"
       "convox.com/idles"               = "true"
-      "kubernetes.io/ingress.class"    = "nginx"
     }
 
     labels = {
@@ -143,6 +142,7 @@ resource "kubernetes_ingress" "registry" {
   }
 
   spec {
+    ingress_class_name = "nginx"
     tls {
       hosts       = ["registry.${module.router.endpoint}"]
       secret_name = "registry-certificate"
@@ -154,8 +154,10 @@ resource "kubernetes_ingress" "registry" {
       http {
         path {
           backend {
-            service_name = kubernetes_service.registry.metadata.0.name
-            service_port = 80
+            service {
+              name = kubernetes_service.registry.metadata.0.name
+              port = 80
+            }
           }
         }
       }

--- a/terraform/rack/metal/registry.tf
+++ b/terraform/rack/metal/registry.tf
@@ -126,7 +126,7 @@ resource "kubernetes_service" "registry" {
   }
 }
 
-resource "kubernetes_ingress" "registry" {
+resource "kubernetes_ingress_v1" "registry" {
   wait_for_load_balancer = true
 
   metadata {
@@ -135,7 +135,6 @@ resource "kubernetes_ingress" "registry" {
 
     annotations = {
       "cert-manager.io/cluster-issuer" = "self-signed"
-      "kubernetes.io/ingress.class"    = "nginx"
     }
 
     labels = {
@@ -145,6 +144,7 @@ resource "kubernetes_ingress" "registry" {
   }
 
   spec {
+    ingress_class_name = "nginx"
     tls {
       hosts       = ["registry.${local.endpoint}"]
       secret_name = "registry-certificate"
@@ -156,8 +156,10 @@ resource "kubernetes_ingress" "registry" {
       http {
         path {
           backend {
-            service_name = kubernetes_service.registry.metadata.0.name
-            service_port = 80
+            service {
+              name = kubernetes_service.registry.metadata.0.name
+              port = 80
+            }
           }
         }
       }

--- a/terraform/rack/metal/registry.tf
+++ b/terraform/rack/metal/registry.tf
@@ -158,7 +158,9 @@ resource "kubernetes_ingress_v1" "registry" {
           backend {
             service {
               name = kubernetes_service.registry.metadata.0.name
-              port = 80
+              port {
+                number = 80
+              }
             }
           }
         }

--- a/terraform/router/nginx/main.tf
+++ b/terraform/router/nginx/main.tf
@@ -241,15 +241,6 @@ resource "kubernetes_deployment" "ingress-nginx" {
             "--ingress-class=nginx",
           ]
 
-          security_context {
-            allow_privilege_escalation = true
-            capabilities {
-              drop = ["ALL"]
-              add  = ["NET_BIND_SERVICE"]
-            }
-            run_as_user = var.nginx_user
-          }
-
           env {
             name = "POD_NAME"
             value_from {


### PR DESCRIPTION
### What is the feature/fix?

This will update some k8s deprecated ingress resources we use in terraform and also update the metrics server deployment.
I also made some tweaks on the nginx deployment as the current config has some [known](https://github.com/kubernetes/ingress-nginx/issues/4061#issuecomment-1118439600) bugs.

### Add screenshot or video (optional)

** Any screenshot or video capture using the feature **

### Does it has a breaking change?

Nope

### How to use/test it?

The current e2e tests should cover it, as it communicated with the API server.

### Checklist
- [X] New coverage tests - not needed, it's a simple tf change
- [X] Unit tests passing
- [X] E2E tests passing
- [X] E2E downgrade/update test passing
- [ ] Documentation updated
- [X] No warnings or errors on Deepsource/Codecov
