### PR TITLE
[Feat 729] Ability to Control LetsEncrypt Renewal Frequency

### DIFF
--- a/docs/installation/production-rack/aws.md
+++ b/docs/installation/production-rack/aws.md
@@ -46,6 +46,7 @@ The following environment variables are required:
 | Name                     | Default                | Description                                                                                                    |
 | -------------------------|------------------------|----------------------------------------------------------------------------------------------------------------|
 | **availability_zones**   |                        | Specify a list of AZ names (minimum 3) to override the random automatic selection from AWS                     |
+| **cert_duration**        | **2160h**              | Certification renew period                                                                                     | 
 | **cidr**                 | **10.1.0.0/16**        | CIDR range for VPC                                                                                             |
 | **high_availability**    | **true**               | Setting this to "false" will create a cluster with less reduntant resources for cost optimization              |
 | **internet_gateway_id**  |                        | If you're using an existing vpc for your rack, use this field to pass the id of the attached internet gateway  |

--- a/docs/installation/production-rack/azure.md
+++ b/docs/installation/production-rack/azure.md
@@ -50,7 +50,7 @@ The following environment variables are required:
 ```html
     $ az ad app permission add --id $ARM_CLIENT_ID --api 00000002-0000-0000-c000-000000000000 --api-permissions 311a71cc-e848-46a1-bdf8-97ff7156d8e6=Scope 824c81eb-e3f8-4ee6-8f6d-de7f50d565b7=Role
     $ az ad app permission grant --id $ARM_CLIENT_ID --api 00000002-0000-0000-c000-000000000000 --consent-type AllPrincipals --scope User.Read
-    $ az ad app permission admin-consent --id $ARM_CLIENT_ID 
+    $ az ad app permission admin-consent --id $ARM_CLIENT_ID
 ```
 ## Install Rack
 ```html
@@ -60,6 +60,7 @@ The following environment variables are required:
 
 | Name        | Default          | Description                                                             |
 | ----------- | ---------------- | ----------------------------------------------------------------------- |
-| **node_type** | **Standard_D3_v3** | Node instance type                                                      |
-| **region**    | **eastus**         | Azure region                                                            |
-| **syslog**    |                  | Forward logs to a syslog endpoint (e.g. **tcp+tls://example.org:1234**)   |
+| **cert_duration**        | **2160h**          | Certification renew period                                                |
+| **node_type**            | **Standard_D3_v3** | Node instance type                                                        |
+| **region**               | **eastus**         | Azure region                                                              |
+| **syslog**               |                    | Forward logs to a syslog endpoint (e.g. **tcp+tls://example.org:1234**)   |

--- a/docs/installation/production-rack/do.md
+++ b/docs/installation/production-rack/do.md
@@ -30,7 +30,7 @@ The following environment variables are required:
 Go to https://cloud.digitalocean.com/account/api/tokens and generate a new Personal Access Token.
 
 - `DIGITALOCEAN_TOKEN` is the token you just created
-  
+
 ### Create Spaces Access Key
 
 Go to https://cloud.digitalocean.com/account/api/tokens and generate a new Spaces Access Key.
@@ -46,6 +46,7 @@ Go to https://cloud.digitalocean.com/account/api/tokens and generate a new Space
 
 | Name              | Default         | Description                                                             |
 | ------------------| ----------------| ----------------------------------------------------------------------- |
+| **cert_duration** | **2160h**       | Certification renew period                                              |
 | **node_type**     | **s-2vcpu-4gb** | [Node instance type](https://slugs.do-api.dev/)                         |
 | **region**        | **nyc3**        | [Digital Ocean region](https://slugs.do-api.dev/)                       |
 | **registry_disk** | **50Gi**        | Registry disk size                                                      |

--- a/docs/installation/production-rack/gcp.md
+++ b/docs/installation/production-rack/gcp.md
@@ -44,7 +44,7 @@ The following environment variables are required:
     $ gcloud iam service-accounts keys create ~/gcloud.convox --iam-account=${serviceaccount}
 ```
 - `GOOGLE_CREDENTIALS` is `~/gcloud.convox`
- 
+
 ### Grant Permissions
 ```html
     $ gcloud projects add-iam-policy-binding $GOOGLE_PROJECT --member=serviceAccount:${serviceaccount} --role=roles/owner
@@ -62,7 +62,8 @@ The following environment variables are required:
 
 | Name          | Default         | Description                                                                              |
 | ------------- | --------------- | ---------------------------------------------------------------------------------------- |
-| **node_type**   | **n1-standard-1** | Node instance type                                                                       |
-| **preemptible** | **true**          | Use [preemptible](https://cloud.google.com/compute/docs/instances/preemptible) instances |
-| **region**      | **us-east1**      | GCP Region                                                                               |
-| **syslog**      |                 | Forward logs to a syslog endpoint (e.g. **tcp+tls://example.org:1234**)                    |
+| **cert_duration** | **2160h**         | Certification renew period                                                                 |
+| **node_type**     | **n1-standard-1** | Node instance type                                                                         |
+| **preemptible**   | **true**          | Use [preemptible](https://cloud.google.com/compute/docs/instances/preemptible) instances   |
+| **region**        | **us-east1**      | GCP Region                                                                                 |
+| **syslog**        |                   | Forward logs to a syslog endpoint (e.g. **tcp+tls://example.org:1234**)                    |

--- a/docs/reference/primitives/app/service.md
+++ b/docs/reference/primitives/app/service.md
@@ -77,7 +77,8 @@ services:
 | ------------- | ---------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | **agent**       | boolean    | false               | Set to **true** to declare this Service as an [Agent](/configuration/agents)                                                      |
 | **annotations** | list       |                     | A list of annotation keys and values to populate the metadata for the deployed pods and their serviceaccounts                              |
-| **build**       | string/map | .                   | Build definition (see below)                                                                                                               |
+| **build**       | string/map | .                   | Build definition (see below)                                                                                                                                            |
+| **certDuration**| string     | 2160h | Certificate renew frequency period                                                                       |
 | **command**     | string     | **CMD** of Dockerfile | The command to run to start a [Process](/reference/primitives/app/process) for this Service                                                                       |
 | **deployment**  | map        |                     | Manual control over deployment parameters                                                                                                  |
 | **domain**      | string     |                     | A custom domain(s) (comma separated) to route to this Service                                                                              |

--- a/docs/reference/primitives/app/service.md
+++ b/docs/reference/primitives/app/service.md
@@ -78,7 +78,7 @@ services:
 | **agent**       | boolean    | false               | Set to **true** to declare this Service as an [Agent](/configuration/agents)                                                      |
 | **annotations** | list       |                     | A list of annotation keys and values to populate the metadata for the deployed pods and their serviceaccounts                              |
 | **build**       | string/map | .                   | Build definition (see below)                                                                                                                                            |
-| **certDuration**| string     | 2160h | Certificate renew frequency period                                                                       |
+| **certificate**| map         |                     | Define certificate parameters                                                                       |
 | **command**     | string     | **CMD** of Dockerfile | The command to run to start a [Process](/reference/primitives/app/process) for this Service                                                                       |
 | **deployment**  | map        |                     | Manual control over deployment parameters                                                                                                  |
 | **domain**      | string     |                     | A custom domain(s) (comma separated) to route to this Service                                                                              |
@@ -129,8 +129,14 @@ services:
 | **manifest** | string | Dockerfile | The filename of the Dockerfile                                |
 | **path**     | string | .          | The path (relative to **convox.yml**) to build for this Service |
 
-> Specifying **build** as a string will set the **path** and leave the other values as defaults.
+### certificate
 
+| Attribute  | Type   | Default    | Description                                                   |
+| ---------- | ------ | ---------- | ------------------------------------------------------------- |
+| **duration** | string | 2160h | Certificate renew frequency period                                |
+
+
+> Specifying **build** as a string will set the **path** and leave the other values as defaults.
 ### deployment
 
 | Attribute | Type   | Default | Description                                                                      |

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -10,37 +10,37 @@ import (
 type Service struct {
 	Name string `yaml:"-"`
 
-	Agent         ServiceAgent          `yaml:"agent,omitempty"`
-	Annotations   ServiceAnnotations    `yaml:"annotations,omitempty"`
-	Build         ServiceBuild          `yaml:"build,omitempty"`
-	Certification Certification         `yaml:"certification,omitempty"`
-	Command       string                `yaml:"command,omitempty"`
-	Deployment    ServiceDeployment     `yaml:"deployment,omitempty"`
-	Domains       ServiceDomains        `yaml:"domain,omitempty"`
-	Drain         int                   `yaml:"drain,omitempty"`
-	Environment   Environment           `yaml:"environment,omitempty"`
-	Health        ServiceHealth         `yaml:"health,omitempty"`
-	Image         string                `yaml:"image,omitempty"`
-	Init          bool                  `yaml:"init,omitempty"`
-	Internal      bool                  `yaml:"internal,omitempty"`
-	Port          ServicePortScheme     `yaml:"port,omitempty"`
-	Ports         []ServicePortProtocol `yaml:"ports,omitempty"`
-	Privileged    bool                  `yaml:"privileged,omitempty"`
-	Resources     []string              `yaml:"resources,omitempty"`
-	Scale         ServiceScale          `yaml:"scale,omitempty"`
-	Singleton     bool                  `yaml:"singleton,omitempty"`
-	Sticky        bool                  `yaml:"sticky,omitempty"`
-	Termination   ServiceTermination    `yaml:"termination,omitempty"`
-	Test          string                `yaml:"test,omitempty"`
-	Timeout       int                   `yaml:"timeout,omitempty"`
-	Tls           ServiceTls            `yaml:"tls,omitempty"`
-	Volumes       []string              `yaml:"volumes,omitempty"`
-	Whitelist     string                `yaml:"whitelist,omitempty"`
+	Agent       ServiceAgent          `yaml:"agent,omitempty"`
+	Annotations ServiceAnnotations    `yaml:"annotations,omitempty"`
+	Build       ServiceBuild          `yaml:"build,omitempty"`
+	Certificate Certificate           `yaml:"certification,omitempty"`
+	Command     string                `yaml:"command,omitempty"`
+	Deployment  ServiceDeployment     `yaml:"deployment,omitempty"`
+	Domains     ServiceDomains        `yaml:"domain,omitempty"`
+	Drain       int                   `yaml:"drain,omitempty"`
+	Environment Environment           `yaml:"environment,omitempty"`
+	Health      ServiceHealth         `yaml:"health,omitempty"`
+	Image       string                `yaml:"image,omitempty"`
+	Init        bool                  `yaml:"init,omitempty"`
+	Internal    bool                  `yaml:"internal,omitempty"`
+	Port        ServicePortScheme     `yaml:"port,omitempty"`
+	Ports       []ServicePortProtocol `yaml:"ports,omitempty"`
+	Privileged  bool                  `yaml:"privileged,omitempty"`
+	Resources   []string              `yaml:"resources,omitempty"`
+	Scale       ServiceScale          `yaml:"scale,omitempty"`
+	Singleton   bool                  `yaml:"singleton,omitempty"`
+	Sticky      bool                  `yaml:"sticky,omitempty"`
+	Termination ServiceTermination    `yaml:"termination,omitempty"`
+	Test        string                `yaml:"test,omitempty"`
+	Timeout     int                   `yaml:"timeout,omitempty"`
+	Tls         ServiceTls            `yaml:"tls,omitempty"`
+	Volumes     []string              `yaml:"volumes,omitempty"`
+	Whitelist   string                `yaml:"whitelist,omitempty"`
 }
 
 type Services []Service
 
-type Certification struct {
+type Certificate struct {
 	Duration string `yaml:"duration,omitempty"`
 }
 

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -10,35 +10,39 @@ import (
 type Service struct {
 	Name string `yaml:"-"`
 
-	Agent        ServiceAgent          `yaml:"agent,omitempty"`
-	Annotations  ServiceAnnotations    `yaml:"annotations,omitempty"`
-	Build        ServiceBuild          `yaml:"build,omitempty"`
-	CertDuration string                `yaml:"certDuration,omitempty"`
-	Command      string                `yaml:"command,omitempty"`
-	Deployment   ServiceDeployment     `yaml:"deployment,omitempty"`
-	Domains      ServiceDomains        `yaml:"domain,omitempty"`
-	Drain        int                   `yaml:"drain,omitempty"`
-	Environment  Environment           `yaml:"environment,omitempty"`
-	Health       ServiceHealth         `yaml:"health,omitempty"`
-	Image        string                `yaml:"image,omitempty"`
-	Init         bool                  `yaml:"init,omitempty"`
-	Internal     bool                  `yaml:"internal,omitempty"`
-	Port         ServicePortScheme     `yaml:"port,omitempty"`
-	Ports        []ServicePortProtocol `yaml:"ports,omitempty"`
-	Privileged   bool                  `yaml:"privileged,omitempty"`
-	Resources    []string              `yaml:"resources,omitempty"`
-	Scale        ServiceScale          `yaml:"scale,omitempty"`
-	Singleton    bool                  `yaml:"singleton,omitempty"`
-	Sticky       bool                  `yaml:"sticky,omitempty"`
-	Termination  ServiceTermination    `yaml:"termination,omitempty"`
-	Test         string                `yaml:"test,omitempty"`
-	Timeout      int                   `yaml:"timeout,omitempty"`
-	Tls          ServiceTls            `yaml:"tls,omitempty"`
-	Volumes      []string              `yaml:"volumes,omitempty"`
-	Whitelist    string                `yaml:"whitelist,omitempty"`
+	Agent         ServiceAgent          `yaml:"agent,omitempty"`
+	Annotations   ServiceAnnotations    `yaml:"annotations,omitempty"`
+	Build         ServiceBuild          `yaml:"build,omitempty"`
+	Certification Certification         `yaml:"certification,omitempty"`
+	Command       string                `yaml:"command,omitempty"`
+	Deployment    ServiceDeployment     `yaml:"deployment,omitempty"`
+	Domains       ServiceDomains        `yaml:"domain,omitempty"`
+	Drain         int                   `yaml:"drain,omitempty"`
+	Environment   Environment           `yaml:"environment,omitempty"`
+	Health        ServiceHealth         `yaml:"health,omitempty"`
+	Image         string                `yaml:"image,omitempty"`
+	Init          bool                  `yaml:"init,omitempty"`
+	Internal      bool                  `yaml:"internal,omitempty"`
+	Port          ServicePortScheme     `yaml:"port,omitempty"`
+	Ports         []ServicePortProtocol `yaml:"ports,omitempty"`
+	Privileged    bool                  `yaml:"privileged,omitempty"`
+	Resources     []string              `yaml:"resources,omitempty"`
+	Scale         ServiceScale          `yaml:"scale,omitempty"`
+	Singleton     bool                  `yaml:"singleton,omitempty"`
+	Sticky        bool                  `yaml:"sticky,omitempty"`
+	Termination   ServiceTermination    `yaml:"termination,omitempty"`
+	Test          string                `yaml:"test,omitempty"`
+	Timeout       int                   `yaml:"timeout,omitempty"`
+	Tls           ServiceTls            `yaml:"tls,omitempty"`
+	Volumes       []string              `yaml:"volumes,omitempty"`
+	Whitelist     string                `yaml:"whitelist,omitempty"`
 }
 
 type Services []Service
+
+type Certification struct {
+	Duration string `yaml:"duration,omitempty"`
+}
 
 type ServiceAgent struct {
 	Enabled bool `yaml:"enabled,omitempty"`

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -10,31 +10,32 @@ import (
 type Service struct {
 	Name string `yaml:"-"`
 
-	Agent       ServiceAgent          `yaml:"agent,omitempty"`
-	Annotations ServiceAnnotations    `yaml:"annotations,omitempty"`
-	Build       ServiceBuild          `yaml:"build,omitempty"`
-	Command     string                `yaml:"command,omitempty"`
-	Deployment  ServiceDeployment     `yaml:"deployment,omitempty"`
-	Domains     ServiceDomains        `yaml:"domain,omitempty"`
-	Drain       int                   `yaml:"drain,omitempty"`
-	Environment Environment           `yaml:"environment,omitempty"`
-	Health      ServiceHealth         `yaml:"health,omitempty"`
-	Image       string                `yaml:"image,omitempty"`
-	Init        bool                  `yaml:"init,omitempty"`
-	Internal    bool                  `yaml:"internal,omitempty"`
-	Port        ServicePortScheme     `yaml:"port,omitempty"`
-	Ports       []ServicePortProtocol `yaml:"ports,omitempty"`
-	Privileged  bool                  `yaml:"privileged,omitempty"`
-	Resources   []string              `yaml:"resources,omitempty"`
-	Scale       ServiceScale          `yaml:"scale,omitempty"`
-	Singleton   bool                  `yaml:"singleton,omitempty"`
-	Sticky      bool                  `yaml:"sticky,omitempty"`
-	Termination ServiceTermination    `yaml:"termination,omitempty"`
-	Test        string                `yaml:"test,omitempty"`
-	Timeout     int                   `yaml:"timeout,omitempty"`
-	Tls         ServiceTls            `yaml:"tls,omitempty"`
-	Volumes     []string              `yaml:"volumes,omitempty"`
-	Whitelist   string                `yaml:"whitelist,omitempty"`
+	Agent        ServiceAgent          `yaml:"agent,omitempty"`
+	Annotations  ServiceAnnotations    `yaml:"annotations,omitempty"`
+	Build        ServiceBuild          `yaml:"build,omitempty"`
+	CertDuration string                `yaml:"certDuration,omitempty"`
+	Command      string                `yaml:"command,omitempty"`
+	Deployment   ServiceDeployment     `yaml:"deployment,omitempty"`
+	Domains      ServiceDomains        `yaml:"domain,omitempty"`
+	Drain        int                   `yaml:"drain,omitempty"`
+	Environment  Environment           `yaml:"environment,omitempty"`
+	Health       ServiceHealth         `yaml:"health,omitempty"`
+	Image        string                `yaml:"image,omitempty"`
+	Init         bool                  `yaml:"init,omitempty"`
+	Internal     bool                  `yaml:"internal,omitempty"`
+	Port         ServicePortScheme     `yaml:"port,omitempty"`
+	Ports        []ServicePortProtocol `yaml:"ports,omitempty"`
+	Privileged   bool                  `yaml:"privileged,omitempty"`
+	Resources    []string              `yaml:"resources,omitempty"`
+	Scale        ServiceScale          `yaml:"scale,omitempty"`
+	Singleton    bool                  `yaml:"singleton,omitempty"`
+	Sticky       bool                  `yaml:"sticky,omitempty"`
+	Termination  ServiceTermination    `yaml:"termination,omitempty"`
+	Test         string                `yaml:"test,omitempty"`
+	Timeout      int                   `yaml:"timeout,omitempty"`
+	Tls          ServiceTls            `yaml:"tls,omitempty"`
+	Volumes      []string              `yaml:"volumes,omitempty"`
+	Whitelist    string                `yaml:"whitelist,omitempty"`
 }
 
 type Services []Service
@@ -78,7 +79,7 @@ type ServicePortScheme struct {
 type ServiceScale struct {
 	Count   ServiceScaleCount
 	Cpu     int
-	Gpu     ServiceScaleGpu     `yaml:"gpu,omitempty"`
+	Gpu     ServiceScaleGpu `yaml:"gpu,omitempty"`
 	Memory  int
 	Targets ServiceScaleTargets `yaml:"targets,omitempty"`
 }
@@ -97,7 +98,7 @@ type ServiceScaleExternalMetric struct {
 type ServiceScaleExternalMetrics []ServiceScaleExternalMetric
 
 type ServiceScaleGpu struct {
-	Count int
+	Count  int
 	Vendor string
 }
 

--- a/provider/aws/ingress.go
+++ b/provider/aws/ingress.go
@@ -1,8 +1,12 @@
 package aws
 
-func (p *Provider) IngressAnnotations(app string) (map[string]string, error) {
+func (p *Provider) IngressAnnotations(certDuration string) (map[string]string, error) {
 	as := map[string]string{
 		"cert-manager.io/cluster-issuer": "letsencrypt",
+	}
+
+	if certDuration != "" {
+		as["cert-manager.io/duration"] = certDuration
 	}
 
 	return as, nil

--- a/provider/aws/ingress_test.go
+++ b/provider/aws/ingress_test.go
@@ -15,11 +15,34 @@ func TestIngressClass(t *testing.T) {
 }
 
 func TestIngressAnnotations(t *testing.T) {
-	testProvider(t, func(p *aws.Provider) {
-		ann, err := p.IngressAnnotations("")
-		require.NoError(t, err)
+	tests := []struct {
+		Name        string
+		Duration    string
+		Annotations map[string]string
+	}{
+		{
+			Name:        "Not passing duration",
+			Duration:    "",
+			Annotations: map[string]string{"cert-manager.io/cluster-issuer": "letsencrypt"},
+		},
+		{
+			Name:     "Passing duration",
+			Duration: "720h",
+			Annotations: map[string]string{
+				"cert-manager.io/cluster-issuer": "letsencrypt",
+				"cert-manager.io/duration":       "720h",
+			},
+		},
+	}
 
-		annotations := map[string]string{"cert-manager.io/cluster-issuer": "letsencrypt"}
-		assert.Equal(t, annotations, ann)
-	})
+	for _, test := range tests {
+		fn := func(t *testing.T) {
+			testProvider(t, func(p *aws.Provider) {
+				ann, err := p.IngressAnnotations(test.Duration)
+				require.NoError(t, err)
+				assert.Equal(t, test.Annotations, ann)
+			})
+		}
+		t.Run(test.Name, fn)
+	}
 }

--- a/provider/azure/ingress.go
+++ b/provider/azure/ingress.go
@@ -1,8 +1,12 @@
 package azure
 
-func (p *Provider) IngressAnnotations(app string) (map[string]string, error) {
+func (p *Provider) IngressAnnotations(certDuration string) (map[string]string, error) {
 	ans := map[string]string{
 		"cert-manager.io/cluster-issuer": "letsencrypt",
+	}
+
+	if certDuration != "" {
+		ans["cert-manager.io/duration"] = certDuration
 	}
 
 	return ans, nil

--- a/provider/do/ingress.go
+++ b/provider/do/ingress.go
@@ -1,8 +1,12 @@
 package do
 
-func (p *Provider) IngressAnnotations(app string) (map[string]string, error) {
+func (p *Provider) IngressAnnotations(certDuration string) (map[string]string, error) {
 	ans := map[string]string{
 		"cert-manager.io/cluster-issuer": "letsencrypt",
+	}
+
+	if certDuration != "" {
+		ans["cert-manager.io/duration"] = certDuration
 	}
 
 	return ans, nil

--- a/provider/gcp/ingress.go
+++ b/provider/gcp/ingress.go
@@ -1,8 +1,12 @@
 package gcp
 
-func (p *Provider) IngressAnnotations(app string) (map[string]string, error) {
+func (p *Provider) IngressAnnotations(certDuration string) (map[string]string, error) {
 	ans := map[string]string{
 		"cert-manager.io/cluster-issuer": "letsencrypt",
+	}
+
+	if certDuration != "" {
+		ans["cert-manager.io/duration"] = certDuration
 	}
 
 	return ans, nil

--- a/provider/k8s/engine.go
+++ b/provider/k8s/engine.go
@@ -10,7 +10,7 @@ type Engine interface {
 	AppIdles(app string) (bool, error)
 	AppParameters() map[string]string
 	Heartbeat() (map[string]interface{}, error)
-	IngressAnnotations(app string) (map[string]string, error)
+	IngressAnnotations(certDuration string) (map[string]string, error)
 	IngressClass() string
 	Log(app, stream string, ts time.Time, message string) error
 	ManifestValidate(m *manifest.Manifest) error

--- a/provider/k8s/release.go
+++ b/provider/k8s/release.go
@@ -341,7 +341,8 @@ func (p *Provider) releaseTemplateIngress(a *structs.App, ss manifest.Services, 
 
 	items := [][]byte{}
 
-	for _, s := range ss {
+	for i := range ss {
+		s := ss[i]
 		ans, err := p.Engine.IngressAnnotations(s.Certificate.Duration)
 		if err != nil {
 			return nil, errors.WithStack(err)

--- a/provider/k8s/release.go
+++ b/provider/k8s/release.go
@@ -334,11 +334,6 @@ func (p *Provider) releaseTemplateCA(a *structs.App, ca *v1.Secret) ([]byte, err
 }
 
 func (p *Provider) releaseTemplateIngress(a *structs.App, ss manifest.Services, opts structs.ReleasePromoteOptions) ([]byte, error) {
-	ans, err := p.Engine.IngressAnnotations(a.Name)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
 	idles, err := p.Engine.AppIdles(a.Name)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -347,6 +342,11 @@ func (p *Provider) releaseTemplateIngress(a *structs.App, ss manifest.Services, 
 	items := [][]byte{}
 
 	for _, s := range ss {
+		ans, err := p.Engine.IngressAnnotations(s.CertDuration)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+
 		params := map[string]interface{}{
 			"Annotations": ans,
 			"App":         a.Name,

--- a/provider/k8s/release.go
+++ b/provider/k8s/release.go
@@ -342,7 +342,7 @@ func (p *Provider) releaseTemplateIngress(a *structs.App, ss manifest.Services, 
 	items := [][]byte{}
 
 	for _, s := range ss {
-		ans, err := p.Engine.IngressAnnotations(s.CertDuration)
+		ans, err := p.Engine.IngressAnnotations(s.Certification.Duration)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}

--- a/provider/k8s/release.go
+++ b/provider/k8s/release.go
@@ -342,7 +342,7 @@ func (p *Provider) releaseTemplateIngress(a *structs.App, ss manifest.Services, 
 	items := [][]byte{}
 
 	for _, s := range ss {
-		ans, err := p.Engine.IngressAnnotations(s.Certification.Duration)
+		ans, err := p.Engine.IngressAnnotations(s.Certificate.Duration)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}

--- a/provider/k8s/release.go
+++ b/provider/k8s/release.go
@@ -422,7 +422,8 @@ func (p *Provider) releaseTemplateServices(a *structs.App, e structs.Environment
 		sc[s.Name] = s.Count
 	}
 
-	for _, s := range ss {
+	for i := range ss {
+		s := ss[i]
 		min := s.Deployment.Minimum
 		max := s.Deployment.Maximum
 
@@ -502,7 +503,8 @@ func (p *Provider) releaseTemplateTimer(a *structs.App, e structs.Environment, r
 func (p *Provider) releaseTemplateVolumes(a *structs.App, ss manifest.Services) ([]byte, error) {
 	vsh := map[string]bool{}
 
-	for _, s := range ss {
+	for i := range ss {
+		s := ss[i]
 		for _, v := range p.volumeSources(a.Name, s.Name, s.Volumes) {
 			if !systemVolume(v) {
 				vsh[v] = true

--- a/provider/local/ingress.go
+++ b/provider/local/ingress.go
@@ -1,6 +1,6 @@
 package local
 
-func (p *Provider) IngressAnnotations(app string) (map[string]string, error) {
+func (p *Provider) IngressAnnotations(certDuration string) (map[string]string, error) {
 	ans := map[string]string{
 		"cert-manager.io/cluster-issuer": "self-signed",
 	}

--- a/provider/local/ingress.go
+++ b/provider/local/ingress.go
@@ -5,6 +5,10 @@ func (p *Provider) IngressAnnotations(certDuration string) (map[string]string, e
 		"cert-manager.io/cluster-issuer": "self-signed",
 	}
 
+	if certDuration != "" {
+		ans["cert-manager.io/duration"] = certDuration
+	}
+
 	return ans, nil
 }
 

--- a/provider/metal/ingress.go
+++ b/provider/metal/ingress.go
@@ -1,6 +1,6 @@
 package metal
 
-func (p *Provider) IngressAnnotations(app string) (map[string]string, error) {
+func (p *Provider) IngressAnnotations(certDuration string) (map[string]string, error) {
 	ans := map[string]string{
 		"cert-manager.io/cluster-issuer": "self-signed",
 	}

--- a/provider/metal/ingress.go
+++ b/provider/metal/ingress.go
@@ -5,6 +5,10 @@ func (p *Provider) IngressAnnotations(certDuration string) (map[string]string, e
 		"cert-manager.io/cluster-issuer": "self-signed",
 	}
 
+	if certDuration != "" {
+		ans["cert-manager.io/duration"] = certDuration
+	}
+
 	return ans, nil
 }
 

--- a/terraform/api/aws/main.tf
+++ b/terraform/api/aws/main.tf
@@ -27,6 +27,7 @@ module "k8s" {
 
   annotations = {
     "cert-manager.io/cluster-issuer" = "letsencrypt"
+    "cert-manager.io/duration"       = var.cert_duration
     "eks.amazonaws.com/role-arn"     = aws_iam_role.api.arn
     "iam.amazonaws.com/role"         = aws_iam_role.api.arn
   }

--- a/terraform/api/aws/variables.tf
+++ b/terraform/api/aws/variables.tf
@@ -1,3 +1,8 @@
+variable "cert_duration" {
+  default = "2160h"
+  type    = string
+}
+
 variable "docker_hub_authentication" {
   type = string
 }

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -2,6 +2,11 @@ variable "availability_zones" {
   default = ""
 }
 
+variable "cert_duration" {
+  default = "2160h"
+  type    = string
+}
+
 variable "cidr" {
   default = "10.1.0.0/16"
 }

--- a/terraform/system/azure/variables.tf
+++ b/terraform/system/azure/variables.tf
@@ -1,3 +1,8 @@
+variable "cert_duration" {
+  default = "2160h"
+  type    = string
+}
+
 variable "docker_hub_username" {
   default = ""
 }

--- a/terraform/system/do/variables.tf
+++ b/terraform/system/do/variables.tf
@@ -2,6 +2,11 @@ variable "access_id" {
   type = string
 }
 
+variable "cert_duration" {
+  default = "2160h"
+  type    = string
+}
+
 variable "docker_hub_username" {
   default = ""
 }

--- a/terraform/system/gcp/variables.tf
+++ b/terraform/system/gcp/variables.tf
@@ -1,3 +1,8 @@
+variable "cert_duration" {
+  default = "2160h"
+  type    = string
+}
+
 variable "docker_hub_username" {
   default = ""
 }


### PR DESCRIPTION
### What is the feature/fix?
[Task 729](https://github.com/convox/issues-private/issues/729)

Ability to control LetsEncrypt renewal frequency.
There are two levels of control: 

1. The rack component, it will be done by terraform.
2. Services, it will be controlled by the convox.yaml file.


### Does it has a breaking change?

No, I had the concern to set the default values that is alread in use.

### How to use/test it?
Add param `cert_duration` for the terraform part.

In the convox.yaml, It was created a field `certDuration` that will control the renew for the service perspective.
