### PR TITLE
Fix resource custom link name

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -96,12 +96,7 @@ convox exec -a httpd $ps -- env | grep "ONE_PASS="
 convox exec -a httpd $ps -- env | grep "ONE_HOST="
 convox exec -a httpd $ps -- env | grep "ONE_PORT="
 convox exec -a httpd $ps -- env | grep "ONE_NAME="
-convox exec -a httpd $ps -- env | grep "MY_DB_URL="
-convox exec -a httpd $ps -- env | grep "MY_DB_USER="
-convox exec -a httpd $ps -- env | grep "MY_DB_PASS="
-convox exec -a httpd $ps -- env | grep "MY_DB_HOST="
-convox exec -a httpd $ps -- env | grep "MY_DB_PORT="
-convox exec -a httpd $ps -- env | grep "MY_DB_NAME="
+convox exec -a httpd $ps -- env | grep "CUSTOM_DATABASE="
 
 # test apps cancel
 echo "FOO=not-bar" | convox env set -a httpd

--- a/docs/reference/primitives/app/resource/README.md
+++ b/docs/reference/primitives/app/resource/README.md
@@ -40,7 +40,7 @@ The credential details will be stored in the environment variables, you can use 
 
 For example, a `postgres` resource named `main` (as in the example above) would injected like this:
 
-```
+```html
 MAIN_URL=postgres://username:password@host.name:port/database`
 MYDB_USER=username
 MYDB_PASS=password

--- a/examples/httpd/convox.yml
+++ b/examples/httpd/convox.yml
@@ -28,7 +28,7 @@ services:
       - mysqldb:MYSQL_URL
       - mariadb:MARIA_URL
       - one
-      - my-db
+      - my-db:CUSTOM_DATABASE
 timers:
   example:
     command: /usr/scripts/timer_cmd.sh

--- a/pkg/manifest/resource.go
+++ b/pkg/manifest/resource.go
@@ -5,6 +5,21 @@ import (
 	"strings"
 )
 
+const (
+	DEFAULT_RESOURCE_ENV_NAME = "URL"
+)
+
+var (
+	AdditionalEnvNames = []string{
+		DEFAULT_RESOURCE_ENV_NAME,
+		"USER",
+		"PASS",
+		"HOST",
+		"PORT",
+		"NAME",
+	}
+)
+
 type Resource struct {
 	Name    string            `yaml:"-"`
 	Type    string            `yaml:"type"`
@@ -18,14 +33,11 @@ func (r Resource) DefaultEnv() string {
 }
 
 func (r Resource) LoadEnv() []string {
-	return []string{
-		r.mountEnv("URL"),
-		r.mountEnv("USER"),
-		r.mountEnv("PASS"),
-		r.mountEnv("HOST"),
-		r.mountEnv("PORT"),
-		r.mountEnv("NAME"),
+	envs := []string{}
+	for _, e := range AdditionalEnvNames {
+		envs = append(envs, r.mountEnv(e))
 	}
+	return envs
 }
 
 func (r Resource) GetName() string {

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -185,6 +185,19 @@ type ServiceResource struct {
 	Env  string
 }
 
+func (sr ServiceResource) GetConfigMapKey() string {
+	parts := strings.Split(sr.Env, "_")
+	key := parts[len(parts)-1]
+
+	for _, en := range AdditionalEnvNames {
+		if key == en {
+			return key
+		}
+	}
+
+	return DEFAULT_RESOURCE_ENV_NAME
+}
+
 func (s Service) AnnotationsMap() map[string]string {
 	annotations := map[string]string{}
 

--- a/provider/k8s/process.go
+++ b/provider/k8s/process.go
@@ -428,8 +428,7 @@ func (p *Provider) podSpecFromService(app, service, release string) (*ac.PodSpec
 			c.Image = fmt.Sprintf("%s:%s.%s", repo, service, r.Build)
 
 			for _, r := range s.ResourceMap() {
-				parts := strings.Split(r.Env, "_")
-				key := parts[len(parts)-1]
+				key := r.GetConfigMapKey()
 				c.Env = append(c.Env, ac.EnvVar{
 					Name: r.Env,
 					ValueFrom: &ac.EnvVarSource{

--- a/provider/k8s/template.go
+++ b/provider/k8s/template.go
@@ -82,10 +82,6 @@ func (p *Provider) templateHelpers() template.FuncMap {
 		"k8sname": func(s string) string {
 			return nameFilter(s)
 		},
-		"resourceEnv": func(s string) string {
-			parts := strings.Split(s, "_")
-			return parts[len(parts)-1]
-		},
 		"lower": func(s string) string {
 			return strings.ToLower(s)
 		},

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -109,7 +109,7 @@ spec:
           valueFrom:
             configMapKeyRef:
               name: resource-{{ k8sname .Name }}
-              key: {{ resourceEnv .Env }}
+              key: {{ .GetConfigMapKey }}
         {{ end }}
         envFrom:
         - secretRef:

--- a/provider/k8s/template/app/timer.yml.tmpl
+++ b/provider/k8s/template/app/timer.yml.tmpl
@@ -54,7 +54,7 @@ spec:
               valueFrom:
                 configMapKeyRef:
                   name: resource-{{ k8sname .Name }}
-                  key: {{ resourceEnv .Env }}
+                  key: {{ .GetConfigMapKey }}
             {{ end }}
             envFrom:
             - secretRef:


### PR DESCRIPTION
### What is the feature/fix?

As described [here](https://github.com/convox/convox/pull/530), when you have a resource linked with a different name than ending with `URL` it breaks because doesn't find the correct key. 

In this case, it should use the default CM key instead of using the last resource link name.

### Add screenshot or video (optional)

![image](https://user-images.githubusercontent.com/8239709/202567080-529ca062-efae-4711-be71-00667246472b.png)

### Does it has a breaking change?

No.

### How to use/test it?

- Install a rack with the fix
- Deploy an app using a custom resource link name (see convox.yml below)

```
resources:
  my-db:
    type: postgres
services:
  web:
    build: .
    port: 80
    resources:
      - my-db:CUSTOM_DATABASE
```

It should deploy with no errors.

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
