### PR TITLE
Feature/multiline annotations

### DIFF
--- a/pkg/common/format.go
+++ b/pkg/common/format.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"bytes"
+	"html"
 	"regexp"
 
 	yaml "gopkg.in/yaml.v2"
@@ -12,6 +13,10 @@ var (
 )
 
 func FormatYAML(data []byte) ([]byte, error) {
+
+	// Unescape HTML entities first
+	data = []byte(html.UnescapeString(string(data)))
+
 	ps := yamlSplitter.Split(string(data), -1)
 	bs := make([][]byte, len(ps))
 

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -62,10 +62,20 @@ func TestManifestLoad(t *testing.T) {
 		Services: manifest.Services{
 			manifest.Service{
 				Name: "api",
-				Annotations: []string{
-					"eks.amazonaws.com/role-arn=arn:aws:iam::123456789012:role/eksctl-irptest-addon-iamsa-default-my-serviceaccount-Role1-UCGG6NDYZ3UE",
-					"test.other.com/annotation=myothervalue",
-					"string.test.com/annotation=\"thishasquotes\""},
+				Annotations: manifest.Annotations{
+					manifest.Annotation{
+						Key:   "eks.amazonaws.com/role-arn",
+						Value: "arn:aws:iam::123456789012:role/eksctl-irptest-addon-iamsa-default-my-serviceaccount-Role1-UCGG6NDYZ3UE",
+					},
+					manifest.Annotation{
+						Key:   "test.other.com/annotation",
+						Value: "myothervalue",
+					},
+					manifest.Annotation{
+						Key:   "string.test.com/annotation",
+						Value: "\"thishasquotes\"",
+					},
+				},
 				Build: manifest.ServiceBuild{
 					Manifest: "Dockerfile2",
 					Path:     "api",

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-
-	yaml "gopkg.in/yaml.v2"
 )
 
 const (
@@ -19,7 +17,7 @@ type Service struct {
 	Name string `yaml:"-"`
 
 	Agent              ServiceAgent          `yaml:"agent,omitempty"`
-	Annotations        ServiceAnnotations    `yaml:"annotations,omitempty"`
+	Annotations        Annotations           `yaml:"annotations,omitempty"`
 	Build              ServiceBuild          `yaml:"build,omitempty"`
 	Certificate        Certificate           `yaml:"certificate,omitempty"`
 	Command            string                `yaml:"command,omitempty"`
@@ -54,6 +52,13 @@ type Service struct {
 	VolumeOptions      []VolumeOption        `yaml:"volumeOptions,omitempty"`
 	Whitelist          string                `yaml:"whitelist,omitempty"`
 	AccessControl      AccessControlOptions  `yaml:"accessControl,omitempty"`
+}
+
+type Annotations []Annotation
+
+type Annotation struct {
+	Key   string
+	Value string
 }
 
 type InitContainer struct {
@@ -350,36 +355,23 @@ func (sr ServiceResource) GetConfigMapKey() string {
 // 	return annotations
 // }
 
-
 func (s Service) AnnotationsMap() map[string]string {
 	annotations := map[string]string{}
 
 	for _, a := range s.Annotations {
-		for k, v := range a {
-			switch val := v.(type) {
-			case string:
-				annotations[k] = val
-			case map[interface{}]interface{}:
-				multilineValue, err := parseMultiLineValue(val)
-				if err != nil {
-					continue
-				}
-				annotations[k] = multilineValue
-			default:
-				annotations[k] = fmt.Sprintf("%v", val)
-			}
-		}
+		annotations[a.Key] = a.Value
 	}
+
 	return annotations
 }
 
-func parseMultiLineValue(value map[interface{}]interface{}) (string, error) {
-	data, err := yaml.Marshal(value)
-	if err != nil {
-		return "", err
-	}
-	return string(data), nil
-}
+// func parseMultiLineValue(value map[interface{}]interface{}) (string, error) {
+// 	data, err := yaml.Marshal(value)
+// 	if err != nil {
+// 		return "", err
+// 	}
+// 	return string(data), nil
+// }
 
 // skipcq
 func (s Service) IngressAnnotationsMap() map[string]string {

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -142,8 +142,7 @@ type ServiceAgent struct {
 	Enabled bool `yaml:"enabled,omitempty"`
 }
 
-type ServiceAnnotations []map[string]interface{}
-
+type ServiceAnnotations []string
 
 type ServiceBuild struct {
 	Args     []string `yaml:"args,omitempty"`
@@ -379,9 +378,8 @@ func (s Service) IngressAnnotationsMap() map[string]string {
 	annotations := map[string]string{}
 
 	for _, a := range s.IngressAnnotations {
-		for k, v := range a {
-			annotations[k] = v.(string)
-		}
+		parts := strings.SplitN(a, "=", 2)
+		annotations[parts[0]] = parts[1]
 	}
 
 	return annotations

--- a/pkg/manifest/timer.go
+++ b/pkg/manifest/timer.go
@@ -1,5 +1,7 @@
 package manifest
 
+import "strings"
+
 type Timer struct {
 	Name        string             `yaml:"-"`
 	Annotations ServiceAnnotations `yaml:"annotations,omitempty"`
@@ -17,9 +19,8 @@ func (t Timer) AnnotationsMap() map[string]string {
 	annotations := map[string]string{}
 
 	for _, a := range t.Annotations {
-		for k, v := range a {
-			annotations[k] = v.(string)
-		}
+		parts := strings.SplitN(a, "=", 2)
+		annotations[parts[0]] = parts[1]
 	}
 
 	return annotations

--- a/pkg/manifest/timer.go
+++ b/pkg/manifest/timer.go
@@ -1,7 +1,5 @@
 package manifest
 
-import "strings"
-
 type Timer struct {
 	Name        string             `yaml:"-"`
 	Annotations ServiceAnnotations `yaml:"annotations,omitempty"`
@@ -19,8 +17,9 @@ func (t Timer) AnnotationsMap() map[string]string {
 	annotations := map[string]string{}
 
 	for _, a := range t.Annotations {
-		parts := strings.SplitN(a, "=", 2)
-		annotations[parts[0]] = parts[1]
+		for k, v := range a {
+			annotations[k] = v.(string)
+		}
 	}
 
 	return annotations

--- a/provider/k8s/template.go
+++ b/provider/k8s/template.go
@@ -129,11 +129,11 @@ func (p *Provider) templateHelpers() template.FuncMap {
 		"volumeTo": func(v string) (string, error) {
 			return volumeTo(v)
 		},
-		"splitIntoLines": splitIntoLinesUnified,
+		"splitIntoLines": splitIntoLines,
 	}
 }
 
-func splitIntoLinesUnified(value interface{}) []string {
+func splitIntoLines(value interface{}) []string {
 	var lines []string
 	var valueStr string
 

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -70,8 +70,8 @@ spec:
         {{ if .Service.Agent.Enabled }}
         scheduler.alpha.kubernetes.io/critical-pod: ""
         {{ end }}
-        {{ range keyValue .Annotations }}
-        {{.Key}}: "{{ quoteEscape .Value}}"
+        {{ range .Annotations }}
+        - {{.Key}}: "{{ .Value}}"
         {{ end }}
       labels:
         system: convox

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -19,9 +19,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    {{ range keyValue .Annotations }}
-    {{.Key}}: "{{ quoteEscape .Value}}"
-    {{ end }}
+    {{- range $key, $value := .Annotations }}
+        {{ $key }}
+        {{- $lines := splitIntoLines $value }}
+        {{- range $lines }}
+          {{ . }}
+        {{- end }}
+    {{- end }}
   namespace: {{.Namespace}}
   name: {{.Service.Name}}
   labels:
@@ -70,9 +74,13 @@ spec:
         {{ if .Service.Agent.Enabled }}
         scheduler.alpha.kubernetes.io/critical-pod: ""
         {{ end }}
-        {{ range .Annotations }}
-        - {{.Key}}: "{{ .Value}}"
-        {{ end }}
+        {{- range $key, $value := .Annotations }}
+            {{ $key }}
+            {{- $lines := splitIntoLines $value }}
+            {{- range $lines }}
+              {{ . }}
+            {{- end }}
+        {{- end }}
       labels:
         system: convox
         rack: {{.Rack}}


### PR DESCRIPTION
### What is the feature/fix?
Added Support for adding multiline annotations to deployments. 
example manifest:
```
services:
  web:
    build: .
    command: node app.js
    port: 3000
    annotations:
        - "key1=value1"
        - key2: "value2"
        - key3: |
            this is it
        - ad.datadoghq.com/test.checks: |
            {   
                "my-test": {
                "init_config": {
                    "is_jmx": true,
                    "collect_default_metrics": true
                },
                "instances": [{
                    "host": "localhost",
                    "port": "1234"
                }]
            }
            }
```