### PR TITLE
Add rack param to disable convox resolver for services

### DIFF
--- a/provider/k8s/resolver.go
+++ b/provider/k8s/resolver.go
@@ -1,5 +1,10 @@
 package k8s
 
+import "fmt"
+
 func (p *Provider) ResolverHost() (string, error) {
+	if p.Resolver == "" {
+		return "", fmt.Errorf("resolver host not set")
+	}
 	return p.Resolver, nil
 }

--- a/terraform/api/aws/main.tf
+++ b/terraform/api/aws/main.tf
@@ -49,7 +49,7 @@ module "k8s" {
     BUILD_DISABLE_CONVOX_RESOLVER        = var.build_disable_convox_resolver
     PDB_DEFAULT_MIN_AVAILABLE_PERCENTAGE = var.pdb_default_min_available_percentage
     PROVIDER                             = "aws"
-    RESOLVER                             = var.resolver
+    RESOLVER                             = var.disable_convox_resolver ? "" : var.resolver
     ROUTER                               = var.router
     SOCKET                               = "/var/run/docker.sock"
     ECR_SCAN_ON_PUSH_ENABLE              = var.ecr_scan_on_push_enable

--- a/terraform/api/aws/variables.tf
+++ b/terraform/api/aws/variables.tf
@@ -43,6 +43,11 @@ variable "domain_internal" {
   type = string
 }
 
+variable "disable_convox_resolver" {
+  type    = bool
+  default = false
+}
+
 variable "disable_image_manifest_cache" {
   type    = bool
   default = false

--- a/terraform/rack/aws/main.tf
+++ b/terraform/rack/aws/main.tf
@@ -47,6 +47,7 @@ module "api" {
   oidc_sub                             = var.oidc_sub
   pdb_default_min_available_percentage = var.pdb_default_min_available_percentage
   release                              = var.release
+  disable_convox_resolver              = var.disable_convox_resolver
   resolver                             = module.resolver.endpoint
   router                               = module.router.endpoint
   subnets                              = var.subnets

--- a/terraform/rack/aws/variables.tf
+++ b/terraform/rack/aws/variables.tf
@@ -38,6 +38,11 @@ variable "docker_hub_password" {
   default = ""
 }
 
+variable "disable_convox_resolver" {
+  type    = bool
+  default = false
+}
+
 variable "disable_image_manifest_cache" {
   type    = bool
   default = false

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -164,6 +164,7 @@ module "rack" {
   deploy_extra_nlb                     = var.deploy_extra_nlb
   docker_hub_username                  = var.docker_hub_username
   docker_hub_password                  = var.docker_hub_password
+  disable_convox_resolver              = var.disable_convox_resolver
   disable_image_manifest_cache         = var.disable_image_manifest_cache
   eks_addons                           = module.cluster.eks_addons
   efs_csi_driver_enable                = var.efs_csi_driver_enable

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -81,6 +81,11 @@ variable "fluentd_disable" {
   default = false
 }
 
+variable "disable_convox_resolver" {
+  type    = bool
+  default = false
+}
+
 variable "disable_image_manifest_cache" {
   type    = bool
   default = false


### PR DESCRIPTION
Use following rack param to disable convox resolver.

```
convox rack params set disable_convox_resolver=true
```
