### PR TITLE
Change rack name

### DIFF
--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -178,7 +178,7 @@ func RackInstall(_ sdk.Interface, c *stdcli.Context) error {
 			Vars:     opts,
 		}
 
-		if _, err := rack.Create(c, name, md); err != nil {
+		if _, err := rack.Create(c, name, md, false); err != nil {
 			return err
 		}
 
@@ -279,7 +279,7 @@ func RackMv(_ sdk.Interface, c *stdcli.Context) error {
 		return fmt.Errorf("rack %s has dependencies and can not be moved", from)
 	}
 
-	if _, err := rack.Create(c, to, md); err != nil {
+	if _, err := rack.Create(c, to, md, true); err != nil {
 		return err
 	}
 

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -178,7 +178,7 @@ func RackInstall(_ sdk.Interface, c *stdcli.Context) error {
 			Vars:     opts,
 		}
 
-		if _, err := rack.Create(c, name, md, false); err != nil {
+		if _, err := rack.Create(c, name, md); err != nil {
 			return err
 		}
 
@@ -279,12 +279,34 @@ func RackMv(_ sdk.Interface, c *stdcli.Context) error {
 		return fmt.Errorf("rack %s has dependencies and can not be moved", from)
 	}
 
-	if _, err := rack.Create(c, to, md, true); err != nil {
+	movedToConsole, newRackName := false, to
+	parts := strings.SplitN(to, "/", 2)
+	if len(parts) == 2 {
+		movedToConsole = true
+		newRackName = parts[1]
+	}
+	params := make(map[string]string)
+	params["rack_name"] = newRackName
+	if err := fr.UpdateParams(params); err != nil {
+		return err
+	}
+
+	md, err = fr.Metadata()
+	if err != nil {
+		return err
+	}
+
+	if _, err := rack.Create(c, to, md); err != nil {
 		return err
 	}
 
 	if err := fr.Delete(); err != nil {
 		return err
+	}
+
+	if movedToConsole {
+		ci := c.Info()
+		ci.Add("Attention!", "Login in the console and attach a runtime integration to the rack")
 	}
 
 	return c.OK()

--- a/pkg/cli/testdata/terraform/dev1.args.tf
+++ b/pkg/cli/testdata/terraform/dev1.args.tf
@@ -3,6 +3,7 @@
 			baz = "qux"
 			foo = "bar"
 			name = "dev1"
+			rack_name = "dev1"
 			release = "foo"
 		}
 

--- a/pkg/cli/testdata/terraform/dev1.tf
+++ b/pkg/cli/testdata/terraform/dev1.tf
@@ -1,6 +1,7 @@
 		module "system" {
 			source = "github.com/convox/convox//terraform/system/local?ref=foo"
 			name = "dev1"
+			rack_name = "dev1"
 			release = "foo"
 		}
 

--- a/pkg/cli/testdata/terraform/dev1.version.tf
+++ b/pkg/cli/testdata/terraform/dev1.version.tf
@@ -1,6 +1,7 @@
 		module "system" {
 			source = "github.com/convox/convox//terraform/system/local?ref=otherver"
 			name = "dev1"
+			rack_name = "dev1"
 			release = "otherver"
 		}
 

--- a/pkg/cli/testdata/terraform/dev2.args.tf
+++ b/pkg/cli/testdata/terraform/dev2.args.tf
@@ -3,6 +3,7 @@
 			baz = "qux"
 			foo = "bar"
 			name = "dev2"
+			rack_name = "dev2"
 			release = ""
 		}
 

--- a/pkg/cli/testdata/terraform/dev2.update.tf
+++ b/pkg/cli/testdata/terraform/dev2.update.tf
@@ -3,6 +3,7 @@
 			baz = "qux"
 			name = "dev2"
 			other = "side"
+			rack_name = "dev2"
 			release = ""
 		}
 

--- a/pkg/rack/rack.go
+++ b/pkg/rack/rack.go
@@ -39,10 +39,10 @@ type Rack interface {
 	Sync() error
 }
 
-func Create(c *stdcli.Context, name string, md *Metadata) (Rack, error) {
+func Create(c *stdcli.Context, name string, md *Metadata, apply bool) (Rack, error) {
 	switch len(strings.Split(name, "/")) {
 	case 1:
-		return CreateTerraform(c, name, md)
+		return CreateTerraform(c, name, md, apply)
 	case 2:
 		return CreateConsole(c, name, md)
 	default:

--- a/pkg/rack/rack.go
+++ b/pkg/rack/rack.go
@@ -39,10 +39,10 @@ type Rack interface {
 	Sync() error
 }
 
-func Create(c *stdcli.Context, name string, md *Metadata, apply bool) (Rack, error) {
+func Create(c *stdcli.Context, name string, md *Metadata) (Rack, error) {
 	switch len(strings.Split(name, "/")) {
 	case 1:
-		return CreateTerraform(c, name, md, apply)
+		return CreateTerraform(c, name, md)
 	case 2:
 		return CreateConsole(c, name, md)
 	default:

--- a/pkg/rack/terraform.go
+++ b/pkg/rack/terraform.go
@@ -196,6 +196,7 @@ func (t Terraform) Metadata() (*Metadata, error) {
 	}
 
 	vars["name"] = common.CoalesceString(vars["name"], t.name)
+	vars["rack_name"] = common.CoalesceString(vars["rack_name"], t.name)
 
 	m := &Metadata{
 		Deletable: true,
@@ -415,6 +416,7 @@ func (t Terraform) update(release string, vars map[string]string) error {
 	}
 
 	vars["name"] = common.CoalesceString(vars["name"], t.name)
+	vars["rack_name"] = common.CoalesceString(vars["name"], t.name)
 	vars["release"] = release
 
 	pv, err := terraformProviderVars(t.provider)

--- a/pkg/rack/terraform.go
+++ b/pkg/rack/terraform.go
@@ -41,7 +41,7 @@ func (rv *ReleaseVersion) sameMinor(compare *ReleaseVersion) bool {
 	return (rv.Major == compare.Major) && (rv.Minor == compare.Minor)
 }
 
-func CreateTerraform(c *stdcli.Context, name string, md *Metadata, apply bool) (*Terraform, error) {
+func CreateTerraform(c *stdcli.Context, name string, md *Metadata) (*Terraform, error) {
 	if !terraformInstalled(c) {
 		return nil, fmt.Errorf("terraform required")
 	}
@@ -56,12 +56,6 @@ func CreateTerraform(c *stdcli.Context, name string, md *Metadata, apply bool) (
 	if err := t.init(); err != nil {
 		t.Delete()
 		return nil, err
-	}
-
-	if apply {
-		if err := t.apply(); err != nil {
-			return nil, err
-		}
 	}
 
 	return t, nil
@@ -421,11 +415,9 @@ func (t Terraform) update(release string, vars map[string]string) error {
 		vars = map[string]string{}
 	}
 
-	// rack_name can be updated
-	vars["rack_name"] = t.name
-	// name must be the same or it will not link to the cluster name
 	vars["name"] = common.CoalesceString(vars["name"], t.name)
 	vars["release"] = release
+	vars["rack_name"] = common.CoalesceString(vars["rack_name"], t.name)
 
 	pv, err := terraformProviderVars(t.provider)
 	if err != nil {

--- a/pkg/rack/terraform.go
+++ b/pkg/rack/terraform.go
@@ -41,7 +41,7 @@ func (rv *ReleaseVersion) sameMinor(compare *ReleaseVersion) bool {
 	return (rv.Major == compare.Major) && (rv.Minor == compare.Minor)
 }
 
-func CreateTerraform(c *stdcli.Context, name string, md *Metadata) (*Terraform, error) {
+func CreateTerraform(c *stdcli.Context, name string, md *Metadata, apply bool) (*Terraform, error) {
 	if !terraformInstalled(c) {
 		return nil, fmt.Errorf("terraform required")
 	}
@@ -56,6 +56,12 @@ func CreateTerraform(c *stdcli.Context, name string, md *Metadata) (*Terraform, 
 	if err := t.init(); err != nil {
 		t.Delete()
 		return nil, err
+	}
+
+	if apply {
+		if err := t.apply(); err != nil {
+			return nil, err
+		}
 	}
 
 	return t, nil
@@ -415,8 +421,10 @@ func (t Terraform) update(release string, vars map[string]string) error {
 		vars = map[string]string{}
 	}
 
+	// rack_name can be updated
+	vars["rack_name"] = t.name
+	// name must be the same or it will not link to the cluster name
 	vars["name"] = common.CoalesceString(vars["name"], t.name)
-	vars["rack_name"] = common.CoalesceString(vars["name"], t.name)
 	vars["release"] = release
 
 	pv, err := terraformProviderVars(t.provider)

--- a/provider/k8s/k8s.go
+++ b/provider/k8s/k8s.go
@@ -51,6 +51,7 @@ type Provider struct {
 	Namespace       string
 	Password        string
 	Provider        string
+	RackName        string
 	Resolver        string
 	Router          string
 	Socket          string
@@ -103,6 +104,8 @@ func FromEnv() (*Provider, error) {
 
 	ms := NewMetricScraperClient(kc, os.Getenv("METRICS_SCRAPER_HOST"))
 
+	rn := common.CoalesceString(os.Getenv("RACK_NAME"), ns.Labels["rack"])
+
 	p := &Provider{
 		Atom:            ac,
 		BuildkitEnabled: os.Getenv("BUILDKIT_ENABLED"),
@@ -119,6 +122,7 @@ func FromEnv() (*Provider, error) {
 		Namespace:       ns.Name,
 		Password:        os.Getenv("PASSWORD"),
 		Provider:        common.CoalesceString(os.Getenv("PROVIDER"), "k8s"),
+		RackName:        rn,
 		Resolver:        os.Getenv("RESOLVER"),
 		Router:          os.Getenv("ROUTER"),
 		Socket:          common.CoalesceString(os.Getenv("SOCKET"), "/var/run/docker.sock"),

--- a/provider/k8s/system.go
+++ b/provider/k8s/system.go
@@ -15,6 +15,7 @@ import (
 
 func (p *Provider) SystemGet() (*structs.System, error) {
 	status := "running"
+	fmt.Printf("provider SystemGet: %+v\n", p)
 
 	// status, err := p.Engine.SystemStatus()
 	// if err != nil {
@@ -35,7 +36,7 @@ func (p *Provider) SystemGet() (*structs.System, error) {
 
 	s := &structs.System{
 		Domain:   fmt.Sprintf("router.%s", p.Domain),
-		Name:     p.Name,
+		Name:     p.RackName,
 		Provider: p.Provider,
 		Status:   status,
 		Version:  p.Version,

--- a/provider/k8s/system.go
+++ b/provider/k8s/system.go
@@ -15,7 +15,6 @@ import (
 
 func (p *Provider) SystemGet() (*structs.System, error) {
 	status := "running"
-	fmt.Printf("provider SystemGet: %+v\n", p)
 
 	// status, err := p.Engine.SystemStatus()
 	// if err != nil {

--- a/terraform/api/aws/main.tf
+++ b/terraform/api/aws/main.tf
@@ -23,6 +23,7 @@ module "k8s" {
   metrics_scraper_host      = var.metrics_scraper_host
   namespace                 = var.namespace
   rack                      = var.name
+  rack_name                 = var.rack_name
   release                   = var.release
   replicas                  = var.high_availability ? 2 : 1
   resolver                  = var.resolver

--- a/terraform/api/aws/variables.tf
+++ b/terraform/api/aws/variables.tf
@@ -36,6 +36,10 @@ variable "name" {
   type = string
 }
 
+variable "rack_name" {
+  type = string
+}
+
 variable "namespace" {
   type = string
 }

--- a/terraform/api/azure/main.tf
+++ b/terraform/api/azure/main.tf
@@ -54,6 +54,7 @@ module "k8s" {
   image                     = var.image
   namespace                 = var.namespace
   rack                      = var.name
+  rack_name                 = var.rack_name
   release                   = var.release
 
   labels = {

--- a/terraform/api/azure/variables.tf
+++ b/terraform/api/azure/variables.tf
@@ -22,6 +22,10 @@ variable "name" {
   type = string
 }
 
+variable "rack_name" {
+  type = string
+}
+
 variable "namespace" {
   type = string
 }

--- a/terraform/api/do/main.tf
+++ b/terraform/api/do/main.tf
@@ -43,6 +43,7 @@ module "k8s" {
   image                     = var.image
   namespace                 = var.namespace
   rack                      = var.name
+  rack_name                 = var.rack_name
   release                   = var.release
   resolver                  = var.resolver
   replicas                  = var.high_availability ? 2 : 1

--- a/terraform/api/do/variables.tf
+++ b/terraform/api/do/variables.tf
@@ -30,6 +30,10 @@ variable "name" {
   type = string
 }
 
+variable "rack_name" {
+  type = string
+}
+
 variable "namespace" {
   type = string
 }

--- a/terraform/api/gcp/main.tf
+++ b/terraform/api/gcp/main.tf
@@ -44,6 +44,7 @@ module "k8s" {
   image                     = var.image
   namespace                 = var.namespace
   rack                      = var.name
+  rack_name                 = var.rack_name
   release                   = var.release
   resolver                  = var.resolver
 

--- a/terraform/api/gcp/variables.tf
+++ b/terraform/api/gcp/variables.tf
@@ -22,6 +22,10 @@ variable "name" {
   type = string
 }
 
+variable "rack_name" {
+  type = string
+}
+
 variable "namespace" {
   type = string
 }

--- a/terraform/api/k8s/main.tf
+++ b/terraform/api/k8s/main.tf
@@ -153,6 +153,11 @@ resource "kubernetes_deployment" "api" {
           }
 
           env {
+            name  = "RACK_NAME"
+            value = var.rack_name
+          }
+
+          env {
             name  = "VERSION"
             value = var.release
           }

--- a/terraform/api/k8s/variables.tf
+++ b/terraform/api/k8s/variables.tf
@@ -74,3 +74,7 @@ variable "socket" {
 variable "volumes" {
   default = {}
 }
+
+variable "rack_name" {
+  type = string
+}

--- a/terraform/api/local/main.tf
+++ b/terraform/api/local/main.tf
@@ -18,6 +18,7 @@ module "k8s" {
   image                     = var.image
   namespace                 = var.namespace
   rack                      = var.name
+  rack_name                 = var.rack_name
   release                   = var.release
   replicas                  = 1
   resolver                  = var.resolver

--- a/terraform/api/local/variables.tf
+++ b/terraform/api/local/variables.tf
@@ -14,6 +14,10 @@ variable "name" {
   type = string
 }
 
+variable "rack_name" {
+  type = string
+}
+
 variable "namespace" {
   type = string
 }

--- a/terraform/api/metal/variables.tf
+++ b/terraform/api/metal/variables.tf
@@ -14,6 +14,10 @@ variable "name" {
   type = string
 }
 
+variable "rack_name" {
+  type = string
+}
+
 variable "namespace" {
   type = string
 }

--- a/terraform/rack/aws/main.tf
+++ b/terraform/rack/aws/main.tf
@@ -28,6 +28,7 @@ module "api" {
   metrics_scraper_host      = module.metrics.metrics_scraper_host
   image                     = var.image
   name                      = var.name
+  rack_name                 = var.rack_name
   namespace                 = module.k8s.namespace
   oidc_arn                  = var.oidc_arn
   oidc_sub                  = var.oidc_sub

--- a/terraform/rack/aws/variables.tf
+++ b/terraform/rack/aws/variables.tf
@@ -42,6 +42,10 @@ variable "name" {
   type = string
 }
 
+variable "rack_name" {
+  type = string
+}
+
 variable "oidc_arn" {
   type = string
 }

--- a/terraform/rack/azure/main.tf
+++ b/terraform/rack/azure/main.tf
@@ -26,6 +26,7 @@ module "api" {
   domain                    = module.router.endpoint
   image                     = var.image
   name                      = var.name
+  rack_name                 = var.rack_name
   namespace                 = module.k8s.namespace
   region                    = var.region
   release                   = var.release

--- a/terraform/rack/azure/variables.tf
+++ b/terraform/rack/azure/variables.tf
@@ -22,6 +22,10 @@ variable "name" {
   type = string
 }
 
+variable "rack_name" {
+  type = string
+}
+
 variable "region" {
   type = string
 }

--- a/terraform/rack/do/main.tf
+++ b/terraform/rack/do/main.tf
@@ -28,6 +28,7 @@ module "api" {
   high_availability         = var.high_availability
   image                     = var.image
   name                      = var.name
+  rack_name                 = var.rack_name
   namespace                 = module.k8s.namespace
   region                    = var.region
   release                   = var.release

--- a/terraform/rack/do/variables.tf
+++ b/terraform/rack/do/variables.tf
@@ -30,6 +30,10 @@ variable "name" {
   type = string
 }
 
+variable "rack_name" {
+  type = string
+}
+
 variable "region" {
   type = string
 }

--- a/terraform/rack/gcp/main.tf
+++ b/terraform/rack/gcp/main.tf
@@ -26,6 +26,7 @@ module "api" {
   domain                    = module.router.endpoint
   image                     = var.image
   name                      = var.name
+  rack_name                 = var.rack_name
   namespace                 = module.k8s.namespace
   nodes_account             = var.nodes_account
   project_id                = var.project_id

--- a/terraform/rack/gcp/variables.tf
+++ b/terraform/rack/gcp/variables.tf
@@ -22,6 +22,10 @@ variable "name" {
   type = string
 }
 
+variable "rack_name" {
+  type = string
+}
+
 variable "network" {
   type = string
 }

--- a/terraform/rack/local/main.tf
+++ b/terraform/rack/local/main.tf
@@ -23,6 +23,7 @@ module "api" {
   docker_hub_authentication = module.k8s.docker_hub_authentication
   image                     = var.image
   name                      = var.name
+  rack_name                 = var.rack_name
   namespace                 = module.k8s.namespace
   release                   = var.release
   resolver                  = module.resolver.endpoint

--- a/terraform/rack/local/variables.tf
+++ b/terraform/rack/local/variables.tf
@@ -15,6 +15,10 @@ variable "name" {
   type = string
 }
 
+variable "rack_name" {
+  type = string
+}
+
 variable "os" {
   default = "ubuntu"
 }

--- a/terraform/rack/metal/main.tf
+++ b/terraform/rack/metal/main.tf
@@ -11,9 +11,9 @@ module "k8s" {
 
   docker_hub_username = var.docker_hub_username
   docker_hub_password = var.docker_hub_password
-  domain  = module.router.endpoint
-  name    = var.name
-  release = var.release
+  domain              = module.router.endpoint
+  name                = var.name
+  release             = var.release
 }
 
 module "api" {
@@ -24,15 +24,16 @@ module "api" {
   }
 
   docker_hub_authentication = module.k8s.docker_hub_authentication
-  domain    = local.endpoint
-  image     = var.image
-  name      = var.name
-  namespace = module.k8s.namespace
-  release   = var.release
-  resolver  = module.resolver.endpoint
-  router    = module.router.endpoint
-  secret    = random_string.secret.result
-  syslog    = var.syslog
+  domain                    = local.endpoint
+  image                     = var.image
+  name                      = var.name
+  rack_name                 = var.rack_name
+  namespace                 = module.k8s.namespace
+  release                   = var.release
+  resolver                  = module.resolver.endpoint
+  router                    = module.router.endpoint
+  secret                    = random_string.secret.result
+  syslog                    = var.syslog
 }
 
 module "resolver" {
@@ -43,10 +44,10 @@ module "resolver" {
   }
 
   docker_hub_authentication = module.k8s.docker_hub_authentication
-  image     = var.image
-  namespace = module.k8s.namespace
-  rack      = var.name
-  release   = var.release
+  image                     = var.image
+  namespace                 = module.k8s.namespace
+  rack                      = var.name
+  release                   = var.release
 }
 
 module "router" {

--- a/terraform/rack/metal/variables.tf
+++ b/terraform/rack/metal/variables.tf
@@ -18,6 +18,10 @@ variable "name" {
   type = string
 }
 
+variable "rack_name" {
+  type = string
+}
+
 variable "registry_disk" {
   default = "50Gi"
 }

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -106,6 +106,7 @@ module "rack" {
   internal_router     = var.internal_router
   image               = local.image
   name                = var.name
+  rack_name           = var.rack_name
   oidc_arn            = module.cluster.oidc_arn
   oidc_sub            = module.cluster.oidc_sub
   proxy_protocol      = var.proxy_protocol

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -89,6 +89,10 @@ variable "name" {
   type = string
 }
 
+variable "rack_name" {
+  type = string
+}
+
 variable "node_capacity_type" {
   default = "on_demand"
 }

--- a/terraform/system/azure/main.tf
+++ b/terraform/system/azure/main.tf
@@ -54,6 +54,7 @@ module "rack" {
   docker_hub_password = var.docker_hub_password
   image               = var.image
   name                = var.name
+  rack_name           = var.rack_name
   region              = var.region
   release             = local.release
   resource_group      = azurerm_resource_group.rack.id

--- a/terraform/system/azure/variables.tf
+++ b/terraform/system/azure/variables.tf
@@ -28,6 +28,10 @@ variable "name" {
   type = string
 }
 
+variable "rack_name" {
+  type = string
+}
+
 variable "node_type" {
   default = "Standard_D2_v3"
 }

--- a/terraform/system/do/main.tf
+++ b/terraform/system/do/main.tf
@@ -49,6 +49,7 @@ module "rack" {
   high_availability   = var.high_availability
   image               = var.image
   name                = var.name
+  rack_name           = var.rack_name
   region              = var.region
   registry_disk       = var.registry_disk
   release             = local.release

--- a/terraform/system/do/variables.tf
+++ b/terraform/system/do/variables.tf
@@ -36,6 +36,10 @@ variable "name" {
   type = string
 }
 
+variable "rack_name" {
+  type = string
+}
+
 variable "node_type" {
   default = "s-2vcpu-4gb"
 }

--- a/terraform/system/gcp/main.tf
+++ b/terraform/system/gcp/main.tf
@@ -52,6 +52,7 @@ module "rack" {
   docker_hub_password = var.docker_hub_password
   image               = var.image
   name                = var.name
+  rack_name           = var.rack_name
   network             = module.cluster.network
   nodes_account       = module.cluster.nodes_account
   project_id          = module.project.id

--- a/terraform/system/gcp/variables.tf
+++ b/terraform/system/gcp/variables.tf
@@ -28,6 +28,10 @@ variable "name" {
   type = string
 }
 
+variable "rack_name" {
+  type = string
+}
+
 variable "node_type" {
   default = "n1-standard-2"
 }

--- a/terraform/system/local/main.tf
+++ b/terraform/system/local/main.tf
@@ -27,6 +27,7 @@ module "rack" {
   docker_hub_password = var.docker_hub_password
   image               = var.image
   name                = var.name
+  rack_name           = var.rack_name
   platform            = module.platform.name
   os                  = var.os
   release             = local.release

--- a/terraform/system/local/variables.tf
+++ b/terraform/system/local/variables.tf
@@ -14,6 +14,10 @@ variable "name" {
   type = string
 }
 
+variable "rack_name" {
+  type = string
+}
+
 variable "os" {
   default = "ubuntu"
 }

--- a/terraform/system/metal/variables.tf
+++ b/terraform/system/metal/variables.tf
@@ -18,6 +18,10 @@ variable "name" {
   type = string
 }
 
+variable "rack_name" {
+  type = string
+}
+
 variable "registry_disk" {
   default = "50Gi"
 }


### PR DESCRIPTION
### What is the feature/fix?

Enables change on rack names using CLI.

### Does it has a breaking change?

No, new feature.

### How to use/test it?

1. Install the RC CLI
2. Install rack using the CLI: `convox rack install rackname -v RC` (RC is being created)
3. Move the rack `convox rack mv rackname newrackname`
4. Switch to the new name: `convox switch newrackname`
5. Run `convox rack` and the name should be `newrackname`.

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
