### PR TITLE
Feat-692: Add custom tags support for v3

### DIFF
--- a/docs/installation/production-rack/aws.md
+++ b/docs/installation/production-rack/aws.md
@@ -58,6 +58,7 @@ The following environment variables are required:
 | **proxy_protocol**       | **false**               | Enable proxy protocol. With this parameter set, the client source ip will be available in the request header `x-forwarded-for` key. **Requires 5 - 10 minutes downtime**.          |
 | **region**               | **us-east-1**          | AWS Region                                                                                                     |
 | **syslog**               |                        | Forward logs to a syslog endpoint (e.g. **tcp+tls://example.org:1234**)                                        |
+| **tags**                 |                        | Custom tags to add with AWS resources (e.g. **key1=val1,key2=val2**)|
 | **vpc_id** *             |                        | Use an existing VPC for cluster creation. Make sure to also pass the **cidr** block and **internet_gateway_id**|
 
 \* To avoid CIDR block collision with existing VPC subnets, please add a new CIDR block to your VPC to separate rack resources. Also, remember to pass the **internet_gateway_id** attached to the VPC. If the VPC doesn't have an IG attached, the rack installation will create one automatically, which will also be destroyed if you delete the rack.

--- a/docs/management/cli-rack-management.md
+++ b/docs/management/cli-rack-management.md
@@ -48,6 +48,7 @@ The parameters available for your Rack depend on the underlying cloud provider.
 | **high_availability** *           | **true**        |
 | **proxy_protocol** **             | **false**       |
 | **vpc_id** ***                    |                 |
+| **tags**                          |                 |
 
 \* Parameter cannot be changed after rack creation
 

--- a/docs/management/console-rack-management.md
+++ b/docs/management/console-rack-management.md
@@ -125,7 +125,7 @@ data:
 ### `Warning`
 When you edit the `aws-auth` ConfigMap, proceed with caution, if you misconfigure it, you can lock the user out of their rack.
 
-### Console Ract Metrics
+### Console Rack Metrics
 
 Rack cpu and memory usages metrics support added from version `3.6.3`. So If your rack version is >= `3.6.3`, you'll be able to visualize resource consumption for your rack nodes and workloads.
 

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -104,6 +104,16 @@ func validateParams(params map[string]string) error {
 		return errors.New("to schedule your rack to turn on/off you need both ScheduleRackScaleDown and ScheduleRackScaleUp parameters")
 	}
 
+	// format: "key1=val1,key2=val2"
+	if tags, has := params["tags"]; has {
+		tList := strings.Split(tags, ",")
+		for _, p := range tList {
+			if len(strings.Split(p, "=")) != 2 {
+				return errors.New("invalid value for tags param")
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/terraform/cluster/aws/network.tf
+++ b/terraform/cluster/aws/network.tf
@@ -1,8 +1,9 @@
 locals {
   internet_gateway_id = var.internet_gateway_id == "" ? aws_internet_gateway.nodes[0].id : var.internet_gateway_id
-  tags = {
+  tags = merge(var.tags, {
     Name = var.name
-  }
+    Rack = var.name
+  })
   vpc_id = var.vpc_id == "" ? aws_vpc.nodes[0].id : var.vpc_id
 }
 

--- a/terraform/cluster/aws/variables.tf
+++ b/terraform/cluster/aws/variables.tf
@@ -51,6 +51,10 @@ variable "private" {
   default = true
 }
 
+variable "tags" {
+  default = {}
+}
+
 variable "vpc_id" {
   default = ""
 }

--- a/terraform/rack/aws/main.tf
+++ b/terraform/rack/aws/main.tf
@@ -75,5 +75,6 @@ module "router" {
   oidc_sub          = var.oidc_sub
   proxy_protocol    = var.proxy_protocol
   release           = var.release
+  tags              = var.tags
   whitelist         = var.whitelist
 }

--- a/terraform/rack/aws/variables.tf
+++ b/terraform/rack/aws/variables.tf
@@ -46,6 +46,10 @@ variable "release" {
   type = string
 }
 
+variable "tags" {
+  default = {}
+}
+
 variable "subnets" {
   type = list
 }

--- a/terraform/router/aws/main.tf
+++ b/terraform/router/aws/main.tf
@@ -1,8 +1,8 @@
 locals {
-  tags = {
+  tags = merge(var.tags, {
     System = "convox"
     Rack   = var.name
-  }
+  })
 }
 
 data "aws_region" "current" {
@@ -60,8 +60,9 @@ resource "kubernetes_service" "router" {
     name      = "router"
 
     annotations = {
-      "service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout" = "${var.idle_timeout}"
-      "service.beta.kubernetes.io/aws-load-balancer-type"                    = "nlb"
+      "service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout"  = "${var.idle_timeout}"
+      "service.beta.kubernetes.io/aws-load-balancer-type"                     = "nlb"
+      "service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags" = join(",", [for key, value in local.tags : "${key}=${value}"])
     }
   }
 

--- a/terraform/router/aws/variables.tf
+++ b/terraform/router/aws/variables.tf
@@ -34,6 +34,10 @@ variable "release" {
   type = string
 }
 
+variable "tags" {
+  default = {}
+}
+
 variable "whitelist" {
   default = ["0.0.0.0/0"]
 }

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -32,6 +32,10 @@ locals {
   gpu_type  = substr(local.node_type, 0, 1) == "g" || substr(local.node_type, 0, 1) == "p"
   image     = var.image
   release   = local.arm_type ? format("%s-%s", coalesce(var.release, local.current), "arm64") : coalesce(var.release, local.current)
+  tag_map   = length(var.tags) == 0 ? {} : {
+    for v in split(",", var.tags):
+      "${split("=", v)[0]}" => split("=", v)[1]
+  }
 }
 
 module "cluster" {
@@ -54,6 +58,7 @@ module "cluster" {
   node_disk           = var.node_disk
   node_type           = var.node_type
   private             = var.private
+  tags                = local.tag_map
   vpc_id              = var.vpc_id
 }
 
@@ -94,6 +99,7 @@ module "rack" {
   proxy_protocol      = var.proxy_protocol
   release             = local.release
   subnets             = module.cluster.subnets
+  tags                = local.tag_map
   whitelist           = split(",", var.whitelist)
   ebs_csi_driver_name = module.cluster.ebs_csi_driver_name
 }

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -82,6 +82,10 @@ variable "syslog" {
   default = ""
 }
 
+variable "tags" {
+  default = ""
+}
+
 variable "vpc_id" {
   default = ""
 }


### PR DESCRIPTION
### What is the feature/fix?
https://github.com/convox/issues-private/issues/692

NLB doesn't updates the tags: https://github.com/kubernetes/cloud-provider-aws/issues/113

https://user-images.githubusercontent.com/12232198/200738462-6baed797-0393-486a-b9fe-2fee2dcf9d23.mp4

### Does it has a breaking change?
no, just adding tag

### How to use/test it?
- update or install rack of this branch
- `convox rack params set tags="key1=val1,key2=val2"`

### Checklist
- [ ] New coverage tests
- [x] Unit tests passing
- [x] E2E tests passing
- [ ] E2E downgrade/update test passing
- [x] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
