### PR TITLE
Added resource quota for priority class in convox system namespace to fix gcp rack installation

### DIFF
--- a/terraform/api/k8s/atom.tf
+++ b/terraform/api/k8s/atom.tf
@@ -113,4 +113,5 @@ resource "kubernetes_deployment" "atom" {
       }
     }
   }
+  depends_on = [ kubernetes_resource_quota.gcp-critical-pods ]
 }

--- a/terraform/api/k8s/main.tf
+++ b/terraform/api/k8s/main.tf
@@ -3,6 +3,25 @@ resource "random_string" "password" {
   special = false
 }
 
+resource "kubernetes_resource_quota" "gcp-critical-pods" {
+  metadata {
+    name = "gcp-critical-pods"
+    namespace = var.namespace
+  }
+  spec {
+    hard = {
+      pods = "1G"
+    }
+    scope_selector {
+      match_expression {
+        scope_name = "PriorityClass"
+        operator = "In"
+        values = ["system-node-critical", "system-cluster-critical"]
+      }
+    }
+  }
+}
+
 resource "kubernetes_cluster_role" "api" {
   metadata {
     name = "${var.rack}-api"
@@ -291,6 +310,7 @@ resource "kubernetes_deployment" "api" {
       }
     }
   }
+  depends_on = [ kubernetes_resource_quota.gcp-critical-pods ]
 }
 
 resource "kubernetes_service" "api" {

--- a/terraform/api/k8s/main.tf
+++ b/terraform/api/k8s/main.tf
@@ -10,7 +10,7 @@ resource "kubernetes_resource_quota" "gcp-critical-pods" {
   }
   spec {
     hard = {
-      pods = "1G"
+      pods = "1000"
     }
     scope_selector {
       match_expression {

--- a/terraform/system/gcp/versions.tf
+++ b/terraform/system/gcp/versions.tf
@@ -3,7 +3,7 @@ terraform {
     google = {
       source  = "hashicorp/google"
       version = "~> 4.69.1"
-      configuration_aliases = [ google.direct, ]
+      configuration_aliases = [ google.direct ]
     }
     http = {
       source  = "hashicorp/http"

--- a/terraform/system/gcp/versions.tf
+++ b/terraform/system/gcp/versions.tf
@@ -3,6 +3,7 @@ terraform {
     google = {
       source  = "hashicorp/google"
       version = "~> 4.69.1"
+      configuration_aliases = [ google.direct, ]
     }
     http = {
       source  = "hashicorp/http"

--- a/terraform/system/gcp/versions.tf
+++ b/terraform/system/gcp/versions.tf
@@ -3,7 +3,6 @@ terraform {
     google = {
       source  = "hashicorp/google"
       version = "~> 4.69.1"
-      configuration_aliases = [ google.direct ]
     }
     http = {
       source  = "hashicorp/http"


### PR DESCRIPTION
### What is the feature/fix?
This PR contains fix for failing rack creation and github action job failures on GCP platform. This is caused due to resource quota handled differently in GCP and AWS, GCP requires us to create seperate namespaced resource quota for the default priority class that k8s provides.
Added Resource quota in the convox system namespace which can be used by GKE to assign appropriate priority to pods assigned priority class during scheduling.