### PR TITLE
feat-673: Manage eks addons

### DIFF
--- a/terraform/cluster/aws/autoscaler.tf
+++ b/terraform/cluster/aws/autoscaler.tf
@@ -54,7 +54,7 @@ locals {
 
 resource "kubernetes_service_account" "autoscaler" {
   depends_on = [
-    null_resource.wait_k8s_api
+    null_resource.wait_eks_addons
   ]
   metadata {
     name      = "cluster-autoscaler"
@@ -69,7 +69,7 @@ resource "kubernetes_service_account" "autoscaler" {
 
 resource "kubernetes_cluster_role" "autoscaler" {
   depends_on = [
-    null_resource.wait_k8s_api
+    null_resource.wait_eks_addons
   ]
   metadata {
     name   = "cluster-autoscaler"
@@ -159,7 +159,7 @@ resource "kubernetes_cluster_role" "autoscaler" {
 
 resource "kubernetes_cluster_role_binding" "autoscaler" {
   depends_on = [
-    null_resource.wait_k8s_api
+    null_resource.wait_eks_addons
   ]
   metadata {
     name   = "cluster-autoscaler"
@@ -181,7 +181,7 @@ resource "kubernetes_cluster_role_binding" "autoscaler" {
 
 resource "kubernetes_role" "autoscaler" {
   depends_on = [
-    null_resource.wait_k8s_api
+    null_resource.wait_eks_addons
   ]
   metadata {
     name      = "cluster-autoscaler"
@@ -205,7 +205,7 @@ resource "kubernetes_role" "autoscaler" {
 
 resource "kubernetes_role_binding" "autoscaler" {
   depends_on = [
-    null_resource.wait_k8s_api
+    null_resource.wait_eks_addons
   ]
   metadata {
     name      = "cluster-autoscaler"
@@ -229,7 +229,7 @@ resource "kubernetes_role_binding" "autoscaler" {
 resource "kubernetes_deployment" "autoscaler" {
   depends_on = [
     aws_iam_role_policy.autoscaler_autoscale,
-    null_resource.wait_k8s_api
+    null_resource.wait_eks_addons
   ]
 
   metadata {

--- a/terraform/cluster/aws/console.tf
+++ b/terraform/cluster/aws/console.tf
@@ -3,12 +3,12 @@ resource "kubernetes_cluster_role" "console" {
     null_resource.wait_eks_addons
   ]
   metadata {
-    name   = "eks-console-dashboard-full-access-clusterrole"
+    name = "eks-console-dashboard-full-access-clusterrole"
   }
 
   rule {
     api_groups = [""]
-    resources  = ["nodes", "namespaces", "pods", "configmaps", "endpoints", "events", "limitranges", "persistentvolumeclaims", "podtemplates", "replicationcontrollers", "resourcequotas", "secrets", "serviceaccounts", "services",]
+    resources  = ["nodes", "namespaces", "pods", "configmaps", "endpoints", "events", "limitranges", "persistentvolumeclaims", "podtemplates", "replicationcontrollers", "resourcequotas", "secrets", "serviceaccounts", "services", ]
     verbs      = ["get", "list"]
   }
 
@@ -78,7 +78,7 @@ resource "kubernetes_cluster_role_binding" "console" {
     null_resource.wait_eks_addons
   ]
   metadata {
-    name   = "eks-console-dashboard-full-access-binding"
+    name = "eks-console-dashboard-full-access-binding"
   }
 
   role_ref {

--- a/terraform/cluster/aws/console.tf
+++ b/terraform/cluster/aws/console.tf
@@ -1,6 +1,6 @@
 resource "kubernetes_cluster_role" "console" {
   depends_on = [
-    null_resource.wait_k8s_api
+    null_resource.wait_eks_addons
   ]
   metadata {
     name   = "eks-console-dashboard-full-access-clusterrole"
@@ -75,7 +75,7 @@ resource "kubernetes_cluster_role" "console" {
 
 resource "kubernetes_cluster_role_binding" "console" {
   depends_on = [
-    null_resource.wait_k8s_api
+    null_resource.wait_eks_addons
   ]
   metadata {
     name   = "eks-console-dashboard-full-access-binding"

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -106,7 +106,7 @@ resource "aws_eks_node_group" "cluster" {
   version         = var.k8s_version
 
   launch_template {
-    id = aws_launch_template.cluster.id
+    id      = aws_launch_template.cluster.id
     version = "$Latest"
   }
 
@@ -158,7 +158,7 @@ resource "aws_launch_template" "cluster" {
     for_each = toset(["instance", "volume", "elastic-gpu", "network-interface", "spot-instances-request"])
     content {
       resource_type = tag_specifications.key
-      tags = local.tags
+      tags          = local.tags
     }
   }
 
@@ -170,7 +170,7 @@ module "ebs_csi_driver_controller" {
     null_resource.wait_eks_addons
   ]
 
-  source  = "github.com/convox/terraform-kubernetes-ebs-csi-driver?ref=48f5650f72684b581697f8831b3f5b60ea624092"
+  source = "github.com/convox/terraform-kubernetes-ebs-csi-driver?ref=48f5650f72684b581697f8831b3f5b60ea624092"
 
   ebs_csi_controller_image                   = "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver"
   ebs_csi_driver_version                     = "v1.9.0"

--- a/terraform/cluster/aws/outputs.tf
+++ b/terraform/cluster/aws/outputs.tf
@@ -40,3 +40,7 @@ output "subnets" {
 output "vpc" {
   value = var.vpc_id == "" ? aws_vpc.nodes[0].id : var.vpc_id
 }
+
+output "eks_addons" {
+  value = [aws_eks_addon.coredns.id, aws_eks_addon.vpc_cni.id, aws_eks_addon.kube_proxy.id]
+}

--- a/terraform/cluster/aws/variables.tf
+++ b/terraform/cluster/aws/variables.tf
@@ -11,7 +11,7 @@ variable "cidr" {
 }
 
 variable "coredns_version" {
-  type = string
+  type    = string
   default = null
 }
 
@@ -28,17 +28,17 @@ variable "internet_gateway_id" {
 }
 
 variable "key_pair_name" {
-  type = string
+  type    = string
   default = ""
 }
 
 variable "kube_proxy_version" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "k8s_version" {
-  type = string
+  type    = string
   default = "1.21"
 }
 
@@ -71,6 +71,6 @@ variable "vpc_id" {
 }
 
 variable "vpc_cni_version" {
-  type = string
+  type    = string
   default = null
 }

--- a/terraform/cluster/aws/variables.tf
+++ b/terraform/cluster/aws/variables.tf
@@ -10,6 +10,11 @@ variable "cidr" {
   default = "10.1.0.0/16"
 }
 
+variable "coredns_version" {
+  type = string
+  default = null
+}
+
 variable "gpu_type" {
   default = false
 }
@@ -26,6 +31,12 @@ variable "key_pair_name" {
   type = string
   default = ""
 }
+
+variable "kube_proxy_version" {
+  type = string
+  default = null
+}
+
 variable "k8s_version" {
   type = string
   default = "1.21"
@@ -57,4 +68,9 @@ variable "tags" {
 
 variable "vpc_id" {
   default = ""
+}
+
+variable "vpc_cni_version" {
+  type = string
+  default = null
 }

--- a/terraform/fluentd/aws/variables.tf
+++ b/terraform/fluentd/aws/variables.tf
@@ -6,6 +6,9 @@ variable "cluster" {
   type = string
 }
 
+// for eks addons dependency
+variable "eks_addons" {}
+
 variable "namespace" {
   type = string
 }

--- a/terraform/rack/aws/variables.tf
+++ b/terraform/rack/aws/variables.tf
@@ -14,6 +14,9 @@ variable "ebs_csi_driver_name" {
   type = string
 }
 
+// for eks addons dependency
+variable "eks_addons" {}
+
 variable "high_availability" {
   default = true
 }

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -60,6 +60,9 @@ module "cluster" {
   private             = var.private
   tags                = local.tag_map
   vpc_id              = var.vpc_id
+  vpc_cni_version = var.vpc_cni_version
+  coredns_version = var.coredns_version
+  kube_proxy_version = var.kube_proxy_version
 }
 
 module "fluentd" {
@@ -70,13 +73,14 @@ module "fluentd" {
     kubernetes = kubernetes
   }
 
-  arm_type  = local.arm_type
-  cluster   = module.cluster.id
-  namespace = "kube-system"
-  oidc_arn  = module.cluster.oidc_arn
-  oidc_sub  = module.cluster.oidc_sub
-  rack      = var.name
-  syslog    = var.syslog
+  arm_type   = local.arm_type
+  cluster    = module.cluster.id
+  eks_addons = module.cluster.eks_addons
+  namespace  = "kube-system"
+  oidc_arn   = module.cluster.oidc_arn
+  oidc_sub   = module.cluster.oidc_sub
+  rack       = var.name
+  syslog     = var.syslog
 }
 
 module "rack" {
@@ -90,6 +94,7 @@ module "rack" {
   cluster             = module.cluster.id
   docker_hub_username = var.docker_hub_username
   docker_hub_password = var.docker_hub_password
+  eks_addons          = module.cluster.eks_addons
   high_availability   = var.high_availability
   idle_timeout        = var.idle_timeout
   image               = local.image

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -48,10 +48,12 @@ module "cluster" {
   arm_type            = local.arm_type
   availability_zones  = var.availability_zones
   cidr                = var.cidr
+  coredns_version     = var.coredns_version
   gpu_type            = local.gpu_type
   high_availability   = var.high_availability
   internet_gateway_id = var.internet_gateway_id
   key_pair_name       = var.key_pair_name
+  kube_proxy_version  = var.kube_proxy_version
   k8s_version         = var.k8s_version
   name                = var.name
   node_capacity_type  = upper(var.node_capacity_type)
@@ -59,10 +61,8 @@ module "cluster" {
   node_type           = var.node_type
   private             = var.private
   tags                = local.tag_map
+  vpc_cni_version     = var.vpc_cni_version
   vpc_id              = var.vpc_id
-  vpc_cni_version = var.vpc_cni_version
-  coredns_version = var.coredns_version
-  kube_proxy_version = var.kube_proxy_version
 }
 
 module "fluentd" {

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -8,7 +8,7 @@ variable "cidr" {
 
 // https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html
 variable "coredns_version" {
-  type = string
+  type    = string
   default = "v1.8.7-eksbuild.1"
 }
 
@@ -43,18 +43,18 @@ variable "internet_gateway_id" {
 }
 
 variable "key_pair_name" {
-  type = string
+  type    = string
   default = ""
 }
 
 // https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html
 variable "kube_proxy_version" {
-  type = string
+  type    = string
   default = "v1.22.11-eksbuild.2"
 }
 
 variable "k8s_version" {
-  type = string
+  type    = string
   default = "1.22"
 }
 
@@ -104,7 +104,7 @@ variable "vpc_id" {
 
 // https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
 variable "vpc_cni_version" {
-  type = string
+  type    = string
   default = "v1.11.4-eksbuild.1"
 }
 

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -6,6 +6,12 @@ variable "cidr" {
   default = "10.1.0.0/16"
 }
 
+// https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html
+variable "coredns_version" {
+  type = string
+  default = "v1.8.7-eksbuild.1"
+}
+
 variable "docker_hub_username" {
   default = ""
 }
@@ -39,6 +45,12 @@ variable "internet_gateway_id" {
 variable "key_pair_name" {
   type = string
   default = ""
+}
+
+// https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html
+variable "kube_proxy_version" {
+  type = string
+  default = "v1.22.11-eksbuild.2"
 }
 
 variable "k8s_version" {
@@ -88,6 +100,12 @@ variable "tags" {
 
 variable "vpc_id" {
   default = ""
+}
+
+// https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
+variable "vpc_cni_version" {
+  type = string
+  default = "v1.11.4-eksbuild.1"
 }
 
 variable "whitelist" {


### PR DESCRIPTION


### What is the feature/fix?
https://github.com/convox/issues-private/issues/673

Rack update doesn't update the addons , so
Manage aws eks addons: vpc-cni, kube-proxy and coredns

### Add screenshot or video (optional)


### Does it has a breaking change?
**yes**
Once you upgrade to this version you can't downgrade, since addons are now managed by tf, so downgrading to lower version will delete those addons since they are not tf managed before and thus cluster breaks

### How to use/test it?
Install or upgrade your rack to this version

### Checklist
- [ ] New coverage tests
- [x] Unit tests passing
- [x] E2E tests passing
- [x] E2E downgrade/update test passing
- [ ] Documentation updated
- [x] No warnings or errors on Deepsource/Codecov
