### PR TITLE
Add rds:CreateDBSnapshot permission due to recent aws changes

### DIFF
--- a/terraform/api/aws/iam.tf
+++ b/terraform/api/aws/iam.tf
@@ -137,6 +137,7 @@ data "aws_iam_policy_document" "rds_provisioner" {
       "rds:CreateDBInstance*",
       "rds:DeleteDBInstance*",
       "rds:ModifyDBInstance*",
+      "rds:CreateDBSnapshot",
       "rds:Describe*",
       "rds:CreateDBSubnetGroup",
       "rds:DeleteDBSubnetGroup",


### PR DESCRIPTION
Hello,

We are contacting you regarding a change to AWS Identity and Access Management (IAM) policies for certain Amazon Relational Database Service (RDS) APIs that require your action by February 28, 2025. IAM is a service that lets you specify who or what can access services and resources in AWS. RDS is a service that provides cost-efficient, resizable capacity for an industry-standard relational database and manages common database administration tasks. On August 15, 2024, we implemented a change to database snapshot creation when using the "DeleteDBCluster" [1], "DeleteDBInstance" [2] , "DeleteTenantDatabase" [3] and "StopDBInstance" APIs [4].

If you want to create a final snapshot of the database when calling "DeleteDBInstance" or "DeleteTenantDatabase" or "StopDBInstance", you must have an IAM Allow effect for the "rds:CreateDBSnapshot" permission.

Similarly, if you want to create a final snapshot of a database cluster when calling "DeleteDBCluster", you must have an IAM Allow effect for the "rds:CreateDBClusterSnapshot" permission.

Additionally, if the database instance or database cluster has CopyTagsToSnapshot enabled and you are calling “DeleteDBInstance” or “DeleteDBCluster” or “StopDBInstance”, you must have an IAM allow effect “rds:AddTagsToResource” permission for the "DBSnapshot" resource.

In case of “DeleteTenantDatabase” you must have an IAM allow effect "rds:AddTagsToResource" permission for "DBSnapshot" and "Snapshot-tenant-database" resources.

We have identified one or more of your accounts has previously created an RDS Database Snapshot without the RDS IAM permission which will soon be required. If you intend to allow a final snapshot creation using these APIs, you must update your IAM policies by February 28, 2025.

A list of your affected IAM users and roles can be found in the 'Affected resources' tab of your AWS Health Dashboard.

Example policies:
```

1) Example of an incorrect policy before the change for DeleteDBInstance API:

{
  "Version": "2012-10-17",
  "Statement": [
    {
        "Effect": "Allow",
        "Action": ["rds:DeleteDBInstance"],
        "Resource": ["arn:aws:rds:us-east-1:123456789012:db:*"]
    }
  ]
}


Example of the policy after the change:

{
  "Version": "2012-10-17",
  "Statement": [
    {
        "Effect": "Allow",
        "Action": ["rds:DeleteDBInstance", "rds:CreateDBSnapshot"],
        "Resource": ["arn:aws:rds:us-east-1:123456789012:db:*", "arn:aws:rds:us-east-1:123456789012:snapshot:*"]
    },
    {
        "Effect": "Allow",
        "Action": ["rds:AddTagsToResource"],
        "Resource": ["arn:aws:rds:us-east-1:123456789012:snapshot:*"]
    }
  ]
}

2) Example of an incorrect policy before the change for DeleteDBCluster API:

{
  "Version": "2012-10-17",
  "Statement": [
    {
        "Effect": "Allow",
        "Action": ["rds:DeleteDBCluster"],
        "Resource": ["arn:aws:rds:us-east-1:123456789012:cluster:*"]
    }
  ]
}


Example of the policy after the change:

{
  "Version": "2012-10-17",
  "Statement": [
    {
        "Effect": "Allow",
        "Action": ["rds:DeleteDBCluster", "rds:CreateDBClusterSnapshot"],
        "Resource": ["arn:aws:rds:us-east-1:123456789012:cluster:*", "arn:aws:rds:us-east-1:123456789012:cluster-snapshot:*"]
    },
    {
        "Effect": "Allow",
        "Action": ["rds:AddTagsToResource"],
        "Resource": ["arn:aws:rds:us-east-1:123456789012:cluster-snapshot:*"]
    }
  ]
}

3) Example of an incorrect policy before the change for StopDBInstance API:

{
  "Version": "2012-10-17",
  "Statement": [
    {
        "Effect": "Allow",
        "Action": ["rds:StopDBInstance"],
        "Resource": ["arn:aws:rds:us-east-1:123456789012:db:*"]
    }
  ]
}


Example of the policy after the change:

{
  "Version": "2012-10-17",
  "Statement": [
    {
        "Effect": "Allow",
        "Action": ["rds:StopDBInstance", "rds:CreateDBSnapshot"],
        "Resource": ["arn:aws:rds:us-east-1:123456789012:db:*", "arn:aws:rds:us-east-1:123456789012:snapshot:*"]
    },
    {
        "Effect": "Allow",
        "Action": ["rds:AddTagsToResource"],
        "Resource": ["arn:aws:rds:us-east-1:123456789012:snapshot:*"]
    }
  ]
}

 4) Example of an incorrect policy before the change for DeleteTenantDatabase API:

{
  "Version": "2012-10-17",
  "Statement": [
    {
        "Effect": "Allow",
        "Action": ["rds:DeleteTenantDatabase"],
        "Resource": ["arn:aws:rds:us-east-1:123456789012:db:*", "arn:aws:rds:us-east-1:123456789012:tenant-database:*"]
    }
  ]
}


Example of the policy after the change:

{
  "Version": "2012-10-17",
  "Statement": [
    {
        "Effect": "Allow",
        "Action": ["rds:DeleteTenantDatabase", "rds:CreateDBSnapshot"],
        "Resource": ["arn:aws:rds:us-east-1:123456789012:db:*", "arn:aws:rds:us-east-1:123456789012:tenant-database:*", "arn:aws:rds:us-east-1:123456789012:snapshot:*"]
    },
    {
        "Effect": "Allow",
        "Action": ["rds:AddTagsToResource"],
        "Resource": ["arn:aws:rds:us-east-1:123456789012:snapshot:*", "arn:aws:rds:us-east-1:123456789012:snapshot-tenant-database:*" ]
    }
  ]
}

```

If you have any questions or concerns, please contact AWS Support [5].


[1] https://docs.aws.amazon.com/cli/latest/reference/rds/delete-db-cluster.html
[2] https://docs.aws.amazon.com/cli/latest/reference/rds/delete-db-instance.html
[3] https://docs.aws.amazon.com/cli/latest/reference/rds/delete-tenant-database.html
[4] https://docs.aws.amazon.com/cli/latest/reference/rds/stop-db-instance.html
[5] https://aws.amazon.com/support

Sincerely,
Amazon Web Services
