### PR TITLE
feat-694: Add external metrics support for scaling

### DIFF
--- a/docs/reference/primitives/app/service.md
+++ b/docs/reference/primitives/app/service.md
@@ -167,7 +167,7 @@ services:
 | --------- | ------ | ------- | ------------------------------------------------------------------------------------------ |
 | **cpu**     | number |         | The percentage of CPU utilization to target for [Processes](/reference/primitives/app/process) of this Service    |
 | **memory**  | number |         | The percentage of memory utilization to target for [Processes](/reference/primitives/app/process) of this Service |
-| **external**  | array of object |         | The array of the external metrics based on which it will scale the Service |
+| **external**  | map |         | The array of the external metrics based on which it will scale the Service |
 
 ### scale.targets.[]external
 

--- a/docs/reference/primitives/app/service.md
+++ b/docs/reference/primitives/app/service.md
@@ -59,6 +59,9 @@ services:
       targets:
         cpu: 50
         memory: 80
+        external:
+          - name: "datadogmetric@default:web-requests"
+            averageValue: 200
     singleton: false
     sticky: true
     termination:
@@ -164,6 +167,29 @@ services:
 | --------- | ------ | ------- | ------------------------------------------------------------------------------------------ |
 | **cpu**     | number |         | The percentage of CPU utilization to target for [Processes](/reference/primitives/app/process) of this Service    |
 | **memory**  | number |         | The percentage of memory utilization to target for [Processes](/reference/primitives/app/process) of this Service |
+| **external**  | array of object |         | The array of the external metrics based on which it will scale the Service |
+
+### scale.targets.[]external
+
+| Attribute | Type   | Default | Description                                                                                |
+| --------- | ------ | ------- | ------------------------------------------------------------------------------------------ |
+| **name**     | string |         | The name of the metric |
+| **matchLabels**  | map |         | Key value lablels for the metrics |
+| **averageValue**  | number |         | The target value of the average of the metric across all relevant pods |
+| **value**  | number |         | The target value of the metric |
+
+```yaml
+services:
+  web:
+    build: .
+    port: 3000
+    scale:
+      count: 1-3
+      targets:
+        external:
+          - name: "datadogmetric@default:web-requests"
+            averageValue: 200
+```
 
 &nbsp;
 

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -121,10 +121,12 @@ type ServiceTls struct {
 	Redirect bool
 }
 
+// skipcq
 func (s Service) BuildHash(key string) string {
 	return fmt.Sprintf("%x", sha256.Sum224([]byte(fmt.Sprintf("key=%q build[path=%q, manifest=%q, args=%v] image=%q", key, s.Build.Path, s.Build.Manifest, s.Build.Args, s.Image))))
 }
 
+// skipcq
 func (s Service) Domain() string {
 	if len(s.Domains) < 1 {
 		return ""
@@ -133,6 +135,7 @@ func (s Service) Domain() string {
 	return s.Domains[0]
 }
 
+// skipcq
 func (s Service) EnvironmentDefaults() map[string]string {
 	defaults := map[string]string{}
 
@@ -146,6 +149,7 @@ func (s Service) EnvironmentDefaults() map[string]string {
 	return defaults
 }
 
+// skipcq
 func (s Service) EnvironmentKeys() string {
 	kh := map[string]bool{}
 
@@ -164,10 +168,12 @@ func (s Service) EnvironmentKeys() string {
 	return strings.Join(keys, ",")
 }
 
+// skipcq
 func (s Service) GetName() string {
 	return s.Name
 }
 
+// skipcq
 func (s Service) Autoscale() bool {
 	if s.Agent.Enabled {
 		return false
@@ -194,6 +200,7 @@ type ServiceResource struct {
 	Env  string
 }
 
+// skipcq
 func (s Service) AnnotationsMap() map[string]string {
 	annotations := map[string]string{}
 
@@ -205,6 +212,7 @@ func (s Service) AnnotationsMap() map[string]string {
 	return annotations
 }
 
+// skipcq
 func (s Service) ResourceMap() []ServiceResource {
 	srs := []ServiceResource{}
 
@@ -225,6 +233,7 @@ func (s Service) ResourceMap() []ServiceResource {
 	return srs
 }
 
+// skipcq
 func (s Service) ResourcesName() []string {
 	srs := []string{}
 
@@ -245,6 +254,7 @@ func (ss Services) External() Services {
 func (ss Services) Filter(fn func(s Service) bool) Services {
 	fss := Services{}
 
+	// skipcq
 	for _, s := range ss {
 		if fn(s) {
 			fss = append(fss, s)

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -86,6 +86,14 @@ type ServiceScaleCount struct {
 	Min int
 	Max int
 }
+type ServiceScaleExternalMetric struct {
+	AverageValue *float64          `yaml:"averageValue,omitempty"`
+	MatchLabels  map[string]string `yaml:"matchLabels,omitempty"`
+	Name         string            `yaml:"name"`
+	Value        *float64          `yaml:"value,omitempty"`
+}
+
+type ServiceScaleExternalMetrics []ServiceScaleExternalMetric
 
 type ServiceScaleMetric struct {
 	Aggregate  string
@@ -100,6 +108,7 @@ type ServiceScaleMetrics []ServiceScaleMetric
 type ServiceScaleTargets struct {
 	Cpu      int
 	Custom   ServiceScaleMetrics
+	External ServiceScaleExternalMetrics
 	Memory   int
 	Requests int
 }

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -177,7 +177,7 @@ spec:
       {{ end }}
 {{ if not (eq .Service.Scale.Count.Min .Service.Scale.Count.Max) }}
 ---
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   namespace: {{.Namespace}}
@@ -196,13 +196,36 @@ spec:
   - type: Resource
     resource:
       name: cpu
-      targetAverageUtilization: {{.}}
+      target:
+        type: Utilization
+        averageUtilization: {{.}}
   {{ end }}
   {{ with .Service.Scale.Targets.Memory }}
   - type: Resource
     resource:
       name: memory
-      targetAverageUtilization: {{.}}
+      target:
+        type: Utilization
+        averageUtilization: {{.}}
+  {{ end }}
+  {{ range .Service.Scale.Targets.External }}
+  - type: External
+    external:
+      metric:
+        name: {{ .Name }}
+        selector:
+          matchLabels:
+            {{ range $k, $v := .MatchLabels }}
+            {{ $k }}: {{ $v }}
+            {{ end }}
+      target:
+        {{ if .AverageValue }}
+        type: AverageValue
+        averageValue: {{ .AverageValue }}
+        {{ else }}
+        type: Value
+        value: {{ .Value }}
+        {{ end }}
   {{ end }}
 {{ end }}
 {{ if or .Service.Port.Port .Service.Ports }}

--- a/terraform/cluster/aws/autoscaler.tf
+++ b/terraform/cluster/aws/autoscaler.tf
@@ -315,3 +315,39 @@ resource "kubernetes_deployment" "autoscaler" {
     }
   }
 }
+
+resource "kubernetes_cluster_role" "hpa_external_metrics" {
+  depends_on = [
+    null_resource.wait_k8s_api
+  ]
+  metadata {
+    name   = "hpa-external-metrics"
+  }
+
+  rule {
+    api_groups = ["external.metrics.k8s.io"]
+    resources  = ["*"]
+    verbs      = ["watch", "list", "get"]
+  }
+}
+
+resource "kubernetes_cluster_role_binding" "hpa_external_metrics" {
+  depends_on = [
+    null_resource.wait_k8s_api
+  ]
+  metadata {
+    name   = "hpa-external-metrics"
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "hpa-external-metrics"
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = "horizontal-pod-autoscaler"
+    namespace = "kube-system"
+  }
+}


### PR DESCRIPTION
### What is the feature/fix?

https://github.com/convox/issues-private/issues/694

This external metrics support will enable service scaling based on external metrics server like datadog

### Add screenshot or video (optional)

** Any screenshot or video capture using the feature **

### Does it has a breaking change?


https://user-images.githubusercontent.com/12232198/203349203-00d2e3f7-45e0-4c21-bf59-75c45618f38a.mp4

### How to use/test it?

- deploy/update rack to branch
- setup you external metrics for k8s for example datadog: https://docs.datadoghq.com/containers/cluster_agent/external_metrics/?tab=helm
- add external metrics to your convox service:
```
environment:
  - PORT=3000
services:
  web:
    domain: ${HOST}
    build: .
    port: 3000
    environment:
      - DD_AGENT_HOST=dd-agent.default.svc.cluster.local
    scale:
      count: 1-3
      targets:
        external:
          - name: "datadogmetric@default:nodejs-page-requests"
            averageValue: 20
```

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
