### PR TITLE
Reintroduce multiple node types

### DIFF
--- a/terraform/cluster/aws/amitype.tf
+++ b/terraform/cluster/aws/amitype.tf
@@ -1,0 +1,11 @@
+variable "node_type" {
+  type = string
+}
+
+output "gpu_type" {
+  value = substr(var.node_type, 0, 1) == "g" || substr(var.node_type, 0, 1) == "p" || substr(var.node_type, 0, 3) == "inf" || substr(var.node_type, 0, 3) == "trn"
+}
+
+output "arm_type" {
+  value = substr(var.node_type, 0, 2) == "a1" || substr(var.node_type, 0, 5) == "hpc7g" || substr(var.node_type, 0, 4) == "im4g" || substr(var.node_type, 0, 4) == "is4g" || substr(var.node_type, 2, 1) == "g"
+}

--- a/terraform/cluster/aws/variables.tf
+++ b/terraform/cluster/aws/variables.tf
@@ -118,6 +118,7 @@ variable "node_max_unavailable_percentage" {
 }
 
 variable "node_type" {
+  description = "Comma-delimited list of node types"
   default = "t3.small"
 }
 

--- a/terraform/cluster/aws/variables.tf
+++ b/terraform/cluster/aws/variables.tf
@@ -1,17 +1,5 @@
-variable "arm_type" {
-  default = false
-}
-
 variable "availability_zones" {
   default = ""
-}
-
-variable "build_arm_type" {
-  default = false
-}
-
-variable "build_gpu_type" {
-  default = false
 }
 
 variable "build_node_enabled" {
@@ -49,10 +37,6 @@ variable "efs_csi_driver_enable" {
 variable "efs_csi_driver_version" {
   type    = string
   default = "v2.0.1-eksbuild.1"
-}
-
-variable "gpu_type" {
-  default = false
 }
 
 variable "gpu_tag_enable" {

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -31,20 +31,22 @@ data "http" "releases" {
   }
 }
 
+module "primary_node_type" {
+  source = "../../cluster/aws/amitype"
+
+  // var.node_type can be assigned a comma separated list of instance types
+  node_type = split(",", var.node_type)[0]
+}
+
 locals {
   name      = lower(var.name)
   rack_name = lower(var.rack_name)
 
-  // var.node_type can be assigned a comma separated list of instance types
-  node_type       = split(",", var.node_type)[0]
-  build_node_type = var.build_node_type != "" ? var.build_node_type : local.node_type
-  arm_type        = substr(local.node_type, 0, 2) == "a1" || substr(local.node_type, 0, 3) == "c6g" || substr(local.node_type, 0, 3) == "c7g" || substr(local.node_type, 0, 3) == "m6g" || substr(local.node_type, 0, 3) == "r6g" || substr(local.node_type, 0, 3) == "t4g"
-  build_arm_type  = substr(local.build_node_type, 0, 2) == "a1" || substr(local.build_node_type, 0, 3) == "c6g" || substr(local.build_node_type, 0, 3) == "c7g" || substr(local.build_node_type, 0, 3) == "m6g" || substr(local.build_node_type, 0, 3) == "r6g" || substr(local.build_node_type, 0, 3) == "t4g"
+  primary_arm_type = module.primary_node_type.arm_type
+  primary_gpu_type = module.primary_node_type.gpu_type
   current         = jsondecode(data.http.releases.response_body).tag_name
-  gpu_type        = substr(local.node_type, 0, 1) == "g" || substr(local.node_type, 0, 1) == "p"
-  build_gpu_type  = substr(local.build_node_type, 0, 1) == "g" || substr(local.build_node_type, 0, 1) == "p"
   image           = var.image
-  release         = local.arm_type ? format("%s-%s", coalesce(var.release, local.current), "arm64") : coalesce(var.release, local.current)
+  release         = local.primary_arm_type ? format("%s-%s", coalesce(var.release, local.current), "arm64") : coalesce(var.release, local.current)
   tag_map = length(var.tags) == 0 ? {} : {
     for v in split(",", var.tags) :
     "${split("=", v)[0]}" => split("=", v)[1]
@@ -58,8 +60,6 @@ module "cluster" {
     aws = aws
   }
 
-  arm_type                        = local.arm_type
-  build_arm_type                  = local.build_arm_type
   availability_zones              = var.availability_zones
   build_node_enabled              = var.build_node_enabled
   build_node_min_count            = var.build_node_min_count
@@ -69,8 +69,6 @@ module "cluster" {
   disable_public_access           = var.disable_public_access
   efs_csi_driver_enable           = var.efs_csi_driver_enable
   efs_csi_driver_version          = var.efs_csi_driver_version
-  gpu_type                        = local.gpu_type
-  build_gpu_type                  = local.build_gpu_type
   gpu_tag_enable                  = var.gpu_tag_enable
   high_availability               = var.high_availability
   internet_gateway_id             = var.internet_gateway_id
@@ -125,7 +123,7 @@ module "fluentd" {
   ]
 
   access_log_retention_in_days = var.access_log_retention_in_days
-  arm_type                     = local.arm_type
+  arm_type                     = local.primary_arm_type
   cluster                      = module.cluster.id
   eks_addons                   = module.cluster.eks_addons
   fluentd_disable              = var.fluentd_disable


### PR DESCRIPTION
### What is the feature/fix?

This reintroduces being able to run multiple instance types on an AWS rack, which was the state for a long while until launch templates were introduced.

We've run into issues fairly frequently when running spot instances where all the capacity for a specific instance is used up in a region so our Rack will disappear or be completely decimated.  If we allow for multiple instance types, it would give us more opportunity to create nodes of other types to not suffer from this!

Launch templates in Terraform only allow for one instance type to be set, so this PR creates one node group per node_type set in the rack parameter and an associated launch template for that node group.

The first node_type in the rack parameter is considered the primary type to determine the appropriate release of the API etc to use, so it would be highly recommended to keep all the instance types in the same family (at least keep them all ARM or non-ARM!).

The functionality to determine if the instance type contains a GPU or runs on an ARM processor has been moved to a specific module so that it can be more easily referenced in multiple places.

Node groups for any instance beyond the first one will have their minimum and desired instance count set to 0 so they don't all spin up instances immediately, and will allow the kube-scheduler/ASG to scale them up as needed by the apps on the rack.

The implementation of the `MIXED` capacity type has changed from setting on-demand in one AZ only, to setting on-demand for the first node type and spot for all subsequent ones.  This should be more reliable in the case of a spot shortage as it will maintain instances across 3 AZ's for redundancy rather than just in one.

There is undoubtedly other factors or things I'm missing in this PR but I hope it's a great starting off point for a more reliable underlying infrastructure.

I also implemented the same for the build node groups but if this is intended to purely by a singleton instance, maybe this is unnecessary and we should enforce the build_node_type being a single instance type. 

### Add screenshot or video (optional)

** Any screenshot or video capture using the feature **

### Does it has a breaking change?

Change in implementation to the `MIXED` capacity type which isn't breaking but could be highlighted.

### How to use/test it?

Set `node_type` rack param to a comma-delimited list of instance types and see the node groups being created.  Check that node groups beyond the first one have a desired and minimum size of 0.  Cause scale up events on the rack and see if other instance types get scaled up as desired.

### Checklist
- [ ] New coverage tests
- [x] Unit tests passing
- [x] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [x] No warnings or errors on Deepsource/Codecov
