### PR TITLE
Added support to provide gpu flag with convox run command and fixed liveness check

### DIFF
--- a/pkg/structs/process.go
+++ b/pkg/structs/process.go
@@ -42,6 +42,7 @@ type ProcessRunOptions struct {
 	Cpu         *int              `flag:"cpu" header:"Cpu"`
 	CpuLimit    *int              `flag:"cpu-limit" header:"Cpu-Limit"`
 	Environment map[string]string `header:"Environment"`
+	Gpu         *int              `flag:"gpu" header:"Gpu"`
 	Height      *int              `header:"Height"`
 	Image       *string           `header:"Image"`
 	Memory      *int              `flag:"memory" header:"Memory"`

--- a/provider/k8s/process.go
+++ b/provider/k8s/process.go
@@ -593,6 +593,14 @@ func (p *Provider) podSpecFromRunOptions(app, service string, opts structs.Proce
 		s.Containers[0].Resources.Limits["cpu"] = resource.MustParse(fmt.Sprintf("%dm", *opts.CpuLimit))
 	}
 
+	if opts.Gpu != nil {
+		s.Containers[0].Resources.Requests["nvidia.com/gpu"] = resource.MustParse(fmt.Sprintf("%d", *opts.Gpu))
+		if s.Containers[0].Resources.Limits == nil {
+			s.Containers[0].Resources.Limits = ac.ResourceList{}
+		}
+		s.Containers[0].Resources.Limits["nvidia.com/gpu"] = resource.MustParse(fmt.Sprintf("%d", *opts.Gpu))
+	}
+
 	if opts.Memory != nil {
 		s.Containers[0].Resources.Requests["memory"] = resource.MustParse(fmt.Sprintf("%dMi", *opts.Memory))
 	}

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -219,7 +219,7 @@ spec:
         startupProbe:
           {{ if not (eq $.Service.StartupProbe.Path "")}}
           httpGet:
-            path: {{$.Service.StartupProbe.Path}}"
+            path: "{{$.Service.StartupProbe.Path}}"
             port: {{.}}
           {{ end }}
           {{ if not (eq $.Service.StartupProbe.TcpSocketPort "")}}
@@ -235,7 +235,7 @@ spec:
         {{ if and (not (eq $.Service.Port.Scheme "GRPC")) (not (eq $.Service.Liveness.Path ""))}}
         livenessProbe:
           httpGet:
-            path: {{$.Service.Liveness.Path}}"
+            path: "{{$.Service.Liveness.Path}}"
             port: {{.}}
           initialDelaySeconds: {{$.Service.Liveness.Grace}}
           periodSeconds: {{$.Service.Liveness.Interval}}


### PR DESCRIPTION
### What is the feature/fix?

- fixed liveness probe
- Added support to provide gpu flag for convox run command
```
convox run web sh -a <app> --gpu 1
```