### PR TITLE
Use indirect depends_on EKS Cluster to avoid error cycle

### DIFF
--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -46,7 +46,6 @@ resource "null_resource" "wait_k8s_api" {
   depends_on = [
     aws_eks_cluster.cluster
   ]
-
 }
 
 resource "aws_eks_cluster" "cluster" {
@@ -118,6 +117,16 @@ resource "aws_eks_node_group" "cluster" {
     create_before_destroy = true
     ignore_changes        = [scaling_config[0].desired_size]
   }
+}
+
+resource "null_resource" "wait_k8s_cluster" {
+  provisioner "local-exec" {
+    command = "sleep 10"
+  }
+
+  depends_on = [
+    aws_eks_node_group.cluster
+  ]
 }
 
 resource "local_file" "kubeconfig" {

--- a/terraform/cluster/aws/outputs.tf
+++ b/terraform/cluster/aws/outputs.tf
@@ -1,5 +1,7 @@
+# ALL depends_on are required in order of kubernetes provider to work
+# DO NOT remove depends_on tag
 output "ca" {
-  depends_on = [aws_eks_node_group.cluster]
+  depends_on = [null_resource.wait_k8s_cluster]
   value      = base64decode(aws_eks_cluster.cluster.certificate_authority.0.data)
 }
 
@@ -8,22 +10,22 @@ output "ebs_csi_driver_name" {
 }
 
 output "endpoint" {
-  depends_on = [aws_eks_node_group.cluster]
+  depends_on = [null_resource.wait_k8s_cluster]
   value      = aws_eks_cluster.cluster.endpoint
 }
 
 output "id" {
-  depends_on = [aws_eks_node_group.cluster]
+  depends_on = [null_resource.wait_k8s_cluster]
   value      = aws_eks_cluster.cluster.id
 }
 
 output "oidc_arn" {
-  depends_on = [aws_eks_node_group.cluster]
+  depends_on = [null_resource.wait_k8s_cluster]
   value      = aws_iam_openid_connect_provider.cluster.arn
 }
 
 output "oidc_sub" {
-  depends_on = [aws_eks_node_group.cluster]
+  depends_on = [null_resource.wait_k8s_cluster]
   value      = local.oidc_sub
 }
 

--- a/terraform/cluster/azure/main.tf
+++ b/terraform/cluster/azure/main.tf
@@ -64,10 +64,10 @@ resource "local_file" "kubeconfig" {
 
   filename = pathexpand("~/.kube/config.azure.${var.name}")
   content = templatefile("${path.module}/kubeconfig.tpl", {
-    ca                 = azurerm_kubernetes_cluster.rack.kube_config.0.cluster_ca_certificate
-    endpoint           = azurerm_kubernetes_cluster.rack.kube_config.0.host
-    client_certificate = azurerm_kubernetes_cluster.rack.kube_config.0.client_certificate
-    client_key         = azurerm_kubernetes_cluster.rack.kube_config.0.client_key
+    ca                 = azurerm_kubernetes_cluster.rack.kube_config[0].cluster_ca_certificate
+    endpoint           = azurerm_kubernetes_cluster.rack.kube_config[0].host
+    client_certificate = azurerm_kubernetes_cluster.rack.kube_config[0].client_certificate
+    client_key         = azurerm_kubernetes_cluster.rack.kube_config[0].client_key
   })
 
   lifecycle {

--- a/terraform/cluster/azure/outputs.tf
+++ b/terraform/cluster/azure/outputs.tf
@@ -1,17 +1,17 @@
 output "ca" {
-  value = base64decode(azurerm_kubernetes_cluster.rack.kube_config.0.cluster_ca_certificate)
+  value = base64decode(azurerm_kubernetes_cluster.rack.kube_config[0].cluster_ca_certificate)
 }
 
 output "client_certificate" {
-  value = base64decode(azurerm_kubernetes_cluster.rack.kube_config.0.client_certificate)
+  value = base64decode(azurerm_kubernetes_cluster.rack.kube_config[0].client_certificate)
 }
 
 output "client_key" {
-  value = base64decode(azurerm_kubernetes_cluster.rack.kube_config.0.client_key)
+  value = base64decode(azurerm_kubernetes_cluster.rack.kube_config[0].client_key)
 }
 
 output "endpoint" {
-  value = azurerm_kubernetes_cluster.rack.kube_config.0.host
+  value = azurerm_kubernetes_cluster.rack.kube_config[0].host
 }
 
 output "id" {

--- a/terraform/cluster/azure/outputs.tf
+++ b/terraform/cluster/azure/outputs.tf
@@ -1,26 +1,21 @@
 output "ca" {
-  depends_on = [azurerm_kubernetes_cluster.rack]
-  value      = base64decode(azurerm_kubernetes_cluster.rack.kube_config.0.cluster_ca_certificate)
+  value = base64decode(azurerm_kubernetes_cluster.rack.kube_config.0.cluster_ca_certificate)
 }
 
 output "client_certificate" {
-  depends_on = [azurerm_kubernetes_cluster.rack]
-  value      = base64decode(azurerm_kubernetes_cluster.rack.kube_config.0.client_certificate)
+  value = base64decode(azurerm_kubernetes_cluster.rack.kube_config.0.client_certificate)
 }
 
 output "client_key" {
-  depends_on = [azurerm_kubernetes_cluster.rack]
-  value      = base64decode(azurerm_kubernetes_cluster.rack.kube_config.0.client_key)
+  value = base64decode(azurerm_kubernetes_cluster.rack.kube_config.0.client_key)
 }
 
 output "endpoint" {
-  depends_on = [azurerm_kubernetes_cluster.rack]
-  value      = azurerm_kubernetes_cluster.rack.kube_config.0.host
+  value = azurerm_kubernetes_cluster.rack.kube_config.0.host
 }
 
 output "id" {
-  depends_on = [azurerm_kubernetes_cluster.rack]
-  value      = azurerm_kubernetes_cluster.rack.name
+  value = azurerm_kubernetes_cluster.rack.name
 }
 
 output "workspace" {

--- a/terraform/cluster/do/outputs.tf
+++ b/terraform/cluster/do/outputs.tf
@@ -1,24 +1,19 @@
 output "ca" {
-  depends_on = [digitalocean_kubernetes_cluster.rack]
-  value      = base64decode(digitalocean_kubernetes_cluster.rack.kube_config[0].cluster_ca_certificate)
+  value = base64decode(digitalocean_kubernetes_cluster.rack.kube_config[0].cluster_ca_certificate)
 }
 
 output "endpoint" {
-  depends_on = [digitalocean_kubernetes_cluster.rack]
-  value      = digitalocean_kubernetes_cluster.rack.endpoint
+  value = digitalocean_kubernetes_cluster.rack.endpoint
 }
 
 output "id" {
-  depends_on = [digitalocean_kubernetes_cluster.rack]
-  value      = digitalocean_kubernetes_cluster.rack.id
+  value = digitalocean_kubernetes_cluster.rack.id
 }
 
 output "name" {
-  depends_on = [digitalocean_kubernetes_cluster.rack]
-  value      = digitalocean_kubernetes_cluster.rack.name
+  value = digitalocean_kubernetes_cluster.rack.name
 }
 
 output "token" {
-  depends_on = [digitalocean_kubernetes_cluster.rack, null_resource.delay_token]
-  value      = digitalocean_kubernetes_cluster.rack.kube_config[0].token
+  value = digitalocean_kubernetes_cluster.rack.kube_config[0].token
 }

--- a/terraform/cluster/do/outputs.tf
+++ b/terraform/cluster/do/outputs.tf
@@ -15,5 +15,6 @@ output "name" {
 }
 
 output "token" {
-  value = digitalocean_kubernetes_cluster.rack.kube_config[0].token
+  depends_on = [null_resource.delay_token]
+  value      = digitalocean_kubernetes_cluster.rack.kube_config[0].token
 }

--- a/terraform/cluster/gcp/outputs.tf
+++ b/terraform/cluster/gcp/outputs.tf
@@ -3,7 +3,7 @@ output "ca" {
     google_container_node_pool.rack,
     kubernetes_cluster_role_binding.client,
   ]
-  value = base64decode(google_container_cluster.rack.master_auth.0.cluster_ca_certificate)
+  value = base64decode(google_container_cluster.rack.master_auth[0].cluster_ca_certificate)
 }
 
 output "client_certificate" {
@@ -11,7 +11,7 @@ output "client_certificate" {
     google_container_node_pool.rack,
     kubernetes_cluster_role_binding.client,
   ]
-  value = base64decode(google_container_cluster.rack.master_auth.0.client_certificate)
+  value = base64decode(google_container_cluster.rack.master_auth[0].client_certificate)
 }
 
 output "client_key" {
@@ -19,7 +19,7 @@ output "client_key" {
     google_container_node_pool.rack,
     kubernetes_cluster_role_binding.client,
   ]
-  value = base64decode(google_container_cluster.rack.master_auth.0.client_key)
+  value = base64decode(google_container_cluster.rack.master_auth[0].client_key)
 }
 
 output "endpoint" {

--- a/terraform/cluster/gcp/outputs.tf
+++ b/terraform/cluster/gcp/outputs.tf
@@ -1,6 +1,5 @@
 output "ca" {
   depends_on = [
-    google_container_cluster.rack,
     google_container_node_pool.rack,
     kubernetes_cluster_role_binding.client,
   ]
@@ -9,7 +8,6 @@ output "ca" {
 
 output "client_certificate" {
   depends_on = [
-    google_container_cluster.rack,
     google_container_node_pool.rack,
     kubernetes_cluster_role_binding.client,
   ]
@@ -18,7 +16,6 @@ output "client_certificate" {
 
 output "client_key" {
   depends_on = [
-    google_container_cluster.rack,
     google_container_node_pool.rack,
     kubernetes_cluster_role_binding.client,
   ]
@@ -27,7 +24,6 @@ output "client_key" {
 
 output "endpoint" {
   depends_on = [
-    google_container_cluster.rack,
     google_container_node_pool.rack,
     kubernetes_cluster_role_binding.client,
   ]
@@ -36,7 +32,6 @@ output "endpoint" {
 
 output "id" {
   depends_on = [
-    google_container_cluster.rack,
     google_container_node_pool.rack,
     kubernetes_cluster_role_binding.client,
   ]


### PR DESCRIPTION
### What is the feature/fix?

The `depends_on` flag in the outputs from the cluster module is causing the dependency cycle. Although `depends_on` on outputs should be avoided it's needed to avoid timeout errors when creating the kubernetes_services/kubernetes_ingress.

> The depends_on argument should be used only as a last resort. When using it, always include a comment explaining why it is being used, to help future maintainers understand the purpose of the additional dependency.

See [documentation](https://developer.hashicorp.com/terraform/language/values/outputs#depends_on-explicit-output-dependencies).

### Does it has a breaking change?

No.

### How to use/test it?

You'd need changes on any Kubernetes resources to test it.

### Checklist
- [x] ~~New coverage tests~~
- [x] Unit tests passing
- [x] E2E tests passing
- [ ] E2E downgrade/update test passing
- [x] ~~Documentation updated~~
- [x] No warnings or errors on Deepsource/Codecov
