### PR TITLE
Return only the suffix for additional credential

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -96,6 +96,12 @@ convox exec -a httpd $ps -- env | grep "ONE_PASS="
 convox exec -a httpd $ps -- env | grep "ONE_HOST="
 convox exec -a httpd $ps -- env | grep "ONE_PORT="
 convox exec -a httpd $ps -- env | grep "ONE_NAME="
+convox exec -a httpd $ps -- env | grep "MY_DB_URL="
+convox exec -a httpd $ps -- env | grep "MY_DB_USER="
+convox exec -a httpd $ps -- env | grep "MY_DB_PASS="
+convox exec -a httpd $ps -- env | grep "MY_DB_HOST="
+convox exec -a httpd $ps -- env | grep "MY_DB_PORT="
+convox exec -a httpd $ps -- env | grep "MY_DB_NAME="
 
 # test apps cancel
 echo "FOO=not-bar" | convox env set -a httpd

--- a/examples/httpd/convox.yml
+++ b/examples/httpd/convox.yml
@@ -1,6 +1,8 @@
 resources:
   one:
     type: postgres
+  my-db:
+    type: postgres
   postgresdb:
     type: postgres
   rediscache:
@@ -26,6 +28,7 @@ services:
       - mysqldb:MYSQL_URL
       - mariadb:MARIA_URL
       - one
+      - my-db
 timers:
   example:
     command: /usr/scripts/timer_cmd.sh

--- a/provider/k8s/process.go
+++ b/provider/k8s/process.go
@@ -428,7 +428,8 @@ func (p *Provider) podSpecFromService(app, service, release string) (*ac.PodSpec
 			c.Image = fmt.Sprintf("%s:%s.%s", repo, service, r.Build)
 
 			for _, r := range s.ResourceMap() {
-				key := strings.Join(strings.Split(r.Env, "_")[1:], "_")
+				parts := strings.Split(r.Env, "_")
+				key := parts[len(parts)-1]
 				c.Env = append(c.Env, ac.EnvVar{
 					Name: r.Env,
 					ValueFrom: &ac.EnvVarSource{

--- a/provider/k8s/template.go
+++ b/provider/k8s/template.go
@@ -83,7 +83,8 @@ func (p *Provider) templateHelpers() template.FuncMap {
 			return nameFilter(s)
 		},
 		"resourceEnv": func(s string) string {
-			return strings.Join(strings.Split(s, "_")[1:], "_")
+			parts := strings.Split(s, "_")
+			return parts[len(parts)-1]
 		},
 		"lower": func(s string) string {
 			return strings.ToLower(s)


### PR DESCRIPTION
### What is the feature/fix?

Fix multi-name resources, it will return only the additional env var suffix. As described [here](https://github.com/convox/convox/pull/481#discussion_r1008209750), apps linking to resources with multi-part names are failing to boot because it's referencing the wrong data in the ConfigMap. It will get only the `URL`, `USER`, `PASS`, ...

### Does it has a breaking change?

No, it's a fix.

### How to use/test it?

1. On a V3 rack, deploy an app with a service linking to a multi-part name resource:

```
resources:
  primary-database:
    type: postgres
    options:
      storage: 10
services:
  web:
    build: .
    port: 3000
    resources:
      - primary-database
```

### Checklist
- [x] New coverage tests
- [x] Unit tests passing
- [x] E2E tests passing
- [ ] E2E downgrade/update test passing
- [x] Documentation updated
- [x] No warnings or errors on Deepsource/Codecov
