### PR TITLE
Replace the deprecated registry

### DIFF
--- a/docs/reference/primitives/app/service.md
+++ b/docs/reference/primitives/app/service.md
@@ -82,7 +82,7 @@ services:
 | **command**     | string     | **CMD** of Dockerfile | The command to run to start a [Process](/reference/primitives/app/process) for this Service                                                                       |
 | **deployment**  | map        |                     | Manual control over deployment parameters                                                                                                  |
 | **domain**      | string     |                     | A custom domain(s) (comma separated) to route to this Service                                                                              |
-| **drain**       | number     |                     | The number of seconds to wait for connections to drain when terminating a [Process](/reference/primitives/app/process) of this Service                            |
+| **drain**       | number     |                     | The number of seconds to wait for connections to drain when terminating a [Process](/reference/primitives/app/process) of this Service. Only applies for version 2 rack services. For version 3 rack services use termination grace period **termination.grace** |
 | **environment** | list       |                     | A list of environment variables (with optional defaults) to populate from the [Release](/reference/primitives/app/release) environment                            |
 | **health**      | string/map | /                   | Health check definition (see below)                                                                                                        |
 | **image**       | string     |                     | An external Docker image to use for this Service (supercedes **build**)                                                                      |

--- a/provider/k8s/template/system/metrics.yml.tmpl
+++ b/provider/k8s/template/system/metrics.yml.tmpl
@@ -69,7 +69,7 @@ spec:
         emptyDir: {}
       containers:
       - name: metrics-server
-        image: k8s.gcr.io/metrics-server-amd64:v0.3.0
+        image: registry.k8s.io/metrics-server-amd64:v0.3.0
         imagePullPolicy: Always
         volumeMounts:
         - name: tmp-dir

--- a/terraform/cluster/aws/autoscaler.tf
+++ b/terraform/cluster/aws/autoscaler.tf
@@ -269,7 +269,7 @@ resource "kubernetes_deployment" "autoscaler" {
         priority_class_name             = "system-cluster-critical"
 
         container {
-          image             = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.22.1"
+          image             = "registry.k8s.io/autoscaling/cluster-autoscaler:v1.22.1"
           image_pull_policy = "IfNotPresent"
           name              = "cluster-autoscaler"
 

--- a/terraform/metrics/k8s/main.tf
+++ b/terraform/metrics/k8s/main.tf
@@ -146,7 +146,7 @@ resource "kubernetes_deployment" "metrics" {
 
         container {
           name              = "metrics-server"
-          image             = "k8s.gcr.io/metrics-server/metrics-server:v0.6.1"
+          image             = "registry.k8s.io/metrics-server/metrics-server:v0.6.1"
           image_pull_policy = "IfNotPresent"
           args = [
             "--cert-dir=/tmp",


### PR DESCRIPTION
### What is the feature/fix?

Replace the deprecated registry

https://app.asana.com/0/1203637156732418/1204261402442155/f


### Does it has a breaking change?

no

### How to use/test it?

- deploy the rack of this version

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
