### PR TITLE
Support custom dockerignore files

### DIFF
--- a/pkg/cli/builds.go
+++ b/pkg/cli/builds.go
@@ -122,7 +122,15 @@ func build(rack sdk.Interface, c *stdcli.Context, development bool) (*structs.Bu
 
 	c.Startf("Packaging source")
 
-	data, err := common.Tarball(dir)
+	var ignorefile string
+
+	if c.String("ignore") == "" {
+		ignorefile = ".dockerignore"
+	} else {
+		ignorefile = c.String("ignore")
+	}
+
+	data, err := common.Tarball(dir, ignorefile)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/common/tar.go
+++ b/pkg/common/tar.go
@@ -65,7 +65,7 @@ func RebaseArchive(r io.Reader, src, dst string) (io.Reader, error) {
 	return &buf, nil
 }
 
-func Tarball(dir string) ([]byte, error) {
+func Tarball(dir string, ignorefile string) ([]byte, error) {
 	abs, err := filepath.Abs(dir)
 	if err != nil {
 		return nil, err
@@ -76,7 +76,7 @@ func Tarball(dir string) ([]byte, error) {
 		return nil, err
 	}
 
-	data, err := ioutil.ReadFile(filepath.Join(sym, ".dockerignore"))
+	data, err := ioutil.ReadFile(filepath.Join(sym, ignorefile))
 	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}

--- a/pkg/structs/build.go
+++ b/pkg/structs/build.go
@@ -31,6 +31,7 @@ type BuildCreateOptions struct {
 	Description    *string   `flag:"description,d" param:"description"`
 	Development    *bool     `flag:"development" param:"development"`
 	External       *bool     `flag:"external" param:"external"`
+	Ignore         *string   `flag:"ignore" param:"ignore"`
 	Manifest       *string   `flag:"manifest,m" param:"manifest"`
 	NoCache        *bool     `flag:"no-cache" param:"no-cache"`
 	WildcardDomain *bool     `flag:"wildcard-domain" param:"wildcard-domain"`


### PR DESCRIPTION
### What is the feature/fix?

Docker added support for custom .dockerignore files based on the Dockerfile name [here](https://github.com/moby/moby/issues/12886#issuecomment-480575928).  As Convox tars up the dir to upload the build before analysing the Dockerfile name, we can support a custom ignorefile with a flag on the build CLI simply like this.

### Does it has a breaking change?

No, it will default to the standard .dockerignore filename if not specfied.

### How to use/test it?

Create a different .dockerignore file, pass this on a build with the `--ignore` flag and see if it is respected in the way the directory is tar'd up to upload for the build.

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
