### PR TITLE
K8s 1.22 update preparation

### DIFF
--- a/terraform/api/aws/main.tf
+++ b/terraform/api/aws/main.tf
@@ -29,7 +29,6 @@ module "k8s" {
     "cert-manager.io/cluster-issuer" = "letsencrypt"
     "eks.amazonaws.com/role-arn"     = aws_iam_role.api.arn
     "iam.amazonaws.com/role"         = aws_iam_role.api.arn
-    "kubernetes.io/ingress.class"    = "nginx"
   }
 
   env = {

--- a/terraform/api/do/main.tf
+++ b/terraform/api/do/main.tf
@@ -49,7 +49,6 @@ module "k8s" {
 
   annotations = {
     "cert-manager.io/cluster-issuer" = "letsencrypt"
-    "kubernetes.io/ingress.class"    = "nginx"
   }
 
   env = {

--- a/terraform/api/k8s/main.tf
+++ b/terraform/api/k8s/main.tf
@@ -268,7 +268,7 @@ resource "kubernetes_service" "api" {
   }
 }
 
-resource "kubernetes_ingress" "api" {
+resource "kubernetes_ingress_v1" "api" {
   wait_for_load_balancer = true
 
   metadata {
@@ -289,6 +289,7 @@ resource "kubernetes_ingress" "api" {
   }
 
   spec {
+    ingress_class_name = "nginx"
     tls {
       hosts       = ["api.${var.domain}"]
       secret_name = "api-certificate"
@@ -300,8 +301,12 @@ resource "kubernetes_ingress" "api" {
       http {
         path {
           backend {
-            service_name = kubernetes_service.api.metadata.0.name
-            service_port = 5443
+            service {
+              name = kubernetes_service.api.metadata.0.name
+              port {
+                number = 5443
+              }
+            }
           }
         }
       }
@@ -309,7 +314,7 @@ resource "kubernetes_ingress" "api" {
   }
 }
 
-resource "kubernetes_ingress" "kubernetes" {
+resource "kubernetes_ingress_v1" "kubernetes" {
   wait_for_load_balancer = true
 
   metadata {
@@ -327,6 +332,7 @@ resource "kubernetes_ingress" "kubernetes" {
   }
 
   spec {
+    ingress_class_name = "nginx"
     tls {
       hosts       = ["api.${var.domain}"]
       secret_name = "api-certificate"
@@ -340,8 +346,12 @@ resource "kubernetes_ingress" "kubernetes" {
           path = "/kubernetes/.*"
 
           backend {
-            service_name = kubernetes_service.api.metadata.0.name
-            service_port = 8001
+            service {
+              name = kubernetes_service.api.metadata.0.name
+              port {
+                number = 8001
+              }
+            }
           }
         }
       }

--- a/terraform/api/k8s/main.tf
+++ b/terraform/api/k8s/main.tf
@@ -273,7 +273,7 @@ resource "kubernetes_ingress_v1" "api" {
 
   metadata {
     namespace = var.namespace
-    name      = "api"
+    name      = "api-ing-v1"
 
     annotations = merge({
       "convox.com/backend-protocol" : "https",
@@ -319,7 +319,7 @@ resource "kubernetes_ingress_v1" "kubernetes" {
 
   metadata {
     namespace = var.namespace
-    name      = "kubernetes"
+    name      = "kubernetes-ing-v1"
 
     annotations = merge({
       "nginx.ingress.kubernetes.io/use-regex" : "true",

--- a/terraform/api/k8s/main.tf
+++ b/terraform/api/k8s/main.tf
@@ -302,7 +302,7 @@ resource "kubernetes_ingress_v1" "api" {
         path {
           backend {
             service {
-              name = kubernetes_service.api.metadata.0.name
+              name = kubernetes_service.api.metadata[0].name
               port {
                 number = 5443
               }
@@ -347,7 +347,7 @@ resource "kubernetes_ingress_v1" "kubernetes" {
 
           backend {
             service {
-              name = kubernetes_service.api.metadata.0.name
+              name = kubernetes_service.api.metadata[0].name
               port {
                 number = 8001
               }

--- a/terraform/api/local/main.tf
+++ b/terraform/api/local/main.tf
@@ -25,7 +25,6 @@ module "k8s" {
   annotations = {
     "cert-manager.io/cluster-issuer" = "self-signed"
     "convox.com/idles"               = "true"
-    "kubernetes.io/ingress.class"    = "nginx"
   }
 
   env = {

--- a/terraform/api/metal/main.tf
+++ b/terraform/api/metal/main.tf
@@ -46,7 +46,6 @@ module "k8s" {
 
   annotations = {
     "cert-manager.io/cluster-issuer" = "self-signed"
-    "kubernetes.io/ingress.class"    = "nginx"
   }
 
   env = {

--- a/terraform/cluster/aws/kubeconfig.tpl
+++ b/terraform/cluster/aws/kubeconfig.tpl
@@ -16,7 +16,7 @@ users:
 - name: aws
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
+      apiVersion: client.authentication.k8s.io/v1
       command: aws
       args:
         - "eks"

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -150,14 +150,21 @@ module "ebs_csi_driver_controller" {
     null_resource.wait_k8s_api
   ]
 
-  source  = "DrFaust92/ebs-csi-driver/kubernetes"
-  version = "3.3.1"
+  source  = "github.com/convox/terraform-kubernetes-ebs-csi-driver?ref=48f5650f72684b581697f8831b3f5b60ea624092"
 
   ebs_csi_controller_image                   = "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver"
   ebs_csi_driver_version                     = "v1.9.0"
   ebs_csi_controller_role_name               = "convox-ebs-csi-driver-controller"
   ebs_csi_controller_role_policy_name_prefix = "convox-ebs-csi-driver-policy"
-  oidc_url                                   = aws_iam_openid_connect_provider.cluster.url
+  csi_controller_tolerations = [
+    { operator = "Exists", key = "CriticalAddonsOnly" },
+    { operator = "Exists", effect = "NoExecute", toleration_seconds = 300 }
+  ]
+  node_tolerations = [
+    { operator = "Exists", key = "CriticalAddonsOnly" },
+    { operator = "Exists", effect = "NoExecute", toleration_seconds = 300 }
+  ]
+  oidc_url = aws_iam_openid_connect_provider.cluster.url
 }
 
 resource "kubernetes_storage_class" "default" {

--- a/terraform/rack/do/registry.tf
+++ b/terraform/rack/do/registry.tf
@@ -167,7 +167,7 @@ resource "kubernetes_service" "registry" {
     }
   }
 }
-resource "kubernetes_ingress" "registry" {
+resource "kubernetes_ingress_v1" "registry" {
   wait_for_load_balancer = true
 
   metadata {
@@ -176,7 +176,6 @@ resource "kubernetes_ingress" "registry" {
 
     annotations = {
       "cert-manager.io/cluster-issuer" = "letsencrypt"
-      "kubernetes.io/ingress.class"    = "nginx"
     }
 
     labels = {
@@ -186,6 +185,7 @@ resource "kubernetes_ingress" "registry" {
   }
 
   spec {
+    ingress_class_name = "nginx"
     tls {
       hosts       = ["registry.${module.router.endpoint}"]
       secret_name = "registry-certificate"
@@ -197,8 +197,12 @@ resource "kubernetes_ingress" "registry" {
       http {
         path {
           backend {
-            service_name = kubernetes_service.registry.metadata.0.name
-            service_port = 80
+            service {
+              name = kubernetes_service.registry.metadata.0.name
+              port {
+                number = 80
+              }
+            }
           }
         }
       }

--- a/terraform/rack/local/registry.tf
+++ b/terraform/rack/local/registry.tf
@@ -123,7 +123,7 @@ resource "kubernetes_service" "registry" {
   }
 }
 
-resource "kubernetes_ingress" "registry" {
+resource "kubernetes_ingress_v1" "registry" {
   wait_for_load_balancer = true
 
   metadata {
@@ -133,7 +133,6 @@ resource "kubernetes_ingress" "registry" {
     annotations = {
       "cert-manager.io/cluster-issuer" = "self-signed"
       "convox.com/idles"               = "true"
-      "kubernetes.io/ingress.class"    = "nginx"
     }
 
     labels = {
@@ -143,6 +142,7 @@ resource "kubernetes_ingress" "registry" {
   }
 
   spec {
+    ingress_class_name = "nginx"
     tls {
       hosts       = ["registry.${module.router.endpoint}"]
       secret_name = "registry-certificate"
@@ -154,8 +154,12 @@ resource "kubernetes_ingress" "registry" {
       http {
         path {
           backend {
-            service_name = kubernetes_service.registry.metadata.0.name
-            service_port = 80
+            service {
+              name = kubernetes_service.registry.metadata.0.name
+              port {
+                number = 80
+              }
+            }
           }
         }
       }

--- a/terraform/rack/metal/registry.tf
+++ b/terraform/rack/metal/registry.tf
@@ -126,7 +126,7 @@ resource "kubernetes_service" "registry" {
   }
 }
 
-resource "kubernetes_ingress" "registry" {
+resource "kubernetes_ingress_v1" "registry" {
   wait_for_load_balancer = true
 
   metadata {
@@ -135,7 +135,6 @@ resource "kubernetes_ingress" "registry" {
 
     annotations = {
       "cert-manager.io/cluster-issuer" = "self-signed"
-      "kubernetes.io/ingress.class"    = "nginx"
     }
 
     labels = {
@@ -145,6 +144,7 @@ resource "kubernetes_ingress" "registry" {
   }
 
   spec {
+    ingress_class_name = "nginx"
     tls {
       hosts       = ["registry.${local.endpoint}"]
       secret_name = "registry-certificate"
@@ -156,8 +156,12 @@ resource "kubernetes_ingress" "registry" {
       http {
         path {
           backend {
-            service_name = kubernetes_service.registry.metadata.0.name
-            service_port = 80
+            service {
+              name = kubernetes_service.registry.metadata.0.name
+              port {
+                number = 80
+              }
+            }
           }
         }
       }

--- a/terraform/router/nginx/main.tf
+++ b/terraform/router/nginx/main.tf
@@ -241,15 +241,6 @@ resource "kubernetes_deployment" "ingress-nginx" {
             "--ingress-class=nginx",
           ]
 
-          security_context {
-            allow_privilege_escalation = true
-            capabilities {
-              drop = ["ALL"]
-              add  = ["NET_BIND_SERVICE"]
-            }
-            run_as_user = var.nginx_user
-          }
-
           env {
             name = "POD_NAME"
             value_from {


### PR DESCRIPTION
### What is the feature/fix?

Adding back the ingress changes + CSI taints.
Also changing the ingress names as terraform was hanging to delete the old ones and I suspect it was because the new and old resources had the same names.

### Add screenshot or video (optional)

** Any screenshot or video capture using the feature **

### Does it has a breaking change?

No, but I will release this under a minor release as it's a required change before updating to k8s 1.22

### How to use/test it?

N/A

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
