### PR TITLE
Allow Custom Load Balancers to direct traffic regardless of release

### DIFF
--- a/provider/k8s/template/app/balancer.yml.tmpl
+++ b/provider/k8s/template/app/balancer.yml.tmpl
@@ -27,7 +27,6 @@ spec:
   {{ end }}
   selector:
     service: {{.Balancer.Service}}
-    release: {{.Release.Id}}
     type: service
   ports:
     {{ range .Balancer.Ports }}


### PR DESCRIPTION
### What is the feature/fix?

We've experienced downtime issues with services that sit behind custom load balancers with slow start up times.  Once the balancer service has updated in k8s, if no pods from the new release are healthy/ready, then the load balancer has nowhere to send traffic to, until the new release pods become available.  I believe the `release` selector label is overly restrictive as it's been in there since inception and probably shouldn't have been.  There aren't any other places where we restrict traffic by release.

### Does it has a breaking change?

No

### How to use/test it?

Deploy a service that sits behind a custom load balancer, create an artificially long time to healthiness on deployments.  Promote a new release of the service and monitor the availability through the custom load balancer.  

### Checklist
- [N/A] New coverage tests
- [x] Unit tests passing
- [x] E2E tests passing
- [ ] E2E downgrade/update test passing
- [N/A] Documentation updated
- [x] No warnings or errors on Deepsource/Codecov
