### PR TITLE
Added Wait flag for making v2 backwards compatible - Fix/v2 option flags support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/convox/go-u2fhost v0.0.0-20220210143516-c133f566e496
 	github.com/convox/logger v0.0.0-20180522214415-e39179955b52
 	github.com/convox/stdapi v1.1.3-0.20221110171947-8d98f61e61ed
-	github.com/convox/stdcli v0.0.0-20221110070640-8f8fb17bfe20
+	github.com/convox/stdcli v0.0.0-20240813092220-8beeb2dc2420
 	github.com/convox/stdsdk v0.0.0-20201005151143-fb7f05286eea
 	github.com/convox/version v0.0.0-20160822184233-ffefa0d565d2
 	github.com/crazy-max/xgo v0.24.0

--- a/go.sum
+++ b/go.sum
@@ -355,6 +355,8 @@ github.com/convox/stdapi v1.1.3-0.20221110171947-8d98f61e61ed h1:lsw6qfOktQBaF0F
 github.com/convox/stdapi v1.1.3-0.20221110171947-8d98f61e61ed/go.mod h1:7hoZ3oU4j6Zv3V1wRpgUO5eWc+480zYTpYxuTKAbugc=
 github.com/convox/stdcli v0.0.0-20221110070640-8f8fb17bfe20 h1:9t+oXf7ycnO1Cz9AnIEqPLdvbE0b0Yf9Pe5NOukvRN0=
 github.com/convox/stdcli v0.0.0-20221110070640-8f8fb17bfe20/go.mod h1:kLknwv4KTN9f9fZ2DDvG/L9ndXkcijaexIZ0enACvSc=
+github.com/convox/stdcli v0.0.0-20240813092220-8beeb2dc2420 h1:M04CSkHEyVyNnuQLhBD+YjhawuaTvjN/TDpOnaSVs5o=
+github.com/convox/stdcli v0.0.0-20240813092220-8beeb2dc2420/go.mod h1:kLknwv4KTN9f9fZ2DDvG/L9ndXkcijaexIZ0enACvSc=
 github.com/convox/stdsdk v0.0.0-20201005151143-fb7f05286eea h1:nVfJ9szLTd2BmyP6XzKvjAkQdGEV16TGcx/2FgOfpcE=
 github.com/convox/stdsdk v0.0.0-20201005151143-fb7f05286eea/go.mod h1:y1vtmkDKBkWSQ6e2gPXAyz1NCuWZ2x3vrP/SFeDDNco=
 github.com/convox/version v0.0.0-20160822184233-ffefa0d565d2 h1:tdp/1KHBnbne0yT1yuKnAdOTBHRue9yQ4oON8rzGgZc=

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -25,6 +25,7 @@ var (
 	flagNoFollow      = stdcli.BoolFlag("no-follow", "", "do not follow logs")
 	flagRack          = stdcli.StringFlag("rack", "r", "rack name")
 	flagWatchInterval = stdcli.StringFlag("watch", "", "cmd watch/rerun interval in seconds")
+	flagWait 		  = stdcli.BoolFlag("wait", "w", "wait for completion")
 )
 
 func New(name, version string) *Engine {

--- a/pkg/cli/engine.go
+++ b/pkg/cli/engine.go
@@ -26,6 +26,9 @@ func (e *Engine) Command(command, description string, fn HandlerFunc, opts stdcl
 		return fn(rc, c)
 	}
 
+	// the wait command flag is added for making the cli tool v2 backwards compatible
+	opts.Flags = append(opts.Flags, stdcli.BoolFlag("wait", "w", "wait for completion") )
+
 	e.Engine.Command(command, description, wfn, opts)
 }
 
@@ -33,6 +36,9 @@ func (e *Engine) CommandWithoutProvider(command, description string, fn HandlerF
 	wfn := func(c *stdcli.Context) error {
 		return fn(nil, c)
 	}
+
+	// the wait command flag is added for making the cli tool v2 backwards compatible
+	opts.Flags = append(opts.Flags, stdcli.BoolFlag("wait", "w", "wait for completion") )
 
 	e.Engine.Command(command, description, wfn, opts)
 }

--- a/pkg/cli/engine.go
+++ b/pkg/cli/engine.go
@@ -27,7 +27,8 @@ func (e *Engine) Command(command, description string, fn HandlerFunc, opts stdcl
 	}
 
 	// the wait command flag is added for making the cli tool v2 backwards compatible
-	opts.Flags = append(opts.Flags, stdcli.BoolFlag("wait", "w", "wait for completion") )
+	flagWait.SkipHelpCommand = true
+	opts.Flags = append(opts.Flags, flagWait)
 
 	e.Engine.Command(command, description, wfn, opts)
 }
@@ -38,7 +39,8 @@ func (e *Engine) CommandWithoutProvider(command, description string, fn HandlerF
 	}
 
 	// the wait command flag is added for making the cli tool v2 backwards compatible
-	opts.Flags = append(opts.Flags, stdcli.BoolFlag("wait", "w", "wait for completion") )
+	flagWait.SkipHelpCommand = true
+	opts.Flags = append(opts.Flags, flagWait)
 
 	e.Engine.Command(command, description, wfn, opts)
 }

--- a/vendor/github.com/convox/stdcli/context.go
+++ b/vendor/github.com/convox/stdcli/context.go
@@ -193,6 +193,10 @@ func (c *Context) SettingWriteKey(name, key, value string) error {
 	return c.engine.SettingWriteKey(name, key, value)
 }
 
+func (c *Context) SettingDeleteKey(name, key string) error {
+	return c.engine.SettingDeleteKey(name, key)
+}
+
 func (c *Context) Table(columns ...string) *Table {
 	return &Table{Columns: columns, Context: c}
 }

--- a/vendor/github.com/convox/stdcli/flag.go
+++ b/vendor/github.com/convox/stdcli/flag.go
@@ -9,11 +9,12 @@ import (
 )
 
 type Flag struct {
-	Default     interface{}
-	Description string
-	Name        string
-	Short       string
-	Value       interface{}
+	Default         interface{}
+	Description     string
+	Name            string
+	Short           string
+	Value           interface{}
+	SkipHelpCommand bool
 
 	kind string
 }

--- a/vendor/github.com/convox/stdcli/help.go
+++ b/vendor/github.com/convox/stdcli/help.go
@@ -53,6 +53,10 @@ func helpCommand(e *Engine, cmd *Command) {
 	fs := []Flag{}
 
 	for _, f := range cmd.Flags {
+		if f.SkipHelpCommand {
+			continue
+		}
+
 		fs = append(fs, f)
 	}
 

--- a/vendor/github.com/convox/stdcli/setting.go
+++ b/vendor/github.com/convox/stdcli/setting.go
@@ -129,6 +129,30 @@ func (e *Engine) SettingWriteKey(name, key, value string) error {
 	return e.SettingWrite(name, string(data))
 }
 
+func (e *Engine) SettingDeleteKey(name, key string) error {
+	s, err := e.SettingRead(name)
+	if err != nil {
+		return err
+	}
+
+	data := []byte(coalesce(s, "{}"))
+
+	var kv map[string]string
+
+	if err := json.Unmarshal(data, &kv); err != nil {
+		return err
+	}
+
+	delete(kv, key)
+
+	data, err = json.MarshalIndent(kv, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return e.SettingWrite(name, string(data))
+}
+
 func (e *Engine) localSettingDir() string {
 	return fmt.Sprintf(".%s", e.Name)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -353,7 +353,7 @@ github.com/convox/logger
 # github.com/convox/stdapi v1.1.3-0.20221110171947-8d98f61e61ed
 ## explicit; go 1.12
 github.com/convox/stdapi
-# github.com/convox/stdcli v0.0.0-20221110070640-8f8fb17bfe20
+# github.com/convox/stdcli v0.0.0-20240813092220-8beeb2dc2420
 ## explicit; go 1.13
 github.com/convox/stdcli
 # github.com/convox/stdsdk v0.0.0-20201005151143-fb7f05286eea


### PR DESCRIPTION
What is the feature/fix?
Added the wait flag in the v3 cli to make it v2 backwards compatible, also modifed the BoolFlag method implementation in stdcli module to provide functionality to skip flag in help section.