### PR TITLE
adding disable_kernel_mitigations rack param

### DIFF
--- a/terraform/cluster/aws/files/kubelet_config_override.sh
+++ b/terraform/cluster/aws/files/kubelet_config_override.sh
@@ -5,9 +5,12 @@ Content-Type: multipart/mixed; boundary="==MYBOUNDARY=="
 Content-Type: text/x-shellscript; charset="us-ascii"
 
 #!/bin/bash
+exec > >(tee /var/log/user-data.log | logger -t user-data -s 2>/dev/console) 2>&1
 echo "Running custom user data script"
 cat <<'SCRIPT' > /opt/modify_kubelet.sh
 #!/bin/bash
+# Enable logging for debugging purposes
+exec > >(tee /var/log/user-data.log | logger -t user-data -s 2>/dev/console) 2>&1
 
 # Install jq if not already installed
 yum install -y jq
@@ -24,6 +27,19 @@ systemctl daemon-reload
 
 # Restart the kubelet service to apply the new configuration
 systemctl restart kubelet
+
+if [ "${disable_kernel_mitigations}" == "true" ]; then
+    echo "Disabling kernel mitigations"
+
+    mitigation_param=" mitigations=off"
+    cp /etc/default/grub /etc/default/grub.bak
+    current_cmdline=$(grep -Po 'GRUB_CMDLINE_LINUX_DEFAULT=.*(?=")' /etc/default/grub)
+    new_cmdline="$current_cmdline$mitigation_param"
+    sed -i "s/GRUB_CMDLINE_LINUX_DEFAULT=.*$/$new_cmdline\"/" /etc/default/grub
+    grub2-mkconfig -o /boot/grub2/grub.cfg
+    shutdown -r +1 "Rebooting to apply kernel mitigation changes after 1 minute"
+fi
+
 SCRIPT
 
 chmod +x /opt/modify_kubelet.sh

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -292,9 +292,10 @@ resource "aws_launch_template" "cluster" {
     }
   }
 
-  user_data = var.kubelet_registry_pull_qps != 5 || var.kubelet_registry_burst != 10 ? base64encode(templatefile("${path.module}/files/kubelet_config_override.sh",{
+  user_data = var.kubelet_registry_pull_qps != 5 || var.kubelet_registry_burst != 10 || var.disable_kernel_mitigations ? base64encode(templatefile("${path.module}/files/kubelet_config_override.sh",{
     kubelet_registry_pull_qps = var.kubelet_registry_pull_qps
     kubelet_registry_burst = var.kubelet_registry_burst
+    disable_kernel_mitigations = var.disable_kernel_mitigations
   })) : ""
 
   key_name = var.key_pair_name != "" ? var.key_pair_name : null

--- a/terraform/cluster/aws/variables.tf
+++ b/terraform/cluster/aws/variables.tf
@@ -41,6 +41,11 @@ variable "disable_public_access" {
   default = false
 }
 
+variable "disable_kernel_mitigations" {
+  type    = bool
+  default = false
+}
+
 variable "efs_csi_driver_enable" {
   type    = bool
   default = false

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -67,6 +67,7 @@ module "cluster" {
   cidr                            = var.cidr
   coredns_version                 = var.coredns_version
   disable_public_access           = var.disable_public_access
+  disable_kernel_mitigations      = var.disable_kernel_mitigations
   efs_csi_driver_enable           = var.efs_csi_driver_enable
   efs_csi_driver_version          = var.efs_csi_driver_version
   gpu_type                        = local.gpu_type

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -76,6 +76,11 @@ variable "disable_public_access" {
   default = false
 }
 
+variable "disable_kernel_mitigations" {
+  type    = bool
+  default = false
+}
+
 variable "ecr_scan_on_push_enable" {
   type    = bool
   default = false


### PR DESCRIPTION
### What is the feature/fix?
Added Rack parameter `disable_kernel_mitigations` to disable the kernel mitigations on all nodes. 
Note-
1. Enabling this disabled mitigations which can improve performance but also introduce new security vulnerabilities.
2. Enabling this param recreates all nodes.

Usage:
```
convox rack params set disable_kernel_mitigations=true
``` 