### PR TITLE
Only use rack_name on a supported version

### DIFF
--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -259,7 +259,7 @@ func RackLogs(rack sdk.Interface, c *stdcli.Context) error {
 	return nil
 }
 
-func RackMv(ri sdk.Interface, c *stdcli.Context) error {
+func RackMv(_ sdk.Interface, c *stdcli.Context) error {
 	from := c.Arg(0)
 	to := c.Arg(1)
 
@@ -288,9 +288,10 @@ func RackMv(ri sdk.Interface, c *stdcli.Context) error {
 	params := make(map[string]string)
 
 	// only 3.11.2+ supports rack_name
-	s, _ := ri.SystemGet()
-	if s.Name != "" {
-		if rack.HasSupport(s.Version, rack.MINOR_RACK_NAME_SUPPORT, rack.PATCH_RACK_NAME_SUPPORT) {
+	ri, err := fr.Client()
+	if err == nil {
+		s, err := ri.SystemGet()
+		if err == nil && rack.HasSupport(s.Version, rack.MINOR_RACK_NAME_SUPPORT, rack.PATCH_RACK_NAME_SUPPORT) {
 			params["rack_name"] = newRackName
 		}
 	}

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -259,7 +259,7 @@ func RackLogs(rack sdk.Interface, c *stdcli.Context) error {
 	return nil
 }
 
-func RackMv(_ sdk.Interface, c *stdcli.Context) error {
+func RackMv(ri sdk.Interface, c *stdcli.Context) error {
 	from := c.Arg(0)
 	to := c.Arg(1)
 
@@ -286,7 +286,15 @@ func RackMv(_ sdk.Interface, c *stdcli.Context) error {
 		newRackName = parts[1]
 	}
 	params := make(map[string]string)
-	params["rack_name"] = newRackName
+
+	// only 3.11.2+ supports rack_name
+	s, _ := ri.SystemGet()
+	if s.Name != "" {
+		if rack.HasSupport(s.Version, rack.MINOR_RACK_NAME_SUPPORT, rack.PATCH_RACK_NAME_SUPPORT) {
+			params["rack_name"] = newRackName
+		}
+	}
+
 	if err := fr.UpdateParams(params); err != nil {
 		return err
 	}

--- a/pkg/cli/testdata/terraform/dev1.args.tf
+++ b/pkg/cli/testdata/terraform/dev1.args.tf
@@ -3,7 +3,6 @@
 			baz = "qux"
 			foo = "bar"
 			name = "dev1"
-			rack_name = "dev1"
 			release = "foo"
 		}
 

--- a/pkg/cli/testdata/terraform/dev1.tf
+++ b/pkg/cli/testdata/terraform/dev1.tf
@@ -1,7 +1,6 @@
 		module "system" {
 			source = "github.com/convox/convox//terraform/system/local?ref=foo"
 			name = "dev1"
-			rack_name = "dev1"
 			release = "foo"
 		}
 

--- a/pkg/cli/testdata/terraform/dev1.version.tf
+++ b/pkg/cli/testdata/terraform/dev1.version.tf
@@ -1,7 +1,6 @@
 		module "system" {
 			source = "github.com/convox/convox//terraform/system/local?ref=otherver"
 			name = "dev1"
-			rack_name = "dev1"
 			release = "otherver"
 		}
 

--- a/pkg/cli/testdata/terraform/dev2.args.tf
+++ b/pkg/cli/testdata/terraform/dev2.args.tf
@@ -3,7 +3,6 @@
 			baz = "qux"
 			foo = "bar"
 			name = "dev2"
-			rack_name = "dev2"
 			release = ""
 		}
 

--- a/pkg/cli/testdata/terraform/dev2.update.tf
+++ b/pkg/cli/testdata/terraform/dev2.update.tf
@@ -3,7 +3,6 @@
 			baz = "qux"
 			name = "dev2"
 			other = "side"
-			rack_name = "dev2"
 			release = ""
 		}
 

--- a/pkg/rack/terraform.go
+++ b/pkg/rack/terraform.go
@@ -19,8 +19,13 @@ import (
 	"github.com/convox/stdcli"
 )
 
-const MINOR_TELEMETRY_SUPPORTED = 12
-const PATCH_TELEMETRY_SUPPORTED = 1
+const (
+	MINOR_TELEMETRY_SUPPORTED = 12
+	PATCH_TELEMETRY_SUPPORTED = 1
+
+	MINOR_RACK_NAME_SUPPORT = 11
+	PATCH_RACK_NAME_SUPPORT = 2
+)
 
 type Terraform struct {
 	ctx      *stdcli.Context
@@ -199,7 +204,15 @@ func (t Terraform) Metadata() (*Metadata, error) {
 	}
 
 	vars["name"] = common.CoalesceString(vars["name"], t.name)
-	vars["rack_name"] = common.CoalesceString(vars["rack_name"], t.name)
+
+	// only 3.11.2+ supports rack_name
+	c, err := t.Client()
+	if err == nil {
+		s, _ := c.SystemGet()
+		if s.Name != "" && HasSupport(s.Version, MINOR_RACK_NAME_SUPPORT, PATCH_RACK_NAME_SUPPORT) {
+			vars["rack_name"] = common.CoalesceString(vars["rack_name"], t.name)
+		}
+	}
 
 	m := &Metadata{
 		Deletable: true,
@@ -420,7 +433,16 @@ func (t Terraform) update(release string, vars map[string]string) error {
 
 	vars["name"] = common.CoalesceString(vars["name"], t.name)
 	vars["release"] = release
-	vars["rack_name"] = common.CoalesceString(vars["rack_name"], t.name)
+
+	// only 3.11.2+ supports rack_name
+	c, err := t.Client()
+	if err == nil {
+		s, _ := c.SystemGet()
+
+		if s.Name != "" && HasSupport(s.Version, MINOR_RACK_NAME_SUPPORT, PATCH_RACK_NAME_SUPPORT) {
+			vars["rack_name"] = common.CoalesceString(vars["rack_name"], t.name)
+		}
+	}
 
 	pv, err := terraformProviderVars(t.provider)
 	if err != nil {
@@ -444,7 +466,7 @@ func (t Terraform) update(release string, vars map[string]string) error {
 
 	tf := filepath.Join(dir, "main.tf")
 
-	if hasSupport(release) {
+	if HasSupport(release, MINOR_TELEMETRY_SUPPORTED, PATCH_TELEMETRY_SUPPORTED) {
 		vars["settings"] = dir
 	}
 
@@ -467,10 +489,16 @@ func (t Terraform) update(release string, vars map[string]string) error {
 	return nil
 }
 
-func hasSupport(release string) bool {
-	rv, _ := convertToReleaseVersion(release)
+// HasSupport compares the release version with the given minor and patch version
+// returns true if the release version is greater than or equal to the given minor and patch version
+func HasSupport(release string, minor, patch int) bool {
+	rv, err := ConvertToReleaseVersion(release)
+	if err != nil {
+		return false
+	}
+
 	if rv != nil {
-		if rv.Minor > MINOR_TELEMETRY_SUPPORTED || (rv.Minor == MINOR_TELEMETRY_SUPPORTED && rv.Revision >= PATCH_TELEMETRY_SUPPORTED) {
+		if rv.Minor > minor || (rv.Minor == minor && rv.Revision >= patch) {
 			return true
 		}
 	}
@@ -657,7 +685,7 @@ func terraformLatestVersion(current string) (string, error) {
 		return TestLatest, nil
 	}
 
-	currentReleaseVersion, err := convertToReleaseVersion(current)
+	currentReleaseVersion, err := ConvertToReleaseVersion(current)
 	if err != nil {
 		return getTheLatestRelease()
 	} else {
@@ -713,7 +741,7 @@ func getLatestRevisionForCurrentVersion(currentReleaseVersion *ReleaseVersion) (
 		}
 
 		for _, release := range response {
-			thisReleaseVersion, err := convertToReleaseVersion(release.Tag)
+			thisReleaseVersion, err := ConvertToReleaseVersion(release.Tag)
 			if err != nil {
 				continue
 			}
@@ -730,7 +758,7 @@ func getLatestRevisionForCurrentVersion(currentReleaseVersion *ReleaseVersion) (
 	return "", fmt.Errorf("No published revisions found for this version: " + currentReleaseVersion.toString())
 }
 
-func convertToReleaseVersion(version string) (*ReleaseVersion, error) {
+func ConvertToReleaseVersion(version string) (*ReleaseVersion, error) {
 	release := &ReleaseVersion{}
 	releaseVersion := strings.Split(version, ".")
 	if len(releaseVersion) != 3 {
@@ -842,7 +870,7 @@ func terraformWriteTemplate(filename, version string, params map[string]interfac
 	t, err := template.New("main").Funcs(terraformTemplateHelpers()).Parse(`
 		module "system" {
 			source = "{{.Source}}"
-			
+
 			{{- range (keys .Vars) }}
 			{{.}} = "{{index $.Vars .}}"
 			{{- end }}

--- a/terraform/api/k8s/variables.tf
+++ b/terraform/api/k8s/variables.tf
@@ -81,5 +81,6 @@ variable "volumes" {
 }
 
 variable "rack_name" {
-  type = string
+  default = ""
+  type    = string
 }

--- a/terraform/system/do/variables.tf
+++ b/terraform/system/do/variables.tf
@@ -37,7 +37,8 @@ variable "name" {
 }
 
 variable "rack_name" {
-  type = string
+  default = ""
+  type    = string
 }
 
 variable "node_type" {

--- a/terraform/system/local/variables.tf
+++ b/terraform/system/local/variables.tf
@@ -15,7 +15,8 @@ variable "name" {
 }
 
 variable "rack_name" {
-  type = string
+  default = ""
+  type    = string
 }
 
 variable "os" {


### PR DESCRIPTION
### What is the feature/fix?

`rack_name` is only supported on 3.11.2+. CLI will only attach rack_name if it's on a supported version

### Does it has a breaking change?

No, it's a fix for CLI

### How to use/test it?

Install the CLI with the RC version and install a rack in a previous version: `convox rack install aws v3-8-5 --version=3.8.5`

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
