### PR TITLE
Add option to create release using the build from one release and the environment from another

### DIFF
--- a/pkg/structs/process.go
+++ b/pkg/structs/process.go
@@ -38,20 +38,21 @@ type ProcessListOptions struct {
 }
 
 type ProcessRunOptions struct {
-	Command     *string           `header:"Command"`
-	Cpu         *int              `flag:"cpu" header:"Cpu"`
-	CpuLimit    *int              `flag:"cpu-limit" header:"Cpu-Limit"`
-	Environment map[string]string `header:"Environment"`
-	Gpu         *int              `flag:"gpu" header:"Gpu"`
-	Height      *int              `header:"Height"`
-	Image       *string           `header:"Image"`
-	Memory      *int              `flag:"memory" header:"Memory"`
-	MemoryLimit *int              `flag:"memory-limit" header:"Memory-Limit"`
-	Release     *string           `flag:"release" header:"Release"`
-	Volumes     map[string]string `header:"Volumes"`
-	Width       *int              `header:"Width"`
-	Privileged  *bool             `header:"Privileged"`
-	NodeLabels  *string           `flag:"node-labels" header:"Node-Labels"`
+	Command        *string           `header:"Command"`
+	Cpu            *int              `flag:"cpu" header:"Cpu"`
+	CpuLimit       *int              `flag:"cpu-limit" header:"Cpu-Limit"`
+	Environment    map[string]string `header:"Environment"`
+	Gpu            *int              `flag:"gpu" header:"Gpu"`
+	Height         *int              `header:"Height"`
+	Image          *string           `header:"Image"`
+	Memory         *int              `flag:"memory" header:"Memory"`
+	MemoryLimit    *int              `flag:"memory-limit" header:"Memory-Limit"`
+	Release        *string           `flag:"release" header:"Release"`
+	Volumes        map[string]string `header:"Volumes"`
+	Width          *int              `header:"Width"`
+	Privileged     *bool             `header:"Privileged"`
+	NodeLabels     *string           `flag:"node-labels" header:"Node-Labels"`
+	SystemCritical *bool             `flag:"system-critical" header:"System-Critical"`
 }
 
 func (p *Process) sortKey() string {

--- a/pkg/structs/release.go
+++ b/pkg/structs/release.go
@@ -23,6 +23,14 @@ type ReleaseCreateOptions struct {
 	ParentRelease *string `param:"parent-release"`
 }
 
+type ReleaseCreateFromOptions struct {
+	BuildFrom             *string `flag:"build-from"`
+	EnvFrom               *string `flag:"env-from"`
+	UseActiveReleaseBuild *bool   `flag:"use-active-release-build"`
+	UseActiveReleaseEnv   *bool   `flag:"use-active-release-env"`
+	Promote               *bool   `flag:"promote"`
+}
+
 type ReleaseListOptions struct {
 	Limit *int `flag:"limit,l" query:"limit"`
 }

--- a/provider/k8s/process.go
+++ b/provider/k8s/process.go
@@ -354,6 +354,10 @@ func (p *Provider) ProcessRun(app, service string, opts structs.ProcessRunOption
 		}
 	}
 
+	if opts.SystemCritical != nil && *opts.SystemCritical {
+		s.PriorityClassName = "system-node-critical"
+	}
+
 	pod := &ac.Pod{
 		ObjectMeta: am.ObjectMeta{
 			Annotations:  ans,


### PR DESCRIPTION
This will create release create release using the build from one release and the environment from another
```
convox releases create-from --build-from=REOTXPGRDNR --env-from RRMZIRZLEYM -a <app> --promote
```

Flags

```
  --app app                    -a app 
  --build-from                                 
  --env-from                                   
  --promote                                               
  --rack rack                  -r rack
  --use-active-release-build                              
  --use-active-release-env  
```
