### PR TITLE
Fix resource URL mapping

### DIFF
--- a/provider/k8s/process.go
+++ b/provider/k8s/process.go
@@ -428,14 +428,12 @@ func (p *Provider) podSpecFromService(app, service, release string) (*ac.PodSpec
 			c.Image = fmt.Sprintf("%s:%s.%s", repo, service, r.Build)
 
 			for _, r := range s.ResourceMap() {
-				parts := strings.Split(r.Env, "_")
-				key := parts[len(parts)-1]
 				c.Env = append(c.Env, ac.EnvVar{
 					Name: r.Env,
 					ValueFrom: &ac.EnvVarSource{
 						ConfigMapKeyRef: &ac.ConfigMapKeySelector{
 							LocalObjectReference: ac.LocalObjectReference{Name: fmt.Sprintf("resource-%s", nameFilter(r.Name))},
-							Key:                  key,
+							Key:                  "URL",
 						},
 					},
 				})


### PR DESCRIPTION
We use a product called metabase and previously we could deploy this nice little convox.yml:

```yml
resources:
    database:
      type: postgres

services:
  metabase:
    image: metabase/metabase:v0.44.6
    environment:
      - JAVA_TOOL_OPTIONS=-Xmx1g
    port: 3000
    resources:
      - database:MB_DB_CONNECTION_URI
```

But after #481 it will not work anymore because it changed that the exposed env var from a resource from `URL` to whatever is at the end of the env var we want to map it to, in our example `URI`. 

I don't think that was intentional as the "contract" for a resource seemed to be that it exposes a `URL` env var.
