### PR TITLE
GPU reservation requirements

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -155,6 +155,15 @@ $root/ci/test/resources_memcache.sh &
 $root/ci/test/app_internal_communication.sh &
 wait
 
+# app (gpu)
+cd $root/examples/gpu
+convox apps create gpu
+convox apps
+convox apps | grep gpu
+convox apps info gpu | grep running
+release=$(convox build -a gpu -d cibuild --id) && [ -n "$release" ]
+
 # cleanup
+convox apps delete gpu
 convox apps delete httpd
 convox apps delete httpd2

--- a/docs/reference/primitives/app/service.md
+++ b/docs/reference/primitives/app/service.md
@@ -152,11 +152,22 @@ services:
 | Attribute | Type   | Default | Description                                                                                                   |
 | --------- | ------ | ------- | ------------------------------------------------------------------------------------------------------------- |
 | **count**   | number | 1       | The number of [Processes](/reference/primitives/app/process) to run for this Service. For autoscaling use a range, e.g. **1-5**        |
-| **cpu**     | number | 128     | The number of CPU units to reserve for [Processes](/reference/primitives/app/process) of this Service where 1024 units is a full CPU |
-| **memory**  | number | 256     | The number of MB of RAM to reserve for [Processes](/reference/primitives/app/process) of this Service                                |
+| **cpu**     | number | 256     | The number of CPU units to reserve for [Processes](/reference/primitives/app/process) of this Service where 1024 units is a full CPU |
+| **gpu**     | map    |         | The number/type of GPUs to reserve for [Processes](/reference/primitives/app/process) of this Service  |
+| **memory**  | number | 512     | The number of MB of RAM to reserve for [Processes](/reference/primitives/app/process) of this Service                                |
 | **targets** | map    |         | Target metrics to trigger autoscaling                                                                         |
 
 > Specifying **scale** as a number will set the **count** and leave the other values as defaults.
+
+### scale.gpu
+
+| Attribute | Type   | Default | Description                                                                                |
+| --------- | ------ | ------- | ------------------------------------------------------------------------------------------ |
+| **count**  | number |        | The number of GPUs to reserve for [Processes](/reference/primitives/app/process) of this Service    |
+| **vendor** | string | nvidia | The GPU vendor to target for [Processes](/reference/primitives/app/process) of this Service |
+
+> Specifying **gpu** as a number will set the **count** and leave the vendor as default.
+> Specifying a **gpu** value and not specifying the cpu or memory to reserve will remove their defaults to purely reserve based on GPU.
 
 ### scale.targets
 

--- a/docs/reference/primitives/app/service.md
+++ b/docs/reference/primitives/app/service.md
@@ -168,6 +168,7 @@ services:
 
 > Specifying **gpu** as a number will set the **count** and leave the vendor as default.
 > Specifying a **gpu** value and not specifying the cpu or memory to reserve will remove their defaults to purely reserve based on GPU.
+> You should ensure that your Rack is running on GPU enabled instances (of the correct vendor) before specifying the **gpu** section in your convox.yml
 
 ### scale.targets
 

--- a/examples/gpu/convox.yml
+++ b/examples/gpu/convox.yml
@@ -1,0 +1,6 @@
+services:
+  cuda:
+    image: nvidia/cuda:11.6.2-base-ubuntu20.04
+    command: nvidia-smi
+    scale:
+      gpu: 1

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -169,12 +169,18 @@ func (m *Manifest) ApplyDefaults() error {
 			m.Services[i].Scale.Count = ServiceScaleCount{Min: 1, Max: 1}
 		}
 
-		if m.Services[i].Scale.Cpu == 0 {
-			m.Services[i].Scale.Cpu = DefaultCpu
+		if m.Services[i].Scale.Gpu.Count == 0 {
+			if m.Services[i].Scale.Cpu == 0 {
+				m.Services[i].Scale.Cpu = DefaultCpu
+			}
+
+			if m.Services[i].Scale.Memory == 0 {
+				m.Services[i].Scale.Memory = DefaultMem
+			}
 		}
 
-		if m.Services[i].Scale.Memory == 0 {
-			m.Services[i].Scale.Memory = DefaultMem
+		if m.Services[i].Scale.Gpu.Count > 0 && m.Services[i].Scale.Gpu.Vendor == "" {
+			m.Services[i].Scale.Gpu.Vendor = "nvidia"
 		}
 
 		if !m.AttributeExists(fmt.Sprintf("services.%s.termination.grace", s.Name)) {

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -216,6 +216,72 @@ func TestManifestLoad(t *testing.T) {
 				},
 			},
 			manifest.Service{
+				Name: "gpuscaler",
+				Build: manifest.ServiceBuild{
+					Manifest: "Dockerfile",
+					Path:     ".",
+				},
+				Command: "",
+				Deployment: manifest.ServiceDeployment{
+					Minimum: 50,
+					Maximum: 200,
+				},
+				Drain: 30,
+				Health: manifest.ServiceHealth{
+					Grace:    5,
+					Interval: 5,
+					Path:     "/",
+					Timeout:  4,
+				},
+				Init: true,
+				Scale: manifest.ServiceScale{
+					Count:  manifest.ServiceScaleCount{Min: 1, Max: 1},
+					Cpu:    768,
+					Gpu:    manifest.ServiceScaleGpu{Count: 1, Vendor: "amd"},
+					Memory: 2048,
+				},
+				Sticky: false,
+				Termination: manifest.ServiceTermination{
+					Grace: 30,
+				},
+				Timeout: 60,
+				Tls: manifest.ServiceTls{
+					Redirect: true,
+				},
+			},
+			manifest.Service{
+				Name: "defaultgpuscaler",
+				Build: manifest.ServiceBuild{
+					Manifest: "Dockerfile",
+					Path:     ".",
+				},
+				Command: "",
+				Deployment: manifest.ServiceDeployment{
+					Minimum: 50,
+					Maximum: 200,
+				},
+				Drain: 30,
+				Health: manifest.ServiceHealth{
+					Grace:    5,
+					Interval: 5,
+					Path:     "/",
+					Timeout:  4,
+				},
+				Init: true,
+				Scale: manifest.ServiceScale{
+					Count:  manifest.ServiceScaleCount{Min: 1, Max: 1},
+					Gpu:    manifest.ServiceScaleGpu{Count: 2, Vendor: "nvidia"},
+				},
+				Sticky: false,
+				Termination: manifest.ServiceTermination{
+					Grace: 30,
+				},
+				Timeout: 60,
+				Tls: manifest.ServiceTls{
+					Redirect: true,
+				},
+			},
+			manifest.Service{
 				Name: "scaler",
 				Build: manifest.ServiceBuild{
 					Manifest: "Dockerfile",
@@ -410,6 +476,9 @@ func TestManifestLoad(t *testing.T) {
 		"services.api.tls.redirect",
 		"services.api.whitelist",
 		"services.bar",
+		"services.defaultgpuscaler",
+		"services.defaultgpuscaler.scale",
+		"services.defaultgpuscaler.scale.gpu",
 		"services.foo",
 		"services.foo.command",
 		"services.foo.domain",
@@ -424,6 +493,13 @@ func TestManifestLoad(t *testing.T) {
 		"services.foo.singleton",
 		"services.foo.sticky",
 		"services.foo.timeout",
+		"services.gpuscaler",
+		"services.gpuscaler.scale",
+		"services.gpuscaler.scale.cpu",
+		"services.gpuscaler.scale.gpu",
+		"services.gpuscaler.scale.gpu.count",
+		"services.gpuscaler.scale.gpu.vendor",
+		"services.gpuscaler.scale.memory",
 		"services.inherit",
 		"services.inherit.command",
 		"services.inherit.domain",

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -78,6 +78,7 @@ type ServicePortScheme struct {
 type ServiceScale struct {
 	Count   ServiceScaleCount
 	Cpu     int
+	Gpu     ServiceScaleGpu     `yaml:"gpu,omitempty"`
 	Memory  int
 	Targets ServiceScaleTargets `yaml:"targets,omitempty"`
 }
@@ -85,6 +86,11 @@ type ServiceScale struct {
 type ServiceScaleCount struct {
 	Min int
 	Max int
+}
+
+type ServiceScaleGpu struct {
+	Count int
+	Vendor string
 }
 
 type ServiceScaleMetric struct {

--- a/pkg/manifest/testdata/full.yml
+++ b/pkg/manifest/testdata/full.yml
@@ -84,6 +84,16 @@ services:
     sticky: true
     timeout: 3600
   bar:
+  gpuscaler:
+    scale:
+      gpu:
+        count: 1
+        vendor: amd
+      cpu: 768
+      memory: 2048
+  defaultgpuscaler:
+    scale:
+      gpu: 2
   scaler:
     scale:
       count: 1-5

--- a/pkg/manifest/yaml.go
+++ b/pkg/manifest/yaml.go
@@ -394,6 +394,13 @@ func (v *ServiceScale) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if w, ok := t["cpu"].(int); ok {
 			v.Cpu = w
 		}
+		if w, ok := t["gpu"].(interface{}); ok {
+			var g ServiceScaleGpu
+			if err := remarshal(w, &g); err != nil {
+				return err
+			}
+			v.Gpu = g
+		}
 		if w, ok := t["memory"].(int); ok {
 			v.Memory = w
 		}
@@ -406,6 +413,30 @@ func (v *ServiceScale) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	default:
 		return fmt.Errorf("unknown type for service scale: %T", t)
+	}
+
+	return nil
+}
+
+func (v *ServiceScaleGpu) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var w interface{}
+
+	if err := unmarshal(&w); err != nil {
+		return err
+	}
+
+	switch t := w.(type) {
+	case map[interface{}]interface{}:
+		if w, ok := t["count"].(int); ok {
+			v.Count = w
+		}
+		if w, ok := t["vendor"].(string); ok {
+			v.Vendor = w
+		}
+	case int:
+		v.Count = t
+	default:
+		return fmt.Errorf("unknown type for service scale gpu: %T", t)
 	}
 
 	return nil

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -143,12 +143,18 @@ spec:
         {{ end }}
         resources:
           limits:
+            {{ with .Service.Scale.Gpu.Count }}
+            {{$.Service.Scale.Gpu.Vendor}}.com/gpu: "{{.}}"
+            {{ end }}
             {{ with .Service.Scale.Memory }}
             memory: "{{.}}Mi"
             {{ end }}
           requests:
             {{ with .Service.Scale.Cpu }}
             cpu: "{{.}}m"
+            {{ end }}
+            {{ with .Service.Scale.Gpu.Count }}
+            {{$.Service.Scale.Gpu.Vendor}}.com/gpu: "{{.}}"
             {{ end }}
             {{ with .Service.Scale.Memory }}
             memory: "{{.}}Mi"


### PR DESCRIPTION
### What is the feature/fix?

Allow services to reserve gpu resources.  Also handles bug within nvidia-docker with regards to cgroups where specifying cpu/memory limits/requests at the same time as gpu causes container crashes. 

### Does it has a breaking change?

No

### How to use/test it?

See test yaml / docs.

### Checklist
- [x] New coverage tests
- [x] Unit tests passing
- [x] E2E tests passing
- [ ] E2E downgrade/update test passing
- [x] Documentation updated
- [x] No warnings or errors on Deepsource/Codecov
