### PR TITLE
Adding ECR image scan rack parameter

### DIFF
--- a/assets/provider/aws/params.yaml
+++ b/assets/provider/aws/params.yaml
@@ -118,6 +118,10 @@ Groups:
           &b Advanced Configuration &b &l SSL protocols to use for
           (Nginx)[https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_protocols] &l 
           &l They must be listed separated by spaces. &i e.g. &i - TLSv1.2 TLSv1.3 &l
+      - name: ecr_scan_on_push_enable
+        default: "false"
+        type: boolean
+        description: Automatically scans images for vulnerabilities upon push to the ECR repository.
   - name: Networking
     order: 3
     params:

--- a/docs/configuration/rack-parameters/aws/ecr_scan_on_push_enable.md
+++ b/docs/configuration/rack-parameters/aws/ecr_scan_on_push_enable.md
@@ -1,0 +1,39 @@
+---
+title: "ecr_scan_on_push_enable"
+draft: false
+slug: ecr_scan_on_push_enable
+url: /configuration/rack-parameters/aws/ecr_scan_on_push_enable
+---
+
+# ecr_scan_on_push_enable
+
+## Description
+The `ecr_scan_on_push_enable` parameter enables automatic security scanning of container images pushed to your ECR repositories.
+
+## Default Value
+The default value for `ecr_scan_on_push_enable` is `false`.
+
+## Use Cases
+- **Improved Security Posture**: Automatically scan container images for vulnerabilities helps identify potential security risks before deploying them to production.
+- **Streamlined Workflow**: Automating vulnerability scans saves time and ensures consistent security practices.
+
+## Setting Parameters
+To enable the ECR Scan on Push feature, use the following command:
+```html
+$ convox rack params set ecr_scan_on_push_enable=true -r rackName
+Setting parameters... OK
+```
+This command will trigger vulnerability scans for any new image pushed to ECR repositories associated with your rack.
+
+## Additional Information
+Enabling ecr_scan_on_push_enable provides an extra layer of security for your containerized applications. When enabled, It will trigger a vulnerability scan whenever a new image is pushed to a repository within your rack.
+
+### How to Use
+1. Enable automatic image scanning on push by executing:
+   ```html
+   convox rack params set ecr_scan_on_push_enable=true -r rackName
+   ```
+
+2. Push your container image to the ECR repository within your rack. It will automatically trigger a vulnerability scan.
+   
+By enabling this parameter, you can automate the initial security assessment of your container images.

--- a/provider/aws/app.go
+++ b/provider/aws/app.go
@@ -24,6 +24,9 @@ func (p *Provider) AppCreate(name string, opts structs.AppCreateOptions) (*struc
 
 	res, err := p.ECR.CreateRepository(&ecr.CreateRepositoryInput{
 		RepositoryName: aws.String(fmt.Sprintf("%s%s", p.RepositoryPrefix(), name)),
+		ImageScanningConfiguration: &ecr.ImageScanningConfiguration{
+			ScanOnPush: aws.Bool( p.ecr_scan_on_push_enable == "true"),
+		},
 	})
 	if err != nil {
 		return nil, err

--- a/provider/aws/app.go
+++ b/provider/aws/app.go
@@ -25,7 +25,7 @@ func (p *Provider) AppCreate(name string, opts structs.AppCreateOptions) (*struc
 	res, err := p.ECR.CreateRepository(&ecr.CreateRepositoryInput{
 		RepositoryName: aws.String(fmt.Sprintf("%s%s", p.RepositoryPrefix(), name)),
 		ImageScanningConfiguration: &ecr.ImageScanningConfiguration{
-			ScanOnPush: aws.Bool( p.ecr_scan_on_push_enable == "true"),
+			ScanOnPush: aws.Bool(p.EcrScanOnPushEnable),
 		},
 	})
 	if err != nil {

--- a/provider/aws/app_test.go
+++ b/provider/aws/app_test.go
@@ -57,7 +57,7 @@ func TestAppCreate(t *testing.T) {
 				ecrapi.On("CreateRepository", &ecr.CreateRepositoryInput{
 					RepositoryName: awssdk.String(test.BucketName),
 					ImageScanningConfiguration: &ecr.ImageScanningConfiguration{
-						ScanOnPush: awssdk.Bool(true),
+						ScanOnPush: awssdk.Bool(false),
 					},
 				}).Return(test.Output, test.Err)
 

--- a/provider/aws/app_test.go
+++ b/provider/aws/app_test.go
@@ -56,6 +56,9 @@ func TestAppCreate(t *testing.T) {
 				ecrapi := p.ECR.(*mocks.ECRAPI)
 				ecrapi.On("CreateRepository", &ecr.CreateRepositoryInput{
 					RepositoryName: awssdk.String(test.BucketName),
+					ImageScanningConfiguration: &ecr.ImageScanningConfiguration{
+						ScanOnPush: awssdk.Bool(true),
+					},
 				}).Return(test.Output, test.Err)
 
 				a, err := p.AppCreate(test.AppName, structs.AppCreateOptions{})

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -52,7 +52,7 @@ func FromEnv() (*Provider, error) {
 		return nil, err
 	}
 
-	EcrScanOnPushEnable, err := strconv.ParseBool(os.Getenv("ECR_SCAN_ON_PUSH_ENABLE"))
+	ecrScanOnPushEnable, err := strconv.ParseBool(os.Getenv("ECR_SCAN_ON_PUSH_ENABLE"))
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func FromEnv() (*Provider, error) {
 		Bucket:              os.Getenv("BUCKET"),
 		EncryptionKey:       os.Getenv("ENCRYPTION_KEY"),
 		Region:              os.Getenv("AWS_REGION"),
-		EcrScanOnPushEnable: EcrScanOnPushEnable,
+		EcrScanOnPushEnable: ecrScanOnPushEnable,
 	}
 
 	k.Engine = p

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -32,6 +32,8 @@ type Provider struct {
 	EncryptionKey string
 	Region        string
 
+	ecr_scan_on_push_enable string
+
 	Ec2 *ec2.EC2
 
 	CloudFormation cloudformationiface.CloudFormationAPI
@@ -50,10 +52,11 @@ func FromEnv() (*Provider, error) {
 	}
 
 	p := &Provider{
-		Provider:      k,
-		Bucket:        os.Getenv("BUCKET"),
-		EncryptionKey: os.Getenv("ENCRYPTION_KEY"),
-		Region:        os.Getenv("AWS_REGION"),
+		Provider:                k,
+		Bucket:                  os.Getenv("BUCKET"),
+		EncryptionKey:           os.Getenv("ENCRYPTION_KEY"),
+		Region:                  os.Getenv("AWS_REGION"),
+		ecr_scan_on_push_enable: os.Getenv("ECR_SCAN_ON_PUSH_ENABLE"),
 	}
 
 	k.Engine = p

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 	"os"
+	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -32,7 +33,7 @@ type Provider struct {
 	EncryptionKey string
 	Region        string
 
-	ecr_scan_on_push_enable string
+	EcrScanOnPushEnable bool
 
 	Ec2 *ec2.EC2
 
@@ -51,12 +52,17 @@ func FromEnv() (*Provider, error) {
 		return nil, err
 	}
 
+	EcrScanOnPushEnable, err := strconv.ParseBool(os.Getenv("ECR_SCAN_ON_PUSH_ENABLE"))
+	if err != nil {
+		return nil, err
+	}
+
 	p := &Provider{
-		Provider:                k,
-		Bucket:                  os.Getenv("BUCKET"),
-		EncryptionKey:           os.Getenv("ENCRYPTION_KEY"),
-		Region:                  os.Getenv("AWS_REGION"),
-		ecr_scan_on_push_enable: os.Getenv("ECR_SCAN_ON_PUSH_ENABLE"),
+		Provider:            k,
+		Bucket:              os.Getenv("BUCKET"),
+		EncryptionKey:       os.Getenv("ENCRYPTION_KEY"),
+		Region:              os.Getenv("AWS_REGION"),
+		EcrScanOnPushEnable: EcrScanOnPushEnable,
 	}
 
 	k.Engine = p

--- a/terraform/api/aws/main.tf
+++ b/terraform/api/aws/main.tf
@@ -49,5 +49,6 @@ module "k8s" {
     RESOLVER                      = var.resolver
     ROUTER                        = var.router
     SOCKET                        = "/var/run/docker.sock"
+    ECR_SCAN_ON_PUSH_ENABLE       = var.ecr_scan_on_push_enable
   }
 }

--- a/terraform/api/aws/variables.tf
+++ b/terraform/api/aws/variables.tf
@@ -87,3 +87,8 @@ variable "resolver" {
 variable "router" {
   type = string
 }
+
+variable "ecr_scan_on_push_enable" {
+  type    = bool
+  default = false
+}

--- a/terraform/rack/aws/main.tf
+++ b/terraform/rack/aws/main.tf
@@ -44,6 +44,7 @@ module "api" {
   release                        = var.release
   resolver                       = module.resolver.endpoint
   router                         = module.router.endpoint
+  ecr_scan_on_push_enable        = var.ecr_scan_on_push_enable
 }
 
 module "metrics" {

--- a/terraform/rack/aws/variables.tf
+++ b/terraform/rack/aws/variables.tf
@@ -139,3 +139,8 @@ variable "telemetry_default_map" {
 variable "whitelist" {
   default = ["0.0.0.0/0"]
 }
+
+variable "ecr_scan_on_push_enable" {
+  type    = bool
+  default = false
+}

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -166,4 +166,5 @@ module "rack" {
   telemetry_default_map          = local.telemetry_default_map
   whitelist                      = split(",", var.whitelist)
   ebs_csi_driver_name            = module.cluster.ebs_csi_driver_name
+  ecr_scan_on_push_enable        = var.ecr_scan_on_push_enable
 }

--- a/terraform/system/aws/telemetry.tf
+++ b/terraform/system/aws/telemetry.tf
@@ -18,6 +18,7 @@ locals {
     disable_image_manifest_cache = var.disable_image_manifest_cache
     docker_hub_password = var.docker_hub_password
     docker_hub_username = var.docker_hub_username
+    ecr_scan_on_push_enable = var.ecr_scan_on_push_enable
     efs_csi_driver_enable = var.efs_csi_driver_enable
     efs_csi_driver_version = var.efs_csi_driver_version
     fluentd_disable = var.fluentd_disable
@@ -79,6 +80,7 @@ locals {
     disable_image_manifest_cache = "false"
     docker_hub_password = ""
     docker_hub_username = ""
+    ecr_scan_on_push_enable = "false"
     efs_csi_driver_enable = "false"
     efs_csi_driver_version = "v2.0.1-eksbuild.1"
     fluentd_disable = "false"

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -269,3 +269,8 @@ variable "vpc_cni_version" {
 variable "whitelist" {
   default = "0.0.0.0/0"
 }
+
+variable "ecr_scan_on_push_enable" {
+  type    = bool
+  default = false
+}


### PR DESCRIPTION
Added Rack parameter ecr_scan_on_push_enable which can be used to change Image scan feature for images on ECR repository.

How to use:
`convox rack install <provider> <rackName> ecr_scan_on_push_enable=true`
