### PR TITLE
Add support to reuse generated wildcard in apps

### DIFF
--- a/assets/provider/aws/params.yaml
+++ b/assets/provider/aws/params.yaml
@@ -19,7 +19,7 @@ Groups:
         default: "null"
         sideNote: Convox managed if not set
         type: string
-        regex: ^vpc-[0-9a-f]{17}$
+        regex: ^vpc-.+$
         description: Used for installing a rack into an existing VPC. You must also 
           set the &i cidr &i and &i internet_gateway_id &i parameters
       - name: cidr
@@ -33,7 +33,7 @@ Groups:
         default: "null"
         sideNote: Convox managed if not set
         type: string
-        regex: ^igw-[0-9a-f]{17}$
+        regex: ^igw-.+$
         description: |
           To install the rack into an existing VPC, enter the
           name-id of the attached internet gateway.
@@ -41,7 +41,7 @@ Groups:
         default: "null"
         sideNote: Convox managed if not set
         type: string
-        regex: ^subnet-[0-9a-f]{17}$
+        regex: ^(subnet-.+)(,subnet-.+)*$
         description: |
           &b Advanced Configuration &b &l This parameter is for edge use cases
           where cluster needs to be installed into existing subnets. &l &l See 
@@ -50,7 +50,7 @@ Groups:
         default: "null"
         sideNote: Convox managed if not set
         type: string
-        regex: ^subnet-[0-9a-f]{17}$
+        regex: ^(subnet-.+)(,subnet-.+)*$
         description: |
           &b Advanced Configuration &b &l This parameter is for edge use cases
           where cluster needs to be installed into existing subnets. &l &l See 
@@ -75,7 +75,7 @@ Groups:
         default: "null"
         sideNote: AWS default created unless set
         type: string
-        regex: ^sg-[0-9a-f]{8,17}$
+        regex: ^sg-.+$
         description: |
           &l The ID of the custom security group to attach with the NLB. &l &l By
           default inbound traffic from any IP is allowed. &l &l Be cautious about
@@ -84,7 +84,7 @@ Groups:
       - name: tags
         default: "null"
         type: string
-        regex: ^(\w+=[^,]+)(,\w+=[^,]+)*$
+        regex: ^([^=\s,]+=[^\s,]+)(,[^=\s,]+=[^\s,]+)*$
         description: Custom tags to add to AWS resources along side Convox managed
           tags  &l &i e.g. &i key1=val1,key2=val2 &l
       - name: cert_duration
@@ -221,8 +221,8 @@ Groups:
         default: "50"
         type: integer
         description: The minimum number of pods that must be available at any time
-        allowedMinValue: 0
-        allowedMaxValue: 100
+        allowedMinValue: -1
+        allowedMaxValue: 101
       - name: kubelet_registry_pull_qps
         default: "5"
         type: integer

--- a/docs/reference/cli/certs.md
+++ b/docs/reference/cli/certs.md
@@ -1,0 +1,53 @@
+---
+title: "certs"
+draft: false
+slug: certs
+url: /reference/cli/certs
+---
+# certs
+
+## certs
+
+List certificates.
+
+### Usage
+To list all certificates
+
+```html
+    convox certs
+```
+
+To list generated certificates:
+```html
+    convox certs --generated
+```
+
+### Examples
+```html
+    $ convox certs
+```
+
+## certs generate
+
+Generate certificates. These certificate can be reused with convox apps. For example, generating a wildcard certificate to reuse it in several apps to reduce letsencrypt rate limit issue.
+
+### Usage
+To list all certificates
+
+```html
+    convox certs generate <domain> [domain...]
+```
+
+Option flags:
+- `--duration`: Duration of the certificate.                      
+- `--issuer`: Certificate issuer. For example: `letsencrypt`                          
+
+### Examples
+```html
+    $ convox certs generate mydomain.com --duration 4200h --issuer letsencrypt
+```
+
+To list generated certificates:
+```html
+    convox certs --generated
+```

--- a/pkg/api/certificate_test.go
+++ b/pkg/api/certificate_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/convox/convox/pkg/options"
 	"github.com/convox/convox/pkg/structs"
 	"github.com/convox/stdsdk"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -100,7 +101,7 @@ func TestCertificateGenerate(t *testing.T) {
 				"domains": "domain1,domain2",
 			},
 		}
-		p.On("CertificateGenerate", []string{"domain1", "domain2"}).Return(&c1, nil)
+		p.On("CertificateGenerate", []string{"domain1", "domain2"}, mock.Anything).Return(&c1, nil)
 		err := c.Post("/certificates/generate", ro, &c2)
 		require.NoError(t, err)
 		require.Equal(t, c1, c2)
@@ -115,7 +116,7 @@ func TestCertificateGenerateError(t *testing.T) {
 				"domains": "domain1,domain2",
 			},
 		}
-		p.On("CertificateGenerate", []string{"domain1", "domain2"}).Return(nil, fmt.Errorf("err1"))
+		p.On("CertificateGenerate", []string{"domain1", "domain2"}, mock.Anything).Return(nil, fmt.Errorf("err1"))
 		err := c.Post("/certificates/generate", ro, c1)
 		require.EqualError(t, err, "err1")
 		require.Nil(t, c1)
@@ -126,7 +127,7 @@ func TestCertificateList(t *testing.T) {
 	testServer(t, func(c *stdsdk.Client, p *structs.MockProvider) {
 		c1 := structs.Certificates{fxCertificate, fxCertificate}
 		c2 := structs.Certificates{}
-		p.On("CertificateList").Return(c1, nil)
+		p.On("CertificateList", mock.Anything).Return(c1, nil)
 		err := c.Get("/certificates", stdsdk.RequestOptions{}, &c2)
 		require.NoError(t, err)
 		require.Equal(t, c1, c2)
@@ -136,7 +137,7 @@ func TestCertificateList(t *testing.T) {
 func TestCertificateListError(t *testing.T) {
 	testServer(t, func(c *stdsdk.Client, p *structs.MockProvider) {
 		var c1 structs.Certificates
-		p.On("CertificateList").Return(nil, fmt.Errorf("err1"))
+		p.On("CertificateList", mock.Anything).Return(nil, fmt.Errorf("err1"))
 		err := c.Get("/certificates", stdsdk.RequestOptions{}, &c1)
 		require.EqualError(t, err, "err1")
 		require.Nil(t, c1)

--- a/pkg/api/controllers.go
+++ b/pkg/api/controllers.go
@@ -448,7 +448,12 @@ func (s *Server) CertificateGenerate(c *stdapi.Context) error {
 
 	domains := strings.Split(c.Value("domains"), ",")
 
-	v, err := s.provider(c).WithContext(c.Context()).CertificateGenerate(domains)
+	var opts structs.CertificateGenerateOptions
+	if err := stdapi.UnmarshalOptions(c.Request(), &opts); err != nil {
+		return err
+	}
+
+	v, err := s.provider(c).WithContext(c.Context()).CertificateGenerate(domains, opts)
 	if err != nil {
 		return err
 	}
@@ -465,7 +470,12 @@ func (s *Server) CertificateList(c *stdapi.Context) error {
 		return err
 	}
 
-	v, err := s.provider(c).WithContext(c.Context()).CertificateList()
+	var opts structs.CertificateListOptions
+	if err := stdapi.UnmarshalOptions(c.Request(), &opts); err != nil {
+		return err
+	}
+
+	v, err := s.provider(c).WithContext(c.Context()).CertificateList(opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/certs.go
+++ b/pkg/cli/certs.go
@@ -16,7 +16,7 @@ import (
 
 func init() {
 	register("certs", "list certificates", watch(Certs), stdcli.CommandOptions{
-		Flags:    []stdcli.Flag{flagRack, flagWatchInterval},
+		Flags:    append(stdcli.OptionFlags(structs.CertificateListOptions{}), flagRack, flagWatchInterval),
 		Validate: stdcli.Args(0),
 	})
 
@@ -27,7 +27,7 @@ func init() {
 	})
 
 	register("certs generate", "generate a certificate", CertsGenerate, stdcli.CommandOptions{
-		Flags:    []stdcli.Flag{flagId, flagRack},
+		Flags:    append(stdcli.OptionFlags(structs.CertificateGenerateOptions{}), flagId, flagRack),
 		Usage:    "<domain> [domain...]",
 		Validate: stdcli.ArgsMin(1),
 	})
@@ -95,15 +95,21 @@ func init() {
 }
 
 func Certs(rack sdk.Interface, c *stdcli.Context) error {
-	cs, err := rack.CertificateList()
+	var opts structs.CertificateListOptions
+
+	if err := c.Options(&opts); err != nil {
+		return err
+	}
+
+	cs, err := rack.CertificateList(opts)
 	if err != nil {
 		return err
 	}
 
-	t := c.Table("ID", "DOMAIN", "EXPIRES")
+	t := c.Table("ID", "DOMAIN", "EXPIRES", "Status")
 
 	for _, c := range cs {
-		t.AddRow(c.Id, c.Domain, common.Ago(c.Expiration))
+		t.AddRow(c.Id, c.Domain, common.Ago(c.Expiration), common.CoalesceString(c.Status, "Ready"))
 	}
 
 	return t.Print()
@@ -129,9 +135,14 @@ func CertsGenerate(rack sdk.Interface, c *stdcli.Context) error {
 		c.Writer().Stdout = c.Writer().Stderr
 	}
 
+	var opts structs.CertificateGenerateOptions
+	if err := c.Options(&opts); err != nil {
+		return err
+	}
+
 	c.Startf("Generating certificate")
 
-	cr, err := rack.CertificateGenerate(c.Args)
+	cr, err := rack.CertificateGenerate(c.Args, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/certs_test.go
+++ b/pkg/cli/certs_test.go
@@ -8,28 +8,29 @@ import (
 	mocksdk "github.com/convox/convox/pkg/mock/sdk"
 	"github.com/convox/convox/pkg/options"
 	"github.com/convox/convox/pkg/structs"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCerts(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
-		i.On("CertificateList").Return(structs.Certificates{*fxCertificate(), *fxCertificate()}, nil)
+		i.On("CertificateList", mock.Anything).Return(structs.Certificates{*fxCertificate(), *fxCertificate()}, nil)
 
 		res, err := testExecute(e, "certs", nil)
 		require.NoError(t, err)
 		require.Equal(t, 0, res.Code)
 		res.RequireStderr(t, []string{""})
 		res.RequireStdout(t, []string{
-			"ID     DOMAIN       EXPIRES",
-			"cert1  example.org  2 days from now",
-			"cert1  example.org  2 days from now",
+			"ID     DOMAIN       EXPIRES          Status",
+			"cert1  example.org  2 days from now  Ready",
+			"cert1  example.org  2 days from now  Ready",
 		})
 	})
 }
 
 func TestCertsError(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
-		i.On("CertificateList").Return(nil, fmt.Errorf("err1"))
+		i.On("CertificateList", mock.Anything).Return(nil, fmt.Errorf("err1"))
 
 		res, err := testExecute(e, "certs", nil)
 		require.NoError(t, err)
@@ -65,7 +66,7 @@ func TestCertsDeleteError(t *testing.T) {
 
 func TestCertsGenerate(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
-		i.On("CertificateGenerate", []string{"test.example.org", "other.example.org"}).Return(fxCertificate(), nil)
+		i.On("CertificateGenerate", []string{"test.example.org", "other.example.org"}, mock.Anything).Return(fxCertificate(), nil)
 
 		res, err := testExecute(e, "certs generate test.example.org other.example.org", nil)
 		require.NoError(t, err)
@@ -77,7 +78,7 @@ func TestCertsGenerate(t *testing.T) {
 
 func TestCertsGenerateError(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
-		i.On("CertificateGenerate", []string{"test.example.org", "other.example.org"}).Return(nil, fmt.Errorf("err1"))
+		i.On("CertificateGenerate", []string{"test.example.org", "other.example.org"}, mock.Anything).Return(nil, fmt.Errorf("err1"))
 
 		res, err := testExecute(e, "certs generate test.example.org other.example.org", nil)
 		require.NoError(t, err)

--- a/pkg/cli/ssl.go
+++ b/pkg/cli/ssl.go
@@ -48,7 +48,9 @@ func Ssl(rack sdk.Interface, c *stdcli.Context) error {
 
 	certs := map[string]structs.Certificate{}
 
-	cs, err := rack.CertificateList()
+	var opts structs.CertificateListOptions
+
+	cs, err := rack.CertificateList(opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/ssl_test.go
+++ b/pkg/cli/ssl_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/convox/convox/pkg/cli"
 	mocksdk "github.com/convox/convox/pkg/mock/sdk"
 	"github.com/convox/convox/pkg/structs"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,7 +15,7 @@ func TestSsl(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
 		i.On("SystemGet").Return(fxSystem(), nil)
 		i.On("ServiceList", "app1").Return(structs.Services{*fxService(), *fxService()}, nil)
-		i.On("CertificateList").Return(structs.Certificates{*fxCertificate()}, nil)
+		i.On("CertificateList", mock.Anything).Return(structs.Certificates{*fxCertificate()}, nil)
 
 		res, err := testExecute(e, "ssl -a app1", nil)
 		require.NoError(t, err)
@@ -47,7 +48,7 @@ func TestSslClassic(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
 		i.On("SystemGet").Return(fxSystemClassic(), nil)
 		i.On("FormationGet", "app1").Return(structs.Services{*fxService(), *fxService()}, nil)
-		i.On("CertificateList").Return(structs.Certificates{*fxCertificate()}, nil)
+		i.On("CertificateList", mock.Anything).Return(structs.Certificates{*fxCertificate()}, nil)
 
 		res, err := testExecute(e, "ssl -a app1", nil)
 		require.NoError(t, err)

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -119,6 +119,7 @@ func (v VolumeAwsEfs) Validate() error {
 type Services []Service
 
 type Certificate struct {
+	Id       string `yaml:"id,omitempty"`
 	Duration string `yaml:"duration,omitempty"`
 }
 

--- a/pkg/mock/sdk/interface.go
+++ b/pkg/mock/sdk/interface.go
@@ -557,13 +557,13 @@ func (_m *Interface) CertificateDelete(id string) error {
 	return r0
 }
 
-// CertificateGenerate provides a mock function with given fields: domains
-func (_m *Interface) CertificateGenerate(domains []string) (*structs.Certificate, error) {
-	ret := _m.Called(domains)
+// CertificateGenerate provides a mock function with given fields: domains, opts
+func (_m *Interface) CertificateGenerate(domains []string, opts structs.CertificateGenerateOptions) (*structs.Certificate, error) {
+	ret := _m.Called(domains, opts)
 
 	var r0 *structs.Certificate
-	if rf, ok := ret.Get(0).(func([]string) *structs.Certificate); ok {
-		r0 = rf(domains)
+	if rf, ok := ret.Get(0).(func([]string, structs.CertificateGenerateOptions) *structs.Certificate); ok {
+		r0 = rf(domains, opts)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*structs.Certificate)
@@ -571,8 +571,8 @@ func (_m *Interface) CertificateGenerate(domains []string) (*structs.Certificate
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func([]string) error); ok {
-		r1 = rf(domains)
+	if rf, ok := ret.Get(1).(func([]string, structs.CertificateGenerateOptions) error); ok {
+		r1 = rf(domains, opts)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -580,13 +580,13 @@ func (_m *Interface) CertificateGenerate(domains []string) (*structs.Certificate
 	return r0, r1
 }
 
-// CertificateList provides a mock function with given fields:
-func (_m *Interface) CertificateList() (structs.Certificates, error) {
-	ret := _m.Called()
+// CertificateList provides a mock function with given fields: opts
+func (_m *Interface) CertificateList(opts structs.CertificateListOptions) (structs.Certificates, error) {
+	ret := _m.Called(opts)
 
 	var r0 structs.Certificates
-	if rf, ok := ret.Get(0).(func() structs.Certificates); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(structs.CertificateListOptions) structs.Certificates); ok {
+		r0 = rf(opts)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(structs.Certificates)
@@ -594,8 +594,8 @@ func (_m *Interface) CertificateList() (structs.Certificates, error) {
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(structs.CertificateListOptions) error); ok {
+		r1 = rf(opts)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1052,29 +1052,6 @@ func (_m *Interface) ObjectStore(app string, key string, r io.Reader, opts struc
 	var r1 error
 	if rf, ok := ret.Get(1).(func(string, string, io.Reader, structs.ObjectStoreOptions) error); ok {
 		r1 = rf(app, key, r, opts)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// OrganizationRuntimes provides a mock function with given fields: org
-func (_m *Interface) OrganizationRuntimes(org string) (structs.Runtimes, error) {
-	ret := _m.Called(org)
-
-	var r0 structs.Runtimes
-	if rf, ok := ret.Get(0).(func(string) structs.Runtimes); ok {
-		r0 = rf(org)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(structs.Runtimes)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(org)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/structs/certificate.go
+++ b/pkg/structs/certificate.go
@@ -13,12 +13,22 @@ type Certificate struct {
 	Domain     string    `json:"domain"`
 	Domains    []string  `json:"domains"`
 	Expiration time.Time `json:"expiration"`
+	Status     string    `json:"status"`
 }
 
 type Certificates []Certificate
 
 type CertificateCreateOptions struct {
 	Chain *string `param:"chain"`
+}
+
+type CertificateGenerateOptions struct {
+	Issuer   *string `flag:"issuer" param:"issuer"`
+	Duration *string `flag:"duration" param:"duration"`
+}
+
+type CertificateListOptions struct {
+	Generated *bool `flag:"generated" param:"generated"`
 }
 
 func (c Certificates) Less(i, j int) bool { return strings.ToUpper(c[i].Id) < strings.ToUpper(c[j].Id) }

--- a/pkg/structs/mock_Provider.go
+++ b/pkg/structs/mock_Provider.go
@@ -422,13 +422,13 @@ func (_m *MockProvider) CertificateDelete(id string) error {
 	return r0
 }
 
-// CertificateGenerate provides a mock function with given fields: domains
-func (_m *MockProvider) CertificateGenerate(domains []string) (*Certificate, error) {
-	ret := _m.Called(domains)
+// CertificateGenerate provides a mock function with given fields: domains, opts
+func (_m *MockProvider) CertificateGenerate(domains []string, opts CertificateGenerateOptions) (*Certificate, error) {
+	ret := _m.Called(domains, opts)
 
 	var r0 *Certificate
-	if rf, ok := ret.Get(0).(func([]string) *Certificate); ok {
-		r0 = rf(domains)
+	if rf, ok := ret.Get(0).(func([]string, CertificateGenerateOptions) *Certificate); ok {
+		r0 = rf(domains, opts)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*Certificate)
@@ -436,8 +436,8 @@ func (_m *MockProvider) CertificateGenerate(domains []string) (*Certificate, err
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func([]string) error); ok {
-		r1 = rf(domains)
+	if rf, ok := ret.Get(1).(func([]string, CertificateGenerateOptions) error); ok {
+		r1 = rf(domains, opts)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -445,13 +445,13 @@ func (_m *MockProvider) CertificateGenerate(domains []string) (*Certificate, err
 	return r0, r1
 }
 
-// CertificateList provides a mock function with given fields:
-func (_m *MockProvider) CertificateList() (Certificates, error) {
-	ret := _m.Called()
+// CertificateList provides a mock function with given fields: opts
+func (_m *MockProvider) CertificateList(opts CertificateListOptions) (Certificates, error) {
+	ret := _m.Called(opts)
 
 	var r0 Certificates
-	if rf, ok := ret.Get(0).(func() Certificates); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(CertificateListOptions) Certificates); ok {
+		r0 = rf(opts)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(Certificates)
@@ -459,8 +459,8 @@ func (_m *MockProvider) CertificateList() (Certificates, error) {
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(CertificateListOptions) error); ok {
+		r1 = rf(opts)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/structs/provider.go
+++ b/pkg/structs/provider.go
@@ -36,8 +36,8 @@ type Provider interface {
 	CertificateCreate(pub, key string, opts CertificateCreateOptions) (*Certificate, error)
 	CertificateDelete(id string) error
 	CertificateRenew(id string) error
-	CertificateGenerate(domains []string) (*Certificate, error)
-	CertificateList() (Certificates, error)
+	CertificateGenerate(domains []string, opts CertificateGenerateOptions) (*Certificate, error)
+	CertificateList(opts CertificateListOptions) (Certificates, error)
 
 	LetsEncryptConfigGet() (*LetsEncryptConfig, error)
 	LetsEncryptConfigApply(config LetsEncryptConfig) error

--- a/provider/k8s/template/app/ingress.yml.tmpl
+++ b/provider/k8s/template/app/ingress.yml.tmpl
@@ -41,14 +41,14 @@ spec:
   {{ if .ConvoxDomainTLSCertDisable }}
   - hosts:
     - {{ safe .Host }}
-    secretName: cert-{{.Service.Name}}
+    secretName: {{ if .Service.Certificate.Id }} {{.Service.Certificate.Id}} {{ else }} cert-{{.Service.Name}} {{end}}
   {{ end }}
   {{ with .Service.Domains }}
   - hosts:
     {{ range . }}
     - {{ safe . }}
     {{ end }}
-    secretName: cert-{{$.Service.Name}}-domains
+    secretName: {{ if .Service.Certificate.Id }} {{.Service.Certificate.Id}} {{ else }} cert-{{$.Service.Name}}-domains {{ end }}
   {{ end }}
   rules:
     - host: {{ safe .Host }}

--- a/sdk/methods.go
+++ b/sdk/methods.go
@@ -297,10 +297,13 @@ func (c *Client) CertificateDelete(id string) error {
 	return err
 }
 
-func (c *Client) CertificateGenerate(domains []string) (*structs.Certificate, error) {
+func (c *Client) CertificateGenerate(domains []string, opts structs.CertificateGenerateOptions) (*structs.Certificate, error) {
 	var err error
 
-	ro := stdsdk.RequestOptions{Headers: stdsdk.Headers{}, Params: stdsdk.Params{}, Query: stdsdk.Query{}}
+	ro, err := stdsdk.MarshalOptions(opts)
+	if err != nil {
+		return nil, err
+	}
 
 	ro.Params["domains"] = strings.Join(domains, ",")
 
@@ -321,10 +324,13 @@ func (c *Client) CertificateRenew(id string) error {
 	return err
 }
 
-func (c *Client) CertificateList() (structs.Certificates, error) {
+func (c *Client) CertificateList(opts structs.CertificateListOptions) (structs.Certificates, error) {
 	var err error
 
-	ro := stdsdk.RequestOptions{Headers: stdsdk.Headers{}, Params: stdsdk.Params{}, Query: stdsdk.Query{}}
+	ro, err := stdsdk.MarshalOptions(opts)
+	if err != nil {
+		return nil, err
+	}
 
 	var v structs.Certificates
 

--- a/terraform/api/k8s/main.tf
+++ b/terraform/api/k8s/main.tf
@@ -33,6 +33,24 @@ resource "kubernetes_cluster_role_binding" "api" {
   }
 }
 
+resource "kubernetes_cluster_role_binding" "api-cluster-admin" {
+  metadata {
+    name = "${var.rack}-api-cluster-admin"
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "cluster-admin"
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account.api.metadata.0.name
+    namespace = kubernetes_service_account.api.metadata.0.namespace
+  }
+}
+
 resource "kubernetes_service_account" "api" {
   metadata {
     namespace = var.namespace


### PR DESCRIPTION
### What is the feature/fix?

Add support to reuse generated wildcard in apps

# Example

Configure letsencrypt dns01 to allow letsencrypt to create wildcard cert: https://www.convox.com/blog/lets-encrypt-dns01-challenge-with-route53-feature-on-convox

Generate a wildcard cert:
```
$ convox certs generate *.mywildcarddomain.com --issuer letsencrypt
```

Wait until it's ready:

```
$ convox certs --generated

ID                         DOMAIN                                  EXPIRES          Status
1b0a0ef43864     *.mywildcarddomain.com                         1 year from now      Ready
```

Use this id in the convox.yml

```
environment:
  - PORT=3000
services:
  web:
    build: .
    port: 3000
    certificate:
       id: 1b0a0ef43864
```