### PR TITLE
Feat-838: Internal router  for rack to communication

### DIFF
--- a/docs/installation/production-rack/aws.md
+++ b/docs/installation/production-rack/aws.md
@@ -49,7 +49,7 @@ The following environment variables are required:
 | **cert_duration**        | **2160h**              | Certification renew period                                                                                     | 
 | **cidr**                 | **10.1.0.0/16**        | CIDR range for VPC                                                                                             |
 | **high_availability**    | **true**               | Setting this to "false" will create a cluster with less reduntant resources for cost optimization              |
-| **internal_router**  |     **false**        | This will install an internal loadbalancer within the vpc |
+| **internal_router**  |     **false**        | Install an internal loadbalancer within the vpc |
 | **internet_gateway_id**  |                        | If you're using an existing vpc for your rack, use this field to pass the id of the attached internet gateway  |
 | **idle_timeout**         | **3600**               | Idle timeout value (in seconds) for the Rack Load Balancer                                                     |
 | **key_pair_name**        |                        | AWS key pair to use for ssh|

--- a/docs/installation/production-rack/aws.md
+++ b/docs/installation/production-rack/aws.md
@@ -49,6 +49,7 @@ The following environment variables are required:
 | **cert_duration**        | **2160h**              | Certification renew period                                                                                     | 
 | **cidr**                 | **10.1.0.0/16**        | CIDR range for VPC                                                                                             |
 | **high_availability**    | **true**               | Setting this to "false" will create a cluster with less reduntant resources for cost optimization              |
+| **internal_router**  |     **false**        | This will install an internal loadbalancer within the vpc |
 | **internet_gateway_id**  |                        | If you're using an existing vpc for your rack, use this field to pass the id of the attached internet gateway  |
 | **idle_timeout**         | **3600**               | Idle timeout value (in seconds) for the Rack Load Balancer                                                     |
 | **key_pair_name**        |                        | AWS key pair to use for ssh|

--- a/docs/management/cli-rack-management.md
+++ b/docs/management/cli-rack-management.md
@@ -46,6 +46,7 @@ The parameters available for your Rack depend on the underlying cloud provider.
 |---------------------------------- |-----------------|
 | **cidr**                          | **10.1.0.0/16** |
 | **internet_gateway_id**           |                 |
+| **internal_router**               | **false**       |
 | **node_capacity_type**            | **on_demand**   |
 | **node_disk**                     | **20**          |
 | **node_type**                     | **t3.small**    |

--- a/docs/reference/primitives/app/service.md
+++ b/docs/reference/primitives/app/service.md
@@ -87,6 +87,7 @@ services:
 | **health**      | string/map | /                   | Health check definition (see below)                                                                                                        |
 | **image**       | string     |                     | An external Docker image to use for this Service (supercedes **build**)                                                                      |
 | **internal**    | boolean    | false               | Set to **true** to make this Service only accessible inside the Rack                                                                         |
+| **internalRouter** | boolean    | false               | Set it to **true** to make this Service only accessible using internal loadbalancer. You also have to set the rack parameter [internal_router](/installation/production-rack/aws) to **true**                 |
 | **port**        | string     |                     | The port that the default Rack balancer will use to [route incoming traffic](/configuration/load-balancers)                     |
 | **ports**       | list       |                     | A list of ports available for internal [service discovery](/configuration/service-discovery) or custom [Balancers](/reference/primitives/app/balancer) |
 | **privileged**  | boolean    | true                | Set to **false** to prevent [Processes](/reference/primitives/app/process) of this Service from running as root inside their container                              |

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -269,8 +269,8 @@ func TestManifestLoad(t *testing.T) {
 				},
 				Init: true,
 				Scale: manifest.ServiceScale{
-					Count:  manifest.ServiceScaleCount{Min: 1, Max: 1},
-					Gpu:    manifest.ServiceScaleGpu{Count: 2, Vendor: "nvidia"},
+					Count: manifest.ServiceScaleCount{Min: 1, Max: 1},
+					Gpu:   manifest.ServiceScaleGpu{Count: 2, Vendor: "nvidia"},
 				},
 				Sticky: false,
 				Termination: manifest.ServiceTermination{
@@ -695,6 +695,7 @@ func TestManifestValidate(t *testing.T) {
 		"service deployment-invalid-low deployment maximum can not be less than 100",
 		"service deployment-invalid-high deployment minimum can not be greater than 100",
 		"service deployment-invalid-high deployment maximum can not be greater than 200",
+		"service internal-router-invalid can not have both internal and internalRouter set as true",
 		"service name serviceF invalid, must contain only lowercase alphanumeric and dashes",
 		"service serviceF references a resource that does not exist: foo",
 		"timer name timer_1 invalid, must contain only lowercase alphanumeric and dashes",

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -10,32 +10,33 @@ import (
 type Service struct {
 	Name string `yaml:"-"`
 
-	Agent       ServiceAgent          `yaml:"agent,omitempty"`
-	Annotations ServiceAnnotations    `yaml:"annotations,omitempty"`
-	Build       ServiceBuild          `yaml:"build,omitempty"`
-	Certificate Certificate           `yaml:"certificate,omitempty"`
-	Command     string                `yaml:"command,omitempty"`
-	Deployment  ServiceDeployment     `yaml:"deployment,omitempty"`
-	Domains     ServiceDomains        `yaml:"domain,omitempty"`
-	Drain       int                   `yaml:"drain,omitempty"`
-	Environment Environment           `yaml:"environment,omitempty"`
-	Health      ServiceHealth         `yaml:"health,omitempty"`
-	Image       string                `yaml:"image,omitempty"`
-	Init        bool                  `yaml:"init,omitempty"`
-	Internal    bool                  `yaml:"internal,omitempty"`
-	Port        ServicePortScheme     `yaml:"port,omitempty"`
-	Ports       []ServicePortProtocol `yaml:"ports,omitempty"`
-	Privileged  bool                  `yaml:"privileged,omitempty"`
-	Resources   []string              `yaml:"resources,omitempty"`
-	Scale       ServiceScale          `yaml:"scale,omitempty"`
-	Singleton   bool                  `yaml:"singleton,omitempty"`
-	Sticky      bool                  `yaml:"sticky,omitempty"`
-	Termination ServiceTermination    `yaml:"termination,omitempty"`
-	Test        string                `yaml:"test,omitempty"`
-	Timeout     int                   `yaml:"timeout,omitempty"`
-	Tls         ServiceTls            `yaml:"tls,omitempty"`
-	Volumes     []string              `yaml:"volumes,omitempty"`
-	Whitelist   string                `yaml:"whitelist,omitempty"`
+	Agent          ServiceAgent          `yaml:"agent,omitempty"`
+	Annotations    ServiceAnnotations    `yaml:"annotations,omitempty"`
+	Build          ServiceBuild          `yaml:"build,omitempty"`
+	Certificate    Certificate           `yaml:"certificate,omitempty"`
+	Command        string                `yaml:"command,omitempty"`
+	Deployment     ServiceDeployment     `yaml:"deployment,omitempty"`
+	Domains        ServiceDomains        `yaml:"domain,omitempty"`
+	Drain          int                   `yaml:"drain,omitempty"`
+	Environment    Environment           `yaml:"environment,omitempty"`
+	Health         ServiceHealth         `yaml:"health,omitempty"`
+	Image          string                `yaml:"image,omitempty"`
+	Init           bool                  `yaml:"init,omitempty"`
+	Internal       bool                  `yaml:"internal,omitempty"`
+	InternalRouter bool                  `yaml:"internalRouter,omitempty"`
+	Port           ServicePortScheme     `yaml:"port,omitempty"`
+	Ports          []ServicePortProtocol `yaml:"ports,omitempty"`
+	Privileged     bool                  `yaml:"privileged,omitempty"`
+	Resources      []string              `yaml:"resources,omitempty"`
+	Scale          ServiceScale          `yaml:"scale,omitempty"`
+	Singleton      bool                  `yaml:"singleton,omitempty"`
+	Sticky         bool                  `yaml:"sticky,omitempty"`
+	Termination    ServiceTermination    `yaml:"termination,omitempty"`
+	Test           string                `yaml:"test,omitempty"`
+	Timeout        int                   `yaml:"timeout,omitempty"`
+	Tls            ServiceTls            `yaml:"tls,omitempty"`
+	Volumes        []string              `yaml:"volumes,omitempty"`
+	Whitelist      string                `yaml:"whitelist,omitempty"`
 }
 
 type Services []Service
@@ -271,7 +272,7 @@ func (s Service) ResourcesName() []string {
 
 func (ss Services) External() Services {
 	return ss.Filter(func(s Service) bool {
-		return !s.Internal
+		return !s.Internal && !s.InternalRouter
 	})
 }
 
@@ -286,6 +287,12 @@ func (ss Services) Filter(fn func(s Service) bool) Services {
 	}
 
 	return fss
+}
+
+func (ss Services) InternalRouter() Services {
+	return ss.Filter(func(s Service) bool {
+		return s.InternalRouter
+	})
 }
 
 func (ss Services) Routable() Services {

--- a/pkg/manifest/testdata/validate.yml
+++ b/pkg/manifest/testdata/validate.yml
@@ -17,6 +17,9 @@ services:
     deployment:
       minimum: 101
       maximum: 201
+  internal-router-invalid:
+    internal: true
+    internalRouter: true
   serviceF:
     build: .
     resources:

--- a/pkg/manifest/validate.go
+++ b/pkg/manifest/validate.go
@@ -114,6 +114,10 @@ func (m *Manifest) validateServices() []error {
 			errs = append(errs, fmt.Errorf("service %s deployment maximum can not be greater than 200", s.Name))
 		}
 
+		if s.Internal && s.InternalRouter {
+			errs = append(errs, fmt.Errorf("service %s can not have both internal and internalRouter set as true", s.Name))
+		}
+
 		for _, r := range s.ResourcesName() {
 			if _, err := m.Resource(r); err != nil {
 				if strings.HasPrefix(err.Error(), "no such resource") {

--- a/pkg/mock/engine.go
+++ b/pkg/mock/engine.go
@@ -31,6 +31,10 @@ func (*TestEngine) IngressClass() string {
 	return ""
 }
 
+func (*TestEngine) IngressInternalClass() string {
+	return ""
+}
+
 func (*TestEngine) Log(_, _ string, _ time.Time, _ string) error {
 	return nil
 }

--- a/provider/aws/ingress.go
+++ b/provider/aws/ingress.go
@@ -15,3 +15,7 @@ func (p *Provider) IngressAnnotations(certDuration string) (map[string]string, e
 func (p *Provider) IngressClass() string {
 	return "nginx"
 }
+
+func (p *Provider) IngressInternalClass() string {
+	return "nginx-internal"
+}

--- a/provider/azure/ingress.go
+++ b/provider/azure/ingress.go
@@ -15,3 +15,7 @@ func (p *Provider) IngressAnnotations(certDuration string) (map[string]string, e
 func (p *Provider) IngressClass() string {
 	return "convox"
 }
+
+func (p *Provider) IngressInternalClass() string {
+	return "nginx-internal"
+}

--- a/provider/do/ingress.go
+++ b/provider/do/ingress.go
@@ -15,3 +15,7 @@ func (p *Provider) IngressAnnotations(certDuration string) (map[string]string, e
 func (p *Provider) IngressClass() string {
 	return "nginx"
 }
+
+func (p *Provider) IngressInternalClass() string {
+	return "nginx-internal"
+}

--- a/provider/gcp/ingress.go
+++ b/provider/gcp/ingress.go
@@ -15,3 +15,7 @@ func (p *Provider) IngressAnnotations(certDuration string) (map[string]string, e
 func (p *Provider) IngressClass() string {
 	return "nginx"
 }
+
+func (p *Provider) IngressInternalClass() string {
+	return "nginx-internal"
+}

--- a/provider/k8s/engine.go
+++ b/provider/k8s/engine.go
@@ -12,6 +12,7 @@ type Engine interface {
 	Heartbeat() (map[string]interface{}, error)
 	IngressAnnotations(certDuration string) (map[string]string, error)
 	IngressClass() string
+	IngressInternalClass() string
 	Log(app, stream string, ts time.Time, message string) error
 	ManifestValidate(m *manifest.Manifest) error
 	RegistryAuth(host, username, password string) (string, string, error)

--- a/provider/k8s/k8s.go
+++ b/provider/k8s/k8s.go
@@ -35,25 +35,26 @@ const (
 )
 
 type Provider struct {
-	Atom          atom.Interface
-	CertManager   bool
-	Config        *rest.Config
-	Convox        cv.Interface
-	Cluster       kubernetes.Interface
-	Domain        string
-	Engine        Engine
-	Image         string
-	Name          string
-	MetricsClient metricsclientset.Interface
-	MetricScraper *MetricScraperClient
-	Namespace     string
-	Password      string
-	Provider      string
-	Resolver      string
-	Router        string
-	Socket        string
-	Storage       string
-	Version       string
+	Atom           atom.Interface
+	CertManager    bool
+	Config         *rest.Config
+	Convox         cv.Interface
+	Cluster        kubernetes.Interface
+	Domain         string
+	DomainInternal string
+	Engine         Engine
+	Image          string
+	Name           string
+	MetricsClient  metricsclientset.Interface
+	MetricScraper  *MetricScraperClient
+	Namespace      string
+	Password       string
+	Provider       string
+	Resolver       string
+	Router         string
+	Socket         string
+	Storage        string
+	Version        string
 
 	ctx       context.Context
 	logger    *logger.Logger
@@ -102,24 +103,25 @@ func FromEnv() (*Provider, error) {
 	ms := NewMetricScraperClient(kc, os.Getenv("METRICS_SCRAPER_HOST"))
 
 	p := &Provider{
-		Atom:          ac,
-		CertManager:   os.Getenv("CERT_MANAGER") == "true",
-		Config:        rc,
-		Convox:        cc,
-		Cluster:       kc,
-		Domain:        os.Getenv("DOMAIN"),
-		Image:         os.Getenv("IMAGE"),
-		MetricsClient: mc,
-		MetricScraper: ms,
-		Name:          ns.Labels["rack"],
-		Namespace:     ns.Name,
-		Password:      os.Getenv("PASSWORD"),
-		Provider:      common.CoalesceString(os.Getenv("PROVIDER"), "k8s"),
-		Resolver:      os.Getenv("RESOLVER"),
-		Router:        os.Getenv("ROUTER"),
-		Socket:        common.CoalesceString(os.Getenv("SOCKET"), "/var/run/docker.sock"),
-		Storage:       common.CoalesceString(os.Getenv("STORAGE"), "/var/storage"),
-		Version:       common.CoalesceString(os.Getenv("VERSION"), "dev"),
+		Atom:           ac,
+		CertManager:    os.Getenv("CERT_MANAGER") == "true",
+		Config:         rc,
+		Convox:         cc,
+		Cluster:        kc,
+		Domain:         os.Getenv("DOMAIN"),
+		DomainInternal: os.Getenv("DOMAIN_INTERNAL"),
+		Image:          os.Getenv("IMAGE"),
+		MetricsClient:  mc,
+		MetricScraper:  ms,
+		Name:           ns.Labels["rack"],
+		Namespace:      ns.Name,
+		Password:       os.Getenv("PASSWORD"),
+		Provider:       common.CoalesceString(os.Getenv("PROVIDER"), "k8s"),
+		Resolver:       os.Getenv("RESOLVER"),
+		Router:         os.Getenv("ROUTER"),
+		Socket:         common.CoalesceString(os.Getenv("SOCKET"), "/var/run/docker.sock"),
+		Storage:        common.CoalesceString(os.Getenv("STORAGE"), "/var/storage"),
+		Version:        common.CoalesceString(os.Getenv("VERSION"), "dev"),
 	}
 
 	return p, nil

--- a/provider/k8s/k8s_test.go
+++ b/provider/k8s/k8s_test.go
@@ -81,15 +81,16 @@ func testProvider(t *testing.T, fn func(*k8s.Provider)) {
 	require.NoError(t, err)
 
 	p := &k8s.Provider{
-		Atom:          a,
-		Cluster:       c,
-		Convox:        cc,
-		Domain:        "domain1",
-		Engine:        &mock.TestEngine{},
-		MetricsClient: mc,
-		Name:          "rack1",
-		Namespace:     "ns1",
-		Provider:      "test",
+		Atom:           a,
+		Cluster:        c,
+		Convox:         cc,
+		Domain:         "domain1",
+		DomainInternal: "domain-internal",
+		Engine:         &mock.TestEngine{},
+		MetricsClient:  mc,
+		Name:           "rack1",
+		Namespace:      "ns1",
+		Provider:       "test",
 	}
 
 	err = p.Initialize(structs.ProviderOptions{})

--- a/provider/k8s/service.go
+++ b/provider/k8s/service.go
@@ -18,6 +18,8 @@ import (
 func (p *Provider) ServiceHost(app string, s manifest.Service) string {
 	if s.Internal {
 		return fmt.Sprintf("%s.%s.%s.local", s.Name, app, p.Name)
+	} else if s.InternalRouter {
+		return fmt.Sprintf("%s.%s.%s", s.Name, app, p.DomainInternal)
 	} else {
 		return fmt.Sprintf("%s.%s.%s", s.Name, app, p.Domain)
 	}

--- a/provider/k8s/service_test.go
+++ b/provider/k8s/service_test.go
@@ -29,6 +29,15 @@ func TestServiceHost(t *testing.T) {
 			HostResponse: "app1-service.app1.rack1.local",
 		},
 		{
+			Name:    "Internal Router",
+			AppName: "app1",
+			Service: manifest.Service{
+				Name:           "app1-service",
+				InternalRouter: true,
+			},
+			HostResponse: "app1-service.app1.domain-internal",
+		},
+		{
 			Name:    "Public",
 			AppName: "app2",
 			Service: manifest.Service{

--- a/provider/k8s/template/app/ingress-internal.yml.tmpl
+++ b/provider/k8s/template/app/ingress-internal.yml.tmpl
@@ -1,0 +1,57 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: {{.Namespace}}
+  name: {{.Service.Name}}-internal
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internal
+    convox.com/backend-protocol: "{{.Service.Port.Scheme}}"
+    convox.com/idles: "{{.Idles}}"
+    nginx.ingress.kubernetes.io/backend-protocol: "{{.Service.Port.Scheme}}"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "{{.Service.Timeout}}"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "{{.Service.Timeout}}"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "{{.Service.Timeout}}"
+    nginx.ingress.kubernetes.io/server-snippet: |
+        keepalive_timeout {{.Service.Timeout}}s;
+        grpc_read_timeout {{.Service.Timeout}}s;
+        grpc_send_timeout {{.Service.Timeout}}s;
+        client_body_timeout {{.Service.Timeout}}s;
+    {{ if .Service.Sticky }}
+    nginx.ingress.kubernetes.io/affinity: cookie
+    nginx.ingress.kubernetes.io/session-cookie-name: CONVOXSESSION
+    {{ end }}
+    nginx.ingress.kubernetes.io/ssl-redirect: "{{.Service.Tls.Redirect}}"
+    {{ if .Service.Whitelist }}
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{{.Service.Whitelist}}"
+    {{ end }}
+    {{ range $k, $v := .Annotations }}
+    {{$k}}: {{ safe $v }}
+    {{ end }}
+  labels:
+    app: {{.App}}
+    service: {{.Service.Name}}
+    system: convox
+    type: service
+spec:
+  ingressClassName: "{{.Class}}"
+  rules:
+    - host: {{ safe .Host }}
+      http:
+        paths:
+        - backend:
+            service:
+              name: {{.Service.Name}}
+              port:
+                number: {{.Service.Port.Port}}
+          pathType: ImplementationSpecific
+    {{ range .Service.Domains }}
+    - host: {{ safe . }}
+      http:
+        paths:
+        - backend:
+            service:
+              name: {{$.Service.Name}}
+              port:
+                number: {{$.Service.Port.Port}}
+          pathType: ImplementationSpecific
+    {{ end }}

--- a/provider/local/ingress.go
+++ b/provider/local/ingress.go
@@ -15,3 +15,7 @@ func (p *Provider) IngressAnnotations(certDuration string) (map[string]string, e
 func (p *Provider) IngressClass() string {
 	return "nginx"
 }
+
+func (p *Provider) IngressInternalClass() string {
+	return "nginx-internal"
+}

--- a/provider/metal/ingress.go
+++ b/provider/metal/ingress.go
@@ -15,3 +15,7 @@ func (p *Provider) IngressAnnotations(certDuration string) (map[string]string, e
 func (p *Provider) IngressClass() string {
 	return "nginx"
 }
+
+func (p *Provider) IngressInternalClass() string {
+	return "nginx-internal"
+}

--- a/terraform/api/aws/iam.tf
+++ b/terraform/api/aws/iam.tf
@@ -27,7 +27,7 @@ resource "aws_iam_role" "api" {
 
 data "aws_iam_policy_document" "ec2_key_pair" {
   statement {
-    actions = ["ec2:CreateKeyPair*"]
+    actions   = ["ec2:CreateKeyPair*"]
     resources = ["*"]
   }
 }

--- a/terraform/api/aws/main.tf
+++ b/terraform/api/aws/main.tf
@@ -17,6 +17,7 @@ module "k8s" {
 
   docker_hub_authentication = var.docker_hub_authentication
   domain                    = var.domain
+  domain_internal           = var.domain_internal
   image                     = var.image
   metrics_scraper_host      = var.metrics_scraper_host
   namespace                 = var.namespace

--- a/terraform/api/aws/variables.tf
+++ b/terraform/api/aws/variables.tf
@@ -11,6 +11,10 @@ variable "domain" {
   type = string
 }
 
+variable "domain_internal" {
+  type = string
+}
+
 variable "high_availability" {
   default = true
 }

--- a/terraform/api/k8s/main.tf
+++ b/terraform/api/k8s/main.tf
@@ -120,6 +120,11 @@ resource "kubernetes_deployment" "api" {
           }
 
           env {
+            name  = "DOMAIN_INTERNAL"
+            value = var.domain_internal
+          }
+
+          env {
             name  = "IMAGE"
             value = "${var.image}:${var.release}"
           }

--- a/terraform/api/k8s/variables.tf
+++ b/terraform/api/k8s/variables.tf
@@ -15,6 +15,11 @@ variable "domain" {
   type = string
 }
 
+variable "domain_internal" {
+  type    = string
+  default = ""
+}
+
 variable "env" {
   default = {}
 }

--- a/terraform/rack/aws/main.tf
+++ b/terraform/rack/aws/main.tf
@@ -22,6 +22,7 @@ module "api" {
 
   docker_hub_authentication = module.k8s.docker_hub_authentication
   domain                    = module.router.endpoint
+  domain_internal           = module.router.endpoint_internal
   high_availability         = var.high_availability
   metrics_scraper_host      = module.metrics.metrics_scraper_host
   image                     = var.image
@@ -69,6 +70,7 @@ module "router" {
 
   high_availability = var.high_availability
   idle_timeout      = var.idle_timeout
+  internal_router   = var.internal_router
   name              = var.name
   namespace         = module.k8s.namespace
   oidc_arn          = var.oidc_arn

--- a/terraform/rack/aws/outputs.tf
+++ b/terraform/rack/aws/outputs.tf
@@ -5,3 +5,7 @@ output "api" {
 output "endpoint" {
   value = module.router.endpoint
 }
+
+output "endpoint_internal" {
+  value = module.router.endpoint_internal
+}

--- a/terraform/rack/aws/variables.tf
+++ b/terraform/rack/aws/variables.tf
@@ -25,6 +25,11 @@ variable "idle_timeout" {
   type = number
 }
 
+variable "internal_router" {
+  type    = bool
+  default = false
+}
+
 variable "image" {
   type = string
 }
@@ -54,7 +59,7 @@ variable "tags" {
 }
 
 variable "subnets" {
-  type = list
+  type = list(any)
 }
 
 variable "whitelist" {

--- a/terraform/router/aws/outputs.tf
+++ b/terraform/router/aws/outputs.tf
@@ -1,3 +1,7 @@
 output "endpoint" {
   value = data.http.alias.response_body
 }
+
+output "endpoint_internal" {
+  value = var.internal_router ? data.http.alias-internal[0].response_body : ""
+}

--- a/terraform/router/aws/variables.tf
+++ b/terraform/router/aws/variables.tf
@@ -6,6 +6,11 @@ variable "idle_timeout" {
   type = number
 }
 
+variable "internal_router" {
+  type    = bool
+  default = false
+}
+
 variable "high_availability" {
   default = true
 }

--- a/terraform/router/nginx/outputs.tf
+++ b/terraform/router/nginx/outputs.tf
@@ -4,3 +4,10 @@ output "selector" {
     service = "ingress-nginx"
   }
 }
+
+output "selector-internal" {
+  value = {
+    system  = "convox"
+    service = "ingress-nginx-internal"
+  }
+}

--- a/terraform/router/nginx/variables.tf
+++ b/terraform/router/nginx/variables.tf
@@ -1,10 +1,16 @@
+
+variable "internal_router" {
+  type    = bool
+  default = false
+}
+
 variable "nginx_image" {
-  type = string
+  type    = string
   default = "registry.k8s.io/ingress-nginx/controller:v1.3.0@sha256:d1707ca76d3b044ab8a28277a2466a02100ee9f58a86af1535a3edf9323ea1b5"
 }
 
 variable "nginx_user" {
-  type = string
+  type    = string
   default = "101"
 }
 

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -99,6 +99,7 @@ module "rack" {
   eks_addons          = module.cluster.eks_addons
   high_availability   = var.high_availability
   idle_timeout        = var.idle_timeout
+  internal_router     = var.internal_router
   image               = local.image
   name                = var.name
   oidc_arn            = module.cluster.oidc_arn

--- a/terraform/system/aws/outputs.tf
+++ b/terraform/system/aws/outputs.tf
@@ -10,6 +10,10 @@ output "endpoint" {
   value = module.rack.endpoint
 }
 
+output "endpoint_internal" {
+  value = module.rack.endpoint_internal
+}
+
 output "release" {
   value = local.release
 }

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -39,6 +39,11 @@ variable "idle_timeout" {
   # }
 }
 
+variable "internal_router" {
+  type    = bool
+  default = false
+}
+
 variable "image" {
   default = "convox/convox"
 }


### PR DESCRIPTION
### What is the feature/fix?

https://github.com/convox/issues-private/issues/838

### Add screenshot or video (optional)

** Any screenshot or video capture using the feature **

### Does it has a breaking change?
No

### How to use/test it?

- deploy/update rack to this version: `convox rack update nahid-internal-router2`
- enable internal router: `convox rack params set internal_router="true"`, this will install a internal loadbalancer
- now deploy the the service with `internalRouter: true`
```
services:
  web:
    build: .
    port: 3000
    internalRouter: true
    environment:
      - PORT=3000
```
- now check the service url: `convox services -a <app>`
- it shouldn't be accessible through internet
### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
