### PR TITLE
First stab at distinct health check ports

### DIFF
--- a/docs/configuration/health-checks.md
+++ b/docs/configuration/health-checks.md
@@ -34,6 +34,7 @@ services:
       grace: 5
       interval: 5
       path: /check
+      port: 8000
       timeout: 3
 ```
 
@@ -42,4 +43,5 @@ services:
 | **grace**    | 5       | The amount of time in seconds to wait for a [Process](/reference/primitives/app/process) to boot before beginning health checks |
 | **interval** | 5       | The number of seconds between health checks                                                                                          |
 | **path**     | /       | The HTTP endpoint that will be requested                                                                                             |
+| **port**     | Inherited from service port | The port that the health check will connect to                                                                   |
 | **timeout**  | 4       | The number of seconds to wait for a valid response                                                                                   |

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -151,6 +151,15 @@ func (m *Manifest) ApplyDefaults() error {
 			m.Services[i].Health.Path = "/"
 		}
 
+		if s.Health.Port.Port == 0 && s.Port.Port > 0 {
+			m.Services[i].Health.Port.Port = s.Port.Port
+			if s.Port.Scheme != "" {
+				m.Services[i].Health.Port.Scheme = s.Port.Scheme
+			} else {
+				m.Services[i].Health.Port.Scheme = "http"
+			}
+		}
+
 		if s.Health.Interval == 0 {
 			m.Services[i].Health.Interval = 5
 		}
@@ -170,6 +179,14 @@ func (m *Manifest) ApplyDefaults() error {
 			}
 			if s.Liveness.Interval == 0 {
 				m.Services[i].Liveness.Interval = 5
+			}
+			if s.Liveness.Port.Port == 0 && s.Port.Port > 0 {
+				m.Services[i].Liveness.Port.Port = s.Port.Port
+				if s.Port.Scheme != "" {
+					m.Services[i].Liveness.Port.Scheme = s.Port.Scheme
+				} else {
+					m.Services[i].Liveness.Port.Scheme = "http"
+				}
 			}
 			if s.Liveness.Timeout == 0 {
 				m.Services[i].Liveness.Timeout = 5

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -123,6 +123,7 @@ func TestManifestLoad(t *testing.T) {
 				Health: manifest.ServiceHealth{
 					Grace:    5,
 					Path:     "/auth",
+					Port:     2001,
 					Interval: 5,
 					Timeout:  4,
 				},

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -108,20 +108,22 @@ type ServiceDnsConfig struct {
 }
 
 type ServiceHealth struct {
-	Disable  bool
-	Grace    int
-	Interval int
-	Path     string
-	Timeout  int
+	Disable  bool              `yaml:"disable,omitempty"`
+	Grace    int               `yaml:"grace,omitempty"`
+	Interval int               `yaml:"interval,omitempty"`
+	Path     string            `yaml:"path,omitempty"`
+	Port     ServicePortScheme `yaml:"port,omitempty"`
+	Timeout  int               `yaml:"timeout,omitempty"`
 }
 
 type ServiceLiveness struct {
-	Grace            int    `yaml:"grace,omitempty"`
-	Interval         int    `yaml:"interval,omitempty"`
-	Path             string `yaml:"path,omitempty"`
-	Timeout          int    `yaml:"timeout,omitempty"`
-	SuccessThreshold int    `yaml:"successThreshold,omitempty"`
-	FailureThreshold int    `yaml:"failureThreshold,omitempty"`
+	Grace            int               `yaml:"grace,omitempty"`
+	Interval         int               `yaml:"interval,omitempty"`
+	Path             string            `yaml:"path,omitempty"`
+	Port             ServicePortScheme `yaml:"port,omitempty"`
+	Timeout          int               `yaml:"timeout,omitempty"`
+	SuccessThreshold int               `yaml:"successThreshold,omitempty"`
+	FailureThreshold int               `yaml:"failureThreshold,omitempty"`
 }
 
 type ServiceLifecycle struct {

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -151,8 +151,8 @@ spec:
               {{ end }}
           {{ end }}
         {{ end }}
-        {{ with .Service.Port.Port }}
-        {{ if and (not (eq $.Service.Port.Scheme "GRPC")) (not (eq $.Service.Liveness.Path ""))}}
+        {{ with .Service.Liveness.Port }}
+        {{ if and (not (eq $.Service.Liveness.Port.Scheme "GRPC")) (not (eq $.Service.Liveness.Path ""))}}
         livenessProbe:
           httpGet:
             path: {{$.Service.Liveness.Path}}"
@@ -163,7 +163,19 @@ spec:
           successThreshold: {{$.Service.Liveness.SuccessThreshold}}
           failureThreshold: {{$.Service.Liveness.FailureThreshold}}
         {{ end }}
-        {{ if and (not (eq $.Service.Port.Scheme "GRPC")) (not $.Service.Health.Disable) }}
+        {{ if (eq $.Service.Liveness.Port.Scheme  "GRPC") }}
+        livenessProbe:
+          grpc:
+            port: {{.}}
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 15
+          successThreshold: 1
+          failureThreshold: 5
+        {{ end }}
+        {{ end }}
+        {{ with .Service.Health.Port }}
+        {{ if and (not (eq $.Service.Health.Port.Scheme "GRPC")) (not $.Service.Health.Disable) }}
         readinessProbe:
           httpGet:
             path: "{{$.Service.Health.Path}}"
@@ -174,15 +186,6 @@ spec:
           timeoutSeconds: {{$.Service.Health.Timeout}}
           successThreshold: 1
           failureThreshold: 3
-        {{ else if $.Service.GrpcHealthEnabled }}
-        livenessProbe:
-          grpc:
-            port: {{.}}
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          timeoutSeconds: 15
-          successThreshold: 1
-          failureThreshold: 5
         {{ end }}
         {{ end }}
         ports:


### PR DESCRIPTION
### What is the feature/fix?

Allows to define a health check and liveness port separate from the main service port.  This is useful in situations where the service is listening on one port which you want to expose via a load balancer, so you define that port under the `ports` list, but this would mean the health/liveness check would not run as it relies on the port being defined under `port`.
It would also allow for a service that exposes multiple ports but you would wish to keep the health/liveness port not exposed beyond the rack, so you define that separately.

### Does it has a breaking change?

I don't believe so.  The manifest is setup to default the port to the service port if it is not defined already.

### How to use/test it?

Specify a port under the the health/liveness sections of your convox.yml

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
