### PR TITLE
Add option provide aws efs storage class and Add support for startupProbe

### DIFF
--- a/pkg/api/controllers.go
+++ b/pkg/api/controllers.go
@@ -595,7 +595,12 @@ func (s *Server) FilesUpload(c *stdapi.Context) error {
 	pid := c.Var("pid")
 	r := c
 
-	err := s.provider(c).WithContext(c.Context()).FilesUpload(app, pid, r)
+	var opts structs.FileTransterOptions
+	if err := stdapi.UnmarshalOptions(c.Request(), &opts); err != nil {
+		return err
+	}
+
+	err := s.provider(c).WithContext(c.Context()).FilesUpload(app, pid, r, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -29,6 +29,7 @@ type Service struct {
 	GrpcHealthEnabled  bool                  `yaml:"grpcHealthEnabled,omitempty"`
 	Health             ServiceHealth         `yaml:"health,omitempty"`
 	Liveness           ServiceLiveness       `yaml:"liveness,omitempty"`
+	StartupProbe       ServiceStartupProbe   `yaml:"startupProbe,omitempty"`
 	Image              string                `yaml:"image,omitempty"`
 	Init               bool                  `yaml:"init,omitempty"`
 	InitContainer      *InitContainer        `yaml:"initContainer,omitempty"`
@@ -106,8 +107,9 @@ func (v VolumeEmptyDir) Validate() error {
 type VolumeAwsEfs struct {
 	Id string `yaml:"id"`
 
-	AccessMode string `yaml:"accessMode,omitempty"`
-	MountPath  string `yaml:"mountPath"`
+	AccessMode   string `yaml:"accessMode,omitempty"`
+	MountPath    string `yaml:"mountPath"`
+	StorageClass string `yaml:"storageClass,omitempty"`
 }
 
 func (v VolumeAwsEfs) Validate() error {
@@ -172,6 +174,16 @@ type ServiceLiveness struct {
 	Grace            int    `yaml:"grace,omitempty"`
 	Interval         int    `yaml:"interval,omitempty"`
 	Path             string `yaml:"path,omitempty"`
+	Timeout          int    `yaml:"timeout,omitempty"`
+	SuccessThreshold int    `yaml:"successThreshold,omitempty"`
+	FailureThreshold int    `yaml:"failureThreshold,omitempty"`
+}
+
+type ServiceStartupProbe struct {
+	Grace            int    `yaml:"grace,omitempty"`
+	Interval         int    `yaml:"interval,omitempty"`
+	Path             string `yaml:"path,omitempty"`
+	TcpSocketPort    string `yaml:"tcpSocketPort,omitempty"`
 	Timeout          int    `yaml:"timeout,omitempty"`
 	SuccessThreshold int    `yaml:"successThreshold,omitempty"`
 	FailureThreshold int    `yaml:"failureThreshold,omitempty"`

--- a/pkg/mock/sdk/interface.go
+++ b/pkg/mock/sdk/interface.go
@@ -738,12 +738,12 @@ func (_m *Interface) FilesDownload(app string, pid string, file string) (io.Read
 }
 
 // FilesUpload provides a mock function with given fields: app, pid, r
-func (_m *Interface) FilesUpload(app string, pid string, r io.Reader) error {
-	ret := _m.Called(app, pid, r)
+func (_m *Interface) FilesUpload(app string, pid string, r io.Reader, opts structs.FileTransterOptions) error {
+	ret := _m.Called(app, pid, r, opts)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, io.Reader) error); ok {
-		r0 = rf(app, pid, r)
+	if rf, ok := ret.Get(0).(func(string, string, io.Reader, structs.FileTransterOptions) error); ok {
+		r0 = rf(app, pid, r, opts)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/start/gen2.go
+++ b/pkg/start/gen2.go
@@ -342,7 +342,7 @@ func (opts Options2) handleAdds(pid, remote string, adds []changes.Change) error
 	ch := make(chan error)
 
 	go func() {
-		ch <- opts.Provider.FilesUpload(opts.App, pid, rp)
+		ch <- opts.Provider.FilesUpload(opts.App, pid, rp, structs.FileTransterOptions{})
 		close(ch)
 	}()
 

--- a/pkg/structs/file.go
+++ b/pkg/structs/file.go
@@ -1,0 +1,5 @@
+package structs
+
+type FileTransterOptions struct {
+	TarExtraFlags *string `flag:"tar-extra" query:"tar-extra"`
+}

--- a/pkg/structs/mock_Provider.go
+++ b/pkg/structs/mock_Provider.go
@@ -557,12 +557,12 @@ func (_m *MockProvider) FilesDownload(app string, pid string, file string) (io.R
 }
 
 // FilesUpload provides a mock function with given fields: app, pid, r
-func (_m *MockProvider) FilesUpload(app string, pid string, r io.Reader) error {
-	ret := _m.Called(app, pid, r)
+func (_m *MockProvider) FilesUpload(app string, pid string, r io.Reader, opts FileTransterOptions) error {
+	ret := _m.Called(app, pid, r, opts)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, io.Reader) error); ok {
-		r0 = rf(app, pid, r)
+	if rf, ok := ret.Get(0).(func(string, string, io.Reader, FileTransterOptions) error); ok {
+		r0 = rf(app, pid, r, opts)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/structs/provider.go
+++ b/pkg/structs/provider.go
@@ -46,7 +46,7 @@ type Provider interface {
 
 	FilesDelete(app, pid string, files []string) error
 	FilesDownload(app, pid string, file string) (io.Reader, error)
-	FilesUpload(app, pid string, r io.Reader) error
+	FilesUpload(app, pid string, r io.Reader, opts FileTransterOptions) error
 
 	InstanceKeyroll() (*KeyPair, error)
 	InstanceList() (Instances, error)

--- a/pkg/templater/templater.go
+++ b/pkg/templater/templater.go
@@ -24,7 +24,7 @@ func New(box packr.Box, helpers template.FuncMap) *Templater {
 func (t *Templater) Render(name string, params interface{}) ([]byte, error) {
 	ts := template.New("").Funcs(t.helpers)
 
-	tdata, err := t.box.MustString(name)
+	tdata, err := t.box.FindString(name)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/k8s/release.go
+++ b/provider/k8s/release.go
@@ -226,6 +226,7 @@ func (p *Provider) ReleasePromote(app, id string, opts structs.ReleasePromoteOpt
 		if len(elastiDeps) > 0 {
 			dependencies = append(dependencies, elastiDeps...)
 		}
+
 	}
 
 	tdata := bytes.Join(items, []byte("---\n"))

--- a/provider/k8s/template/app/efs.yml.tmpl
+++ b/provider/k8s/template/app/efs.yml.tmpl
@@ -14,7 +14,7 @@ metadata:
 spec:
   accessModes:
     - {{.AccessMode}}
-  storageClassName: efs-sc
+  storageClassName: {{ if .StorageClass }} {{.StorageClass}} {{ else }} efs-sc {{end}}
   resources:
     requests:
       storage: 1Mi # efs driver ignores this value

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -117,6 +117,19 @@ spec:
           - {{ safe . }}
         {{ end }}
         {{ end }}
+        env:
+        - name: INIT_CONTAINER
+          value: "true"
+        {{ range $.Resources }}
+        - name: "{{.Env}}"
+          valueFrom:
+            configMapKeyRef:
+              name: resource-{{ k8sname .Name }}
+              key: {{ .GetConfigMapKey }}
+        {{ end }}
+        envFrom:
+        - secretRef:
+            name: env-{{.Service.Name}}
         volumeMounts:
         {{ range .Service.InitContainer.VolumeOptions }}
         {{ with .EmptyDir }}
@@ -174,6 +187,23 @@ spec:
           {{ end }}
         {{ end }}
         {{ with .Service.Port.Port }}
+        {{ if or (not (eq $.Service.StartupProbe.Path "")) (not (eq $.Service.StartupProbe.TcpSocketPort ""))}}
+        startupProbe:
+          {{ if not (eq $.Service.StartupProbe.Path "")}}
+          httpGet:
+            path: {{$.Service.StartupProbe.Path}}"
+            port: {{.}}
+          {{ end }}
+          {{ if not (eq $.Service.StartupProbe.TcpSocketPort "")}}
+          tcpSocket:
+            port: {{$.Service.StartupProbe.TcpSocketPort}}
+          {{ end }}
+          initialDelaySeconds: {{$.Service.Liveness.Grace}}
+          periodSeconds: {{$.Service.Liveness.Interval}}
+          timeoutSeconds: {{$.Service.Liveness.Timeout}}
+          successThreshold: {{$.Service.Liveness.SuccessThreshold}}
+          failureThreshold: {{$.Service.Liveness.FailureThreshold}}
+        {{ end }}
         {{ if and (not (eq $.Service.Port.Scheme "GRPC")) (not (eq $.Service.Liveness.Path ""))}}
         livenessProbe:
           httpGet:

--- a/sdk/methods.go
+++ b/sdk/methods.go
@@ -405,10 +405,13 @@ func (c *Client) FilesDownload(app, pid, file string) (io.Reader, error) {
 	return v, err
 }
 
-func (c *Client) FilesUpload(app, pid string, r io.Reader) error {
+func (c *Client) FilesUpload(app, pid string, r io.Reader, opts structs.FileTransterOptions) error {
 	var err error
 
-	ro := stdsdk.RequestOptions{Headers: stdsdk.Headers{}, Params: stdsdk.Params{}, Query: stdsdk.Query{}}
+	ro, err := stdsdk.MarshalOptions(opts)
+	if err != nil {
+		return err
+	}
 
 	ro.Body = r
 

--- a/terraform/cluster/aws/efs.tf
+++ b/terraform/cluster/aws/efs.tf
@@ -85,3 +85,55 @@ resource "kubernetes_storage_class_v1" "convox_efs" {
     reuseAccessPoint      = "false"                            # optional
   }
 }
+
+resource "kubernetes_storage_class_v1" "convox_efs_775" {
+  depends_on = [null_resource.wait_k8s_api]
+
+  count = var.efs_csi_driver_enable ? 1 : 0
+
+  metadata {
+    name = "efs-sc-775"
+  }
+
+  storage_provisioner = "efs.csi.aws.com"
+
+  parameters = {
+    provisioningMode      = "efs-ap"
+    fileSystemId          = aws_efs_file_system.convox_efs[0].id
+    uid = "33"
+    gid = "33"
+    directoryPerms        = "0775"
+    gidRangeStart         = "1000"                             # optional
+    gidRangeEnd           = "20000"                            # optional
+    basePath              = "/dp775"                              # optional
+    subPathPattern        = "$${.PVC.namespace}/$${.PVC.name}" # optional
+    ensureUniqueDirectory = "false"                            # optional
+    reuseAccessPoint      = "false"                            # optional
+  }
+}
+
+resource "kubernetes_storage_class_v1" "convox_efs_777" {
+  depends_on = [null_resource.wait_k8s_api]
+
+  count = var.efs_csi_driver_enable ? 1 : 0
+
+  metadata {
+    name = "efs-sc-777"
+  }
+
+  storage_provisioner = "efs.csi.aws.com"
+
+  parameters = {
+    provisioningMode      = "efs-ap"
+    fileSystemId          = aws_efs_file_system.convox_efs[0].id
+    uid = "1000"
+    gid = "1000"
+    directoryPerms        = "0775"
+    gidRangeStart         = "1000"                             # optional
+    gidRangeEnd           = "20000"                            # optional
+    basePath              = "/dp777"                              # optional
+    subPathPattern        = "$${.PVC.namespace}/$${.PVC.name}" # optional
+    ensureUniqueDirectory = "false"                            # optional
+    reuseAccessPoint      = "false"                            # optional
+  }
+}


### PR DESCRIPTION
### What is the feature/fix?
- It will add option to specify aws efs storage class in volumes
```
    volumeOptions:
      - awsEfs:
          id: "data"
          accessMode: ReadWriteMany
          mountPath: "/opt/data/"
          storageClass: "efs-sc-33"
```
- This will support for K8s startupProbe(https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes)
```
services:
  web:
    startupProbe:
      tcpSocketPort: 80
      grace: 30
      interval: 10
```

- This will add support to provider tarextra flag option when uploading file
```
convox cp ./test.file <pid>:/opt/test/sample.txt -a <app> --tar-extra "--no-same-owner"
```