### PR TITLE
Added feature for using custom image in convox resources - feature/resource-custom-image-params

### DIFF
--- a/docs/reference/primitives/app/resource/README.md
+++ b/docs/reference/primitives/app/resource/README.md
@@ -50,6 +50,41 @@ MAIN_PORT=port
 MAIN_NAME=database
 ```
 
+## Custom Images:
+
+You can also pass a compatible custom image for all resource type.
+
+To use a custom image, include the `image` field in your resource configuration:
+
+```
+resources:
+  main:
+    type: postgres
+    image: pgvector/pgvector:pg16
+services:
+  web:
+    resources:
+      - main
+```
+
+Note:
+
+1. Always include the image tag when specifying a custom image. If no tag is provided, the `latest` tag will be used. Ensure that the specified image has a `latest` tag or provide a specific tag to avoid errors.
+2. The image field takes precedence over the version field. If both are specified, the version field will be ignored.
+
+Example:
+
+```
+resources:
+  myRedis:
+    type: redis
+    image: custom-redis-image:6.2
+    options:
+      version: 6.0
+```
+
+In this example, a custom Redis image named `custom-redis-image` with tag `6.2` will be used.
+
 ## Overlays
 
 By default, any Resources you define will be satisfied by starting a containerized version on your [Rack](/reference/primitives/rack). This allows you to get up and running as quickly as possible and provides a low-cost solution and more effective usage of your Rack.

--- a/pkg/manifest/resource.go
+++ b/pkg/manifest/resource.go
@@ -26,6 +26,7 @@ var (
 type Resource struct {
 	Name    string            `yaml:"-"`
 	Type    string            `yaml:"type"`
+	Image   string            `yaml:"image"`
 	Options map[string]string `yaml:"options"`
 }
 

--- a/provider/k8s/release.go
+++ b/provider/k8s/release.go
@@ -457,6 +457,7 @@ func (p *Provider) releaseTemplateResource(a *structs.App, e structs.Environment
 		"Parameters": r.Options,
 		"Password":   fmt.Sprintf("%x", sha256.Sum256([]byte(p.Name)))[0:30],
 		"Rack":       p.Name,
+		"Image":	  r.Image,
 	}
 
 	data, err := p.RenderTemplate(fmt.Sprintf("resource/%s", r.Type), params)

--- a/provider/k8s/release.go
+++ b/provider/k8s/release.go
@@ -457,7 +457,7 @@ func (p *Provider) releaseTemplateResource(a *structs.App, e structs.Environment
 		"Parameters": r.Options,
 		"Password":   fmt.Sprintf("%x", sha256.Sum256([]byte(p.Name)))[0:30],
 		"Rack":       p.Name,
-		"Image":	  r.Image,
+		"Image":      r.Image,
 	}
 
 	data, err := p.RenderTemplate(fmt.Sprintf("resource/%s", r.Type), params)

--- a/provider/k8s/template/resource/mariadb.yml.tmpl
+++ b/provider/k8s/template/resource/mariadb.yml.tmpl
@@ -67,7 +67,7 @@ spec:
     spec:
       containers:
       - name: mariadb
-        image: {{ if eq .Image "" }}mariadb:{{ coalesce (index .Parameters "version") "10.6.0" }}{{ else }}{{ .Image }}{{ end }}
+        image: {{ if not .Image }}mariadb:{{ coalesce (index .Parameters "version") "10.6.0" }}{{ else }}{{ .Image }}{{ end }}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3306

--- a/provider/k8s/template/resource/mariadb.yml.tmpl
+++ b/provider/k8s/template/resource/mariadb.yml.tmpl
@@ -67,7 +67,7 @@ spec:
     spec:
       containers:
       - name: mariadb
-        image: mariadb:{{ coalesce (index .Parameters "version") "10.6.0" }}
+        image: {{ if eq .Image "" }}mariadb:{{ coalesce (index .Parameters "version") "10.6.0" }}{{ else }}{{ .Image }}{{ end }}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3306

--- a/provider/k8s/template/resource/memcached.yml.tmpl
+++ b/provider/k8s/template/resource/memcached.yml.tmpl
@@ -50,7 +50,7 @@ spec:
     spec:
       containers:
       - name: memcached
-        image: {{ if eq .Image "" }}memcached:{{ coalesce (index .Parameters "version") "1.4.34" }}{{ else }}{{ .Image }}{{ end }}
+        image: {{ if not .Image }}memcached:{{ coalesce (index .Parameters "version") "1.4.34" }}{{ else }}{{ .Image }}{{ end }}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 11211

--- a/provider/k8s/template/resource/memcached.yml.tmpl
+++ b/provider/k8s/template/resource/memcached.yml.tmpl
@@ -50,7 +50,7 @@ spec:
     spec:
       containers:
       - name: memcached
-        image: memcached:{{ coalesce (index .Parameters "version") "1.4.34" }}
+        image: {{ if eq .Image "" }}memcached:{{ coalesce (index .Parameters "version") "1.4.34" }}{{ else }}{{ .Image }}{{ end }}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 11211

--- a/provider/k8s/template/resource/mysql.yml.tmpl
+++ b/provider/k8s/template/resource/mysql.yml.tmpl
@@ -67,7 +67,7 @@ spec:
     spec:
       containers:
       - name: mysql
-        image: mysql:{{ coalesce (index .Parameters "version") "5.7.23" }}
+        image: {{ if eq .Image "" }}mysql:{{ coalesce (index .Parameters "version") "5.7.23" }}{{ else }}{{ .Image }}{{ end }}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3306

--- a/provider/k8s/template/resource/mysql.yml.tmpl
+++ b/provider/k8s/template/resource/mysql.yml.tmpl
@@ -67,7 +67,7 @@ spec:
     spec:
       containers:
       - name: mysql
-        image: {{ if eq .Image "" }}mysql:{{ coalesce (index .Parameters "version") "5.7.23" }}{{ else }}{{ .Image }}{{ end }}
+        image: {{ if not .Image }}mysql:{{ coalesce (index .Parameters "version") "5.7.23" }}{{ else }}{{ .Image }}{{ end }}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3306

--- a/provider/k8s/template/resource/postgis.yml.tmpl
+++ b/provider/k8s/template/resource/postgis.yml.tmpl
@@ -68,7 +68,7 @@ spec:
     spec:
       containers:
       - name: postgis
-        image: postgis/postgis:{{ coalesce (index .Parameters "version") "10-3.2" }}
+        image: {{ if eq .Image "" }}postgis/postgis:{{ coalesce (index .Parameters "version") "10-3.2" }}{{ else }}{{ .Image }}{{ end }}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 5432

--- a/provider/k8s/template/resource/postgis.yml.tmpl
+++ b/provider/k8s/template/resource/postgis.yml.tmpl
@@ -68,7 +68,7 @@ spec:
     spec:
       containers:
       - name: postgis
-        image: {{ if eq .Image "" }}postgis/postgis:{{ coalesce (index .Parameters "version") "10-3.2" }}{{ else }}{{ .Image }}{{ end }}
+        image: {{ if not .Image }}postgis/postgis:{{ coalesce (index .Parameters "version") "10-3.2" }}{{ else }}{{ .Image }}{{ end }}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 5432

--- a/provider/k8s/template/resource/postgres.yml.tmpl
+++ b/provider/k8s/template/resource/postgres.yml.tmpl
@@ -68,7 +68,7 @@ spec:
     spec:
       containers:
       - name: postgres
-        image: postgres:{{ coalesce (index .Parameters "version") "10.5" }}
+        image: {{ if eq .Image "" }}postgres:{{ coalesce (index .Parameters "version") "10.5" }}{{ else }}{{ .Image }}{{ end }}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 5432

--- a/provider/k8s/template/resource/postgres.yml.tmpl
+++ b/provider/k8s/template/resource/postgres.yml.tmpl
@@ -68,7 +68,7 @@ spec:
     spec:
       containers:
       - name: postgres
-        image: {{ if eq .Image "" }}postgres:{{ coalesce (index .Parameters "version") "10.5" }}{{ else }}{{ .Image }}{{ end }}
+        image: {{ if not .Image }}postgres:{{ coalesce (index .Parameters "version") "10.5" }}{{ else }}{{ .Image }}{{ end }}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 5432

--- a/provider/k8s/template/resource/redis.yml.tmpl
+++ b/provider/k8s/template/resource/redis.yml.tmpl
@@ -50,7 +50,7 @@ spec:
     spec:
       containers:
       - name: redis
-        image: redis:{{ coalesce (index .Parameters "version") "4.0.10" }}
+        image: {{ if eq .Image "" }}redis:{{ coalesce (index .Parameters "version") "4.0.10" }}{{ else }}{{ .Image }}{{ end }}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6379

--- a/provider/k8s/template/resource/redis.yml.tmpl
+++ b/provider/k8s/template/resource/redis.yml.tmpl
@@ -50,7 +50,7 @@ spec:
     spec:
       containers:
       - name: redis
-        image: {{ if eq .Image "" }}redis:{{ coalesce (index .Parameters "version") "4.0.10" }}{{ else }}{{ .Image }}{{ end }}
+        image: {{ if not .Image }}redis:{{ coalesce (index .Parameters "version") "4.0.10" }}{{ else }}{{ .Image }}{{ end }}
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 6379


### PR DESCRIPTION
### What is the feature/fix?
We can pass image parameter in the convox.yml manifest file in resources. It allows for using custom images for the available resource types. 

How to use it:
Earlier:
```
  db:  
    type: postgres
    options:
      version: 13
```

New way:
```
  db2:
    type: postgres
    image: pgvector/pgvector:pg16
```


Note:
1. The Image tag has to be passed with the image name in case the custom image does not have latest tag available on the registry.
2. The custom image used is supposed to be compatible with the resource type. In case if it is not then the resource creation will fail. 