### PR TITLE
feat-695: Add support for schedule for power on and off schedule

### DIFF
--- a/docs/installation/production-rack/aws.md
+++ b/docs/installation/production-rack/aws.md
@@ -54,6 +54,8 @@ The following environment variables are required:
 | **node_capacity_type**   | **on_demand**          | Can be either "on_demand" or "spot". Spot will use AWS spot instances for the cluster nodes                    |
 | **node_disk**            | **20**                 | Node disk size in GB                                                                                           |
 | **node_type**            | **t3.small**           | Node instance type. You can also pass a comma separated list of instance types                                 |
+| **power_off_schedule**   |                        | Power off schedule is specified by the user following the Unix cron syntax format. Example: "0 0 * * 6" |
+| **power_on_schedule**    |                        | Power on schedule is specified by the user following the Unix cron syntax format.Example: "0 0 * * 0" |
 | **private**              | **true**               | Put nodes in private subnets behind NAT gateways                                                               |
 | **proxy_protocol**       | **false**               | Enable proxy protocol. With this parameter set, the client source ip will be available in the request header `x-forwarded-for` key. **Requires 5 - 10 minutes downtime**.          |
 | **region**               | **us-east-1**          | AWS Region                                                                                                     |

--- a/docs/installation/production-rack/aws.md
+++ b/docs/installation/production-rack/aws.md
@@ -54,8 +54,8 @@ The following environment variables are required:
 | **node_capacity_type**   | **on_demand**          | Can be either "on_demand" or "spot". Spot will use AWS spot instances for the cluster nodes                    |
 | **node_disk**            | **20**                 | Node disk size in GB                                                                                           |
 | **node_type**            | **t3.small**           | Node instance type. You can also pass a comma separated list of instance types                                 |
-| **power_off_schedule**   |                        | Power off schedule is specified by the user following the Unix cron syntax format. Example: "0 0 * * 6" |
-| **power_on_schedule**    |                        | Power on schedule is specified by the user following the Unix cron syntax format.Example: "0 0 * * 0" |
+| **schedule_rack_scale_down**   |                        | Rack scale down schedule is specified by the user following the Unix cron syntax format. Example: "0 18 * * 5". The supported cron expression format consists of five fields separated by white spaces: [Minute] [Hour] [Day_of_Month] [Month_of_Year] [Day_of_Week]. More details on the CRON format can be found in (Crontab)[http://crontab.org/] and (examples)[https://crontab.guru/examples.html]. The time is calculated in **UTC**. |
+| **schedule_rack_scale_up**    |                        | Rack scale up schedule is specified by the user following the Unix cron syntax format.Example: "0 0 * * 0". The supported cron expression format consists of five fields separated by white spaces: [Minute] [Hour] [Day_of_Month] [Month_of_Year] [Day_of_Week]. More details on the CRON format can be found in (Crontab)[http://crontab.org/] and (examples)[https://crontab.guru/examples.html]. The time is calculated in **UTC**. |
 | **private**              | **true**               | Put nodes in private subnets behind NAT gateways                                                               |
 | **proxy_protocol**       | **false**               | Enable proxy protocol. With this parameter set, the client source ip will be available in the request header `x-forwarded-for` key. **Requires 5 - 10 minutes downtime**.          |
 | **region**               | **us-east-1**          | AWS Region                                                                                                     |
@@ -64,3 +64,5 @@ The following environment variables are required:
 | **vpc_id** *             |                        | Use an existing VPC for cluster creation. Make sure to also pass the **cidr** block and **internet_gateway_id**|
 
 \* To avoid CIDR block collision with existing VPC subnets, please add a new CIDR block to your VPC to separate rack resources. Also, remember to pass the **internet_gateway_id** attached to the VPC. If the VPC doesn't have an IG attached, the rack installation will create one automatically, which will also be destroyed if you delete the rack.
+
+\* **schedule_rack_scale_down** and **schedule_rack_scale_up** are mutually exclusive. So you have to set both of them properly for the scheduled timed off. If you set only **schedule_rack_scale_down**, it will not scale up on its own.

--- a/docs/management/cli-rack-management.md
+++ b/docs/management/cli-rack-management.md
@@ -46,6 +46,8 @@ The parameters available for your Rack depend on the underlying cloud provider.
 | **node_type**                     | **t3.small**    |
 | **region**                        | **us-east-1**   |
 | **high_availability** *           | **true**        |
+| **power_off_schedule**            |                 |
+| **power_on_schedule**             |                 |
 | **proxy_protocol** **             | **false**       |
 | **vpc_id** ***                    |                 |
 | **tags**                          |                 |

--- a/docs/management/cli-rack-management.md
+++ b/docs/management/cli-rack-management.md
@@ -46,8 +46,8 @@ The parameters available for your Rack depend on the underlying cloud provider.
 | **node_type**                     | **t3.small**    |
 | **region**                        | **us-east-1**   |
 | **high_availability** *           | **true**        |
-| **power_off_schedule**            |                 |
-| **power_on_schedule**             |                 |
+| **schedule_rack_scale_down**      |                 |
+| **schedule_rack_scale_up**        |                 |
 | **proxy_protocol** **             | **false**       |
 | **vpc_id** ***                    |                 |
 | **tags**                          |                 |
@@ -57,6 +57,8 @@ The parameters available for your Rack depend on the underlying cloud provider.
 \*\* Setting **proxy_protocol** in an existing rack will require a 5 - 10 minutes downtime window.
 
 \*\*\* To avoid CIDR block collision with existing VPC subnets, please add a new CIDR block to your VPC to separate rack resources. Also, remember to pass the **internet_gateway_id** attached to the VPC. If the VPC doesn't have an IG attached, the rack installation will create one automatically, which will also be destroyed if you delete the rack.
+
+\*\*\* **schedule_rack_scale_down** and **schedule_rack_scale_up** are mutually exclusive. So you have to set both of them properly for the scheduled timed off. If you set only **schedule_rack_scale_down**, it will not scale up on its own.
 
 &nbsp;
 

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -112,10 +112,12 @@ type ServiceTls struct {
 	Redirect bool
 }
 
+// skipcq
 func (s Service) BuildHash(key string) string {
 	return fmt.Sprintf("%x", sha256.Sum224([]byte(fmt.Sprintf("key=%q build[path=%q, manifest=%q, args=%v] image=%q", key, s.Build.Path, s.Build.Manifest, s.Build.Args, s.Image))))
 }
 
+// skipcq
 func (s Service) Domain() string {
 	if len(s.Domains) < 1 {
 		return ""
@@ -124,6 +126,7 @@ func (s Service) Domain() string {
 	return s.Domains[0]
 }
 
+// skipcq
 func (s Service) EnvironmentDefaults() map[string]string {
 	defaults := map[string]string{}
 
@@ -137,6 +140,7 @@ func (s Service) EnvironmentDefaults() map[string]string {
 	return defaults
 }
 
+// skipcq
 func (s Service) EnvironmentKeys() string {
 	kh := map[string]bool{}
 
@@ -155,10 +159,12 @@ func (s Service) EnvironmentKeys() string {
 	return strings.Join(keys, ",")
 }
 
+// skipcq
 func (s Service) GetName() string {
 	return s.Name
 }
 
+// skipcq
 func (s Service) Autoscale() bool {
 	if s.Agent.Enabled {
 		return false
@@ -198,6 +204,7 @@ func (sr ServiceResource) GetConfigMapKey() string {
 	return DEFAULT_RESOURCE_ENV_NAME
 }
 
+// skipcq
 func (s Service) AnnotationsMap() map[string]string {
 	annotations := map[string]string{}
 
@@ -209,6 +216,7 @@ func (s Service) AnnotationsMap() map[string]string {
 	return annotations
 }
 
+// skipcq
 func (s Service) ResourceMap() []ServiceResource {
 	srs := []ServiceResource{}
 
@@ -229,6 +237,7 @@ func (s Service) ResourceMap() []ServiceResource {
 	return srs
 }
 
+// skipcq
 func (s Service) ResourcesName() []string {
 	srs := []string{}
 
@@ -249,6 +258,7 @@ func (ss Services) External() Services {
 func (ss Services) Filter(fn func(s Service) bool) Services {
 	fss := Services{}
 
+	// skipcq
 	for _, s := range ss {
 		if fn(s) {
 			fss = append(fss, s)

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -275,26 +275,26 @@ resource "null_resource" "wait_eks_addons" {
   ]
 }
 
-resource "aws_autoscaling_schedule" "poweroff" {
-  count = length(var.power_off_schedule) > 6 ? (var.high_availability ? 3 : 1) : 0
+resource "aws_autoscaling_schedule" "scaledown" {
+  count = length(var.schedule_rack_scale_down) > 6 ? (var.high_availability ? 3 : 1) : 0
 
-  scheduled_action_name  = "poweroff${count.index}"
+  scheduled_action_name  = "scaledown${count.index}"
   min_size               = 0
   max_size               = 0
   desired_capacity       = 0
-  recurrence             = var.power_off_schedule
+  recurrence             = var.schedule_rack_scale_down
   time_zone              = "UTC"
   autoscaling_group_name = flatten(aws_eks_node_group.cluster[count.index].resources[*].autoscaling_groups[*].name)[0]
 }
 
-resource "aws_autoscaling_schedule" "poweron" {
-  count = length(var.power_on_schedule) > 6 ? (var.high_availability ? 3 : 1) : 0
+resource "aws_autoscaling_schedule" "scaleup" {
+  count = length(var.schedule_rack_scale_up) > 6 ? (var.high_availability ? 3 : 1) : 0
 
-  scheduled_action_name  = "poweron${count.index}"
+  scheduled_action_name  = "scaleup${count.index}"
   min_size               = 1
   max_size               = 100
   desired_capacity       = 1
-  recurrence             = var.power_on_schedule
+  recurrence             = var.schedule_rack_scale_up
   time_zone              = "UTC"
   autoscaling_group_name = flatten(aws_eks_node_group.cluster[count.index].resources[*].autoscaling_groups[*].name)[0]
 }

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -274,3 +274,27 @@ resource "null_resource" "wait_eks_addons" {
     aws_eks_addon.kube_proxy
   ]
 }
+
+resource "aws_autoscaling_schedule" "poweroff" {
+  count = length(var.power_off_schedule) > 6 ? (var.high_availability ? 3 : 1) : 0
+
+  scheduled_action_name  = "poweroff${count.index}"
+  min_size               = 0
+  max_size               = 0
+  desired_capacity       = 0
+  recurrence             = var.power_off_schedule
+  time_zone              = "UTC"
+  autoscaling_group_name = flatten(aws_eks_node_group.cluster[count.index].resources[*].autoscaling_groups[*].name)[0]
+}
+
+resource "aws_autoscaling_schedule" "poweron" {
+  count = length(var.power_on_schedule) > 6 ? (var.high_availability ? 3 : 1) : 0
+
+  scheduled_action_name  = "poweron${count.index}"
+  min_size               = 1
+  max_size               = 100
+  desired_capacity       = 1
+  recurrence             = var.power_on_schedule
+  time_zone              = "UTC"
+  autoscaling_group_name = flatten(aws_eks_node_group.cluster[count.index].resources[*].autoscaling_groups[*].name)[0]
+}

--- a/terraform/cluster/aws/variables.tf
+++ b/terraform/cluster/aws/variables.tf
@@ -58,18 +58,18 @@ variable "node_type" {
   default = "t3.small"
 }
 
-variable "power_off_schedule" {
-  type    = string
-  default = ""
-}
-
-variable "power_on_schedule" {
-  type    = string
-  default = ""
-}
-
 variable "private" {
   default = true
+}
+
+variable "schedule_rack_scale_down" {
+  type    = string
+  default = ""
+}
+
+variable "schedule_rack_scale_up" {
+  type    = string
+  default = ""
 }
 
 variable "tags" {

--- a/terraform/cluster/aws/variables.tf
+++ b/terraform/cluster/aws/variables.tf
@@ -58,6 +58,16 @@ variable "node_type" {
   default = "t3.small"
 }
 
+variable "power_off_schedule" {
+  type    = string
+  default = ""
+}
+
+variable "power_on_schedule" {
+  type    = string
+  default = ""
+}
+
 variable "private" {
   default = true
 }

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -45,26 +45,26 @@ module "cluster" {
     aws = aws
   }
 
-  arm_type            = local.arm_type
-  availability_zones  = var.availability_zones
-  cidr                = var.cidr
-  coredns_version     = var.coredns_version
-  gpu_type            = local.gpu_type
-  high_availability   = var.high_availability
-  internet_gateway_id = var.internet_gateway_id
-  key_pair_name       = var.key_pair_name
-  kube_proxy_version  = var.kube_proxy_version
-  k8s_version         = var.k8s_version
-  name                = var.name
-  node_capacity_type  = upper(var.node_capacity_type)
-  node_disk           = var.node_disk
-  node_type           = var.node_type
-  power_off_schedule  = var.power_off_schedule
-  power_on_schedule   = var.power_on_schedule
-  private             = var.private
-  tags                = local.tag_map
-  vpc_cni_version     = var.vpc_cni_version
-  vpc_id              = var.vpc_id
+  arm_type                 = local.arm_type
+  availability_zones       = var.availability_zones
+  cidr                     = var.cidr
+  coredns_version          = var.coredns_version
+  gpu_type                 = local.gpu_type
+  high_availability        = var.high_availability
+  internet_gateway_id      = var.internet_gateway_id
+  key_pair_name            = var.key_pair_name
+  kube_proxy_version       = var.kube_proxy_version
+  k8s_version              = var.k8s_version
+  name                     = var.name
+  node_capacity_type       = upper(var.node_capacity_type)
+  node_disk                = var.node_disk
+  node_type                = var.node_type
+  private                  = var.private
+  schedule_rack_scale_down = var.schedule_rack_scale_down
+  schedule_rack_scale_up   = var.schedule_rack_scale_up
+  tags                     = local.tag_map
+  vpc_cni_version          = var.vpc_cni_version
+  vpc_id                   = var.vpc_id
 }
 
 module "fluentd" {

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -32,9 +32,9 @@ locals {
   gpu_type  = substr(local.node_type, 0, 1) == "g" || substr(local.node_type, 0, 1) == "p"
   image     = var.image
   release   = local.arm_type ? format("%s-%s", coalesce(var.release, local.current), "arm64") : coalesce(var.release, local.current)
-  tag_map   = length(var.tags) == 0 ? {} : {
-    for v in split(",", var.tags):
-      "${split("=", v)[0]}" => split("=", v)[1]
+  tag_map = length(var.tags) == 0 ? {} : {
+    for v in split(",", var.tags) :
+    "${split("=", v)[0]}" => split("=", v)[1]
   }
 }
 
@@ -59,6 +59,8 @@ module "cluster" {
   node_capacity_type  = upper(var.node_capacity_type)
   node_disk           = var.node_disk
   node_type           = var.node_type
+  power_off_schedule  = var.power_off_schedule
+  power_on_schedule   = var.power_on_schedule
   private             = var.private
   tags                = local.tag_map
   vpc_cni_version     = var.vpc_cni_version

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -74,6 +74,16 @@ variable "node_type" {
   default = "t3.small"
 }
 
+variable "power_off_schedule" {
+  type    = string
+  default = ""
+}
+
+variable "power_on_schedule" {
+  type    = string
+  default = ""
+}
+
 variable "private" {
   default = true
 }

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -74,16 +74,6 @@ variable "node_type" {
   default = "t3.small"
 }
 
-variable "power_off_schedule" {
-  type    = string
-  default = ""
-}
-
-variable "power_on_schedule" {
-  type    = string
-  default = ""
-}
-
 variable "private" {
   default = true
 }
@@ -98,6 +88,16 @@ variable "release" {
 
 variable "region" {
   default = "us-east-1"
+}
+
+variable "schedule_rack_scale_down" {
+  type    = string
+  default = ""
+}
+
+variable "schedule_rack_scale_up" {
+  type    = string
+  default = ""
 }
 
 variable "syslog" {


### PR DESCRIPTION
### What is the feature/fix?

https://github.com/convox/issues-private/issues/695

EKS doesn't have start stop option so only worker node scaled down to zero.

### Add screenshot or video (optional)
https://user-images.githubusercontent.com/12232198/204042719-a1aefade-5be0-480c-8e64-2813c97f86de.mp4


### Does it has a breaking change?
no

### How to use/test it?

- deploy/update cluster to this branch
- set both param `schedule_rack_scale_down` and `schedule_rack_scale_up` rack param

### Checklist
- [ ] New coverage tests
- [x] Unit tests passing
- [x] E2E tests passing
- [x] E2E downgrade/update test passing
- [x] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
