### PR TITLE
Add support to expose BUILD_ related env

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -121,11 +121,22 @@ do
   sleep 1
 done
 
-echo "app is updating will cancel in 10 secs"
-sleep 10
+echo "app is updating will cancel in 3 secs"
+sleep 3
 
-convox apps cancel -a httpd | grep "OK"
-echo "app deployment canceled"
+for i in {1..30}; do
+  if convox apps cancel -a httpd | grep "OK"; then
+    echo "app deployment canceled"
+    break
+  else
+    echo "cancel attempt $i failed, retrying..."
+    sleep 1
+  fi
+  if [ $i -eq 30 ]; then
+    echo "Failed to cancel app deployment after 20 attempts"
+    exit 1
+  fi
+done
 
 endpoint=$(convox api get /apps/httpd/services | jq -r '.[] | select(.name == "web") | .domain')
 fetch https://$endpoint | grep "It works"

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -106,6 +106,8 @@ func execute() error {
 		flagUrl = v
 	}
 
+	// BUILD_GIT_SHA is exposed as env as well
+
 	opts := build.Options{
 		App:         flagApp,
 		Auth:        flagAuth,

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -87,6 +87,12 @@ func (bb *Build) buildEnvs() (map[string]string, error) {
 	for _, v := range bb.BuildArgs {
 		parts := strings.SplitN(v, "=", 2)
 		if len(parts) != 2 {
+			if len(parts) == 1 {
+				if os.Getenv(parts[0]) != "" {
+					env[parts[0]] = os.Getenv(parts[0])
+				}
+				continue
+			}
 			return env, fmt.Errorf("invalid build args: %s", v)
 		}
 		env[parts[0]] = parts[1]

--- a/provider/k8s/build.go
+++ b/provider/k8s/build.go
@@ -79,6 +79,7 @@ func (p *Provider) BuildCreate(app, url string, opts structs.BuildCreateOptions)
 		"BUILD_MANIFEST":               common.DefaultString(opts.Manifest, "convox.yml"),
 		"BUILD_RACK":                   p.Name,
 		"BUILD_URL":                    url,
+		"BUILD_GIT_SHA":                b.GitSha,
 		"BUILDKIT_ENABLED":             p.BuildkitEnabled,
 		"PROVIDER":                     os.Getenv("PROVIDER"),
 		"DISABLE_IMAGE_MANIFEST_CACHE": os.Getenv("DISABLE_IMAGE_MANIFEST_CACHE"),
@@ -95,7 +96,7 @@ func (p *Provider) BuildCreate(app, url string, opts structs.BuildCreateOptions)
 	buildCmd := fmt.Sprintf("build -method tgz -cache %t", cache)
 	if opts.BuildArgs != nil {
 		for _, v := range *opts.BuildArgs {
-			if len(strings.SplitN(v, "=", 2)) != 2 {
+			if len(strings.SplitN(v, "=", 2)) > 2 {
 				return nil, errors.New("invalid build args:" + v)
 			}
 			buildCmd = fmt.Sprintf("%s -build-args %s", buildCmd, v)


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: Support for BUILD_ Environment Variables During Build Time**

This update introduces support for exposing Convox-managed build arguments during the Docker build phase, allowing applications to access critical build context information at build time. This feature supports both Convox-managed build args and custom build arguments.

**Convox-Managed Build Arguments Available:**
- `BUILD_APP` – The application name
- `BUILD_AUTH` – Docker registry authentication credentials
- `BUILD_DEVELOPMENT` – Development environment flag
- `BUILD_GENERATION` – Build generation identifier
- `BUILD_ID` – Unique build identifier
- `BUILD_MANIFEST` – Build manifest information
- `BUILD_RACK` – Rack name
- `BUILD_GIT_SHA` – Git commit SHA for the build

---

### Why is this important?

- **Enhanced Build Context:**
  - Provides applications with build-time awareness of their deployment context
  - Enables conditional build logic based on environment or rack
  - Allows embedding of build metadata directly into compiled artifacts

- **Version Tracking:**
  - `BUILD_GIT_SHA` enables automatic version stamping in your application
  - `BUILD_ID` provides unique build traceability
  - Simplifies debugging by linking deployed code to specific builds

- **Flexible Configuration:**
  - Supports both Convox-managed and custom build arguments
  - Integrates seamlessly with CI/CD workflows
  - Maintains compatibility with standard Docker build arg patterns

- **Registry Authentication:**
  - `BUILD_AUTH` provides automatic registry authentication during builds
  - Enables pulling private base images without manual credential management

---

### **Using Build Arguments with CLI**

To inject Convox-managed build args during build:
```
$ convox build --build-args=BUILD_APP --build-args=BUILD_ID --build-args=BUILD_GIT_SHA
```

You can combine Convox-managed args with custom build arguments:
```
$ convox build --build-args=BUILD_APP --build-args=FOO=BAR --build-args=VERSION=1.2.3
```

### **Using Build Arguments with CI/CD Workflows**

When using Convox Deployment and Review Workflows:
1. Navigate to your workflow configuration modal
2. Check the "Make Convox Managed Build Args Available" checkbox to include all Convox-managed build arguments
3. Use the custom build args input field to add your own arguments (e.g., `FOO=BAR,VERSION=1.2.3`)

### **Dockerfile Configuration**

**Critical:** Your Dockerfile must declare each ARG that you want to use. Build arguments will not be available unless explicitly declared:

```dockerfile
# Declare Convox-managed args
ARG BUILD_APP
ARG BUILD_ID
ARG BUILD_GIT_SHA
ARG BUILD_RACK

# Declare custom args
ARG FOO
ARG VERSION

# Use the args in your build
RUN echo "Building app: ${BUILD_APP} with version: ${BUILD_GIT_SHA}"

# Pass args to runtime environment if needed
ENV APP_VERSION=${BUILD_GIT_SHA}
ENV APP_NAME=${BUILD_APP}
```

### **Security Consideration**

⚠️ **Warning:** The `BUILD_AUTH` argument contains sensitive Docker registry authentication credentials including usernames and passwords/tokens. This data should never be:
- Logged or printed during builds
- Embedded in final images
- Exposed in build output

Example of `BUILD_AUTH` content (contains sensitive data):
```
BUILD_AUTH: {"registry.url":{"Username":"AWS","Password":"[base64-encoded-token]"}}
```

Only use `BUILD_AUTH` when necessary for authenticating to private registries, and ensure it is not persisted in your final image layers.

---

### Does it have a breaking change?

**Yes, this update contains a breaking change.** This feature is bundled with Kubernetes infrastructure updates in version 3.22.0. Due to Kubernetes versioning constraints, **this update cannot be rolled back once applied**.

**Important:** We strongly recommend testing this update in a staging environment before applying to production racks. Please ensure you have recent backups of your applications and data before proceeding with the update.

---

### Requirements

To use this update, you must be on at least version `3.22.0` for both the CLI and the rack.

**Update the CLI**: Run `convox update` to update your CLI to the latest version. You can verify your CLI version with `convox version`.

For a minor version update, you must state the version during with the command `convox rack update 3.22.0 -r rackName`.  
**_You must be on at least rack version `3.21.0` to perform this update._**

_If you are unfamiliar with v3 rack versioning, we advise checking the documentation [Updating a Rack](https://docs.convox.com/management/cli-rack-management/)_