### PR TITLE
Add support for additional cluster node groups and build node group with advance configurations

### DIFF
--- a/pkg/cli/apps.go
+++ b/pkg/cli/apps.go
@@ -344,7 +344,7 @@ func AppsParamsSet(rack sdk.Interface, c *stdcli.Context) error {
 
 	for k, v := range opts.Parameters {
 		if a.Parameters[k] != v {
-			return fmt.Errorf("rollback")
+			return fmt.Errorf("failed to set params")
 		}
 	}
 

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -38,6 +38,7 @@ type Service struct {
 	InternalRouter     bool                  `yaml:"internalRouter,omitempty"`
 	IngressAnnotations Annotations           `yaml:"ingressAnnotations,omitempty"`
 	Labels             Labels                `yaml:"labels,omitempty"`
+	NodeSelectorLabels Labels                `yaml:"nodeSelectorLabels,omitempty"`
 	Lifecycle          ServiceLifecycle      `yaml:"lifecycle,omitempty"`
 	Port               ServicePortScheme     `yaml:"port,omitempty"`
 	Ports              []ServicePortProtocol `yaml:"ports,omitempty"`

--- a/pkg/manifest/validate.go
+++ b/pkg/manifest/validate.go
@@ -12,7 +12,7 @@ const (
 )
 
 var (
-	nameValidator = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
+	NameValidator = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
 )
 
 func (m *Manifest) validate() []error {
@@ -85,7 +85,7 @@ func (m *Manifest) validateResources() []error {
 	errs := []error{}
 
 	for _, r := range m.Resources {
-		if !nameValidator.MatchString(r.Name) {
+		if !NameValidator.MatchString(r.Name) {
 			errs = append(errs, fmt.Errorf("resource name %s invalid, %s", r.Name, ValidNameDescription))
 		}
 
@@ -106,7 +106,7 @@ func (m *Manifest) validateServices() []error {
 	}
 
 	for _, s := range m.Services {
-		if !nameValidator.MatchString(s.Name) {
+		if !NameValidator.MatchString(s.Name) {
 			errs = append(errs, fmt.Errorf("service name %s invalid, %s", s.Name, ValidNameDescription))
 		}
 
@@ -163,7 +163,7 @@ func (m *Manifest) validateTimers() []error {
 	errs := []error{}
 
 	for _, t := range m.Timers {
-		if !nameValidator.MatchString(t.Name) {
+		if !NameValidator.MatchString(t.Name) {
 			errs = append(errs, fmt.Errorf("timer name %s invalid, %s", t.Name, ValidNameDescription))
 		}
 

--- a/pkg/structs/app.go
+++ b/pkg/structs/app.go
@@ -1,5 +1,11 @@
 package structs
 
+const (
+	AppParamBuildLabels = "BuildLabels"
+	AppParamBuildCpu    = "BuildCpu"
+	AppParamBuildMem    = "BuildMem"
+)
+
 type App struct {
 	Generation string `json:"generation,omitempty"`
 	Locked     bool   `json:"locked"`

--- a/pkg/structs/process.go
+++ b/pkg/structs/process.go
@@ -50,6 +50,7 @@ type ProcessRunOptions struct {
 	Volumes     map[string]string `header:"Volumes"`
 	Width       *int              `header:"Width"`
 	Privileged  *bool             `header:"Privileged"`
+	NodeLabels  *string           `flag:"node-labels" header:"Node-Labels"`
 }
 
 func (p *Process) sortKey() string {

--- a/provider/k8s/build.go
+++ b/provider/k8s/build.go
@@ -104,7 +104,6 @@ func (p *Provider) BuildCreate(app, url string, opts structs.BuildCreateOptions)
 
 	psOpts := structs.ProcessRunOptions{
 		Command:     options.String(buildCmd),
-		Cpu:         options.Int(512),
 		Environment: env,
 	}
 

--- a/provider/k8s/build.go
+++ b/provider/k8s/build.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -36,7 +37,8 @@ func (*Provider) buildPrivileged(provider string) bool {
 }
 
 func (p *Provider) BuildCreate(app, url string, opts structs.BuildCreateOptions) (*structs.Build, error) {
-	if _, err := p.AppGet(app); err != nil {
+	appObj, err := p.AppGet(app)
+	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 
@@ -105,6 +107,27 @@ func (p *Provider) BuildCreate(app, url string, opts structs.BuildCreateOptions)
 		Cpu:         options.Int(512),
 		Environment: env,
 	}
+
+	if nlbs := appObj.Parameters[structs.AppParamBuildLabels]; nlbs != "" {
+		psOpts.NodeLabels = options.String(nlbs)
+	}
+
+	if cpu := appObj.Parameters[structs.AppParamBuildCpu]; cpu != "" {
+		v, err := strconv.ParseInt(cpu, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("invalid build cpu: %s, err: %s", cpu, err)
+		}
+		psOpts.Cpu = options.Int(int(v))
+	}
+
+	if mem := appObj.Parameters[structs.AppParamBuildMem]; mem != "" {
+		v, err := strconv.ParseInt(mem, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("invalid build mem: %s, err: %s", mem, err)
+		}
+		psOpts.Memory = options.Int(int(v))
+	}
+
 	if p.BuildkitEnabled == "true" {
 		psOpts.Image = options.String(p.buildImage(os.Getenv("PROVIDER")))
 		psOpts.Privileged = options.Bool(p.buildPrivileged(os.Getenv("PROVIDER")))

--- a/provider/k8s/process.go
+++ b/provider/k8s/process.go
@@ -345,13 +345,14 @@ func (p *Provider) ProcessRun(app, service string, opts structs.ProcessRunOption
 					},
 				},
 			}
-			s.Tolerations = []ac.Toleration{
-				{
-					Key:      "dedicated",
-					Operator: ac.TolerationOpExists,
-					Effect:   ac.TaintEffectNoSchedule,
-				},
-			}
+		}
+
+		s.Tolerations = []ac.Toleration{
+			{
+				Key:      "dedicated",
+				Operator: ac.TolerationOpExists,
+				Effect:   ac.TaintEffectNoSchedule,
+			},
 		}
 	}
 
@@ -603,6 +604,19 @@ func (p *Provider) podSpecFromRunOptions(app, service string, opts structs.Proce
 			s.Containers[0].Resources.Limits = ac.ResourceList{}
 		}
 		s.Containers[0].Resources.Limits["memory"] = resource.MustParse(fmt.Sprintf("%dMi", *opts.MemoryLimit))
+	}
+
+	if opts.NodeLabels != nil {
+		labelStrList := strings.Split(*opts.NodeLabels, ",")
+		for _, lb := range labelStrList {
+			parts := strings.SplitN(lb, "=", 2)
+			if len(parts) == 2 {
+				if s.NodeSelector == nil {
+					s.NodeSelector = map[string]string{}
+				}
+				s.NodeSelector[parts[0]] = parts[1]
+			}
+		}
 	}
 
 	if p.DockerUsername != "" && p.DockerPassword != "" {

--- a/provider/k8s/process.go
+++ b/provider/k8s/process.go
@@ -316,8 +316,6 @@ func (p *Provider) ProcessRun(app, service string, opts structs.ProcessRunOption
 	ans := map[string]string{}
 	if service == "build" {
 		for idx := 0; idx < len(s.Containers); idx++ {
-			// assign the build container a BestEffor QoS to avoid eating all compute resources
-			s.Containers[idx].Resources = ac.ResourceRequirements{}
 			s.Containers[idx].SecurityContext = &ac.SecurityContext{SeccompProfile: &ac.SeccompProfile{Type: ac.SeccompProfileTypeUnconfined}}
 			if opts.Privileged != nil && *opts.Privileged {
 				s.Containers[idx].SecurityContext.Privileged = options.Bool(true)

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -85,6 +85,29 @@ spec:
         {{.Key}}: "{{.Value}}"
         {{ end }}
     spec:
+      {{ if .Service.NodeSelectorLabels }}
+      nodeSelector:
+        {{ range keyValue .Service.NodeSelectorLabels }}
+        {{.Key}}: "{{.Value}}"
+        {{ end }}
+      {{ $hasTolerations := false }}
+      {{ range keyValue .Service.NodeSelectorLabels }}
+        {{ if eq .Key "convox.io/label" }}
+          {{ $hasTolerations = true }}
+        {{ end }}
+      {{ end }}
+      {{ if $hasTolerations }}
+      tolerations:
+        {{ range keyValue .Service.NodeSelectorLabels }}
+        {{ if eq .Key "convox.io/label" }}
+        - key: "dedicated-node"
+          operator: "Equal"
+          value: "{{.Value}}"
+          effect: "NoSchedule"
+        {{ end }}
+        {{ end }}
+      {{ end }}
+      {{ end }}
       {{ if or (.Resolver) (gt .Service.DnsConfig.Ndots 0) }}
       dnsPolicy: "None"
       dnsConfig:

--- a/provider/k8s/template/app/timer.yml.tmpl
+++ b/provider/k8s/template/app/timer.yml.tmpl
@@ -46,6 +46,12 @@ spec:
             {{.Key}}: "{{.Value}}"
             {{ end }}
         spec:
+          {{ if .Service.NodeSelectorLabels }}
+          nodeSelector:
+            {{ range keyValue .Service.NodeSelectorLabels }}
+            {{.Key}}: "{{.Value}}"
+            {{ end }}
+          {{ end }}
           {{ if or (.Resolver) (gt .Service.DnsConfig.Ndots 0) }}
           dnsPolicy: "None"
           dnsConfig:

--- a/terraform/api/aws/versions.tf
+++ b/terraform/api/aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "4.23.0"
+      version = "4.67.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -455,9 +455,18 @@ resource "aws_eks_addon" "aws_ebs_csi_driver" {
   addon_name    = "aws-ebs-csi-driver"
   addon_version = var.aws_ebs_csi_driver_version
   tags = {
-    "depends": module.ebs_csi_driver_controller.wait_for_it,
+    "depends" : module.ebs_csi_driver_controller.wait_for_it,
   }
+
   resolve_conflicts = "OVERWRITE"
+
+  configuration_values = jsonencode({
+    sidecars = {
+      snapshotter = {
+        forceEnable = false
+      }
+    }
+  })
 }
 
 resource "null_resource" "wait_eks_addons" {

--- a/terraform/cluster/aws/node_groups.tf
+++ b/terraform/cluster/aws/node_groups.tf
@@ -1,0 +1,303 @@
+
+locals {
+  launch_template_user_data_raw = var.user_data_url != "" || var.user_data != "" || var.kubelet_registry_pull_qps != 5 || var.kubelet_registry_burst != 10 ? templatefile("${path.module}/files/custom_user_data.sh", {
+    kubelet_registry_pull_qps = var.kubelet_registry_pull_qps
+    kubelet_registry_burst    = var.kubelet_registry_burst
+    user_data_script_file     = var.user_data_url != "" ? data.http.user_data_content[0].response_body : ""
+    user_data                 = var.user_data
+  }) : ""
+
+  kube_dns_ip = cidrhost(aws_eks_cluster.cluster.kubernetes_network_config[0].service_ipv4_cidr, 10)
+}
+
+resource "random_id" "additional_node_groups" {
+  byte_length = 8
+
+  count = length(var.additional_node_groups)
+
+  keepers = {
+    node_capacity_type  = var.additional_node_groups[count.index].capacity_type != null ? var.additional_node_groups[count.index].capacity_type : "ON_DEMAND"
+    node_disk           = var.additional_node_groups[count.index].disk != null ? var.additional_node_groups[count.index].disk : var.node_disk
+    node_type           = var.additional_node_groups[count.index].type
+    ami_id              = var.additional_node_groups[count.index].ami_id
+    private             = var.private
+    private_subnets_ids = join("-", local.private_subnets_ids)
+    public_subnets_ids  = join("-", local.public_subnets_ids)
+    role_arn            = replace(aws_iam_role.nodes.arn, "role/convox/", "role/") # eks barfs on roles with paths
+  }
+}
+
+module "amitype" {
+  source    = "../../helpers/aws"
+  for_each  = { for idx, ng in var.additional_node_groups : idx => ng }
+  node_type = each.value.type
+}
+
+resource "aws_eks_node_group" "cluster_additional" {
+  depends_on = [
+    aws_eks_cluster.cluster,
+    aws_iam_openid_connect_provider.cluster,
+  ]
+
+  count = length(var.additional_node_groups)
+
+  ami_type        = random_id.additional_node_groups[count.index].keepers.ami_id != null ? "CUSTOM" : module.amitype[count.index].ami_type
+  capacity_type   = random_id.additional_node_groups[count.index].keepers.node_capacity_type
+  cluster_name    = aws_eks_cluster.cluster.name
+  node_group_name = "${var.name}-additional-${count.index}-${random_id.additional_node_groups[count.index].hex}"
+  node_role_arn   = random_id.additional_node_groups[count.index].keepers.role_arn
+  subnet_ids      = var.private ? local.private_subnets_ids : local.public_subnets_ids
+  tags            = local.tags
+  version         = random_id.additional_node_groups[count.index].keepers.ami_id != null ? null : var.k8s_version
+
+  launch_template {
+    id      = aws_launch_template.cluster_additional[count.index].id
+    version = "$Latest"
+  }
+
+  scaling_config {
+    desired_size = var.additional_node_groups[count.index].desired_size != null ? var.additional_node_groups[count.index].desired_size : 1
+    min_size     = var.additional_node_groups[count.index].min_size != null ? var.additional_node_groups[count.index].min_size : 1
+    max_size     = var.additional_node_groups[count.index].max_size != null ? var.additional_node_groups[count.index].max_size : 100
+  }
+
+  dynamic "update_config" {
+    for_each = var.node_max_unavailable_percentage > 0 ? [var.node_max_unavailable_percentage] : []
+    content {
+      max_unavailable_percentage = var.node_max_unavailable_percentage
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+    ignore_changes        = [scaling_config[0].desired_size]
+  }
+
+  labels = {
+    "convox.io/label" = var.additional_node_groups[count.index].label != null ? var.additional_node_groups[count.index].label : "custom"
+  }
+
+  dynamic "taint" {
+    for_each = var.additional_node_groups[count.index].dedicated ? [1] : []
+    content {
+      key    = "dedicated-node"
+      value  = var.additional_node_groups[count.index].label != null ? var.additional_node_groups[count.index].label : "custom"
+      effect = "NO_SCHEDULE"
+    }
+  }
+
+  timeouts {
+    update = "2h"
+    delete = "1h"
+    create = "1h"
+  }
+}
+
+resource "aws_launch_template" "cluster_additional" {
+  count = length(var.additional_node_groups)
+
+  block_device_mappings {
+    device_name = "/dev/xvda"
+    ebs {
+      volume_type = "gp3"
+      volume_size = random_id.additional_node_groups[count.index].keepers.node_disk
+    }
+  }
+
+  metadata_options {
+    http_tokens                 = var.imds_http_tokens
+    http_put_response_hop_limit = var.imds_http_hop_limit
+    http_endpoint               = "enabled"
+    instance_metadata_tags      = var.imds_tags_enable ? "enabled" : "disabled"
+  }
+
+  instance_type = random_id.additional_node_groups[count.index].keepers.node_type
+
+  image_id = random_id.additional_node_groups[count.index].keepers.ami_id
+
+  dynamic "tag_specifications" {
+    for_each = toset(
+      concat(["instance", "volume", "network-interface", "spot-instances-request"],
+        var.gpu_tag_enable ? ["elastic-gpu"] : []
+    ))
+    content {
+      resource_type = tag_specifications.key
+      tags          = local.tags
+    }
+  }
+
+  user_data = random_id.additional_node_groups[count.index].keepers.ami_id == null ? null : base64encode(<<-EOF
+#!/bin/bash
+set -ex
+/etc/eks/bootstrap.sh ${aws_eks_cluster.cluster.name} \
+  --kubelet-extra-args '--node-labels=eks.amazonaws.com/nodegroup=${var.name}-additional-${count.index}-${random_id.additional_node_groups[count.index].hex}' \
+  --b64-cluster-ca ${aws_eks_cluster.cluster.certificate_authority[0].data} \
+  --apiserver-endpoint ${aws_eks_cluster.cluster.endpoint} --use-max-pods true --dns-cluster-ip ${local.kube_dns_ip}
+
+${local.launch_template_user_data_raw}
+EOF
+  )
+  key_name = var.key_pair_name != "" ? var.key_pair_name : null
+}
+
+resource "aws_autoscaling_group_tag" "cluster_additional" {
+  depends_on = [
+    aws_eks_node_group.cluster_additional
+  ]
+
+  count = length(var.additional_node_groups)
+
+  autoscaling_group_name = aws_eks_node_group.cluster_additional[count.index].resources[0].autoscaling_groups[0].name
+  tag {
+    key   = "k8s.io/cluster-autoscaler/node-template/label/convox.io/label"
+    value = var.additional_node_groups[count.index].label != null ? var.additional_node_groups[count.index].label : "custom"
+
+    propagate_at_launch = true
+  }
+}
+
+###### additional build node groups
+
+resource "random_id" "build_node_additional" {
+  count = length(var.additional_build_groups)
+
+  byte_length = 8
+
+  keepers = {
+    node_disk           = var.additional_build_groups[count.index].disk != null ? var.additional_build_groups[count.index].disk : var.node_disk
+    node_type           = var.additional_build_groups[count.index].type
+    ami_id              = var.additional_build_groups[count.index].ami_id
+    private_subnets_ids = join("-", local.private_subnets_ids)
+    role_arn            = replace(aws_iam_role.nodes.arn, "role/convox/", "role/") # eks barfs on roles with paths
+  }
+}
+
+module "build_amitype" {
+  source    = "../../helpers/aws"
+  for_each  = { for idx, ng in var.additional_build_groups : idx => ng }
+  node_type = each.value.type
+}
+
+
+resource "aws_eks_node_group" "build_additional" {
+  depends_on = [
+    aws_eks_cluster.cluster,
+    aws_iam_openid_connect_provider.cluster,
+  ]
+
+  count = length(var.additional_build_groups)
+
+  ami_type        = random_id.build_node_additional[count.index].keepers.ami_id != null ? "CUSTOM" : module.build_amitype[count.index].ami_type
+  capacity_type   = var.additional_build_groups[count.index].capacity_type != null ? var.additional_build_groups[count.index].capacity_type : "ON_DEMAND"
+  cluster_name    = aws_eks_cluster.cluster.name
+  node_group_name = "${var.name}-build-additional-${count.index}-${random_id.build_node_additional[count.index].hex}"
+  node_role_arn   = random_id.build_node_additional[count.index].keepers.role_arn
+  subnet_ids      = local.private_subnets_ids
+  tags            = local.tags
+  version         = random_id.build_node_additional[count.index].keepers.ami_id != null ? null : var.k8s_version
+
+  labels = {
+    "convox-build" : "true"
+    "convox.io/label" = var.additional_build_groups[count.index].label != null ? var.additional_build_groups[count.index].label : "custom-build"
+  }
+
+  taint {
+    key    = "dedicated"
+    value  = "build"
+    effect = "NO_SCHEDULE"
+  }
+
+  launch_template {
+    id      = aws_launch_template.build_additional[count.index].id
+    version = "$Latest"
+  }
+
+  scaling_config {
+    desired_size = var.additional_build_groups[count.index].desired_size != null ? var.additional_build_groups[count.index].desired_size : 0
+    min_size     = var.additional_build_groups[count.index].min_size != null ? var.additional_build_groups[count.index].min_size : 0
+    max_size     = var.additional_build_groups[count.index].max_size != null ? var.additional_build_groups[count.index].max_size : 100
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_launch_template" "build_additional" {
+  count = length(var.additional_build_groups)
+
+  block_device_mappings {
+    device_name = "/dev/xvda"
+    ebs {
+      volume_type = "gp3"
+      volume_size = random_id.build_node_additional[count.index].keepers.node_disk
+    }
+  }
+
+  instance_type = random_id.build_node_additional[count.index].keepers.node_type
+
+  image_id = random_id.build_node_additional[count.index].keepers.ami_id
+
+  metadata_options {
+    http_tokens                 = var.imds_http_tokens
+    http_put_response_hop_limit = var.imds_http_hop_limit
+    http_endpoint               = "enabled"
+    instance_metadata_tags      = var.imds_tags_enable ? "enabled" : "disabled"
+  }
+
+  user_data = random_id.build_node_additional[count.index].keepers.ami_id == null ? null : base64encode(<<-EOF
+#!/bin/bash
+set -ex
+/etc/eks/bootstrap.sh ${aws_eks_cluster.cluster.name} \
+  --kubelet-extra-args '--node-labels=eks.amazonaws.com/nodegroup=${var.name}-build-additional-${count.index}-${random_id.build_node_additional[count.index].hex}' \
+  --b64-cluster-ca ${aws_eks_cluster.cluster.certificate_authority[0].data} \
+  --apiserver-endpoint ${aws_eks_cluster.cluster.endpoint} --use-max-pods true --dns-cluster-ip ${local.kube_dns_ip}
+EOF
+  )
+
+  dynamic "tag_specifications" {
+    for_each = toset(
+      concat(["instance", "volume", "network-interface", "spot-instances-request"],
+        var.gpu_tag_enable ? ["elastic-gpu"] : []
+    ))
+    content {
+      resource_type = tag_specifications.key
+      tags          = local.tags
+    }
+  }
+
+  key_name = var.key_pair_name != "" ? var.key_pair_name : null
+}
+
+resource "aws_autoscaling_group_tag" "build_additional" {
+  depends_on = [
+    aws_eks_node_group.build_additional
+  ]
+
+  count = var.build_node_enabled ? length(var.additional_build_groups) : 0
+
+  autoscaling_group_name = aws_eks_node_group.build_additional[count.index].resources[0].autoscaling_groups[0].name
+
+  tag {
+    key   = "k8s.io/cluster-autoscaler/node-template/label/convox-build"
+    value = "true"
+
+    propagate_at_launch = true
+  }
+}
+
+resource "aws_autoscaling_group_tag" "build_additional_custom" {
+  depends_on = [
+    aws_eks_node_group.build_additional
+  ]
+
+  count = length(var.additional_build_groups)
+
+  autoscaling_group_name = aws_eks_node_group.build_additional[count.index].resources[0].autoscaling_groups[0].name
+  tag {
+    key   = "k8s.io/cluster-autoscaler/node-template/label/convox.io/label"
+    value = var.additional_build_groups[count.index].label != null ? var.additional_build_groups[count.index].label : "custom-build"
+
+    propagate_at_launch = true
+  }
+}

--- a/terraform/cluster/aws/variables.tf
+++ b/terraform/cluster/aws/variables.tf
@@ -1,3 +1,32 @@
+variable "additional_node_groups" {
+  type = list(object({
+    type          = string
+    disk          = optional(number)
+    capacity_type = optional(string)
+    min_size      = optional(number)
+    desired_size  = optional(number)
+    max_size      = optional(number)
+    label         = optional(string)
+    ami_id        = optional(string)
+    dedicated     = optional(bool, false)
+  }))
+  default = []
+}
+
+variable "additional_build_groups" {
+  type = list(object({
+    type          = string
+    disk          = optional(number)
+    capacity_type = optional(string)
+    min_size      = optional(number)
+    desired_size  = optional(number)
+    max_size      = optional(number)
+    label         = optional(string)
+    ami_id        = optional(string)
+  }))
+  default = []
+}
+
 variable "arm_type" {
   default = false
 }

--- a/terraform/cluster/aws/versions.tf
+++ b/terraform/cluster/aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "4.23.0"
+      version = "4.67.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/terraform/fluentd/aws/versions.tf
+++ b/terraform/fluentd/aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "4.23.0"
+      version = "4.67.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/terraform/helpers/aws/main.tf
+++ b/terraform/helpers/aws/main.tf
@@ -1,0 +1,12 @@
+locals {
+  gpu_type = substr(var.node_type, 0, 1) == "g" || substr(var.node_type, 0, 1) == "p" || substr(var.node_type, 0, 3) == "inf" || substr(var.node_type, 0, 3) == "trn"
+  arm_type = substr(var.node_type, 0, 2) == "a1" || substr(var.node_type, 0, 5) == "hpc7g" || substr(var.node_type, 0, 4) == "im4g" || substr(var.node_type, 0, 4) == "is4g" || substr(var.node_type, 2, 1) == "g"
+}
+
+variable "node_type" {
+  type = string
+}
+
+output "ami_type" {
+  value = local.gpu_type ? "AL2_x86_64_GPU" : local.arm_type ? "AL2_ARM_64" : "AL2_x86_64"
+}

--- a/terraform/rack/aws/versions.tf
+++ b/terraform/rack/aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "4.23.0"
+      version = "4.67.0"
     }
     external = {
       source  = "hashicorp/external"

--- a/terraform/resolver/aws/versions.tf
+++ b/terraform/resolver/aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "4.23.0"
+      version = "4.67.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/terraform/resolver/k8s/main.tf
+++ b/terraform/resolver/k8s/main.tf
@@ -4,7 +4,7 @@ resource "kubernetes_cluster_role" "resolver" {
   }
 
   rule {
-    api_groups = ["extensions"]
+    api_groups = ["extensions", "networking.k8s.io"]
     resources  = ["ingresses"]
     verbs      = ["get", "list", "watch"]
   }

--- a/terraform/router/aws/versions.tf
+++ b/terraform/router/aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "4.23.0"
+      version = "4.67.0"
     }
     http = {
       source  = "hashicorp/http"

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -49,6 +49,9 @@ locals {
     for v in split(",", var.tags) :
     "${split("=", v)[0]}" => split("=", v)[1]
   }
+
+  additional_node_groups  = var.additional_node_groups_config != "" ? (startswith(var.additional_node_groups_config, "[") ? jsondecode(var.additional_node_groups_config) : jsondecode(base64decode(var.additional_node_groups_config))): []
+  additional_build_groups = var.additional_build_groups_config != "" ? (startswith(var.additional_build_groups_config, "[") ? jsondecode(var.additional_build_groups_config) : jsondecode(base64decode(var.additional_build_groups_config))): []
 }
 
 module "cluster" {
@@ -58,6 +61,8 @@ module "cluster" {
     aws = aws
   }
 
+  additional_node_groups          = local.additional_node_groups
+  additional_build_groups         = local.additional_build_groups
   arm_type                        = local.arm_type
   aws_ebs_csi_driver_version      = var.aws_ebs_csi_driver_version
   build_arm_type                  = local.build_arm_type

--- a/terraform/system/aws/telemetry.tf
+++ b/terraform/system/aws/telemetry.tf
@@ -4,6 +4,8 @@
 locals {
   telemetry_map = {
     access_log_retention_in_days = var.access_log_retention_in_days
+    additional_build_groups_config = var.additional_build_groups_config
+    additional_node_groups_config = var.additional_node_groups_config
     availability_zones = var.availability_zones
     aws_ebs_csi_driver_version = var.aws_ebs_csi_driver_version
     build_disable_convox_resolver = var.build_disable_convox_resolver
@@ -77,6 +79,8 @@ locals {
 
   telemetry_default_map = {
     access_log_retention_in_days = "7"
+    additional_build_groups_config = ""
+    additional_node_groups_config = ""
     availability_zones = ""
     aws_ebs_csi_driver_version = "v1.39.0-eksbuild.1"
     build_disable_convox_resolver = "false"

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -2,6 +2,16 @@ variable "access_log_retention_in_days" {
   default = "7"
 }
 
+variable "additional_node_groups_config" {
+  type    = string
+  default = ""
+}
+
+variable "additional_build_groups_config" {
+  type    = string
+  default = ""
+}
+
 variable "availability_zones" {
   default = ""
 }
@@ -155,12 +165,12 @@ variable "kube_proxy_version" {
 }
 
 variable "kubelet_registry_pull_qps" {
-  type = number
+  type    = number
   default = 5
 }
 
 variable "kubelet_registry_burst" {
-  type = number
+  type    = number
   default = 10
 }
 

--- a/terraform/system/aws/versions.tf
+++ b/terraform/system/aws/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "4.23.0"
+      version = "4.67.0"
     }
     http = {
       source  = "hashicorp/http"


### PR DESCRIPTION
### What is the feature/update/fix?
**Feature: Enhanced Node Group Configuration Support**
This update adds advanced configuration options for Kubernetes node groups, allowing for more customized infrastructure:

1. **Additional Cluster Node Groups** – Configure multiple specialized node groups with custom settings using `additional_node_groups_config`
2. **Build-Specific Node Groups** – Define dedicated node groups for build processes using `additional_build_groups_config`
3. **Node Selector Support** – Target specific services to run on particular node groups

### Why is this important?
- **Workload Optimization:**
  - Run different workloads on appropriately sized instances for better cost efficiency
  - Use spot instances for non-critical or batch workloads while keeping critical services on on-demand instances
- **Resource Isolation:**
  - Separate build processes from production workloads
  - Dedicate specialized instances to specific applications or services
- **Infrastructure Flexibility:**
  - Customize disk sizes, instance types, and scaling parameters per workload type
  - Apply custom node labels for targeted scheduling

---
### **Configuration Parameters**
Each node group configuration supports the following fields:

| Field | Required | Description | Default |
|-------|----------|-------------|---------|
| `type` | Yes | EC2 instance type for the node group | - |
| `disk` | No | Disk size in GB for the nodes | Same as main node disk |
| `capacity_type` | No | Instance purchasing option (`ON_DEMAND` or `SPOT`) | `ON_DEMAND` |
| `min_size` | No | Minimum number of nodes | 1 |
| `desired_size` | No | Desired number of nodes | 1 |
| `max_size` | No | Maximum number of nodes | 100 |
| `label` | No | Custom label value for the node group (applied as `convox.io/label: <label-value>`) | None |
| `ami_id`* | No | Custom AMI ID to use | EKS-optimized AMI |
| `dedicated` | No | When `true`, only services with matching node group labels will be scheduled on these nodes (only applies to `additional_node_groups_config`) | `false` |

\* **Important**: Custom AMI configuration should be used with extreme caution. AMIs in EKS clusters have strict compatibility requirements, and improper configuration can lead to cluster update failures requiring manual intervention. Only use custom AMIs if you have specific compatibility requirements and thoroughly understand EKS node bootstrapping processes. We recommend testing in a non-production environment before implementation.

---
### **1. Configuring Additional Node Groups**
You can define node groups using JSON format:

```json
[
  {
    "type": "t3.medium",
    "disk": 50,
    "capacity_type": "ON_DEMAND",
    "min_size": 1,
    "desired_size": 2,
    "max_size": 3,
    "label": "app-workers"
  },
  {
    "type": "m5.large",
    "disk": 100,
    "capacity_type": "SPOT",
    "min_size": 2,
    "desired_size": 3,
    "max_size": 5,
    "label": "batch-workers",
    "ami_id": "ami-0123456789abcdef0"
  }
]
```

#### **Applying Configuration**
**Recommended Method:** Using a JSON file (must have `.json` extension):
```
convox rack params set additional_node_groups_config=/path/to/node-config.json
```

**Alternative:** Providing raw JSON directly:
```
convox rack params set 'additional_node_groups_config=[{"type":"t3.medium","disk":50,"capacity_type":"ON_DEMAND","min_size":1,"desired_size":1,"max_size":3,"label":"app-workers"}]'
```

---
### **2. Service Node Selection**
You can specify which node groups should run specific services by adding node selector labels to your `convox.yml`:

```yaml
services:
  web:
    nodeSelectorLabels:
      convox.io/label: app-workers
```

---
### **3. Build Pod Configuration**
#### **Node Selection for Build Pods**
Specify which nodes should run your build processes:
```
convox apps params set BuildLabels=convox.io/label=app-build -a <app>
```
> **Warning**: Specifying incorrect labels may cause application build failures.

#### **Resource Requirements for Build Pods**
You can also specify CPU and memory requirements for application builds:
```
convox apps params set BuildCpu=256 BuildMem=128 -a <app-name>
```

---
### Does it have a breaking change?
No breaking changes are introduced with this update.

### Requirements
To use this update, you must be on at least version `3.20.1` for both the CLI and the rack.

**Update the CLI**: Run `convox update` to update your CLI to the latest version. You can verify your CLI version with `convox version`.

For a minor version update, you must manually update your rack with the command `convox rack update 3.20.1 -r rackName`.  
**_You must be on at least rack version `3.19.0` to perform this update._**

If you are already on minor version `3.20.x`, you can simply run `convox rack update -r rackName`.

*If you are unfamiliar with v3 rack versioning, we advise checking the documentation [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) for more information before applying any updates.*