### PR TITLE
ECR supports image manifest caching in ECR with Buildkit >= 0.12.0. This PR updates the buildkit version to 0.12.2 and adds support for ECR caching.

### DIFF
--- a/Dockerfile.buildkit
+++ b/Dockerfile.buildkit
@@ -10,7 +10,7 @@ RUN make $GOPATH/bin/build
 
 ###########################################################################################
 
-FROM moby/buildkit:v0.11.6-rootless as rootless
+FROM moby/buildkit:v0.12.2-rootless as rootless
 
 USER root
 
@@ -29,7 +29,7 @@ ENTRYPOINT [ "./buildctl-daemonless.sh" ]
 
 ###########################################################################################
 
-FROM moby/buildkit:v0.11.6 as privileged
+FROM moby/buildkit:v0.12.2 as privileged
 
 RUN apk add skopeo --update
 

--- a/pkg/build/buildkit.go
+++ b/pkg/build/buildkit.go
@@ -134,6 +134,10 @@ func (*BuildKit) cacheProvider(provider string) bool {
 	return provider != "" && strings.Contains("do az", provider) // skipcq
 }
 
+func (*BuildKit) imageManifestCacheProvider(provider string) bool {
+	return provider != "" && strings.Contains("aws", provider) // skipcq
+}
+
 func (*BuildKit) buildArgs(development bool, dockerfile string, env map[string]string) ([]string, error) {
 	fd, err := os.Open(dockerfile)
 	if err != nil {
@@ -208,6 +212,10 @@ func (bk *BuildKit) build(bb *Build, path, dockerfile, tag string, env map[strin
 	if bk.cacheProvider(os.Getenv("PROVIDER")) {
 		reg := strings.Split(tag, ":")[0]
 		args = append(args, "--export-cache", fmt.Sprintf("type=registry,ref=%s:buildcache", reg)) // skipcq
+		args = append(args, "--import-cache", fmt.Sprintf("type=registry,ref=%s:buildcache", reg)) // skipcq
+	} else if bk.imageManifestCacheProvider(os.Getenv("PROVIDER")) {
+		reg := strings.Split(tag, ":")[0]
+		args = append(args, "--export-cache", fmt.Sprintf("mode=max,image-manifest=true,type=registry,ref=%s:buildcache", reg)) // skipcq
 		args = append(args, "--import-cache", fmt.Sprintf("type=registry,ref=%s:buildcache", reg)) // skipcq
 	} else {
 		// keep a local cache for services using the same Dockerfile


### PR DESCRIPTION
### What is the feature/fix?

Since moving to buildkit, we've lost the ability to use any caching during builds which slows down deployments massively.  Now that Buildkit 0.12 is released, we can at least utilise image manifest caching in ECR to help speed things up again.

### Add screenshot or video (optional)

** Any screenshot or video capture using the feature **

### Does it has a breaking change?

** Describe the changes and if it has any breaking changes in any feature **

### How to use/test it?

** Describe how to test or use the feature **

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
