### PR TITLE
3.10.3

### DIFF
--- a/docs/configuration/agents.md
+++ b/docs/configuration/agents.md
@@ -40,7 +40,9 @@ Each [Process](/reference/primitives/app/process) will have the IP address of it
 
 In the example above, any [Process](/reference/primitives/app/service) on the same Rack can communicate
 with the `telemetry` Agent running on its [Instance](/reference/primitives/rack/instance) using the
-following endpoints:
+following endpoints**:
 
 * `udp://$INSTANCE_IP:8125`
 * `tcp://$INSTANCE_IP:8126`
+
+** A process will be able to communicate with the agent only if its running on the same node. Be sure the `INSTANCE_IP` correspond to the node that the process is running.

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -85,9 +85,6 @@ spec:
           - "svc.cluster.local"
           - "cluster.local"
       {{ end }}
-      {{ if .Service.Agent.Enabled }}
-      hostNetwork: true
-      {{ end }}
       serviceAccountName: {{.Service.Name}}
       shareProcessNamespace: {{.Service.Init}}
       terminationGracePeriodSeconds: {{$.Service.Termination.Grace}}

--- a/provider/k8s/testdata/release-basic-app.yml
+++ b/provider/k8s/testdata/release-basic-app.yml
@@ -628,7 +628,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/convox
           name: ca
-      hostNetwork: true
       serviceAccountName: agent
       shareProcessNamespace: true
       terminationGracePeriodSeconds: 30


### PR DESCRIPTION
### What is the feature/fix?

Includes:

- https://github.com/convox/convox/pull/549

### Does it has a breaking change?

There's no breaking change on this release. A process will be able to communicate with the agent only if its running on the same node. The old behaviour was a pod could communicate with agents running in any node in a rack. 

### How to use/test it?

1. Deploy an regular app.
2. Deploy an agent.
3. Try to enter into the container running in a single node. Get the instance ip.
4. Run a curl pointing to the same Ip node and to another node. The request to the same IP should work. 

```
$ convox apps
APP      STATUS   RELEASE
nodejs   running  RIYJBVCENJV
nodejs2  running  RWEDHQWXXFV    <----- Agent

$ convox instances
ID                            STATUS   STARTED         PS  CPU    MEM     PUBLIC  PRIVATE
ip-10-1-169-161.ec2.internal  running  27 minutes ago  11  3.68%  68.79%          10.1.169.161
ip-10-1-202-215.ec2.internal  running  27 minutes ago  10  3.11%  66.57%          10.1.202.215
ip-10-1-80-45.ec2.internal    running  27 minutes ago  10  3.78%  65.33%          10.1.80.45

$ kubectl -n localhost-nodejs exec -it deploy/web -- /bin/sh 
/usr/src/app # /usr/src/app # wget http://ip-10-1-169-161.ec2.internal:3000
Connecting to ip-10-1-169-161.ec2.internal:3000 (10.1.169.161:3000)
wget: can't connect to remote host (10.1.169.161): Connection refused

/usr/src/app # wget http://ip-10-1-202-215.ec2.internal:3000
Connecting to ip-10-1-202-215.ec2.internal:3000 (10.1.202.215:3000)
wget: can't connect to remote host (10.1.202.215): Connection refused

/usr/src/app # wget http://ip-10-1-80-45.ec2.internal:3000
Connecting to ip-10-1-80-45.ec2.internal:3000 (10.1.80.45:3000)
index.html           100% |**********************************************************************************************************************************|    86  0:00:00 ETA

```

### Checklist
- [ ] New coverage tests
- [x] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [x] No warnings or errors on Deepsource/Codecov
