### PR TITLE
Fix broken terraform for local racks

### DIFF
--- a/terraform/rack/local/main.tf
+++ b/terraform/rack/local/main.tf
@@ -5,13 +5,14 @@ module "k8s" {
     kubernetes = kubernetes
   }
 
-  docker_hub_username = var.docker_hub_username
-  docker_hub_password = var.docker_hub_password
-  domain              = module.router.endpoint
-  name                = var.name
-  release             = var.release
-  settings            = var.settings
-  telemetry           = var.telemetry
+  docker_hub_username   = var.docker_hub_username
+  docker_hub_password   = var.docker_hub_password
+  domain                = module.router.endpoint
+  name                  = var.name
+  release               = var.release
+  telemetry             = var.telemetry
+  telemetry_map         = var.telemetry_map
+  telemetry_default_map = var.telemetry_default_map
 }
 
 module "api" {

--- a/terraform/rack/local/variables.tf
+++ b/terraform/rack/local/variables.tf
@@ -42,5 +42,13 @@ variable "settings" {
 }
 
 variable "telemetry" {
-  type   = bool
+  type = bool
+}
+
+variable "telemetry_map" {
+  type = any
+}
+
+variable "telemetry_default_map" {
+  type = any
 }

--- a/terraform/system/local/main.tf
+++ b/terraform/system/local/main.tf
@@ -25,14 +25,16 @@ module "rack" {
     kubernetes = kubernetes
   }
 
-  docker_hub_username = var.docker_hub_username
-  docker_hub_password = var.docker_hub_password
-  image               = var.image
-  name                = local.name
-  rack_name           = local.rack_name
-  platform            = module.platform.name
-  os                  = var.os
-  release             = local.release
-  settings            = var.settings
-  telemetry           = var.telemetry
+  docker_hub_username   = var.docker_hub_username
+  docker_hub_password   = var.docker_hub_password
+  image                 = var.image
+  name                  = local.name
+  rack_name             = local.rack_name
+  platform              = module.platform.name
+  os                    = var.os
+  release               = local.release
+  settings              = var.settings
+  telemetry             = var.telemetry
+  telemetry_map         = local.telemetry_map
+  telemetry_default_map = local.telemetry_default_map
 }

--- a/terraform/system/local/telemetry.tf
+++ b/terraform/system/local/telemetry.tf
@@ -5,24 +5,24 @@ locals {
   telemetry_map = {
     docker_hub_password = var.docker_hub_password
     docker_hub_username = var.docker_hub_username
-    image = var.image
-    name = var.name
-    os = var.os
-    rack_name = var.rack_name
-    release = var.release
-    settings = var.settings
-    telemetry = var.telemetry
-    }
+    image               = var.image
+    name                = var.name
+    os                  = var.os
+    rack_name           = var.rack_name
+    release             = var.release
+    settings            = var.settings
+    telemetry           = var.telemetry
+  }
 
   telemetry_default_map = {
     docker_hub_password = ""
     docker_hub_username = ""
-    image = "convox/convox"
-    name = ""
-    os = "ubuntu"
-    rack_name = ""
-    release = ""
-    settings = ""
-    telemetry = "false"
-    }
+    image               = "convox/convox"
+    name                = ""
+    os                  = "ubuntu"
+    rack_name           = ""
+    release             = ""
+    settings            = ""
+    telemetry           = "false"
+  }
 }


### PR DESCRIPTION
### What is the feature/fix?

When #666 got merged, it left some modules for local racks misconfigured, leading to errors like #743. This PR fixes that issue by:

* Removing the dangling `settings` variable
* Correctly threading through the `telemetry_map` & `telemetry_default_map` locals from the `system/local` module.

**Any additional information**

With this patch, I was able to stand up a local rack on macos atop minikube as per the development rack documentation.
Fixes #743.

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
