### PR TITLE
Allow nvidia daemon to run on dedicated node groups

### DIFF
--- a/terraform/cluster/aws/nvidia.tf
+++ b/terraform/cluster/aws/nvidia.tf
@@ -30,6 +30,22 @@ resource "helm_release" "nvidia_device_plugin" {
           }
         }
       }
+      tolerations = [
+        {
+          key      = "CriticalAddonsOnly"
+          operator = "Exists"
+        },
+        {
+          key      = "nvidia.com/gpu"
+          operator = "Exists"
+          effect   = "NoSchedule"
+        },
+        {
+          key      = "dedicated-node"
+          operator = "Exists"
+          effect   = "NoSchedule"
+        }
+      ]
     })
   ]
 }


### PR DESCRIPTION
### What is the feature/fix?

Fixes #885 

### How to use/test it?

On a 3.21.1 or higher rack, enable the nvidia device plugin via the rack parameter:
`convox rack params set nvidia_device_plugin_enable=true`

Use the `additional_node_groups_config` rack parameter to configure a node group which has `dedicated` set to `true` and uses a GPU instance type and a minimum size greater than 0.

Observe how the nvidia daemon will not run on those nodes created for that node group, and therefore processes which require a GPU are not schedulable on that node group.

Now patch the daemonset to update the tolerations to allow this as per the PR, and observe the daemon will now run on the GPU nodes and therefore allow processes to be scheduled on to it.

### Checklist
- [N/A] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [N/A] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
