### PR TITLE
Feat: Export build git sha env

### DIFF
--- a/pkg/cli/builds.go
+++ b/pkg/cli/builds.go
@@ -108,6 +108,14 @@ func build(rack sdk.Interface, c *stdcli.Context, development bool) (*structs.Bu
 
 	dir := coalesce(c.Arg(0), ".")
 
+	if data, err := c.Execute("git", "-C", dir, "rev-parse", "HEAD"); err == nil {
+		opts.GitSha = options.String(strings.TrimSpace(string(data)))
+	}
+
+	if os.Getenv("TEST") == "true" {
+		opts.GitSha = nil
+	}
+
 	if c.Bool("external") {
 		return buildExternal(rack, c, opts)
 	}

--- a/pkg/structs/build.go
+++ b/pkg/structs/build.go
@@ -9,6 +9,7 @@ type Build struct {
 	App         string `json:"app"`
 	Description string `json:"description"`
 	Entrypoint  string `json:"entrypoint"`
+	GitSha      string `json:"git-sha"`
 	Logs        string `json:"logs"`
 	Manifest    string `json:"manifest"`
 	Process     string `json:"process"`
@@ -33,6 +34,8 @@ type BuildCreateOptions struct {
 	Manifest       *string   `flag:"manifest,m" param:"manifest"`
 	NoCache        *bool     `flag:"no-cache" param:"no-cache"`
 	WildcardDomain *bool     `flag:"wildcard-domain" param:"wildcard-domain"`
+
+	GitSha *string `param:"git-sha"`
 }
 
 type BuildListOptions struct {

--- a/provider/k8s/build.go
+++ b/provider/k8s/build.go
@@ -32,6 +32,7 @@ func (p *Provider) BuildCreate(app, url string, opts structs.BuildCreateOptions)
 	b := structs.NewBuild(app)
 
 	b.Description = common.DefaultString(opts.Description, "")
+	b.GitSha = common.DefaultString(opts.GitSha, "")
 	b.Started = time.Now()
 
 	if _, err := p.buildCreate(b); err != nil {
@@ -573,6 +574,9 @@ func (p *Provider) buildList(app string) (structs.Builds, error) {
 func (p *Provider) buildMarshal(b *structs.Build) *ca.Build {
 	return &ca.Build{
 		ObjectMeta: am.ObjectMeta{
+			Annotations: map[string]string{
+				"git-sha": b.GitSha,
+			},
 			Namespace: p.AppNamespace(b.App),
 			Name:      strings.ToLower(b.Id),
 			Labels: map[string]string{
@@ -612,6 +616,7 @@ func (p *Provider) buildUnmarshal(kb *ca.Build) (*structs.Build, error) {
 		Description: kb.Spec.Description,
 		Ended:       ended,
 		Entrypoint:  kb.Spec.Entrypoint,
+		GitSha:      kb.ObjectMeta.Annotations["git-sha"],
 		Id:          strings.ToUpper(kb.ObjectMeta.Name),
 		Logs:        kb.Spec.Logs,
 		Manifest:    kb.Spec.Manifest,

--- a/provider/k8s/helpers.go
+++ b/provider/k8s/helpers.go
@@ -164,6 +164,7 @@ func (p *Provider) buildEnvironment(a *structs.App, b *structs.Build) map[string
 	return map[string]string{
 		"BUILD":             b.Id,
 		"BUILD_DESCRIPTION": b.Description,
+		"BUILD_GIT_SHA":     b.GitSha,
 	}
 }
 

--- a/provider/k8s/k8s_test.go
+++ b/provider/k8s/k8s_test.go
@@ -66,6 +66,9 @@ func testProvider(t *testing.T, fn func(*k8s.Provider)) {
 	_, err := c.CoreV1().Namespaces().Create(
 		context.TODO(), &ac.Namespace{
 			ObjectMeta: am.ObjectMeta{
+				Annotations: map[string]string{
+					"git-sha": "",
+				},
 				Name: "ns1",
 				Labels: map[string]string{
 					"app":    "system",

--- a/provider/k8s/testdata/release-basic-app.yml
+++ b/provider/k8s/testdata/release-basic-app.yml
@@ -526,6 +526,7 @@ data:
   APP: YXBwMQ==
   BUILD: QlVJTEQx
   BUILD_DESCRIPTION: Zm9v
+  BUILD_GIT_SHA: ""
   FOO: YmFy
   FOUR_URL: ""
   RACK: cmFjazE=
@@ -671,6 +672,7 @@ data:
   APP: YXBwMQ==
   BUILD: QlVJTEQx
   BUILD_DESCRIPTION: Zm9v
+  BUILD_GIT_SHA: ""
   FOO: YmFy
   FOUR_URL: ""
   RACK: cmFjazE=
@@ -785,6 +787,7 @@ data:
   APP: YXBwMQ==
   BUILD: QlVJTEQx
   BUILD_DESCRIPTION: Zm9v
+  BUILD_GIT_SHA: ""
   FOO: YmFy
   FOUR_URL: ""
   RACK: cmFjazE=
@@ -899,6 +902,7 @@ data:
   APP: YXBwMQ==
   BUILD: QlVJTEQx
   BUILD_DESCRIPTION: Zm9v
+  BUILD_GIT_SHA: ""
   FOO: YmFy
   FOUR_URL: ""
   PORT: NTAwMA==
@@ -1146,6 +1150,7 @@ data:
   APP: YXBwMQ==
   BUILD: QlVJTEQx
   BUILD_DESCRIPTION: Zm9v
+  BUILD_GIT_SHA: ""
   FOO: YmFy
   FOUR_URL: ""
   PORT: NTAwMA==


### PR DESCRIPTION
### What is the feature/fix?

https://app.asana.com/0/1203637156732418/1204102614167512/f

### Add screenshot or video (optional)

![Screenshot from 2023-03-10 15-39-43](https://user-images.githubusercontent.com/12232198/224394573-fa976406-7fec-4011-b11b-1474dce9be45.png)

### Does it has a breaking change?

no

### How to use/test it?

- deploy rack of this rack
- use cli of this and deploy app using the cli
- you will find the env `BUILD_GIT_SHA`

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
