### PR TITLE
[Fix 729] Fix name of the certificate property on convox.yaml

### DIFF
--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -13,7 +13,7 @@ type Service struct {
 	Agent       ServiceAgent          `yaml:"agent,omitempty"`
 	Annotations ServiceAnnotations    `yaml:"annotations,omitempty"`
 	Build       ServiceBuild          `yaml:"build,omitempty"`
-	Certificate Certificate           `yaml:"certification,omitempty"`
+	Certificate Certificate           `yaml:"certificate,omitempty"`
 	Command     string                `yaml:"command,omitempty"`
 	Deployment  ServiceDeployment     `yaml:"deployment,omitempty"`
 	Domains     ServiceDomains        `yaml:"domain,omitempty"`


### PR DESCRIPTION
### What is the feature/fix?

The certificate property was misspelled as `certification` which doesn't make sense in the context.

### Does it has a breaking change?

No

### How to use/test it?

environment:
  - PORT=3000
services:
  web:
    agent: true
    domain: ${HOST}
    build: .
    port: 3000
    **certificate**: 
      duration: 2160h
