### PR TITLE
Change dependabot to open PRs to the staging branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,14 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    target-branch: "staging"
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "monthly"
+    target-branch: "staging"
   - package-ecosystem: "terraform"
     directory: "/terraform"
     schedule:
       interval: "monthly"
+    target-branch: "staging"


### PR DESCRIPTION
### What is the feature/fix?

Change the target branch for dependabot
