### PR TITLE
Update Buildkit to 0.12.4

### DIFF
--- a/Dockerfile.buildkit
+++ b/Dockerfile.buildkit
@@ -10,7 +10,7 @@ RUN make $GOPATH/bin/build
 
 ###########################################################################################
 
-FROM moby/buildkit:v0.12.2-rootless as rootless
+FROM moby/buildkit:v0.12.4-rootless as rootless
 
 USER root
 
@@ -29,7 +29,7 @@ ENTRYPOINT [ "./buildctl-daemonless.sh" ]
 
 ###########################################################################################
 
-FROM moby/buildkit:v0.12.2 as privileged
+FROM moby/buildkit:v0.12.4 as privileged
 
 RUN apk add skopeo --update
 

--- a/pkg/build/buildkit.go
+++ b/pkg/build/buildkit.go
@@ -220,8 +220,8 @@ func (bk *BuildKit) build(bb *Build, path, dockerfile, tag string, env map[strin
 		args = append(args, "--import-cache", fmt.Sprintf("type=registry,ref=%s:buildcache", reg)) // skipcq
 	} else if bk.imageManifestCacheProvider(os.Getenv("PROVIDER")) {
 		reg := strings.Split(tag, ":")[0]
-		args = append(args, "--export-cache", fmt.Sprintf("mode=max,image-manifest=true,oci-mediatypes=true,type=registry,ref=%s:buildcache", reg)) // skipcq
-		args = append(args, "--import-cache", fmt.Sprintf("type=registry,ref=%s:buildcache", reg))                                                  // skipcq
+		args = append(args, "--export-cache", fmt.Sprintf("mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true,compression=estargz,type=registry,ref=%s:buildcache", reg)) // skipcq
+		args = append(args, "--import-cache", fmt.Sprintf("type=registry,ref=%s:buildcache", reg))                                                                                        // skipcq
 	} else {
 		// keep a local cache for services using the same Dockerfile
 		args = append(args, "--export-cache", "type=local,dest=/var/lib/buildkit") // skipcq

--- a/pkg/build/buildkit.go
+++ b/pkg/build/buildkit.go
@@ -220,8 +220,8 @@ func (bk *BuildKit) build(bb *Build, path, dockerfile, tag string, env map[strin
 		args = append(args, "--import-cache", fmt.Sprintf("type=registry,ref=%s:buildcache", reg)) // skipcq
 	} else if bk.imageManifestCacheProvider(os.Getenv("PROVIDER")) {
 		reg := strings.Split(tag, ":")[0]
-		args = append(args, "--export-cache", fmt.Sprintf("mode=max,image-manifest=true,type=registry,ref=%s:buildcache", reg)) // skipcq
-		args = append(args, "--import-cache", fmt.Sprintf("type=registry,ref=%s:buildcache", reg))                              // skipcq
+		args = append(args, "--export-cache", fmt.Sprintf("mode=max,image-manifest=true,oci-mediatypes=true,type=registry,ref=%s:buildcache", reg)) // skipcq
+		args = append(args, "--import-cache", fmt.Sprintf("type=registry,ref=%s:buildcache", reg))                                                  // skipcq
 	} else {
 		// keep a local cache for services using the same Dockerfile
 		args = append(args, "--export-cache", "type=local,dest=/var/lib/buildkit") // skipcq


### PR DESCRIPTION
### What is the feature/fix?

Update Buildkit to 0.12.4 and ignore build cache error on build time to unblock build

https://app.asana.com/0/1203637156732418/1206136227516802/f

### Add screenshot or video (optional)

** Any screenshot or video capture using the feature **

### Does it has a breaking change?

** Describe the changes and if it has any breaking changes in any feature **

### How to use/test it?

** Describe how to test or use the feature **

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
