### PR TITLE
Add support for multiline annotations

### DIFF
--- a/pkg/common/format.go
+++ b/pkg/common/format.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"bytes"
+	"html"
 	"regexp"
 
 	yaml "gopkg.in/yaml.v2"
@@ -12,6 +13,8 @@ var (
 )
 
 func FormatYAML(data []byte) ([]byte, error) {
+	data = []byte(html.UnescapeString(string(data)))
+
 	ps := yamlSplitter.Split(string(data), -1)
 	bs := make([][]byte, len(ps))
 

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -62,10 +62,20 @@ func TestManifestLoad(t *testing.T) {
 		Services: manifest.Services{
 			manifest.Service{
 				Name: "api",
-				Annotations: []string{
-					"eks.amazonaws.com/role-arn=arn:aws:iam::123456789012:role/eksctl-irptest-addon-iamsa-default-my-serviceaccount-Role1-UCGG6NDYZ3UE",
-					"test.other.com/annotation=myothervalue",
-					"string.test.com/annotation=\"thishasquotes\""},
+				Annotations: manifest.Annotations{
+					manifest.Annotation{
+						Key:   "eks.amazonaws.com/role-arn",
+						Value: "arn:aws:iam::123456789012:role/eksctl-irptest-addon-iamsa-default-my-serviceaccount-Role1-UCGG6NDYZ3UE",
+					},
+					manifest.Annotation{
+						Key:   "test.other.com/annotation",
+						Value: "myothervalue",
+					},
+					manifest.Annotation{
+						Key:   "string.test.com/annotation",
+						Value: "\"thishasquotes\"",
+					},
+				},
 				Build: manifest.ServiceBuild{
 					Manifest: "Dockerfile2",
 					Path:     "api",

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -17,7 +17,7 @@ type Service struct {
 	Name string `yaml:"-"`
 
 	Agent              ServiceAgent          `yaml:"agent,omitempty"`
-	Annotations        ServiceAnnotations    `yaml:"annotations,omitempty"`
+	Annotations        Annotations           `yaml:"annotations,omitempty"`
 	Build              ServiceBuild          `yaml:"build,omitempty"`
 	Certificate        Certificate           `yaml:"certificate,omitempty"`
 	Command            string                `yaml:"command,omitempty"`
@@ -34,7 +34,7 @@ type Service struct {
 	InitContainer      *InitContainer        `yaml:"initContainer,omitempty"`
 	Internal           bool                  `yaml:"internal,omitempty"`
 	InternalRouter     bool                  `yaml:"internalRouter,omitempty"`
-	IngressAnnotations ServiceAnnotations    `yaml:"ingressAnnotations,omitempty"`
+	IngressAnnotations Annotations           `yaml:"ingressAnnotations,omitempty"`
 	Labels             Labels                `yaml:"labels,omitempty"`
 	Lifecycle          ServiceLifecycle      `yaml:"lifecycle,omitempty"`
 	Port               ServicePortScheme     `yaml:"port,omitempty"`
@@ -52,6 +52,13 @@ type Service struct {
 	VolumeOptions      []VolumeOption        `yaml:"volumeOptions,omitempty"`
 	Whitelist          string                `yaml:"whitelist,omitempty"`
 	AccessControl      AccessControlOptions  `yaml:"accessControl,omitempty"`
+}
+
+type Annotations []Annotation
+
+type Annotation struct {
+	Key   string `yaml:"key"`
+	Value string `yaml:"value"`
 }
 
 type InitContainer struct {
@@ -335,13 +342,11 @@ func (sr ServiceResource) GetConfigMapKey() string {
 	return DEFAULT_RESOURCE_ENV_NAME
 }
 
-// skipcq
 func (s Service) AnnotationsMap() map[string]string {
 	annotations := map[string]string{}
 
 	for _, a := range s.Annotations {
-		parts := strings.SplitN(a, "=", 2)
-		annotations[parts[0]] = parts[1]
+		annotations[a.Key] = a.Value
 	}
 
 	return annotations
@@ -351,9 +356,8 @@ func (s Service) AnnotationsMap() map[string]string {
 func (s Service) IngressAnnotationsMap() map[string]string {
 	annotations := map[string]string{}
 
-	for _, a := range s.IngressAnnotations {
-		parts := strings.SplitN(a, "=", 2)
-		annotations[parts[0]] = parts[1]
+	for _, a := range s.Annotations {
+		annotations[a.Key] = a.Value
 	}
 
 	return annotations

--- a/provider/k8s/template.go
+++ b/provider/k8s/template.go
@@ -13,6 +13,7 @@ import (
 	"github.com/convox/convox/pkg/structs"
 	shellquote "github.com/kballard/go-shellquote"
 	"github.com/pkg/errors"
+	yaml "gopkg.in/yaml.v2"
 )
 
 func (p *Provider) RenderTemplate(name string, params map[string]interface{}) ([]byte, error) {
@@ -72,6 +73,14 @@ func (p *Provider) templateHelpers() template.FuncMap {
 			}
 			return fmt.Sprintf("%s:%s.%s", repo, s.Name, r.Build), nil
 		},
+		"indent": func(spaces int, v string) string {
+			pad := strings.Repeat(" ", spaces)
+			return pad + strings.Replace(v, "\n", "\n"+pad, -1)
+		},
+		"nindent": func(spaces int, v string) string {
+			pad := strings.Repeat(" ", spaces)
+			return "\n" + pad + strings.Replace(v, "\n", "\n"+pad, -1)
+		},
 		"json": func(v interface{}) (string, error) {
 			data, err := json.Marshal(v)
 			if err != nil {
@@ -125,6 +134,13 @@ func (p *Provider) templateHelpers() template.FuncMap {
 		},
 		"volumeTo": func(v string) (string, error) {
 			return volumeTo(v)
+		},
+		"yamlMarshal": func(v interface{}) (string, error) {
+			d, err := yaml.Marshal(v)
+			if err != nil {
+				return "", fmt.Errorf("yamlMarshal: %s", err)
+			}
+			return string(d), nil
 		},
 	}
 }

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -19,9 +19,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    {{ range keyValue .Annotations }}
-    {{.Key}}: "{{ quoteEscape .Value}}"
-    {{ end }}
+    {{- if ne (len .Annotations) 0 }}
+    {{- yamlMarshal .Annotations | nindent 4 }}
+    {{- end }}
   namespace: {{.Namespace}}
   name: {{.Service.Name}}
   labels:
@@ -70,9 +70,9 @@ spec:
         {{ if .Service.Agent.Enabled }}
         scheduler.alpha.kubernetes.io/critical-pod: ""
         {{ end }}
-        {{ range keyValue .Annotations }}
-        {{.Key}}: "{{ quoteEscape .Value}}"
-        {{ end }}
+        {{- if ne (len .Annotations) 0 }}
+        {{- yamlMarshal .Annotations | nindent 8 }}
+        {{- end }}
       labels:
         system: convox
         rack: {{.Rack}}

--- a/provider/k8s/template/app/timer.yml.tmpl
+++ b/provider/k8s/template/app/timer.yml.tmpl
@@ -4,9 +4,9 @@ kind: ServiceAccount
 metadata:
   annotations:
     convox.com/type: timer
-    {{ range keyValue .Annotations }}
-    {{.Key}}: "{{ quoteEscape .Value}}"
-    {{ end }}
+    {{- if ne (len .Annotations) 0 }}
+    {{- yamlMarshal .Annotations | nindent 4 }}
+    {{- end }}
   namespace: {{.Namespace}}
   name: timer-{{.Timer.Name}}
   labels:
@@ -31,9 +31,9 @@ spec:
         metadata:
           annotations:
             convox.com/type: timer
-            {{ range keyValue .Annotations }}
-            {{.Key}}: "{{ quoteEscape .Value}}"
-            {{ end }}
+            {{- if ne (len .Annotations) 0 }}
+            {{- yamlMarshal .Annotations | nindent 12 }}
+            {{- end }}
           labels:
             system: convox
             rack: {{.Rack}}

--- a/provider/k8s/testdata/convox1.yml
+++ b/provider/k8s/testdata/convox1.yml
@@ -1,0 +1,95 @@
+environment:
+  - PORT=3000
+  - TRY="qer"
+services:
+  web:
+    build: .
+    port: 3000
+    annotations:
+        - "key1=value1"
+        - k2 : "v2"
+        - "simple.key=value"
+        - "quoted.key=\"quoted value\""
+        - another.key: "another value"
+        - multi.line.test: |
+            This is line 1
+            Line 2 with a "quote" and a special character: $
+        - json.annotation: |
+            {"key1": "value1", "key2": "value2"}
+        - nested.json: |
+            {
+              "config": {
+                "feature_enabled": true,
+                "settings": {
+                  "retry": 3,
+                  "timeout": 120
+                },
+                "targets": ["node1", "node2"]
+              }
+            }
+        - yaml.annotation: |
+            key1: value1
+            key2: value2
+            nested:
+              subkey: subvalue
+        - yaml.config: |
+            feature: true
+            retry: 5
+        - json.config: |
+            {"key": "value", "enabled": false}
+        - large.payload: |
+            {
+              "data": [
+                {"id": 1, "value": "item1"},
+                {"id": 2, "value": "item2"},
+                {"id": 3, "value": "item3"}
+              ],
+              "metadata": {
+                "count": 3,
+                "status": "success"
+              }
+            }
+        - whitespace.test: |
+            Line with trailing space        
+        - "dash-key=value"
+        - "dot.key=value"
+        - "underscore_key=value"
+        - encoded.data: "VGhpcyBpcyBhIGJhc2U2NCBlbmNvZGVkIHZhbHVlLg=="
+        - prometheus.io/scrape: "true"
+        - prometheus.io/path: "/metrics"
+        - nginx.ingress.kubernetes.io/rewrite-target: "/"
+        - ad.datadoghq.com/nginx.logs: |
+            {
+              "source": "nginx",
+              "service": "my-app"
+            }
+        - scheduler.alpha.kubernetes.io/affinity: |
+            {
+              "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "nodeSelectorTerms": [
+                    {
+                      "matchExpressions": [
+                        {
+                          "key": "kubernetes.io/e2e-az-name",
+                          "operator": "In",
+                          "values": ["az1", "az2"]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+    scale:
+      count: 1
+      cpu: 100
+      memory: 55
+      limit:
+        cpu: 128
+        memory: 56
+timers:
+  test:
+    command: "echo ok timer"
+    schedule: "* * * * ? *"
+    service: web


### PR DESCRIPTION
### What is the feature/fix?

This will allow to define multi line service annotation

```
services:
  web:
    build: .
    port: 3000
    annotations:
        - "key1=value1"
        - k2 : "v2"
        - "simple.key=value"
        - "quoted.key=\"quoted value\""
        - another.key: "another value"
        - multi.line.test: |
            This is line 1
            Line 2 with a "quote" and a special character: $
```