### PR TITLE
Show cli expiration error

### DIFF
--- a/pkg/cli/login.go
+++ b/pkg/cli/login.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/convox/convox/sdk"
 	"github.com/convox/stdcli"
@@ -49,6 +50,9 @@ func Login(rack sdk.Interface, c *stdcli.Context) error {
 
 	id, err := cl.Auth()
 	if err != nil {
+		if strings.Contains(err.Error(), "cli token is expired") {
+			return err
+		}
 		return fmt.Errorf("invalid login")
 	}
 

--- a/pkg/rack/console.go
+++ b/pkg/rack/console.go
@@ -388,6 +388,10 @@ func listConsole(c *stdcli.Context) ([]Console, error) {
 	}
 
 	rs, err := cc.RackList()
+	if err != nil && strings.Contains(err.Error(), "cli token is expired") {
+		return nil, err
+	}
+
 	switch err.(type) {
 	case console.AuthenticationError:
 		return nil, err


### PR DESCRIPTION
### What is the feature/fix?

https://github.com/convox/issues-private/issues/828

depends on: 
https://github.com/convox/console/pull/287
https://github.com/convox/console3/pull/225

### Add screenshot or video (optional)

![Screenshot from 2023-01-25 21-50-06](https://user-images.githubusercontent.com/12232198/214615076-0f1039ea-55c8-4365-b077-81f6846ab1c2.png)

![Screenshot 2023-01-25 22:00:37](https://user-images.githubusercontent.com/12232198/214615136-dadb3e01-b0cb-4ba3-80b3-7f2ae7856a3f.png)


### Does it has a breaking change?
no

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
