### PR TITLE
Docs remove unused dns

### DIFF
--- a/docs/configuration/service-discovery.md
+++ b/docs/configuration/service-discovery.md
@@ -62,9 +62,3 @@ The `web` [Service](/reference/primitives/app/service) could reach the `auth` [S
 > Note that the internal port of the `auth` [Service](/reference/primitives/app/service) is not receiving
 > automatic SSL termination. If you want this connection to be encrypted you would need to handle SSL
 > inside the [Service](/reference/primitives/app/service).
-
-DNS search suffixes are automatically configured for internal hostnames on a Rack. The following URLs would
-also work for contacting the `auth` [Service](/reference/primitives/app/service):
-
-* `http://auth:5000` for [Services](/reference/primitives/app/service) on the same app.
-* `http://auth.myapp:5000` for other [Apps](/reference/primitives/app) on the same Rack.


### PR DESCRIPTION
### What is the feature/fix?

Update documentation about DNS suffixes. The pattern `http://SERVICE:PORT` or `http://SERVICE.APP:PORT` is not in use.

### Does it has a breaking change?

N/A

### How to use/test it?

N/A

### Checklist

N/A