### PR TITLE
IMDSv1 to IMDSv2 on v3 racks

### DIFF
--- a/docs/configuration/rack-to-rack.md
+++ b/docs/configuration/rack-to-rack.md
@@ -1,0 +1,36 @@
+--- 
+title: "Rack-to-Rack Communication" 
+draft: false 
+slug: Rack-to-Rack Communication 
+url: /configuration/rack-to-rack 
+---
+# Rack-to-Rack Communication 
+
+Using Convox’s (internal_router)[/installation/production-rack/aws/] rack parameter along with service configuration (internalRouter)[/reference/primitives/app/service/] you can enable private communication between racks/clusters on your cloud platform.  You can complete this in a few simple steps: 
+
+## Prerequisites
+It is required that you are on rack version `3.10.6` or later.  You can check your rack's version by running `convox rack -r rackNAME`
+
+You will first need to establish connectivity between your racks in your given cloud environment.  Under standard conditions rack's will be installed in seperate VPCs. Connectivity is most easily accomplished via VPC Peering and configuration of routes, and security groups.   
+
+You will need to manually complete this setup process on your own as we cannot predict your existing infrastructure or how you would need to facilitate or secure this connection/peering to suit your requirements. 
+
+## Configuration
+Once connectivity is established you will need to change the (internalRouter)[/reference/primitives/app/service/] rack parameter to `true` by running: 
+`convox rack params set internal_router=true –r rackNAME`
+* This will install the internal loadbalancer into the VPC that facilitates rack-to-rack communication. 
+* You can verify that the load balancer was created in your cloud environment by checking it’s applicable service page. 
+
+
+Finally set your desired service to use this internal load balancer by configuring the service attribute (internalRouter)[/reference/primitives/app/service/] to `true` and deploy the application. 
+
+```html
+services: 
+  web: 
+    build: . 
+    port: 3000 
+    internalRouter: true 
+    environment: 
+      - PORT=3000 
+```
+* You can verify that this service is being internally routed by running `convox services –a appNAME` and attempting to access the service URL from the public internet and again from a service within your VPC peered Rack. 

--- a/docs/installation/production-rack/aws.md
+++ b/docs/installation/production-rack/aws.md
@@ -52,6 +52,7 @@ The following environment variables are required:
 | **internal_router**  |     **false**        | Install an internal loadbalancer within the vpc |
 | **internet_gateway_id**  |                        | If you're using an existing vpc for your rack, use this field to pass the id of the attached internet gateway  |
 | **idle_timeout**         | **3600**               | Idle timeout value (in seconds) for the Rack Load Balancer                                                     |
+| **imds_http_tokens**         | **optional**               | Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Can be optional or required                                                     |
 | **key_pair_name**        |                        | AWS key pair to use for ssh|
 | **node_capacity_type**   | **on_demand**          | Can be either "on_demand" or "spot". Spot will use AWS spot instances for the cluster nodes                    |
 | **node_disk**            | **20**                 | Node disk size in GB                                                                                           |

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -96,15 +96,15 @@ resource "aws_eks_node_group" "cluster" {
 
   count = var.high_availability ? 3 : 1
 
-  ami_type        = var.gpu_type ? "AL2_x86_64_GPU" : var.arm_type ? "AL2_ARM_64" : "AL2_x86_64"
-  capacity_type   = var.node_capacity_type
-  cluster_name    = aws_eks_cluster.cluster.name
-  instance_types  = split(",", random_id.node_group.keepers.node_type)
-  node_group_name = "${var.name}-${local.availability_zones[count.index]}-${count.index}${random_id.node_group.hex}"
-  node_role_arn   = random_id.node_group.keepers.role_arn
-  subnet_ids      = [var.private ? aws_subnet.private[count.index].id : aws_subnet.public[count.index].id]
-  tags            = local.tags
-  version         = var.k8s_version
+  ami_type             = var.gpu_type ? "AL2_x86_64_GPU" : var.arm_type ? "AL2_ARM_64" : "AL2_x86_64"
+  capacity_type        = var.node_capacity_type
+  cluster_name         = aws_eks_cluster.cluster.name
+  instance_types       = split(",", random_id.node_group.keepers.node_type)
+  node_group_name      = "${var.name}-${local.availability_zones[count.index]}-${count.index}${random_id.node_group.hex}"
+  node_role_arn        = random_id.node_group.keepers.role_arn
+  subnet_ids           = [var.private ? aws_subnet.private[count.index].id : aws_subnet.public[count.index].id]
+  tags                 = local.tags
+  version              = var.k8s_version
 
   launch_template {
     id      = aws_launch_template.cluster.id
@@ -153,6 +153,10 @@ resource "aws_launch_template" "cluster" {
       volume_type = "gp3"
       volume_size = random_id.node_group.keepers.node_disk
     }
+  }
+
+  metadata_options{
+    http_tokens = var.imds_http_tokens
   }
 
   dynamic "tag_specifications" {

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -155,7 +155,7 @@ resource "aws_launch_template" "cluster" {
     }
   }
 
-  metadata_options{
+  metadata_options {
     http_tokens = var.imds_http_tokens
   }
 

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -96,15 +96,15 @@ resource "aws_eks_node_group" "cluster" {
 
   count = var.high_availability ? 3 : 1
 
-  ami_type             = var.gpu_type ? "AL2_x86_64_GPU" : var.arm_type ? "AL2_ARM_64" : "AL2_x86_64"
-  capacity_type        = var.node_capacity_type
-  cluster_name         = aws_eks_cluster.cluster.name
-  instance_types       = split(",", random_id.node_group.keepers.node_type)
-  node_group_name      = "${var.name}-${local.availability_zones[count.index]}-${count.index}${random_id.node_group.hex}"
-  node_role_arn        = random_id.node_group.keepers.role_arn
-  subnet_ids           = [var.private ? aws_subnet.private[count.index].id : aws_subnet.public[count.index].id]
-  tags                 = local.tags
-  version              = var.k8s_version
+  ami_type        = var.gpu_type ? "AL2_x86_64_GPU" : var.arm_type ? "AL2_ARM_64" : "AL2_x86_64"
+  capacity_type   = var.node_capacity_type
+  cluster_name    = aws_eks_cluster.cluster.name
+  instance_types  = split(",", random_id.node_group.keepers.node_type)
+  node_group_name = "${var.name}-${local.availability_zones[count.index]}-${count.index}${random_id.node_group.hex}"
+  node_role_arn   = random_id.node_group.keepers.role_arn
+  subnet_ids      = [var.private ? aws_subnet.private[count.index].id : aws_subnet.public[count.index].id]
+  tags            = local.tags
+  version         = var.k8s_version
 
   launch_template {
     id      = aws_launch_template.cluster.id
@@ -153,10 +153,6 @@ resource "aws_launch_template" "cluster" {
       volume_type = "gp3"
       volume_size = random_id.node_group.keepers.node_disk
     }
-  }
-
-  metadata_options{
-    http_tokens = var.imds_http_tokens
   }
 
   dynamic "tag_specifications" {

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -155,6 +155,10 @@ resource "aws_launch_template" "cluster" {
     }
   }
 
+  metadata_options{
+    http_tokens = var.imds_http_tokens
+  }
+
   dynamic "tag_specifications" {
     for_each = toset(
       concat(["instance", "volume", "network-interface", "spot-instances-request"],

--- a/terraform/cluster/aws/variables.tf
+++ b/terraform/cluster/aws/variables.tf
@@ -23,6 +23,11 @@ variable "high_availability" {
   default = true
 }
 
+variable "imds_http_tokens" {
+  type    = string
+  default = "optional"
+}
+
 variable "internet_gateway_id" {
   default = ""
 }

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -55,6 +55,7 @@ module "cluster" {
   key_pair_name            = var.key_pair_name
   kube_proxy_version       = var.kube_proxy_version
   k8s_version              = var.k8s_version
+  imds_http_tokens         = var.imds_http_tokens
   name                     = var.name
   node_capacity_type       = upper(var.node_capacity_type)
   node_disk                = var.node_disk

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -48,6 +48,11 @@ variable "image" {
   default = "convox/convox"
 }
 
+variable "imds_http_tokens" {
+  type    = string
+  default = "optional"
+}
+
 variable "internet_gateway_id" {
   default = ""
 }


### PR DESCRIPTION
### What is the feature/fix?

Add field on eks cluster to control if Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Can be optional or required.

Task Link in [Asana](https://app.asana.com/0/1203637156732418/1204066841595405/f)
 
### Does it has a breaking change?

No

### How to use/test it?

There's a new parameter available on rack installation called: imds_http_tokens that can be `optional` or `required`.

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
