### PR TITLE
Exclude ca-central-1 GPU from tagging

### DIFF
--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -13,7 +13,7 @@ locals {
   availability_zones       = var.availability_zones != "" ? compact(split(",", var.availability_zones)) : data.aws_availability_zones.available.names
   network_resource_count   = var.high_availability ? 3 : 2
   oidc_sub                 = "${replace(aws_iam_openid_connect_provider.cluster.url, "https://", "")}:sub"
-  gpu_tag_disabled_regions = ["eu-north-1"]
+  gpu_tag_disabled_regions = ["eu-north-1", "ca-central-1"]
 }
 
 data "aws_availability_zones" "available" {


### PR DESCRIPTION
### What is the feature/fix?

Same as https://github.com/convox/convox/pull/540. The region ca-central-1 doesn't support tagging for GPU instances.

### Does it has a breaking change?

No.

### How to use/test it?

Update/install a rack with GPU instance type in the region `ca-central-1`.

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
