### PR TITLE
masking api endpoint output value in terraform

### DIFF
--- a/pkg/rack/terraform.go
+++ b/pkg/rack/terraform.go
@@ -873,7 +873,8 @@ func terraformWriteTemplate(filename, version string, params map[string]interfac
 		}
 
 		output "api" {
-			value = module.system.api
+			value     = module.system.api
+			sensitive = true
 		}
 
 		output "provider" {


### PR DESCRIPTION
### What is the feature/fix?
When installing a rack, the api endpoint output in terraform is visible which container api user and password, this fix changes it to sensitive value which is no longer visible in the UI. 