### PR TITLE
Feature: App parameter for configuring log retention

### DIFF
--- a/pkg/manifest/app_settings.go
+++ b/pkg/manifest/app_settings.go
@@ -1,10 +1,10 @@
 package manifest
 
 type AppSettings struct {
-	AwsLogs *ServiceLogsRetention `yaml:"aws-logs,omitempty"`
+	AwsLogs *ServiceLogsRetention `yaml:"awsLogs,omitempty"`
 }
 
 type ServiceLogsRetention struct {
-	CwRetention      int  `yaml:"cw-retention,omitempty"`
+	CwRetention      int  `yaml:"cwRetention,omitempty"`
 	RetentionDisable bool `yaml:"disableRetention,omitempty"`
 }

--- a/pkg/manifest/app_settings.go
+++ b/pkg/manifest/app_settings.go
@@ -1,0 +1,10 @@
+package manifest
+
+type AppSettings struct {
+	AwsLogs *ServiceLogsRetention `yaml:"aws-logs,omitempty"`
+}
+
+type ServiceLogsRetention struct {
+	CwRetention      int  `yaml:"cw-retention,omitempty"`
+	RetentionDisable bool `yaml:"disableRetention,omitempty"`
+}

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -25,7 +25,7 @@ var (
 )
 
 type Manifest struct {
-	AppSettings AppSettings `yaml:"app-settings,omitempty"`
+	AppSettings AppSettings `yaml:"appSettings,omitempty"`
 	Balancers   Balancers   `yaml:"balancers,omitempty"`
 	Environment Environment `yaml:"environment,omitempty"`
 	Labels      Labels      `yaml:"labels,omitempty"`

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -25,6 +25,7 @@ var (
 )
 
 type Manifest struct {
+	AppSettings AppSettings `yaml:"app-settings,omitempty"`
 	Balancers   Balancers   `yaml:"balancers,omitempty"`
 	Environment Environment `yaml:"environment,omitempty"`
 	Labels      Labels      `yaml:"labels,omitempty"`

--- a/provider/aws/release.go
+++ b/provider/aws/release.go
@@ -29,6 +29,25 @@ func (p *Provider) ReleasePromote(app, id string, opts structs.ReleasePromoteOpt
 		}
 	}
 
+	if m.AppSettings.AwsLogs != nil {
+		retentionDays := m.AppSettings.AwsLogs.CwRetention
+
+		if !m.AppSettings.AwsLogs.RetentionDisable {
+			//sets the retention time to user given input
+			err := p.UpdateOrDisableLogGroupRetention(app, retentionDays, false)
+			if err != nil {
+				return err
+			}
+		} else {
+			//disable the retention policy on Log group
+			//sets the retention to maximum possible of 10years
+			err := p.UpdateOrDisableLogGroupRetention(app, 0, true)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	for i := range m.Timers {
 		service, ok := servicesMap[m.Timers[i].Service]
 		if ok {

--- a/terraform/api/aws/iam.tf
+++ b/terraform/api/aws/iam.tf
@@ -81,6 +81,7 @@ data "aws_iam_policy_document" "logs" {
       "logs:FilterLogEvents",
       "logs:PutLogEvents",
       "logs:PutRetentionPolicy",
+      "logs:DeleteRetentionPolicy",
     ]
     resources = [
       "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${var.name}-*",


### PR DESCRIPTION
### What is the feature/fix?
Added App settings for v3 rack where user can configure the retention time in days of the Log groups for a particular convox app. 
`aws-logs` is first app level configurable parameter for v3 rack.
This can be passed in the Manifest under the `app-settings` key.

ex-
```
app-settings:
  aws-logs:
    cw-retention: 31
    disableRetention: false
```

1. The `cw-retention` parameter takes an integer representing the no of days of retention time for the log group in cloudwatch for the app.
2. The `disableRetention` parameter is a boolean which if set to true removes the retention policy from the log group and sets the retention to Never Expire.