### PR TITLE
Add support for node ebs encryption

### DIFF
--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -292,6 +292,7 @@ resource "aws_launch_template" "cluster" {
     ebs {
       volume_type = "gp3"
       volume_size = random_id.node_group.keepers.node_disk
+      encrypted   = var.ebs_volume_encryption_enabled
     }
   }
 
@@ -331,6 +332,7 @@ resource "aws_launch_template" "cluster-build" {
     ebs {
       volume_type = "gp3"
       volume_size = random_id.node_group.keepers.node_disk
+      encrypted   = var.ebs_volume_encryption_enabled
     }
   }
 

--- a/terraform/cluster/aws/node_groups.tf
+++ b/terraform/cluster/aws/node_groups.tf
@@ -140,6 +140,7 @@ resource "aws_launch_template" "cluster_additional" {
     ebs {
       volume_type = "gp3"
       volume_size = random_id.additional_node_groups[each.key].keepers.node_disk
+      encrypted   = var.ebs_volume_encryption_enabled
     }
   }
 
@@ -268,6 +269,7 @@ resource "aws_launch_template" "build_additional" {
     ebs {
       volume_type = "gp3"
       volume_size = random_id.build_node_additional[each.key].keepers.node_disk
+      encrypted   = var.ebs_volume_encryption_enabled
     }
   }
 

--- a/terraform/cluster/aws/variables.tf
+++ b/terraform/cluster/aws/variables.tf
@@ -66,6 +66,11 @@ variable "efs_csi_driver_version" {
   default = "v2.0.1-eksbuild.1"
 }
 
+variable "ebs_volume_encryption_enabled" {
+  type    = bool
+  default = false
+}
+
 variable "gpu_type" {
   default = false
 }

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -73,6 +73,7 @@ module "cluster" {
   cidr                                = var.cidr
   coredns_version                     = var.coredns_version
   disable_public_access               = var.disable_public_access
+  ebs_volume_encryption_enabled       = var.ebs_volume_encryption_enabled
   efs_csi_driver_enable               = var.efs_csi_driver_enable
   efs_csi_driver_version              = var.efs_csi_driver_version
   gpu_type                            = local.gpu_type

--- a/terraform/system/aws/telemetry.tf
+++ b/terraform/system/aws/telemetry.tf
@@ -23,6 +23,7 @@ locals {
     disable_public_access = var.disable_public_access
     docker_hub_password = var.docker_hub_password
     docker_hub_username = var.docker_hub_username
+    ebs_volume_encryption_enabled = var.ebs_volume_encryption_enabled
     ecr_scan_on_push_enable = var.ecr_scan_on_push_enable
     efs_csi_driver_enable = var.efs_csi_driver_enable
     efs_csi_driver_version = var.efs_csi_driver_version
@@ -101,6 +102,7 @@ locals {
     disable_public_access = "false"
     docker_hub_password = ""
     docker_hub_username = ""
+    ebs_volume_encryption_enabled = "false"
     ecr_scan_on_push_enable = "false"
     efs_csi_driver_enable = "false"
     efs_csi_driver_version = "v2.1.6-eksbuild.1"

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -101,6 +101,11 @@ variable "ecr_scan_on_push_enable" {
   default = false
 }
 
+variable "ebs_volume_encryption_enabled" {
+  type    = bool
+  default = false
+}
+
 variable "efs_csi_driver_enable" {
   type    = bool
   default = false


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: Added EBS Volume Encryption for EKS Cluster Node Disks**

This update introduces a new rack parameter `ebs_volume_encryption_enabled` that allows users to enable encryption for EBS volumes used by the primary node disks in the rack's EKS cluster. This provides an additional layer of security for data at rest on your Kubernetes worker nodes.

---

### Why is this important?

- **Enhanced Security**: Encrypts data at rest on EKS worker node disks, meeting compliance and security requirements.
- **Simple Configuration**: Easy to enable with a single rack parameter setting.
- **Flexible Deployment**: Can be enabled on existing racks or configured during initial rack setup.
- **AWS Best Practices**: Aligns with AWS security recommendations for encrypting EBS volumes.

Many organizations require encryption of data at rest to meet compliance standards such as HIPAA, PCI DSS, or SOC 2. This feature ensures that all data stored on your EKS worker node disks is automatically encrypted using AWS-managed encryption keys, providing peace of mind without impacting application performance.

#### **How to Enable EBS Volume Encryption**
```
$ convox rack params set ebs_volume_encryption_enabled=true -r rackName
```

**Note**: This parameter defaults to `false`. Once enabled, existing nodes will be converted and new nodes will automatically be provisioned with encrypted EBS volumes.

---

### Does it have a breaking change?

No breaking changes are introduced with this update. The feature is disabled by default, requires explicit activation, and can be deactivated at any time.

---

### Requirements

To use this update, you must be on at least rack version `3.21.5`.

For a minor version update, you must state the version with the command `convox rack update 3.21.5 -r rackName`.  
**_You must be on at least rack version `3.20.0` to perform this update._**

If you are already on minor version `3.21.x`, you can simply run `convox rack update -r rackName`.

_If you are unfamiliar with v3 rack versioning, we advise checking the documentation [Updating a Rack](https://docs.convox.com/management/cli-rack-management/)_