### PR TITLE
Feat: Add support for lifecycle hook

### DIFF
--- a/docs/reference/primitives/app/service.md
+++ b/docs/reference/primitives/app/service.md
@@ -93,7 +93,7 @@ services:
 | **image**       | string     |                     | An external Docker image to use for this Service (supercedes **build**)                                                                      |
 | **internal**    | boolean    | false               | Set to **true** to make this Service only accessible inside the Rack                                                                         |
 | **internalRouter** | boolean    | false               | Set it to **true** to make this Service only accessible using internal loadbalancer. You also have to set the rack parameter [internal_router](/installation/production-rack/aws) to **true**                 |
-| **lifecycle** |  map  |       | Set container prestop and poststart hook. This gives you ability to run command before terminating and after starting the container |
+| **lifecycle** |  map  |       | The prestop and poststart hooks enable running commands before terminating and after starting the container, respectively |
 | **port**        | string     |                     | The port that the default Rack balancer will use to [route incoming traffic](/configuration/load-balancers)                     |
 | **ports**       | list       |                     | A list of ports available for internal [service discovery](/configuration/service-discovery) or custom [Balancers](/reference/primitives/app/balancer) |
 | **privileged**  | boolean    | true                | Set to **false** to prevent [Processes](/reference/primitives/app/process) of this Service from running as root inside their container                              |

--- a/docs/reference/primitives/app/service.md
+++ b/docs/reference/primitives/app/service.md
@@ -49,6 +49,9 @@ services:
       path: /check
       timeout: 3
     internal: false
+    lifecycle:
+      preStop: "sleep 10"
+      postStart: "sleep 10"
     port: 5000
     ports:
       - 5001
@@ -90,6 +93,7 @@ services:
 | **image**       | string     |                     | An external Docker image to use for this Service (supercedes **build**)                                                                      |
 | **internal**    | boolean    | false               | Set to **true** to make this Service only accessible inside the Rack                                                                         |
 | **internalRouter** | boolean    | false               | Set it to **true** to make this Service only accessible using internal loadbalancer. You also have to set the rack parameter [internal_router](/installation/production-rack/aws) to **true**                 |
+| **lifecycle** |  map  |       | Set container prestop and poststart hook. This gives you ability to run command before terminating and after starting the container |
 | **port**        | string     |                     | The port that the default Rack balancer will use to [route incoming traffic](/configuration/load-balancers)                     |
 | **ports**       | list       |                     | A list of ports available for internal [service discovery](/configuration/service-discovery) or custom [Balancers](/reference/primitives/app/balancer) |
 | **privileged**  | boolean    | true                | Set to **false** to prevent [Processes](/reference/primitives/app/process) of this Service from running as root inside their container                              |
@@ -146,6 +150,15 @@ services:
 | --------- | ------ | ------- | -------------------------------------------------------------------------------- |
 | **maximum** | number | 200     | The maximum percentage of Processes to allow during rolling deploys              |
 | **minimum** | number | 50      | The minimum percentage of healthy Processes to keep alive during rolling deploys |
+
+&nbsp;
+
+### lifecycle
+
+| Attribute | Type   | Default | Description                                                                                |
+| --------- | ------ | ------- | ------------------------------------------------------------------------------------------ |
+| **perStop**     | string |         | The pre stop command |
+| **postStart**  | string |         | The post stop command |
 
 &nbsp;
 

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -24,6 +24,7 @@ type Service struct {
 	Init           bool                  `yaml:"init,omitempty"`
 	Internal       bool                  `yaml:"internal,omitempty"`
 	InternalRouter bool                  `yaml:"internalRouter,omitempty"`
+	Lifecycle      ServiceLifecycle      `yaml:"lifecycle,omitempty"`
 	Port           ServicePortScheme     `yaml:"port,omitempty"`
 	Ports          []ServicePortProtocol `yaml:"ports,omitempty"`
 	Privileged     bool                  `yaml:"privileged,omitempty"`
@@ -69,6 +70,11 @@ type ServiceHealth struct {
 	Interval int
 	Path     string
 	Timeout  int
+}
+
+type ServiceLifecycle struct {
+	PreStop   string `yaml:"preStop,omitempty"`
+	PostStart string `yaml:"postStart,omitempty"`
 }
 
 type ServicePortProtocol struct {

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -113,6 +113,25 @@ spec:
             name: env-{{.Service.Name}}
         image: {{ image .App .Service .Release }}
         imagePullPolicy: IfNotPresent
+        {{ if or .Service.Lifecycle.PostStart .Service.Lifecycle.PreStop }}
+        lifecycle:
+          {{ with .Service.Lifecycle.PostStart }}
+          postStart:
+            exec:
+              command:
+              {{ range shellsplit . }}
+                - {{ safe . }}
+              {{ end }}
+          {{ end }}
+          {{ with .Service.Lifecycle.PreStop }}
+          preStop:
+            exec:
+              command:
+              {{ range shellsplit . }}
+                - {{ safe . }}
+              {{ end }}
+          {{ end }}
+        {{ end }}
         {{ with .Service.Port.Port }}
         readinessProbe:
           httpGet:


### PR DESCRIPTION
### What is the feature/fix?

https://app.asana.com/0/1203637156732418/1204602873851067/f

### Add screenshot or video (optional)


### Does it has a breaking change?

no

### How to use/test it?

- install a rack of this version: 
- add lifecycle hook:
```
services:
  web:
    build: .
    port: 3000
    environment:
      - PORT=3000
      - TEST=true
    lifecycle:
      preStop: "sleep 10"
      postStart: "sleep 10"
```

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
