### PR TITLE
Add support to create certificate using dns01 for internal router

### DIFF
--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -167,6 +167,10 @@ func Rack(rack sdk.Interface, c *stdcli.Context) error {
 		}
 	}
 
+	if s.RouterInternal != "" {
+		i.Add("RouterInternal", s.RouterInternal)
+	}
+
 	i.Add("Status", s.Status)
 	i.Add("Version", s.Version)
 

--- a/pkg/structs/system.go
+++ b/pkg/structs/system.go
@@ -3,17 +3,18 @@ package structs
 import "io"
 
 type System struct {
-	Count      int               `json:"count"`
-	Domain     string            `json:"domain"`
-	Name       string            `json:"name"`
-	Outputs    map[string]string `json:"outputs,omitempty"`
-	Parameters map[string]string `json:"parameters,omitempty"`
-	Provider   string            `json:"provider"`
-	RackDomain string            `json:"rack-domain"`
-	Region     string            `json:"region"`
-	Status     string            `json:"status"`
-	Type       string            `json:"type"`
-	Version    string            `json:"version"`
+	Count          int               `json:"count"`
+	Domain         string            `json:"domain"`
+	Name           string            `json:"name"`
+	Outputs        map[string]string `json:"outputs,omitempty"`
+	Parameters     map[string]string `json:"parameters,omitempty"`
+	Provider       string            `json:"provider"`
+	RackDomain     string            `json:"rack-domain"`
+	RouterInternal string            `json:"router-internal"`
+	Region         string            `json:"region"`
+	Status         string            `json:"status"`
+	Type           string            `json:"type"`
+	Version        string            `json:"version"`
 }
 
 type SystemInstallOptions struct {

--- a/provider/aws/provisioner/helpers.go
+++ b/provider/aws/provisioner/helpers.go
@@ -93,11 +93,11 @@ func GenerateSecurePassword(length int) (string, error) {
 	const (
 		letters         = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 		digits          = "0123456789"
-		specialChars    = "#"
+		specialChars    = ""
 		allChars        = letters + digits + specialChars
 		minLetters      = 4
 		minDigits       = 1
-		minSpecialChars = 1
+		minSpecialChars = 0
 	)
 
 	if length < minLetters+minDigits+minSpecialChars {
@@ -124,12 +124,6 @@ func GenerateSecurePassword(length int) (string, error) {
 	}
 	for i := minLetters; i < minLetters+minDigits; i++ {
 		password[i], err = generateChar(digits)
-		if err != nil {
-			return "", err
-		}
-	}
-	for i := minLetters + minDigits; i < minLetters+minDigits+minSpecialChars; i++ {
-		password[i], err = generateChar(specialChars)
 		if err != nil {
 			return "", err
 		}

--- a/provider/k8s/system.go
+++ b/provider/k8s/system.go
@@ -52,6 +52,10 @@ func (p *Provider) SystemGet() (*structs.System, error) {
 		Version:    p.Version,
 	}
 
+	if p.DomainInternal != "" {
+		s.RouterInternal = fmt.Sprintf("router.%s", p.DomainInternal)
+	}
+
 	return s, nil
 }
 

--- a/provider/k8s/template/app/ingress-internal.yml.tmpl
+++ b/provider/k8s/template/app/ingress-internal.yml.tmpl
@@ -37,6 +37,14 @@ metadata:
     {{ end }}
 spec:
   ingressClassName: "{{.Class}}"
+  tls:
+  {{ with .Service.Domains }}
+  - hosts:
+    {{ range . }}
+    - {{ safe . }}
+    {{ end }}
+    secretName: {{ if $.Service.Certificate.Id }} {{$.Service.Certificate.Id}} {{ else }} cert-{{$.Service.Name}}-domains {{ end }}
+  {{ end }}
   rules:
     - host: {{ safe .Host }}
       http:


### PR DESCRIPTION
### What is the feature/fix?

Add support to create certificate using dns01 for internal router

Configure dns01: https://www.convox.com/blog/lets-encrypt-dns01-challenge-with-route53-feature-on-convox

Then specify the domain name for which dns01 is configured. example:
```
environment:
  - PORT=3000
services:
  web:
    build: .
    port: 3000
    domain: "web.nodejs.nahid.convox.biz"
    internalRouter: true
```
