### PR TITLE
3.14.4

### DIFF
--- a/docs/reference/primitives/app/service.md
+++ b/docs/reference/primitives/app/service.md
@@ -66,6 +66,8 @@ services:
       successThreshold: 1
       failureThreshold: 3
     internal: false
+    ingressAnnotations:
+      - nginx.ingress.kubernetes.io/limit-rpm=10
     labels:
       convox.com/test: true
     lifecycle:
@@ -116,6 +118,7 @@ services:
 | **health**      | string/map | /                   | Health check definition (see below)                                                                                                        |
 | **liveness** | map |      | Liveness check definition (see below). By default it is disabled. If it fails then service will restart |
 | **image**       | string     |                     | An external Docker image to use for this Service (supercedes **build**)                                                                      |
+| **ingressAnnotations** | list       |                     | A list of annotation keys and values to add in ingress resource. Check below for reserved annotation keys |
 | **internal**    | boolean    | false               | Set to **true** to make this Service only accessible inside the Rack                                                                         |
 | **internalRouter** | boolean    | false               | Set it to **true** to make this Service only accessible using internal loadbalancer. You also have to set the rack parameter [internal_router](/installation/production-rack/aws) to **true**                 |
 | **labels** |  map  |       | Custom labels for k8s resources. See here for (syntax and character set)[https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set]. Also following keys are reserved: `system`, `rack`, `app`, `name`, `service`, `release`, `type` |
@@ -186,6 +189,34 @@ services:
 | **ndots**     | int |         | The ndots option for the dns config |
 
 &nbsp;
+
+### ingressAnnotations
+
+This accepts list of strings where in each string annotation key and value is separated by `=` sign:
+
+```html
+services:
+  web:
+    ...
+    ingressAnnotations:
+      - nginx.ingress.kubernetes.io/limit-rpm=10
+      - nginx.ingress.kubernetes.io/enable-access-log=false
+  ...
+```
+
+Reserved annotation keys:
+- `alb.ingress.kubernetes.io/scheme`
+- `cert-manager.io/cluster-issuer`
+- `cert-manager.io/duration`
+- `nginx.ingress.kubernetes.io/backend-protocol`
+- `nginx.ingress.kubernetes.io/proxy-connect-timeout`
+- `nginx.ingress.kubernetes.io/proxy-read-timeout`
+- `nginx.ingress.kubernetes.io/proxy-send-timeout`
+- `nginx.ingress.kubernetes.io/server-snippet`
+- `nginx.ingress.kubernetes.io/affinity`
+- `nginx.ingress.kubernetes.io/session-cookie-name`
+- `nginx.ingress.kubernetes.io/ssl-redirect`
+- `nginx.ingress.kubernetes.io/whitelist-source-range`
 
 ### lifecycle
 

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -10,38 +10,39 @@ import (
 type Service struct {
 	Name string `yaml:"-"`
 
-	Agent             ServiceAgent          `yaml:"agent,omitempty"`
-	Annotations       ServiceAnnotations    `yaml:"annotations,omitempty"`
-	Build             ServiceBuild          `yaml:"build,omitempty"`
-	Certificate       Certificate           `yaml:"certificate,omitempty"`
-	Command           string                `yaml:"command,omitempty"`
-	Deployment        ServiceDeployment     `yaml:"deployment,omitempty"`
-	DnsConfig         ServiceDnsConfig      `yaml:"dnsConfig,omitempty"`
-	Domains           ServiceDomains        `yaml:"domain,omitempty"`
-	Drain             int                   `yaml:"drain,omitempty"`
-	Environment       Environment           `yaml:"environment,omitempty"`
-	GrpcHealthEnabled bool                  `yaml:"grpcHealthEnabled,omitempty"`
-	Health            ServiceHealth         `yaml:"health,omitempty"`
-	Liveness          ServiceLiveness       `yaml:"liveness,omitempty"`
-	Image             string                `yaml:"image,omitempty"`
-	Init              bool                  `yaml:"init,omitempty"`
-	Internal          bool                  `yaml:"internal,omitempty"`
-	InternalRouter    bool                  `yaml:"internalRouter,omitempty"`
-	Labels            Labels                `yaml:"labels,omitempty"`
-	Lifecycle         ServiceLifecycle      `yaml:"lifecycle,omitempty"`
-	Port              ServicePortScheme     `yaml:"port,omitempty"`
-	Ports             []ServicePortProtocol `yaml:"ports,omitempty"`
-	Privileged        bool                  `yaml:"privileged,omitempty"`
-	Resources         []string              `yaml:"resources,omitempty"`
-	Scale             ServiceScale          `yaml:"scale,omitempty"`
-	Singleton         bool                  `yaml:"singleton,omitempty"`
-	Sticky            bool                  `yaml:"sticky,omitempty"`
-	Termination       ServiceTermination    `yaml:"termination,omitempty"`
-	Test              string                `yaml:"test,omitempty"`
-	Timeout           int                   `yaml:"timeout,omitempty"`
-	Tls               ServiceTls            `yaml:"tls,omitempty"`
-	Volumes           []string              `yaml:"volumes,omitempty"`
-	Whitelist         string                `yaml:"whitelist,omitempty"`
+	Agent              ServiceAgent          `yaml:"agent,omitempty"`
+	Annotations        ServiceAnnotations    `yaml:"annotations,omitempty"`
+	Build              ServiceBuild          `yaml:"build,omitempty"`
+	Certificate        Certificate           `yaml:"certificate,omitempty"`
+	Command            string                `yaml:"command,omitempty"`
+	Deployment         ServiceDeployment     `yaml:"deployment,omitempty"`
+	DnsConfig          ServiceDnsConfig      `yaml:"dnsConfig,omitempty"`
+	Domains            ServiceDomains        `yaml:"domain,omitempty"`
+	Drain              int                   `yaml:"drain,omitempty"`
+	Environment        Environment           `yaml:"environment,omitempty"`
+	GrpcHealthEnabled  bool                  `yaml:"grpcHealthEnabled,omitempty"`
+	Health             ServiceHealth         `yaml:"health,omitempty"`
+	Liveness           ServiceLiveness       `yaml:"liveness,omitempty"`
+	Image              string                `yaml:"image,omitempty"`
+	Init               bool                  `yaml:"init,omitempty"`
+	Internal           bool                  `yaml:"internal,omitempty"`
+	InternalRouter     bool                  `yaml:"internalRouter,omitempty"`
+	IngressAnnotations ServiceAnnotations    `yaml:"ingressAnnotations,omitempty"`
+	Labels             Labels                `yaml:"labels,omitempty"`
+	Lifecycle          ServiceLifecycle      `yaml:"lifecycle,omitempty"`
+	Port               ServicePortScheme     `yaml:"port,omitempty"`
+	Ports              []ServicePortProtocol `yaml:"ports,omitempty"`
+	Privileged         bool                  `yaml:"privileged,omitempty"`
+	Resources          []string              `yaml:"resources,omitempty"`
+	Scale              ServiceScale          `yaml:"scale,omitempty"`
+	Singleton          bool                  `yaml:"singleton,omitempty"`
+	Sticky             bool                  `yaml:"sticky,omitempty"`
+	Termination        ServiceTermination    `yaml:"termination,omitempty"`
+	Test               string                `yaml:"test,omitempty"`
+	Timeout            int                   `yaml:"timeout,omitempty"`
+	Tls                ServiceTls            `yaml:"tls,omitempty"`
+	Volumes            []string              `yaml:"volumes,omitempty"`
+	Whitelist          string                `yaml:"whitelist,omitempty"`
 }
 
 type Services []Service
@@ -260,6 +261,18 @@ func (s Service) AnnotationsMap() map[string]string {
 	annotations := map[string]string{}
 
 	for _, a := range s.Annotations {
+		parts := strings.SplitN(a, "=", 2)
+		annotations[parts[0]] = parts[1]
+	}
+
+	return annotations
+}
+
+// skipcq
+func (s Service) IngressAnnotationsMap() map[string]string {
+	annotations := map[string]string{}
+
+	for _, a := range s.IngressAnnotations {
 		parts := strings.SplitN(a, "=", 2)
 		annotations[parts[0]] = parts[1]
 	}

--- a/provider/k8s/release.go
+++ b/provider/k8s/release.go
@@ -364,6 +364,15 @@ func (p *Provider) releaseTemplateIngress(a *structs.App, ss manifest.Services, 
 			return nil, errors.WithStack(err)
 		}
 
+		customAns := s.IngressAnnotationsMap()
+		reservedAns := p.reservedNginxAnnotations()
+
+		for k, v := range customAns {
+			if !reservedAns[k] {
+				ans[k] = v
+			}
+		}
+
 		params := map[string]interface{}{
 			"Annotations": ans,
 			"App":         a.Name,
@@ -616,4 +625,21 @@ func (p *Provider) releaseUnmarshal(kr *ca.Release) (*structs.Release, error) {
 	}
 
 	return r, nil
+}
+
+func (p *Provider) reservedNginxAnnotations() map[string]bool {
+	return map[string]bool{
+		"alb.ingress.kubernetes.io/scheme":                   true,
+		"cert-manager.io/cluster-issuer":                     true,
+		"cert-manager.io/duration":                           true,
+		"nginx.ingress.kubernetes.io/backend-protocol":       true,
+		"nginx.ingress.kubernetes.io/proxy-connect-timeout":  true,
+		"nginx.ingress.kubernetes.io/proxy-read-timeout":     true,
+		"nginx.ingress.kubernetes.io/proxy-send-timeout":     true,
+		"nginx.ingress.kubernetes.io/server-snippet":         true,
+		"nginx.ingress.kubernetes.io/affinity":               true,
+		"nginx.ingress.kubernetes.io/session-cookie-name":    true,
+		"nginx.ingress.kubernetes.io/ssl-redirect":           true,
+		"nginx.ingress.kubernetes.io/whitelist-source-range": true,
+	}
 }


### PR DESCRIPTION
### What is the feature/fix?

Feature: [Custom annotations for service's k8s ingress object](https://github.com/convox/convox/pull/730)

### Does it have a breaking change?

Patch release - no breaking change

### How to use/test it?

You can manually update your rack with the command `convox rack update 3.14.4 -r rackName`

_If you are unfamiliar with v3 versioning, we advise checking the documentation [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) for more information before applying any updates_

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
