### PR TITLE
Add support for emptyDir volume

### DIFF
--- a/docs/reference/primitives/app/service.md
+++ b/docs/reference/primitives/app/service.md
@@ -133,6 +133,7 @@ services:
 | **test**        | string     |                     | A command to run to test this Service when running **convox test**                                                                           |
 | **timeout**     | number     | 60                  | Timeout period (in seconds) for reading/writing requests to/from your service                                                              |
 | **tls**         | map        |                     | TLS-related configuration                                                                                                                  |
+| **volumeOptions**  | list    |                     | List of volumes to attach with service |
 | **whitelist**   | string     |                     | Comma delimited list of CIDRs, e.g. `10.0.0.0/24,172.10.0.1`, to allow access to the service                                                                                                                  |
 
 > Environment variables declared on `convox.yml` will be populated for a Service.
@@ -330,6 +331,38 @@ services:
 | Attribute  | Type    | Default | Description                                                                          |
 | ---------- | ------- | ------- | ------------------------------------------------------------------------------------ |
 | **redirect** | boolean | true    | Whether or not HTTP requests should be redirected to HTTPS using a 308 response code |
+
+&nbsp;
+
+### []volumeOptions
+
+| Attribute  | Type    | Default | Description                                                                          |
+| ---------- | ------- | ------- | ------------------------------------------------------------------------------------ |
+| **emptyDir** | map |     | Configuration for [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) volume |
+
+&nbsp;
+
+### []volumeOptions.emptyDir
+
+| Attribute  | Type    | Default | Description                                                                          |
+| ---------- | ------- | ------- | ------------------------------------------------------------------------------------ |
+| **id** | string |     | Required. Id of the volume. |
+| **mountPath** | string |     | Required. Path in the serive file system to mount the volume |
+| **medium** | string |     | Optional. Specifies the emptyDir medium. Allowed values: `"Memory"` or `""` |
+
+
+```yaml
+environment:
+  - PORT=3000
+services:
+  web:
+    build: .
+    port: 3000
+    volumeOptions:
+      - emptyDir:
+          id: "test-vol"
+          mountPath: "/my/test/vol"
+```
 
 &nbsp;
 

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -42,7 +42,40 @@ type Service struct {
 	Timeout            int                   `yaml:"timeout,omitempty"`
 	Tls                ServiceTls            `yaml:"tls,omitempty"`
 	Volumes            []string              `yaml:"volumes,omitempty"`
+	VolumeOptions      []VolumeOption        `yaml:"volumeOptions,omitempty"`
 	Whitelist          string                `yaml:"whitelist,omitempty"`
+}
+
+type VolumeOption struct {
+	EmptyDir *VolumeEmptyDir `yaml:"emptyDir,omitempty"`
+}
+
+func (v VolumeOption) Validate() error {
+	if v.EmptyDir != nil {
+		return v.EmptyDir.Validate()
+	}
+	return nil
+}
+
+type VolumeEmptyDir struct {
+	Id        string `yaml:"id"`
+	Medium    string `yaml:"medium,omitempty"`
+	MountPath string `yaml:"mountPath"`
+}
+
+func (v VolumeEmptyDir) Validate() error {
+	if v.Id == "" {
+		return fmt.Errorf("emptyDir.id is required")
+	}
+	if v.MountPath == "" {
+		return fmt.Errorf("emptyDir.mountPath is required")
+	}
+	if v.Medium != "" {
+		if v.Medium != "Memory" {
+			return fmt.Errorf("emptyDir.medium's allowed values: Memory")
+		}
+	}
+	return nil
 }
 
 type Services []Service

--- a/pkg/manifest/validate.go
+++ b/pkg/manifest/validate.go
@@ -125,8 +125,14 @@ func (m *Manifest) validateServices() []error {
 				}
 			}
 		}
-	}
 
+		for i := range s.VolumeOptions {
+			if err := s.VolumeOptions[i].Validate(); err != nil {
+				errs = append(errs, err)
+			}
+		}
+
+	}
 	return errs
 }
 

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -228,6 +228,12 @@ spec:
         - name: {{ volumeName $.App.Name (volumeFrom $.App.Name $.Service.Name .) }}
           mountPath: "{{ volumeTo . }}"
         {{ end }}
+        {{ range .Service.VolumeOptions }}
+        {{ with .EmptyDir }}
+        - name: ed-{{ .Id }}
+          mountPath: {{ .MountPath }}
+        {{ end }}
+        {{ end }}
       volumes:
       - name: ca
         configMap:
@@ -242,6 +248,17 @@ spec:
         persistentVolumeClaim:
           claimName: {{ volumeName $.App.Name . }}
         {{ end }}
+      {{ end }}
+      {{ range .Service.VolumeOptions }}
+      {{ with .EmptyDir }}
+      - name: ed-{{ .Id }}
+        {{ if .Medium }}
+        emptyDir:
+          medium: {{ .Medium }}
+        {{ else }}
+        emptyDir: {}
+        {{ end }}
+      {{ end }}
       {{ end }}
 {{ if not (eq .Service.Scale.Count.Min .Service.Scale.Count.Max) }}
 ---


### PR DESCRIPTION
### What is the feature/fix?

This will allow user to specify emptyDir volume for service.

https://app.asana.com/0/1203637156732418/1206300968228822/f

### Does it has a breaking change?

no

### How to use/test it?

** Describe how to test or use the feature **
```
environment:
  - PORT=3000
services:
  web:
    build: .
    port: 3000
    volumeOptions:
      - emptyDir:
          id: "test-vol"
          mountPath: "/my/test/vol"
```
### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
