### PR TITLE
Adds support for targeting a specific stage when using multi-stage builds

### DIFF
--- a/docs/reference/primitives/app/service.md
+++ b/docs/reference/primitives/app/service.md
@@ -40,6 +40,7 @@ services:
     build:
       manifest: Dockerfile
       path: .
+      target: production
     certificate:
       duration: 2160h 
     command: bin/web
@@ -161,10 +162,12 @@ services:
 
 ### build
 
-| Attribute  | Type   | Default    | Description                                                   |
-| ---------- | ------ | ---------- | ------------------------------------------------------------- |
-| **manifest** | string | Dockerfile | The filename of the Dockerfile                                |
-| **path**     | string | .          | The path (relative to **convox.yml**) to build for this Service |
+| Attribute    | Type   | Default    | Description                                                                  |
+| ------------ | ------ | ---------- | ---------------------------------------------------------------------------- |
+| **manifest** | string | Dockerfile | The filename of the Dockerfile                                               |
+| **path**     | string | .          | The path (relative to **convox.yml**) to build for this Service              |
+| **args**     | map    |            | The build args to apply to the build for this Service                        |
+| **target**   | string |            | The target stage to build for this Service if using a multi-stage Dockerfile |
 
 > Specifying **build** as a string will set the **path** and leave the other values as defaults.
 
@@ -347,7 +350,7 @@ services:
 | Attribute  | Type    | Default | Description                                                                          |
 | ---------- | ------- | ------- | ------------------------------------------------------------------------------------ |
 | **id** | string |     | Required. Id of the volume. |
-| **mountPath** | string |     | Required. Path in the serive file system to mount the volume |
+| **mountPath** | string |     | Required. Path in the Service file system to mount the volume |
 | **medium** | string |     | Optional. Specifies the emptyDir medium. Allowed values: `"Memory"` or `""` |
 
 

--- a/pkg/build/docker.go
+++ b/pkg/build/docker.go
@@ -82,7 +82,7 @@ func (d *Docker) Build(bb *Build, dir string) error {
 	for hash, b := range builds {
 		bb.Printf("Building: %s\n", b.Path)
 
-		if err := d.build(bb, filepath.Join(dir, b.Path), b.Manifest, hash, env); err != nil {
+		if err := d.build(bb, filepath.Join(dir, b.Path), b.Manifest, b.Target, hash, env); err != nil {
 			return err
 		}
 	}
@@ -166,7 +166,7 @@ func (*Docker) Login(bb *Build) error {
 }
 
 // skipcq
-func (*Docker) build(bb *Build, path, dockerfile, tag string, env map[string]string) error {
+func (*Docker) build(bb *Build, path, dockerfile, target, tag string, env map[string]string) error {
 	if path == "" {
 		return fmt.Errorf("must have path to build")
 	}
@@ -182,6 +182,10 @@ func (*Docker) build(bb *Build, path, dockerfile, tag string, env map[string]str
 	args = append(args, "-t", tag)
 	args = append(args, "-f", df)
 	args = append(args, "--network", "host")
+
+	if target != "" {
+		args = append(args, "--target", target)
+	}
 
 	ba, err := bb.buildArgs(df, env)
 	if err != nil {

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -94,6 +94,7 @@ type ServiceBuild struct {
 	Args     []string `yaml:"args,omitempty"`
 	Manifest string   `yaml:"manifest,omitempty"`
 	Path     string   `yaml:"path,omitempty"`
+	Target   string   `yaml:"target,omitempty"`
 }
 
 type ServiceDeployment struct {


### PR DESCRIPTION

### What is the feature/fix?

If a service uses a multi-stage Dockerfile, this change allows you to specify the stage to build for the service.
Works for both buildkit and docker builders.

### Does it has a breaking change?

No

### How to use/test it?

Create a service with a multi-stage Dockerfile.  Create a convox.yml with a `target` configuration within the `build` section to specify which stage you wish to build and deploy for the service.  Build/deploy the service and see that the correct stage has been built.

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
