### PR TITLE
K8s upgrade to 1.23

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,6 +233,7 @@ jobs:
             provider: do
           - job: gcp
             provider: gcp
+            rack_params: "region=us-west1"
           # - job: azure
           #   provider: azure
     steps:

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -9,7 +9,7 @@ variable "cidr" {
 // https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html
 variable "coredns_version" {
   type    = string
-  default = "v1.8.7-eksbuild.1"
+  default = "v1.8.7-eksbuild.2"
 }
 
 variable "docker_hub_username" {
@@ -50,12 +50,12 @@ variable "key_pair_name" {
 // https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html
 variable "kube_proxy_version" {
   type    = string
-  default = "v1.22.11-eksbuild.2"
+  default = "v1.23.8-eksbuild.2"
 }
 
 variable "k8s_version" {
   type    = string
-  default = "1.22"
+  default = "1.23"
 }
 
 variable "name" {

--- a/terraform/system/azure/main.tf
+++ b/terraform/system/azure/main.tf
@@ -48,15 +48,15 @@ module "rack" {
     kubernetes = kubernetes
   }
 
-  cluster        = module.cluster.id
+  cluster             = module.cluster.id
   docker_hub_username = var.docker_hub_username
   docker_hub_password = var.docker_hub_password
-  image          = var.image
-  name           = var.name
-  region         = var.region
-  release        = local.release
-  resource_group = azurerm_resource_group.rack.id
-  syslog         = var.syslog
-  whitelist      = split(",", var.whitelist)
-  workspace      = module.cluster.workspace
+  image               = var.image
+  name                = var.name
+  region              = var.region
+  release             = local.release
+  resource_group      = azurerm_resource_group.rack.id
+  syslog              = var.syslog
+  whitelist           = split(",", var.whitelist)
+  workspace           = module.cluster.workspace
 }

--- a/terraform/system/azure/variables.tf
+++ b/terraform/system/azure/variables.tf
@@ -12,7 +12,7 @@ variable "image" {
 
 variable "k8s_version" {
   type = string
-  default = "1.22"
+  default = "1.23"
 }
 
 variable "name" {

--- a/terraform/system/azure/variables.tf
+++ b/terraform/system/azure/variables.tf
@@ -11,7 +11,7 @@ variable "image" {
 }
 
 variable "k8s_version" {
-  type = string
+  type    = string
   default = "1.23"
 }
 

--- a/terraform/system/do/variables.tf
+++ b/terraform/system/do/variables.tf
@@ -19,7 +19,7 @@ variable "image" {
 }
 
 variable "k8s_version" {
-  type = string
+  type    = string
   default = "1.23"
 }
 

--- a/terraform/system/do/variables.tf
+++ b/terraform/system/do/variables.tf
@@ -20,7 +20,7 @@ variable "image" {
 
 variable "k8s_version" {
   type = string
-  default = "1.22"
+  default = "1.23"
 }
 
 variable "name" {

--- a/terraform/system/gcp/variables.tf
+++ b/terraform/system/gcp/variables.tf
@@ -12,7 +12,7 @@ variable "image" {
 
 variable "k8s_version" {
   type = string
-  default = "1.22"
+  default = "1.23"
 }
 
 variable "name" {

--- a/terraform/system/gcp/variables.tf
+++ b/terraform/system/gcp/variables.tf
@@ -11,7 +11,7 @@ variable "image" {
 }
 
 variable "k8s_version" {
-  type = string
+  type    = string
   default = "1.23"
 }
 


### PR DESCRIPTION
### What is the feature/fix?

https://github.com/convox/issues-private/issues/707

### Add screenshot or video (optional)


### Does it has a breaking change?

yes

1.23 to 1.22 downgrade is not possible

### How to use/test it?

- deploy/update rack to this release

### Checklist
- [ ] New coverage tests
- [x] Unit tests passing
- [x] E2E tests passing
- [x] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
