### PR TITLE
Add support for custom AMI on EKS racks

### DIFF
--- a/docs/installation/production-rack/aws.md
+++ b/docs/installation/production-rack/aws.md
@@ -48,7 +48,7 @@ The following environment variables are required:
 | **access_log_retention_in_days**   |         7          | Specify nginx access log retention period in cloudwatch logs. The log group name will be `/convox/<rack-name>/system` and stream name `/nginx-access-logs` |
 | **ami_id**               |                        | Custom AMI ID to use in your Rack nodes.  WARNING, an invalid or incomplete AMI will break your rack.  Use with caution. |
 | **availability_zones**   |                        | Specify a list of AZ names (minimum 3) to override the random automatic selection from AWS                     |
-| **build_ami_id**         |                        | Custom AMI ID to use with your build node. If `ami_id` is set and `build_ami_id` is not set, the build node will use the AMI from `ami_id` |
+| **build_ami_id**         |                        | Custom AMI ID to use with your build node. WARNING, an invalid or incomplete AMI will break your rack.  Use with caution. |
 | **build_node_enabled**   |     false              | Enabled dedicated build node for build |
 | **build_node_type**      | same as **node_type**  | Node type for the build node |
 | **build_node_min_count** |     0                  | Minimum number of build nodes to keep running |

--- a/docs/installation/production-rack/aws.md
+++ b/docs/installation/production-rack/aws.md
@@ -46,7 +46,9 @@ The following environment variables are required:
 | Name                     | Default                | Description                                                                                                    |
 | -------------------------|------------------------|----------------------------------------------------------------------------------------------------------------|
 | **access_log_retention_in_days**   |         7          | Specify nginx access log retention period in cloudwatch logs. The log group name will be `/convox/<rack-name>/system` and stream name `/nginx-access-logs` |
+| **ami_id**               |                        | Custom AMI ID to use in your Rack nodes.  WARNING, an invalid or incomplete AMI will break your rack.  Use with caution. |
 | **availability_zones**   |                        | Specify a list of AZ names (minimum 3) to override the random automatic selection from AWS                     |
+| **build_ami_id**         |                        | Custom AMI ID to use with your build node. If `ami_id` is set and `build_ami_id` is not set, the build node will use the AMI from `ami_id` |
 | **build_node_enabled**   |     false              | Enabled dedicated build node for build |
 | **build_node_type**      | same as **node_type**  | Node type for the build node |
 | **build_node_min_count** |     0                  | Minimum number of build nodes to keep running |

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -112,7 +112,7 @@ resource "random_id" "build_node_group" {
   byte_length = 8
 
   keepers = {
-    ami_id              = var.build_ami_id ? var.build_ami_id : var.ami_id
+    ami_id              = var.build_ami_id
     dummy               = "2"
     node_disk           = var.node_disk
     node_type           = var.build_node_type
@@ -176,7 +176,7 @@ resource "aws_eks_node_group" "cluster-build" {
 
   count = var.build_node_enabled ? 1 : 0
 
-  ami_type        = var.ami_id ? "CUSTOM" : (var.build_gpu_type ? "AL2_x86_64_GPU" : (var.build_arm_type ? "AL2_ARM_64" : "AL2_x86_64"))
+  ami_type        = var.build_ami_id ? "CUSTOM" : (var.build_gpu_type ? "AL2_x86_64_GPU" : (var.build_arm_type ? "AL2_ARM_64" : "AL2_x86_64"))
   capacity_type   = "ON_DEMAND"
   cluster_name    = aws_eks_cluster.cluster.name
   instance_types  = split(",", random_id.build_node_group[0].keepers.node_type)
@@ -326,7 +326,7 @@ resource "aws_launch_template" "cluster-build" {
     instance_metadata_tags      = var.imds_tags_enable ? "enabled" : "disabled"
   }
 
-  image_id = random_id.build_node_group[0].keepers.ami_id
+  image_id = var.build_node_enabled ? random_id.build_node_group[0].keepers.ami_id : null
 
   dynamic "tag_specifications" {
     for_each = toset(

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -94,6 +94,7 @@ resource "random_id" "node_group" {
   byte_length = 8
 
   keepers = {
+    ami_id              = var.ami_id
     dummy               = "2"
     node_capacity_type  = var.node_capacity_type
     node_disk           = var.node_disk
@@ -111,6 +112,7 @@ resource "random_id" "build_node_group" {
   byte_length = 8
 
   keepers = {
+    ami_id              = var.build_ami_id ? var.build_ami_id : var.ami_id
     dummy               = "2"
     node_disk           = var.node_disk
     node_type           = var.build_node_type
@@ -127,7 +129,7 @@ resource "aws_eks_node_group" "cluster" {
 
   count = var.high_availability ? 3 : 1
 
-  ami_type        = var.gpu_type ? "AL2_x86_64_GPU" : var.arm_type ? "AL2_ARM_64" : "AL2_x86_64"
+  ami_type        = var.ami_id ? "CUSTOM" : var.gpu_type ? "AL2_x86_64_GPU" : var.arm_type ? "AL2_ARM_64" : "AL2_x86_64"
   capacity_type   = var.node_capacity_type == "MIXED" ? count.index == 0 ? "ON_DEMAND" : "SPOT" : var.node_capacity_type
   cluster_name    = aws_eks_cluster.cluster.name
   node_group_name = "${var.name}-${var.private ? data.aws_subnet.private_subnet_details[count.index].availability_zone : data.aws_subnet.public_subnet_details[count.index].availability_zone}-${count.index}${random_id.node_group.hex}"
@@ -174,7 +176,7 @@ resource "aws_eks_node_group" "cluster-build" {
 
   count = var.build_node_enabled ? 1 : 0
 
-  ami_type        = var.build_gpu_type ? "AL2_x86_64_GPU" : var.build_arm_type ? "AL2_ARM_64" : "AL2_x86_64"
+  ami_type        = var.ami_id ? "CUSTOM" : (var.build_gpu_type ? "AL2_x86_64_GPU" : (var.build_arm_type ? "AL2_ARM_64" : "AL2_x86_64"))
   capacity_type   = "ON_DEMAND"
   cluster_name    = aws_eks_cluster.cluster.name
   instance_types  = split(",", random_id.build_node_group[0].keepers.node_type)
@@ -285,6 +287,7 @@ resource "aws_launch_template" "cluster" {
   }
 
   instance_type = split(",", random_id.node_group.keepers.node_type)[0]
+  image_id = random_id.node_group.keepers.ami_id
 
   dynamic "tag_specifications" {
     for_each = toset(
@@ -322,6 +325,8 @@ resource "aws_launch_template" "cluster-build" {
     http_endpoint               = "enabled"
     instance_metadata_tags      = var.imds_tags_enable ? "enabled" : "disabled"
   }
+
+  image_id = random_id.build_node_group[0].keepers.ami_id
 
   dynamic "tag_specifications" {
     for_each = toset(

--- a/terraform/cluster/aws/variables.tf
+++ b/terraform/cluster/aws/variables.tf
@@ -1,3 +1,8 @@
+variable "ami_id" {
+  type    = string
+  default = null
+}
+
 variable "arm_type" {
   default = false
 }
@@ -6,7 +11,13 @@ variable "availability_zones" {
   default = ""
 }
 
+
 variable "aws_ebs_csi_driver_version" {
+  type    = string
+  default = null
+}
+
+variable "build_ami_id" {
   type    = string
   default = null
 }

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -58,10 +58,12 @@ module "cluster" {
     aws = aws
   }
 
+  ami_id                          = var.ami_id
   arm_type                        = local.arm_type
   aws_ebs_csi_driver_version      = var.aws_ebs_csi_driver_version
   build_arm_type                  = local.build_arm_type
   availability_zones              = var.availability_zones
+  build_ami_id                    = var.build_ami_id
   build_node_enabled              = var.build_node_enabled
   build_node_min_count            = var.build_node_min_count
   build_node_type                 = var.build_node_type != "" ? var.build_node_type : var.node_type

--- a/terraform/system/aws/telemetry.tf
+++ b/terraform/system/aws/telemetry.tf
@@ -4,8 +4,10 @@
 locals {
   telemetry_map = {
     access_log_retention_in_days = var.access_log_retention_in_days
+    ami_id = var.ami_id
     availability_zones = var.availability_zones
     aws_ebs_csi_driver_version = var.aws_ebs_csi_driver_version
+    build_ami_id = var.build_ami_id
     build_disable_convox_resolver = var.build_disable_convox_resolver
     build_node_enabled = var.build_node_enabled
     build_node_min_count = var.build_node_min_count
@@ -77,8 +79,9 @@ locals {
 
   telemetry_default_map = {
     access_log_retention_in_days = "7"
+    ami_id = ""
     availability_zones = ""
-    aws_ebs_csi_driver_version = "v1.39.0-eksbuild.1"
+    build_ami_id = ""
     build_disable_convox_resolver = "false"
     build_node_enabled = "false"
     build_node_min_count = "0"

--- a/terraform/system/aws/telemetry.tf
+++ b/terraform/system/aws/telemetry.tf
@@ -81,6 +81,7 @@ locals {
     access_log_retention_in_days = "7"
     ami_id = ""
     availability_zones = ""
+    aws_ebs_csi_driver_version = "v1.39.0-eksbuild.1"
     build_ami_id = ""
     build_disable_convox_resolver = "false"
     build_node_enabled = "false"

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -2,6 +2,11 @@ variable "access_log_retention_in_days" {
   default = "7"
 }
 
+variable "ami_id" {
+  type    = string
+  default = null
+}
+
 variable "availability_zones" {
   default = ""
 }
@@ -9,6 +14,11 @@ variable "availability_zones" {
 variable "aws_ebs_csi_driver_version" {
   type    = string
   default = "v1.39.0-eksbuild.1"
+}
+
+variable "build_ami_id" {
+  type    = string
+  default = null
 }
 
 variable "build_disable_convox_resolver" {


### PR DESCRIPTION
### What is the feature/fix?

Adds support for custom AMI support on v3/EKS racks.  Also allows for distinct custom AMI support for the build node if needed.

**To use custom ami in build node you have to explicitly define the build node ami id. It won't use node ami id.**

### Does it has a breaking change?

No

### How to use/test it?

Specify the `ami_id` rack parameter with a valid AMI ID to use that as your base node image.
Optionally also specify a `build_ami_id` rack parameter with a valid AMI ID to further use that as the node image for your build node.

### Checklist
- [N/A] New coverage tests
- [N/A] Unit tests passing
- [x] E2E tests passing
- [ ] E2E downgrade/update test passing
- [x] Documentation updated
- [x] No warnings or errors on Deepsource/Codecov
