### PR TITLE
Add support of using pod identity for timer

### DIFF
--- a/provider/aws/release.go
+++ b/provider/aws/release.go
@@ -20,10 +20,22 @@ func (p *Provider) ReleasePromote(app, id string, opts structs.ReleasePromoteOpt
 		return errors.WithStack(err)
 	}
 
+	servicesMap := make(map[string]manifest.Service)
 	for i := range m.Services {
+		servicesMap[m.Services[i].Name] = m.Services[i]
 		err = p.processAccessControl(app, m.Services[i].Name, m.Services[i].AccessControl)
 		if err != nil {
 			return err
+		}
+	}
+
+	for i := range m.Timers {
+		service, ok := servicesMap[m.Timers[i].Service]
+		if ok {
+			err = p.processAccessControl(app, fmt.Sprintf("timer-%s", m.Timers[i].Name), service.AccessControl)
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
What is the feature/fix?
This fix ensures that timer uses pod identity of its associated service for secure resource access on promoting release.

** Describe the changes and if it has any breaking changes in any feature **
There are no breaking changes introduced with this fix.