### PR TITLE
Add cli commands for workflow run

### DIFF
--- a/docs/reference/cli/letsencrypt.md
+++ b/docs/reference/cli/letsencrypt.md
@@ -1,7 +1,7 @@
 ---
-title: "apps"
+title: "letsencrypt"
 draft: false
-slug: apps
+slug: letsencrypt
 url: /reference/cli/letsencrypt
 ---
 # letsencrypt

--- a/docs/reference/cli/workflows.md
+++ b/docs/reference/cli/workflows.md
@@ -1,0 +1,46 @@
+---
+title: "workflows"
+draft: false
+slug: workflows
+url: /reference/cli/workflows
+---
+# workflows
+
+## workflows
+
+List of workflows for the organization. 
+
+### Usage
+```html
+    convox workflows
+```
+### Examples
+```html
+    $ convox workflows
+    ID                                    KIND        NAME
+    55dd9440-eb98-4d9b-816f-9923ee77feff  deployment  deployweb-app
+    c828b45a-070b-46ed-9c43-ddaa905ecd68  review      review-web-app
+```
+
+## workflows run <id>
+
+Trigger workflow run for the specified branch or commit. Specified branch or commit must reside on the workflow repository.
+
+### Usage
+```html
+    convox workflows run <id>
+```
+
+Flags:
+```html
+    --app app        -a app
+    --branch branch                            
+    --commit commit                            
+    --title title   
+```
+
+### Examples
+```html
+    $ convox workflows run 55dd9440-eb98-4d9b-816f-99230077feff --branch feat-branch --title "title"
+    Successfully trigger the workflow, job id: 65a4160a-27cd-47c6-ba74-aaaaaaaa
+```

--- a/pkg/cli/workflows.go
+++ b/pkg/cli/workflows.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/convox/convox/pkg/structs"
+	"github.com/convox/convox/sdk"
+	"github.com/convox/stdcli"
+)
+
+func init() {
+	register("workflows", "get list of workflows", Workflows, stdcli.CommandOptions{
+		Flags:    []stdcli.Flag{flagRack},
+		Validate: stdcli.Args(0),
+	})
+
+	register("workflows run", "run workflow for specified branch or commit", WorkflowCustomRun, stdcli.CommandOptions{
+		Flags:    stdcli.OptionFlags(structs.WorkflowCustomRunOptions{}),
+		Usage:    "<id>",
+		Validate: stdcli.Args(1),
+	})
+
+}
+
+func Workflows(rack sdk.Interface, c *stdcli.Context) error {
+	data, err := c.SettingRead("current")
+	if err != nil {
+		return err
+	}
+	var attrs map[string]string
+	if err := json.Unmarshal([]byte(data), &attrs); err != nil {
+		return err
+	}
+
+	ws, err := rack.WorkflowList(attrs["name"])
+	if err != nil {
+		return err
+	}
+
+	t := c.Table("ID", "KIND", "NAME")
+	for _, r := range ws.Workflows {
+		t.AddRow(r.Id, r.Kind, r.Name)
+	}
+
+	return t.Print()
+}
+
+func WorkflowCustomRun(rack sdk.Interface, c *stdcli.Context) error {
+	wid := c.Arg(0)
+
+	var opts structs.WorkflowCustomRunOptions
+	if err := c.Options(&opts); err != nil {
+		return err
+	}
+
+	if opts.App == nil || *opts.App == "" {
+		return fmt.Errorf("app is required")
+	}
+
+	if opts.Branch == nil && opts.Commit == nil {
+		return fmt.Errorf("branch or commit is required")
+	}
+
+	data, err := c.SettingRead("current")
+	if err != nil {
+		return err
+	}
+	var attrs map[string]string
+	if err := json.Unmarshal([]byte(data), &attrs); err != nil {
+		return err
+	}
+
+	resp, err := rack.WorkflowCustomRun(attrs["name"], wid, opts)
+	if err != nil {
+		return err
+	}
+
+	return c.Writef("Successfully trigger the workflow, job id: %s", resp.JobID)
+}

--- a/pkg/mock/sdk/interface.go
+++ b/pkg/mock/sdk/interface.go
@@ -2288,6 +2288,50 @@ func (_m *Interface) Workers() error {
 	return r0
 }
 
+// WorkflowCustomRun provides a mock function with given fields: rackOrgSlug, workflowId, opts
+func (_m *Interface) WorkflowCustomRun(rackOrgSlug string, workflowId string, opts structs.WorkflowCustomRunOptions) (*structs.WorkflowCustomRunResp, error) {
+	ret := _m.Called(rackOrgSlug, workflowId, opts)
+
+	var r0 *structs.WorkflowCustomRunResp
+	if rf, ok := ret.Get(0).(func(string, string, structs.WorkflowCustomRunOptions) *structs.WorkflowCustomRunResp); ok {
+		r0 = rf(rackOrgSlug, workflowId, opts)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*structs.WorkflowCustomRunResp)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string, structs.WorkflowCustomRunOptions) error); ok {
+		r1 = rf(rackOrgSlug, workflowId, opts)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// WorkflowList provides a mock function with given fields: rackOrgSlug
+func (_m *Interface) WorkflowList(rackOrgSlug string) (structs.WorkflowListResp, error) {
+	ret := _m.Called(rackOrgSlug)
+
+	var r0 structs.WorkflowListResp
+	if rf, ok := ret.Get(0).(func(string) structs.WorkflowListResp); ok {
+		r0 = rf(rackOrgSlug)
+	} else {
+		r0 = ret.Get(0).(structs.WorkflowListResp)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(rackOrgSlug)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 type NewInterfaceT interface {
 	mock.TestingT
 	Cleanup(func())

--- a/pkg/structs/system.go
+++ b/pkg/structs/system.go
@@ -64,3 +64,25 @@ type Runtimes []Runtime
 type RuntimeAttachOptions struct {
 	Runtime *string `param:"runtime"`
 }
+
+type WorkflowResp struct {
+	Id   string `json:"id"`
+	Name string `json:"name"`
+	Kind string `json:"kind"`
+}
+
+type WorkflowListResp struct {
+	Oid       string         `json:"oid"`
+	Workflows []WorkflowResp `json:"workflows"`
+}
+
+type WorkflowCustomRunOptions struct {
+	App    *string `param:"app" flag:"app,a"`
+	Branch *string `param:"branch" flag:"branch"`
+	Commit *string `param:"commit" flag:"commit"`
+	Title  *string `param:"title" flag:"title"`
+}
+
+type WorkflowCustomRunResp struct {
+	JobID string `json:"jod_id"`
+}

--- a/sdk/interface.go
+++ b/sdk/interface.go
@@ -46,4 +46,6 @@ type Interface interface {
 	SystemResourceTypesClassic() (structs.ResourceTypes, error)
 	SystemResourceUnlinkClassic(string, string) (*structs.Resource, error)
 	SystemResourceUpdateClassic(string, structs.ResourceUpdateOptions) (*structs.Resource, error)
+	WorkflowList(rackOrgSlug string) (structs.WorkflowListResp, error)
+	WorkflowCustomRun(rackOrgSlug, workflowId string, opts structs.WorkflowCustomRunOptions) (*structs.WorkflowCustomRunResp, error)
 }

--- a/sdk/methods.go
+++ b/sdk/methods.go
@@ -868,6 +868,33 @@ func (c *Client) Runtimes(rackOrgSlug string) (structs.Runtimes, error) {
 	return v, err
 }
 
+func (c *Client) WorkflowList(rackOrgSlug string) (structs.WorkflowListResp, error) {
+	var err error
+
+	ro := stdsdk.RequestOptions{Headers: stdsdk.Headers{}, Params: stdsdk.Params{}, Query: stdsdk.Query{}}
+
+	var v structs.WorkflowListResp
+
+	err = c.Get(fmt.Sprintf("/racks/%s/workflows", rackOrgSlug), ro, &v)
+
+	return v, err
+}
+
+func (c *Client) WorkflowCustomRun(rackOrgSlug, workflowId string, opts structs.WorkflowCustomRunOptions) (*structs.WorkflowCustomRunResp, error) {
+	var err error
+
+	ro, err := stdsdk.MarshalOptions(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	var v structs.WorkflowCustomRunResp
+
+	err = c.Post(fmt.Sprintf("/racks/%s/workflows/%s/run", rackOrgSlug, workflowId), ro, &v)
+
+	return &v, err
+}
+
 func (c *Client) RuntimeAttach(rackOrgSlug string, opts structs.RuntimeAttachOptions) error {
 	var err error
 


### PR DESCRIPTION
### What is the feature/fix?

Add cli command to trigger workflow for specific branch.

https://app.asana.com/0/1203637156732418/1206312764491829/f


### Does it has a breaking change?

no 

### How to test

```
    $ convox workflows
    ID                                    KIND        NAME
    55dd9440-eb98-4d9b-816f-9923ee77feff  deployment  deployweb-app
    c828b45a-070b-46ed-9c43-ddaa905ecd68  review      review-web-app
```

```
    $ convox workflows run 55dd9440-eb98-4d9b-816f-99230077feff --branch feat-branch --title "title"
    Successfully trigger the workflow, job id: 65a4160a-27cd-47c6-ba74-aaaaaaaa
```


### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
