### PR TITLE
Add watch for list commands

### DIFF
--- a/pkg/cli/apps.go
+++ b/pkg/cli/apps.go
@@ -19,8 +19,8 @@ import (
 )
 
 func init() {
-	register("apps", "list apps", Apps, stdcli.CommandOptions{
-		Flags:    []stdcli.Flag{flagRack},
+	register("apps", "list apps", watch(Apps), stdcli.CommandOptions{
+		Flags:    []stdcli.Flag{flagRack, flagWatchInterval},
 		Validate: stdcli.Args(0),
 	})
 

--- a/pkg/cli/balancers.go
+++ b/pkg/cli/balancers.go
@@ -6,8 +6,8 @@ import (
 )
 
 func init() {
-	register("balancers", "list balancers for an app", Balancers, stdcli.CommandOptions{
-		Flags:    []stdcli.Flag{flagApp, flagRack},
+	register("balancers", "list balancers for an app", watch(Balancers), stdcli.CommandOptions{
+		Flags:    []stdcli.Flag{flagApp, flagRack, flagWatchInterval},
 		Validate: stdcli.Args(0),
 	})
 }

--- a/pkg/cli/builds.go
+++ b/pkg/cli/builds.go
@@ -26,8 +26,8 @@ func init() {
 		Validate: stdcli.ArgsMax(1),
 	})
 
-	register("builds", "list builds", Builds, stdcli.CommandOptions{
-		Flags:    append(stdcli.OptionFlags(structs.BuildListOptions{}), flagRack, flagApp),
+	register("builds", "list builds", watch(Builds), stdcli.CommandOptions{
+		Flags:    append(stdcli.OptionFlags(structs.BuildListOptions{}), flagRack, flagApp, flagWatchInterval),
 		Validate: stdcli.Args(0),
 	})
 

--- a/pkg/cli/certs.go
+++ b/pkg/cli/certs.go
@@ -15,8 +15,8 @@ import (
 )
 
 func init() {
-	register("certs", "list certificates", Certs, stdcli.CommandOptions{
-		Flags:    []stdcli.Flag{flagRack},
+	register("certs", "list certificates", watch(Certs), stdcli.CommandOptions{
+		Flags:    []stdcli.Flag{flagRack, flagWatchInterval},
 		Validate: stdcli.Args(0),
 	})
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -19,11 +19,12 @@ var (
 )
 
 var (
-	flagApp      = stdcli.StringFlag("app", "a", "app name")
-	flagForce    = stdcli.BoolFlag("force", "", "force version update")
-	flagId       = stdcli.BoolFlag("id", "", "put logs on stderr, release id on stdout")
-	flagNoFollow = stdcli.BoolFlag("no-follow", "", "do not follow logs")
-	flagRack     = stdcli.StringFlag("rack", "r", "rack name")
+	flagApp           = stdcli.StringFlag("app", "a", "app name")
+	flagForce         = stdcli.BoolFlag("force", "", "force version update")
+	flagId            = stdcli.BoolFlag("id", "", "put logs on stderr, release id on stdout")
+	flagNoFollow      = stdcli.BoolFlag("no-follow", "", "do not follow logs")
+	flagRack          = stdcli.StringFlag("rack", "r", "rack name")
+	flagWatchInterval = stdcli.StringFlag("watch", "", "cmd watch/rerun interval in seconds")
 )
 
 func New(name, version string) *Engine {

--- a/pkg/cli/env.go
+++ b/pkg/cli/env.go
@@ -19,8 +19,8 @@ import (
 )
 
 func init() {
-	register("env", "list env vars", Env, stdcli.CommandOptions{
-		Flags:    []stdcli.Flag{flagRack, flagApp},
+	register("env", "list env vars", watch(Env), stdcli.CommandOptions{
+		Flags:    []stdcli.Flag{flagRack, flagApp, flagWatchInterval},
 		Validate: stdcli.Args(0),
 	})
 

--- a/pkg/cli/instances.go
+++ b/pkg/cli/instances.go
@@ -20,8 +20,8 @@ var (
 )
 
 func init() {
-	register("instances", "list instances", Instances, stdcli.CommandOptions{
-		Flags:    []stdcli.Flag{flagRack},
+	register("instances", "list instances", watch(Instances), stdcli.CommandOptions{
+		Flags:    []stdcli.Flag{flagRack, flagWatchInterval},
 		Validate: stdcli.Args(0),
 	})
 

--- a/pkg/cli/ps.go
+++ b/pkg/cli/ps.go
@@ -8,13 +8,13 @@ import (
 )
 
 func init() {
-	register("ps", "list app processes", Ps, stdcli.CommandOptions{
-		Flags:    append(stdcli.OptionFlags(structs.ProcessListOptions{}), flagApp, flagRack),
+	register("ps", "list app processes", watch(Ps), stdcli.CommandOptions{
+		Flags:    append(stdcli.OptionFlags(structs.ProcessListOptions{}), flagApp, flagRack, flagWatchInterval),
 		Validate: stdcli.Args(0),
 	})
 
-	register("ps info", "get information about a process", PsInfo, stdcli.CommandOptions{
-		Flags:    []stdcli.Flag{flagApp, flagRack},
+	register("ps info", "get information about a process", watch(PsInfo), stdcli.CommandOptions{
+		Flags:    []stdcli.Flag{flagApp, flagRack, flagWatchInterval},
 		Validate: stdcli.Args(1),
 	})
 

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -20,8 +20,8 @@ import (
 )
 
 func init() {
-	register("rack", "get information about the rack", Rack, stdcli.CommandOptions{
-		Flags:    []stdcli.Flag{flagRack},
+	register("rack", "get information about the rack", watch(Rack), stdcli.CommandOptions{
+		Flags:    []stdcli.Flag{flagRack, flagWatchInterval},
 		Validate: stdcli.Args(0),
 	})
 

--- a/pkg/cli/racks.go
+++ b/pkg/cli/racks.go
@@ -7,7 +7,8 @@ import (
 )
 
 func init() {
-	registerWithoutProvider("racks", "list available racks", Racks, stdcli.CommandOptions{
+	registerWithoutProvider("racks", "list available racks", watch(Racks), stdcli.CommandOptions{
+		Flags:    []stdcli.Flag{flagWatchInterval},
 		Validate: stdcli.Args(0),
 	})
 }

--- a/pkg/cli/registries.go
+++ b/pkg/cli/registries.go
@@ -6,8 +6,8 @@ import (
 )
 
 func init() {
-	register("registries", "list private registries", Registries, stdcli.CommandOptions{
-		Flags:    []stdcli.Flag{flagRack},
+	register("registries", "list private registries", watch(Registries), stdcli.CommandOptions{
+		Flags:    []stdcli.Flag{flagRack, flagWatchInterval},
 		Validate: stdcli.Args(0),
 	})
 

--- a/pkg/cli/releases.go
+++ b/pkg/cli/releases.go
@@ -14,8 +14,8 @@ import (
 )
 
 func init() {
-	register("releases", "list releases for an app", Releases, stdcli.CommandOptions{
-		Flags:    append(stdcli.OptionFlags(structs.ReleaseListOptions{}), flagRack, flagApp),
+	register("releases", "list releases for an app", watch(Releases), stdcli.CommandOptions{
+		Flags:    append(stdcli.OptionFlags(structs.ReleaseListOptions{}), flagRack, flagApp, flagWatchInterval),
 		Validate: stdcli.Args(0),
 	})
 

--- a/pkg/cli/resources.go
+++ b/pkg/cli/resources.go
@@ -16,8 +16,8 @@ import (
 )
 
 func init() {
-	register("resources", "list resources", Resources, stdcli.CommandOptions{
-		Flags:    []stdcli.Flag{flagRack, flagApp},
+	register("resources", "list resources", watch(Resources), stdcli.CommandOptions{
+		Flags:    []stdcli.Flag{flagRack, flagApp, flagWatchInterval},
 		Validate: stdcli.Args(0),
 	})
 
@@ -69,8 +69,8 @@ func init() {
 		Validate: stdcli.Args(1),
 	})
 
-	register("rack resources", "list resources", RackResources, stdcli.CommandOptions{
-		Flags:     []stdcli.Flag{flagRack},
+	register("rack resources", "list resources", watch(RackResources), stdcli.CommandOptions{
+		Flags:     []stdcli.Flag{flagRack, flagWatchInterval},
 		Invisible: true,
 		Validate:  stdcli.Args(0),
 	})

--- a/pkg/cli/services.go
+++ b/pkg/cli/services.go
@@ -10,8 +10,8 @@ import (
 )
 
 func init() {
-	register("services", "list services for an app", Services, stdcli.CommandOptions{
-		Flags:    []stdcli.Flag{flagApp, flagRack},
+	register("services", "list services for an app", watch(Services), stdcli.CommandOptions{
+		Flags:    []stdcli.Flag{flagApp, flagRack, flagWatchInterval},
 		Validate: stdcli.Args(0),
 	})
 


### PR DESCRIPTION
### What is the feature/fix?

This will add `--watch <seconds>` flag command to the most of the list command. This will re-execute command periodically after each specified interval. 

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
