### PR TITLE
3.15.0

### DIFF
--- a/Dockerfile.buildkit
+++ b/Dockerfile.buildkit
@@ -10,7 +10,7 @@ RUN make $GOPATH/bin/build
 
 ###########################################################################################
 
-FROM moby/buildkit:v0.12.2-rootless as rootless
+FROM moby/buildkit:v0.12.4-rootless as rootless
 
 USER root
 
@@ -29,7 +29,7 @@ ENTRYPOINT [ "./buildctl-daemonless.sh" ]
 
 ###########################################################################################
 
-FROM moby/buildkit:v0.12.2 as privileged
+FROM moby/buildkit:v0.12.4 as privileged
 
 RUN apk add skopeo --update
 

--- a/pkg/build/buildkit.go
+++ b/pkg/build/buildkit.go
@@ -220,8 +220,8 @@ func (bk *BuildKit) build(bb *Build, path, dockerfile, tag string, env map[strin
 		args = append(args, "--import-cache", fmt.Sprintf("type=registry,ref=%s:buildcache", reg)) // skipcq
 	} else if bk.imageManifestCacheProvider(os.Getenv("PROVIDER")) {
 		reg := strings.Split(tag, ":")[0]
-		args = append(args, "--export-cache", fmt.Sprintf("mode=max,image-manifest=true,oci-mediatypes=true,type=registry,ref=%s:buildcache", reg)) // skipcq
-		args = append(args, "--import-cache", fmt.Sprintf("type=registry,ref=%s:buildcache", reg))                                                  // skipcq
+		args = append(args, "--export-cache", fmt.Sprintf("mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true,compression=estargz,type=registry,ref=%s:buildcache", reg)) // skipcq
+		args = append(args, "--import-cache", fmt.Sprintf("type=registry,ref=%s:buildcache", reg))                                                                                        // skipcq
 	} else {
 		// keep a local cache for services using the same Dockerfile
 		args = append(args, "--export-cache", "type=local,dest=/var/lib/buildkit") // skipcq

--- a/pkg/build/buildkit.go
+++ b/pkg/build/buildkit.go
@@ -220,8 +220,8 @@ func (bk *BuildKit) build(bb *Build, path, dockerfile, tag string, env map[strin
 		args = append(args, "--import-cache", fmt.Sprintf("type=registry,ref=%s:buildcache", reg)) // skipcq
 	} else if bk.imageManifestCacheProvider(os.Getenv("PROVIDER")) {
 		reg := strings.Split(tag, ":")[0]
-		args = append(args, "--export-cache", fmt.Sprintf("mode=max,image-manifest=true,type=registry,ref=%s:buildcache", reg)) // skipcq
-		args = append(args, "--import-cache", fmt.Sprintf("type=registry,ref=%s:buildcache", reg))                              // skipcq
+		args = append(args, "--export-cache", fmt.Sprintf("mode=max,image-manifest=true,oci-mediatypes=true,type=registry,ref=%s:buildcache", reg)) // skipcq
+		args = append(args, "--import-cache", fmt.Sprintf("type=registry,ref=%s:buildcache", reg))                                                  // skipcq
 	} else {
 		// keep a local cache for services using the same Dockerfile
 		args = append(args, "--export-cache", "type=local,dest=/var/lib/buildkit") // skipcq

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -209,7 +209,7 @@ variable "vpc_id" {
 // https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
 variable "vpc_cni_version" {
   type    = string
-  default = "v1.13.3-eksbuild.1"
+  default = "v1.14.1-eksbuild.1"
 }
 
 variable "whitelist" {


### PR DESCRIPTION
### What is the feature/fix?

**Updates:** 
[Update VPC CNI plugin version to v1.14](https://github.com/convox/convox/pull/735)
[Update Buildkit to v0.12.4](https://github.com/convox/convox/pull/736)

### Does it has a breaking change?

**_Major cluster update. Rack version cannot be downgraded after update_**

### How to use/test it?

Manually update your rack with the command `convox rack update 3.15.0 -r rackName`

You must be on at least rack version `3.14.0` to preform this update.

 _If you are unfamiliar with v3 rack versioning, we advise checking the documentation [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) for more information before applying any updates_
