### PR TITLE
Fix: Internal router fix

### DIFF
--- a/terraform/router/aws/main.tf
+++ b/terraform/router/aws/main.tf
@@ -59,6 +59,18 @@ resource "null_resource" "set_proxy_protocol" {
   ]
 }
 
+resource "null_resource" "set_preserve_client_ip_false" {
+  count = var.internal_router ? 1 : 0
+
+  provisioner "local-exec" {
+    command = "sh ${path.module}/preserve-client-ip.sh ${var.name} ${data.aws_region.current.name}"
+  }
+
+  depends_on = [
+    kubernetes_service.router-internal
+  ]
+}
+
 resource "kubernetes_service" "router" {
   metadata {
     namespace = var.namespace

--- a/terraform/router/nginx/main.tf
+++ b/terraform/router/nginx/main.tf
@@ -133,7 +133,7 @@ resource "kubernetes_role" "ingress-nginx" {
   rule {
     api_groups     = [""]
     resources      = ["configmaps"]
-    resource_names = ["ingress-controller-leader-nginx"]
+    resource_names = ["ingress-controller-leader-nginx", "ingress-internal-controller-leader-nginx"]
     verbs          = ["get", "update"]
   }
 
@@ -151,7 +151,7 @@ resource "kubernetes_role" "ingress-nginx" {
 
   rule {
     api_groups     = ["coordination.k8s.io"]
-    resource_names = ["ingress-controller-leader"]
+    resource_names = ["ingress-controller-leader", "ingress-internal-controller-leader"]
     resources      = ["leases"]
     verbs          = ["get", "update"]
   }
@@ -170,7 +170,7 @@ resource "kubernetes_role" "ingress-nginx" {
 
   rule {
     api_groups     = [""]
-    resource_names = ["ingress-controller-leader"]
+    resource_names = ["ingress-controller-leader", "ingress-internal-controller-leader"]
     resources      = ["configmaps"]
     verbs          = ["get", "update"]
   }


### PR DESCRIPTION
### What is the feature/fix?

https://app.asana.com/0/1203637156732418/1204515779330565/f

Aws changes the default preserve client ip policy. for internal router perserve client ip policy has to be off.

### Add screenshot or video (optional)



### Does it has a breaking change?
no

### How to use/test it?

- deploy rack of this version: `nahid-internal-router`
- test the internal router

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
