### PR TITLE
Add support for additional node groups id and tags

### DIFF
--- a/pkg/cli/env.go
+++ b/pkg/cli/env.go
@@ -52,7 +52,7 @@ func init() {
 			flagRack,
 			stdcli.BoolFlag("replace", "", "replace all environment variables with given ones"),
 			stdcli.BoolFlag("promote", "p", "promote the release"),
-			stdcli.StringFlag("parent-release", "", "id of the parent release"),
+			stdcli.StringFlag("release", "", "id of the release"),
 		},
 		Usage: "<key=value> [key=value]...",
 	})
@@ -202,13 +202,13 @@ func EnvSet(rack sdk.Interface, c *stdcli.Context) error {
 		c.Writer().Stdout = c.Writer().Stderr
 	}
 
-	parentReleaseId := c.String("parent-release")
+	releaseId := c.String("release")
 
 	env := structs.Environment{}
 	var err error
 
 	if !c.Bool("replace") {
-		env, err = getEnvHelper(rack, app(c), parentReleaseId)
+		env, err = getEnvHelper(rack, app(c), releaseId)
 		if err != nil {
 			return err
 		}
@@ -251,7 +251,7 @@ func EnvSet(rack sdk.Interface, c *stdcli.Context) error {
 	} else {
 		r, err = rack.ReleaseCreate(app(c), structs.ReleaseCreateOptions{
 			Env:           options.String(env.String()),
-			ParentRelease: options.StringOrNil(parentReleaseId),
+			ParentRelease: options.StringOrNil(releaseId),
 		})
 		if err != nil {
 			return err

--- a/pkg/common/string.go
+++ b/pkg/common/string.go
@@ -35,3 +35,12 @@ func UpperName(name string) string {
 
 	return us
 }
+
+func ContainsInStringSlice(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -166,6 +166,15 @@ resource "aws_eks_node_group" "cluster" {
   }
 }
 
+module "asg_tags_cluster" {
+  source    = "../../helpers/aws-asg-tag"
+
+  count = var.high_availability ? 3 : 1
+
+  asg_name = aws_eks_node_group.cluster[count.index].resources[0].autoscaling_groups[0].name
+  asg_tags = local.tags
+}
+
 resource "aws_eks_node_group" "cluster-build" {
   depends_on = [
     aws_eks_cluster.cluster,
@@ -208,6 +217,15 @@ resource "aws_eks_node_group" "cluster-build" {
   lifecycle {
     create_before_destroy = true
   }
+}
+
+module "asg_tags_build" {
+  source    = "../../helpers/aws-asg-tag"
+
+  count = var.build_node_enabled ? 1 : 0
+
+  asg_name = aws_eks_node_group.cluster-build[0].resources[0].autoscaling_groups[0].name
+  asg_tags = local.tags
 }
 
 resource "aws_autoscaling_group_tag" "cluster-build" {

--- a/terraform/helpers/aws-asg-tag/main.tf
+++ b/terraform/helpers/aws-asg-tag/main.tf
@@ -1,0 +1,24 @@
+variable "asg_name" {
+  type = string
+}
+
+variable "asg_tags" {
+  type = map(string)
+}
+
+variable "propagate_at_launch" {
+  type = bool
+  default = true
+}
+
+resource "aws_autoscaling_group_tag" "cluster_additional" {
+  for_each = var.asg_tags
+  
+  autoscaling_group_name = var.asg_name
+  
+  tag {
+    key                 = each.key
+    value               = each.value
+    propagate_at_launch = var.propagate_at_launch
+  }
+}

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -161,7 +161,7 @@ variable "key_pair_name" {
 // https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html
 variable "kube_proxy_version" {
   type    = string
-  default = "v1.31.2-eksbuild.3"
+  default = "v1.31.3-eksbuild.2"
 }
 
 variable "kubelet_registry_pull_qps" {


### PR DESCRIPTION
### What is the feature/fix?

Add support for additional node groups id and tags

**cli version must be >= 3.21.1**
```
[
    {
      "id": 2,
      "type": "t3.medium",
      "disk": 50,
      "capacity_type": "ON_DEMAND",
      "min_size": 1,
      "max_size": 3,
      "label": "app-workers",
      "tags": "custom=tag2"
    },
    {
      "id": 11,
      "type": "t3.small",
      "disk": 100,
      "capacity_type": "ON_DEMAND",
      "min_size": 1,
      "max_size": 5,
      "label": "oneoff-workers",
      "tags": "custom=tag13,custom2=tag14"
    }
]

```