### PR TITLE
Updated DD and Scaling v3 docs

### DIFF
--- a/docs/deployment/scaling.md
+++ b/docs/deployment/scaling.md
@@ -67,3 +67,126 @@ You must consider that the targets for CPU and Memory use the service replicas l
 ```html
 desiredReplicas = ceil[currentReplicas * ( currentMetricValue / desiredMetricValue )]
 ```
+
+### Autoscaling With Custom Metrics
+
+#### Datadog
+
+To autoscale based on Datadog metrics you must first have Datadog and the Datadog Cluster Agent installed. If you used the `datadog-agent-all-features.yaml` when [configuring Datadog](/integrations/monitoring/datadog/) then you will already have the Datadog Cluster Agent installed.
+
+You can check your cluster's pods to see what is installed:
+* If you installed into a custom namespace you will have to add the appropriate `-n NAMESPACE_NAME` option to the end of the command
+```html 
+    $ kubectl get pods                                                          
+    NAME                                    READY   STATUS    RESTARTS   AGE 
+    datadog-bjw2m                           5/5     Running   0          16m 
+    datadog-cluster-agent-b5fd4b7f5-tmkql   1/1     Running   0          16m 
+    datadog-j9c9t                           5/5     Running   0          15m 
+    datadog-pnrln                           5/5     Running   0          16m 
+    datadog-vdzc5                           5/5     Running   0          16m 
+``` 
+
+If your installation does not have an active datadog-cluster-agent pod you can install the Datadog Cluster Agent by following the instructions from the [Datadog Documentation](https://docs.datadoghq.com/containers/cluster_agent/setup/?tab=daemonset). 
+
+
+Once the Datadog Cluster Agent is setup follow this [Datadog Documentation](https://docs.datadoghq.com/containers/guide/cluster_agent_autoscaling_metrics/?tab=daemonset#register-the-external-metrics-provider-service) to configure your Datadog Cluster Agent with an external metrics provider service.
+
+
+Next to setup DatadogMetric follow these steps from the [Datadog Documentation](https://docs.datadoghq.com/containers/guide/cluster_agent_autoscaling_metrics/?tab=daemonset#datadog-cluster-agent).
+
+You can now create scaling manifests based on Datadog's provided template:
+```html 
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogMetric
+metadata:
+  name: <your_datadogmetric_name>
+spec:
+  query: <your_custom_query>
+``` 
+You can deploy these metrics with `kubectl apply -f your-custom-metric-file.yaml`
+
+You will finally then need to deploy a service for your apps to push metrics to Datadog.  You can use this example or write your own based on your own custom configurations:
+```html 
+$ cat dd-agent-service.yaml
+apiVersion: v1 
+kind: Service 
+metadata: 
+  name: dd-agent 
+spec: 
+  selector: 
+    app: datadog 
+  ports: 
+    - protocol: UDP 
+      port: 8125 
+      targetPort: 8125 
+``` 
+Deploy the service with `kubectl apply -f dd-agent-service.yaml`
+
+
+In this example we will use a simple [nodejs](https://github.com/convox-examples/nodejs) app to demonstrate how to setup scaling with this method. 
+
+Based on the provided template we can make a basic page views metric for the node application: 
+```html 
+$ cat page-views-metrics.yaml
+apiVersion: datadoghq.com/v1alpha1 
+kind: DatadogMetric 
+metadata: 
+  name: page-views-metrics 
+spec: 
+  query: avg:page.views{*}.as_count() 
+```
+Then add the metric to your cluster via `kubectl apply -f page-views-metrics.yaml`
+
+
+
+Now we are going configure the `convox.yaml` from our [sample nodejs app](https://github.com/convox-examples/nodejs) to autoscale based on this newly created metric. We will specify the `DatadogMetric` object name in the `scale.targets[].external section`. The `DatadogMetric` object name convention to use in `scale.targets[].external` section is : `datadogmetric@<namespace>:<datadogmetric_name>`
+
+We set the env var `DD_AGENT_HOST` to point at the dd-agent service we previously made to push information to Datadog.
+
+```html 
+environment:
+  - PORT=3000
+services:
+  web:
+    build: .
+    port: 3000
+    environment:
+      - DD_AGENT_HOST=dd-agent.default.svc.cluster.local
+    scale:
+      count: 1-3
+      targets:
+        external:
+          - name: "datadogmetric@default:page-views-metrics"
+            averageValue: 5
+``` 
+
+You can now deploy the application with `convox apps create` then `convox deploy`
+
+Once deployed you can check the replica count and deployed services:
+```html
+$ convox ps -a nodejs            
+ID                    SERVICE  STATUS   RELEASE      STARTED        COMMAND
+web-5bc58fb455-psd9h  web      running  RMOGLKGFMOW  7 minutes ago
+
+$ convox services -a nodejs  
+SERVICE  DOMAIN                                    PORTS
+web      web.nodejs.1e5717e816e99649.convox.cloud  443:3000
+```
+
+You can simulate some views to make the application scale via:
+`$ while true; do curl https://<YOUR_SERVICE_DOMAIN>/; sleep 0.2; done`
+
+You can then see that the application is beginning to scale up:
+```html
+$ convox ps -a nodejs                
+ID                    SERVICE  STATUS   RELEASE      STARTED         COMMAND
+web-5675cccf75-chmcc  web      running  RAZUSIKBQGX  25 seconds ago  
+web-5675cccf75-dm6kb  web      running  RAZUSIKBQGX  6 minutes ago   
+```
+
+When you end the view simulation it will scale down again:
+```html
+$ convox ps -a nodejs
+ID                    SERVICE  STATUS   RELEASE      STARTED         COMMAND
+web-5675cccf75-dm6kb  web      running  RAZUSIKBQGX  11 minutes ago  
+```

--- a/docs/integrations/monitoring/datadog.md
+++ b/docs/integrations/monitoring/datadog.md
@@ -21,92 +21,20 @@ This will export the proxy configuration to a temporary file and then point your
 
 ## Deploy the Datadog Agent
 
-Once you have `kubectl` pointing at your Rack you can deploy the datadog agent as a Kubernetes Daemonset. The following is based on the [Datadog Documentation](https://docs.datadoghq.com/agent/kubernetes/?tab=daemonset) so please refer back there for any specific tweaks you may want to make.
+Once you have `kubectl` pointing at your Rack you can deploy the datadog agent as a Kubernetes Daemonset. The following is based on the [Datadog Daemonset Installation Instructions](https://docs.datadoghq.com/agent/kubernetes/?tab=daemonset) so please refer back there for any specific tweaks you may want to make.
 
-## Configure Agent Permissions
+We recommend that you use the manifest `datadog-agent-all-features.yaml` when applying the agent. This ensures you can easily enter and edit the desired variables in one manifest file.   
+If you prefer you can install the agent piecewise manifests.   
 
-The following commands will create the necessary roles in your cluster for the Datadog Agent to monitor your cluster and your [Apps](/reference/primitives/app)
-
-```html
-$ kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/rbac/clusterrole.yaml"
-
-$ kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/rbac/serviceaccount.yaml"
-
-$ kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/rbac/clusterrolebinding.yaml"
-
-```
-
-## Store Your API Key as a Kubernetes Secret
-
-Retrieve your [API Key](https://app.datadoghq.com/account/settings#api) from the Datadog console and store it as a secret in your cluster by replacing `<DATADOG_API_KEY>` with your API key and running the following command.
-
-```html
-$ kubectl create secret generic datadog-secret --from-literal api-key="<DATADOG_API_KEY>" --namespace="default"
-```
-
-You will then need to grab the Base64 encoded version of your API key to put in the Datadog Agent configuration file. You can retrieve the Base64 encoded value by running
-
-`$ kubectl get secret datadog-secret -o yaml`
-
-and grabbing the value for `api-key`
-
-```html
-$ kubectl get secret datadog-secret -o yaml
-apiVersion: v1
-data:
-  api-key: [BASE64 Encoded Key]
-kind: Secret
-metadata:
-  creationTimestamp: "2020-07-27T20:42:29Z"
-  name: datadog-secret
-  namespace: default
-  resourceVersion: "8898"
-  selfLink: /api/v1/namespaces/default/secrets/datadog-secret
-  uid: XXXXX-XXXXXX-XXXXX-XXXXXX
-type: Opaque
-
-```
-
-## Create a Datadog Agent Manifest
-
-Datadog has several example manifests
-- [Manifest with Logs, APM, process, metrics collection enabled.](https://docs.datadoghq.com/resources/yaml/datadog-agent-all-features.yaml)
-- [Manifest with Logs, APM, and metrics collection enabled.](https://docs.datadoghq.com/resources/yaml/datadog-agent-logs-apm.yaml)
-- [Manifest with Logs and metrics collection enabled.](https://docs.datadoghq.com/resources/yaml/datadog-agent-logs.yaml)
-- [Manifest with APM and metrics collection enabled.](https://docs.datadoghq.com/resources/yaml/datadog-agent-apm.yaml)
-- [Manifest with Network Performance Monitoring enabled](https://docs.datadoghq.com/resources/yaml/datadog-agent-npm.yaml)
-- [Vanilla manifest with just metrics collection enabled.](https://docs.datadoghq.com/resources/yaml/datadog-agent-vanilla.yaml)
-
-Whichever one of these examples you use as your starting point, you will need to insert the Base64 encoded key from the previous step in the section at the top where it says:
-
-```html
-# Source: datadog/templates/secrets.yaml
-# API Key
-apiVersion: v1
-kind: Secret
-metadata:
-  name: datadog-agent
-  labels: {}
-type: Opaque
-data:
-  api-key: PUT_YOUR_BASE64_ENCODED_API_KEY_HERE
-```
-
-We also recommend adding the following to the environment section of the Daemonset spec:
+During installation we recommend adding the following to the environment section of the Daemonset spec:
 
 ```html
 - name: DD_CONTAINER_EXCLUDE
   value: "name:datadog-agent"
 ```
-to remove extra noise from the Datadog Agent itself.
+This will remove extra noise from the Datadog Agent itself.
 
-## Create the Daemonset
-
-If you save your customized Agent Manifest as a file called `datadog-agent.yaml` you can then create the daemonset by running
-
-```html
-$ kubectl apply -f datadog-agent.yaml
-```
+## Verify Installation
 
 You can verify the daemonset by running
 
@@ -114,9 +42,9 @@ You can verify the daemonset by running
 $ kubectl get daemonset
 ```
 
-Once your `DESIRED` `CURRENT` and `READY` counts are all equal your Agents should be up and running. To make any changes to your Agent configuration simply modify your manifest and repeat the steps above.
+Once your `DESIRED` `CURRENT` and `READY` counts are all equal your Agents should be up and running. To make any changes to your Agent configuration simply modify your manifest and repeat the steps.
 
-For further customization and troubleshooting please refer to the [Datadog Docs](https://docs.datadoghq.com/agent/kubernetes/?tab=daemonset)
+For further customization and troubleshooting please refer to the [Datadog Daemonset Config Docs](https://docs.datadoghq.com/containers/kubernetes/configuration?tab=daemonset)
 
 ## Metrics and Traces
 


### PR DESCRIPTION
### What is the feature/fix?

Overhauled our Datadog docs:
Removed our partial / outdated installation instructions and redirected everything to Datadog docs itself.  We don't need to constantly update or support the copy/paste of their docs to our doc site. 

Added Scaling docs:
Datadog custom scaling instructions and example to the Scaling page.

### Does it has a breaking change?

no,  the guide/docs are working now

### How to use/test it?

Read the docs and try it!

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
