### PR TITLE
Add param to disable convox resolver for build to fix yarn dns issue

### DIFF
--- a/provider/k8s/k8s.go
+++ b/provider/k8s/k8s.go
@@ -66,6 +66,7 @@ type Provider struct {
 	Provider                   string
 	RackName                   string
 	Resolver                   string
+	BuildDisableResolver       bool
 	RestClient                 rest.Interface
 	Router                     string
 	Socket                     string
@@ -134,6 +135,7 @@ func FromEnv() (*Provider, error) {
 		Atom:                       ac,
 		BuildkitEnabled:            "true",
 		BuildNodeEnabled:           os.Getenv("BUILD_NODE_ENABLED"),
+		BuildDisableResolver:       os.Getenv("BUILD_DISABLE_CONVOX_RESOLVER") == "true",
 		CertManager:                os.Getenv("CERT_MANAGER") == "true",
 		CertManagerRoleArn:         os.Getenv("CERT_MANAGER_ROLE_ARN"),
 		Cluster:                    kc,

--- a/provider/k8s/process.go
+++ b/provider/k8s/process.go
@@ -505,20 +505,22 @@ func (p *Provider) podSpecFromService(app, service, release string) (*ac.PodSpec
 		Volumes:               vs,
 	}
 
-	if ip, err := p.Engine.ResolverHost(); err == nil {
-		ps.DNSPolicy = "None"
-		ps.DNSConfig = &ac.PodDNSConfig{
-			Nameservers: []string{ip},
-			Options: []ac.PodDNSConfigOption{
-				{Name: "ndots", Value: options.String("1")},
-			},
-			Searches: []string{
-				fmt.Sprintf("%s.%s.local", app, p.Name),
-				fmt.Sprintf("%s.svc.cluster.local", p.AppNamespace(app)),
-				fmt.Sprintf("%s.local", p.Name),
-				"svc.cluster.local",
-				"cluster.local",
-			},
+	if service != "build" || !p.BuildDisableResolver {
+		if ip, err := p.Engine.ResolverHost(); err == nil {
+			ps.DNSPolicy = "None"
+			ps.DNSConfig = &ac.PodDNSConfig{
+				Nameservers: []string{ip},
+				Options: []ac.PodDNSConfigOption{
+					{Name: "ndots", Value: options.String("1")},
+				},
+				Searches: []string{
+					fmt.Sprintf("%s.%s.local", app, p.Name),
+					fmt.Sprintf("%s.svc.cluster.local", p.AppNamespace(app)),
+					fmt.Sprintf("%s.local", p.Name),
+					"svc.cluster.local",
+					"cluster.local",
+				},
+			}
 		}
 	}
 

--- a/terraform/api/aws/main.tf
+++ b/terraform/api/aws/main.tf
@@ -39,14 +39,15 @@ module "k8s" {
   }
 
   env = {
-    AWS_REGION            = data.aws_region.current.name
-    BUCKET                = aws_s3_bucket.storage.id
-    CERT_MANAGER          = "true"
-    CERT_MANAGER_ROLE_ARN = aws_iam_role.cert-manager.arn
-    EFS_FILE_SYSTEM_ID    = var.efs_file_system_id
-    PROVIDER              = "aws"
-    RESOLVER              = var.resolver
-    ROUTER                = var.router
-    SOCKET                = "/var/run/docker.sock"
+    AWS_REGION                    = data.aws_region.current.name
+    BUCKET                        = aws_s3_bucket.storage.id
+    CERT_MANAGER                  = "true"
+    CERT_MANAGER_ROLE_ARN         = aws_iam_role.cert-manager.arn
+    EFS_FILE_SYSTEM_ID            = var.efs_file_system_id
+    BUILD_DISABLE_CONVOX_RESOLVER = var.build_disable_convox_resolver
+    PROVIDER                      = "aws"
+    RESOLVER                      = var.resolver
+    ROUTER                        = var.router
+    SOCKET                        = "/var/run/docker.sock"
   }
 }

--- a/terraform/api/aws/variables.tf
+++ b/terraform/api/aws/variables.tf
@@ -2,6 +2,10 @@ variable "buildkit_enabled" {
   default = false
 }
 
+variable "build_disable_convox_resolver" {
+  default = false
+}
+
 variable "build_node_enabled" {
   default = false
   type    = bool

--- a/terraform/rack/aws/main.tf
+++ b/terraform/rack/aws/main.tf
@@ -25,6 +25,7 @@ module "api" {
   }
 
   buildkit_enabled               = var.buildkit_enabled
+  build_disable_convox_resolver  = var.build_disable_convox_resolver
   build_node_enabled             = var.build_node_enabled
   convox_domain_tls_cert_disable = var.convox_domain_tls_cert_disable
   docker_hub_authentication      = module.k8s.docker_hub_authentication

--- a/terraform/rack/aws/variables.tf
+++ b/terraform/rack/aws/variables.tf
@@ -2,6 +2,10 @@ variable "buildkit_enabled" {
   default = false
 }
 
+variable "build_disable_convox_resolver" {
+  default = false
+}
+
 variable "build_node_enabled" {
   default = false
   type    = bool

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -134,6 +134,7 @@ module "rack" {
     null_resource.wait_for_cluster
   ]
 
+  build_disable_convox_resolver  = var.build_disable_convox_resolver
   build_node_enabled             = var.build_node_enabled
   cluster                        = module.cluster.id
   convox_domain_tls_cert_disable = var.convox_domain_tls_cert_disable

--- a/terraform/system/aws/telemetry.tf
+++ b/terraform/system/aws/telemetry.tf
@@ -5,6 +5,7 @@ locals {
   telemetry_map = {
     access_log_retention_in_days = var.access_log_retention_in_days
     availability_zones = var.availability_zones
+    build_disable_convox_resolver = var.build_disable_convox_resolver
     build_node_enabled = var.build_node_enabled
     build_node_min_count = var.build_node_min_count
     build_node_type = var.build_node_type
@@ -65,6 +66,7 @@ locals {
   telemetry_default_map = {
     access_log_retention_in_days = "7"
     availability_zones = ""
+    build_disable_convox_resolver = "false"
     build_node_enabled = "false"
     build_node_min_count = "0"
     build_node_type = ""

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -6,6 +6,10 @@ variable "availability_zones" {
   default = ""
 }
 
+variable "build_disable_convox_resolver" {
+  default = false
+}
+
 variable "build_node_enabled" {
   default = false
   type    = bool


### PR DESCRIPTION
### What is the feature/fix?

Add param to disable convox resolver for build to fix yarn dns issue


rack param : `build_disable_convox_resolver=true`