### PR TITLE
add missing certificate in the service documentation

### DIFF
--- a/docs/reference/primitives/app/service.md
+++ b/docs/reference/primitives/app/service.md
@@ -32,6 +32,8 @@ services:
     build:
       manifest: Dockerfile
       path: .
+    certificate:
+      duration: 2160h 
     command: bin/web
     deployment:
       minimum: 25

--- a/docs/reference/primitives/app/service.md
+++ b/docs/reference/primitives/app/service.md
@@ -132,14 +132,14 @@ services:
 | **manifest** | string | Dockerfile | The filename of the Dockerfile                                |
 | **path**     | string | .          | The path (relative to **convox.yml**) to build for this Service |
 
+> Specifying **build** as a string will set the **path** and leave the other values as defaults.
+
 ### certificate
 
 | Attribute  | Type   | Default    | Description                                                   |
 | ---------- | ------ | ---------- | ------------------------------------------------------------- |
 | **duration** | string | 2160h | Certificate renew frequency period                                |
 
-
-> Specifying **build** as a string will set the **path** and leave the other values as defaults.
 ### deployment
 
 | Attribute | Type   | Default | Description                                                                      |


### PR DESCRIPTION
### What is the feature/fix?

Missing documentation for the `certificate` field.

https://github.com/convox/convox/issues/597
