### PR TITLE
adding init container support for convox service

### DIFF
--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -31,6 +31,7 @@ type Service struct {
 	Liveness           ServiceLiveness       `yaml:"liveness,omitempty"`
 	Image              string                `yaml:"image,omitempty"`
 	Init               bool                  `yaml:"init,omitempty"`
+	InitContainer      InitContainer         `yaml:"initContainer,omitempty"`
 	Internal           bool                  `yaml:"internal,omitempty"`
 	InternalRouter     bool                  `yaml:"internalRouter,omitempty"`
 	IngressAnnotations ServiceAnnotations    `yaml:"ingressAnnotations,omitempty"`
@@ -51,6 +52,12 @@ type Service struct {
 	VolumeOptions      []VolumeOption        `yaml:"volumeOptions,omitempty"`
 	Whitelist          string                `yaml:"whitelist,omitempty"`
 	AccessControl      AccessControlOptions  `yaml:"accessControl,omitempty"`
+}
+
+type InitContainer struct {
+	Image         string         `yaml:"image,omitempty"`
+	Command       string         `yaml:"command,omitempty"`
+	VolumeOptions []VolumeOption `yaml:"volumeOptions,omitempty"`
 }
 
 type VolumeOption struct {

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -31,7 +31,7 @@ type Service struct {
 	Liveness           ServiceLiveness       `yaml:"liveness,omitempty"`
 	Image              string                `yaml:"image,omitempty"`
 	Init               bool                  `yaml:"init,omitempty"`
-	InitContainer      InitContainer         `yaml:"initContainer,omitempty"`
+	InitContainer      *InitContainer        `yaml:"initContainer,omitempty"`
 	Internal           bool                  `yaml:"internal,omitempty"`
 	InternalRouter     bool                  `yaml:"internalRouter,omitempty"`
 	IngressAnnotations ServiceAnnotations    `yaml:"ingressAnnotations,omitempty"`

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -107,6 +107,7 @@ spec:
       serviceAccountName: {{.Service.Name}}
       shareProcessNamespace: {{.Service.Init}}
       terminationGracePeriodSeconds: {{$.Service.Termination.Grace}}
+      {{if .Service.InitContainer.Command }}
       initContainers:
       - name: init-{{.App.Name}}
         image: {{ coalesce .Service.InitContainer.Image (image .App .Service .Release) }}
@@ -127,6 +128,7 @@ spec:
           mountPath: {{ .MountPath }}
         {{ end }}
         {{ end }}
+      {{ end }}
       containers:
       - name: {{.App.Name}}
         {{ with .Service.Command }}

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -109,7 +109,7 @@ spec:
       terminationGracePeriodSeconds: {{$.Service.Termination.Grace}}
       initContainers:
       - name: init-{{.App.Name}}
-        image: {{ .Service.InitContainer.Image }} 
+        image: {{ coalesce .Service.InitContainer.Image (image .App .Service .Release) }}
         {{ with .Service.InitContainer.Command }}
         args:
         {{ range shellsplit . }}

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -107,6 +107,26 @@ spec:
       serviceAccountName: {{.Service.Name}}
       shareProcessNamespace: {{.Service.Init}}
       terminationGracePeriodSeconds: {{$.Service.Termination.Grace}}
+      initContainers:
+      - name: init-{{.App.Name}}
+        image: {{ .Service.InitContainer.Image }} 
+        {{ with .Service.InitContainer.Command }}
+        args:
+        {{ range shellsplit . }}
+          - {{ safe . }}
+        {{ end }}
+        {{ end }}
+        volumeMounts:
+        {{ range .Service.InitContainer.VolumeOptions }}
+        {{ with .EmptyDir }}
+        - name: ed-{{ .Id }}
+          mountPath: {{ .MountPath }}
+        {{ end }}
+        {{ with .AwsEfs }}
+        - name: efs-{{ .Id }}
+          mountPath: {{ .MountPath }}
+        {{ end }}
+        {{ end }}
       containers:
       - name: {{.App.Name}}
         {{ with .Service.Command }}

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -107,7 +107,7 @@ spec:
       serviceAccountName: {{.Service.Name}}
       shareProcessNamespace: {{.Service.Init}}
       terminationGracePeriodSeconds: {{$.Service.Termination.Grace}}
-      {{if .Service.InitContainer.Command }}
+      {{if .Service.InitContainer }}
       initContainers:
       - name: init-{{.App.Name}}
         image: {{ coalesce .Service.InitContainer.Image (image .App .Service .Release) }}


### PR DESCRIPTION
### What is the feature/fix?
Adding support to add initContainer in your service. These InitContainers run before your main application container.
How to add - 
```
services:
  web:
    initContainer:
      image: ubuntu:latest
      command: "mkdir test"
      volumeOptions:
        - awsEfs:
            id: "test"
            accessMode: ReadWriteMany
            mountPath: "/data/"
...
```