### PR TITLE
Allow for more flexibile instance selection in node groups

### DIFF
--- a/docs/configuration/rack-parameters/aws/additional_node_groups_config.md
+++ b/docs/configuration/rack-parameters/aws/additional_node_groups_config.md
@@ -26,7 +26,10 @@ The `additional_node_groups_config` parameter takes a JSON array of node group c
 
 | Field | Required | Description | Default |
 |-------|----------|-------------|---------|
-| `type` | Yes | The EC2 instance type to use for the node group |  |
+| `type` | Yes (or set the `cpu` and `mem` fields) | The EC2 instance type to use for the node group |  |
+| `cpu` | Yes (or set the `type` field) | The minimum number of vCPUs required from the node |  |
+| `mem` | Yes (or set the `type` field) | The minimum mib of memory required from the node |  |
+| `types` | No (but can use in conjunection with the `cpu` and `mem` fields) | List of instance types to apply your specified `cpu` and `mem` attributes against. All other instance types are ignored, even if they match your specified attributes. You can use strings with one or more wild cards, represented by an asterisk (*), to allow an instance type, size, or generation. |  |
 | `disk` | No | The disk size in GB for the nodes | Same as main node disk |
 | `capacity_type` | No | Whether to use on-demand or spot instances | `ON_DEMAND` |
 | `min_size` | No | Minimum number of nodes | 1 |
@@ -82,6 +85,40 @@ The JSON file should be structured as follows:
 $ convox rack params set 'additional_node_groups_config=[{"id":101,"type":"t3.medium","disk":50,"capacity_type":"ON_DEMAND","min_size":1,"max_size":3,"label":"app-workers","tags":"environment=production,team=backend"}]' -r rackName
 Setting parameters... OK
 ```
+
+## Using `cpu`, `mem` and `types` to allow for more flexibility
+
+To allow for more instance type choice within one node group, instead of specifying a single type, you are able to specify minimum `cpu` and `mem` requirements, and optionally provide a list of instance types to match those against.
+
+```json
+[
+  {
+    "id": 101,
+    "cpu": 4,
+    "mem": 8192,
+    "types": "c3.xlarge, c4.xlarge, c5.xlarge, c5d.xlarge, c5a.xlarge, c5n.xlarge",
+    "disk": 50,
+    "capacity_type": "ON_DEMAND",
+    "min_size": 1,
+    "max_size": 3,
+    "label": "compute-xlarge"
+  },
+  {
+    "id": 102,
+    "cpu": 16,
+    "mem": 16384,
+    "types": "*.4xlarge, *.8xlarge",
+    "disk": 100,
+    "capacity_type": "SPOT",
+    "min_size": 2,
+    "max_size": 5,
+    "label": "4xlarge"
+  }
+]
+```
+
+Our first node group (`101`) would use any instance that has at least 4 vCPU and 8GiB of memory that also matches one of the specific types listed.  Our second node group (`102`) would use any instance that has at least 16 vCPU, 16GiB of memory and can be from any family of instance as long as it is a 4xlarge size or an 8xlarge size.
+The following are further examples: `m5.8xlarge, c5*.*, m5a.*, r*, *3*.` For example, if you specify `c5*`, you are allowing the entire C5 instance family, which includes all C5a and C5n instance types. If you specify `m5a.*`, you are allowing all the M5a instance types, but not the M5n instance types.
 
 ## Node Group Identification and Tagging
 

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -126,7 +126,10 @@ func init() {
 
 type NodeGroupConfigParam struct {
 	Id           *int    `json:"id"`
-	Type         string  `json:"type"`
+	Type         *string `json:"type,omitempty"`
+	Types        *string `json:"types,omitempty"`
+	Cpu          *int    `json:"cpu,omitempty"`
+	Mem          *int    `json:"mem,omitempty"`
 	Disk         *int    `json:"disk,omitempty"`
 	CapacityType *string `json:"capacity_type,omitempty"`
 	MinSize      *int    `json:"min_size,omitempty"`
@@ -138,8 +141,11 @@ type NodeGroupConfigParam struct {
 }
 
 func (n *NodeGroupConfigParam) Validate() error {
-	if n.Type == "" {
-		return fmt.Errorf("node type is required: '%s'", n.Type)
+	if ((n.Cpu == nil || n.Mem == nil) && n.Type == nil) {
+		return fmt.Errorf("One of 'type' or 'cpu & mem' is required")
+	}
+	if (n.Type != nil && (n.Cpu != nil || n.Mem != nil)) {
+		return fmt.Errorf("Can't specify 'type' along with 'cpu' or 'mem'")
 	}
 	if n.Disk != nil && *n.Disk < 20 {
 		return fmt.Errorf("node disk is less than 20: '%d'", *n.Disk)

--- a/terraform/cluster/aws/node_groups.tf
+++ b/terraform/cluster/aws/node_groups.tf
@@ -13,6 +13,9 @@ locals {
     for idx, ng in var.additional_node_groups : {
       id            = tonumber(lookup(ng, "id", idx))
       type          = lookup(ng, "type", null)
+      types         = lookup(ng, "types", null)
+      cpu           = tonumber(lookup(ng, "cpu", 0))
+      mem           = tonumber(lookup(ng, "mem", 0))
       disk          = tonumber(lookup(ng, "disk", var.node_disk))
       capacity_type = lookup(ng, "capacity_type", "ON_DEMAND")
       min_size      = tonumber(lookup(ng, "min_size", 1))
@@ -32,6 +35,9 @@ locals {
     for idx, ng in var.additional_build_groups : {
       id            = tonumber(lookup(ng, "id", idx))
       type          = lookup(ng, "type", null)
+      types         = lookup(ng, "types", null)
+      cpu           = tonumber(lookup(ng, "cpu", 0))
+      mem           = tonumber(lookup(ng, "mem", 0))
       disk          = tonumber(lookup(ng, "disk", var.node_disk))
       capacity_type = lookup(ng, "capacity_type", "ON_DEMAND")
       min_size      = tonumber(lookup(ng, "min_size", 0))
@@ -56,7 +62,10 @@ resource "random_id" "additional_node_groups" {
     id                  = each.value.id
     node_capacity_type  = each.value.capacity_type != null ? each.value.capacity_type : "ON_DEMAND"
     node_disk           = each.value.disk != null ? each.value.disk : var.node_disk
-    node_type           = each.value.type
+    node_type           = each.value.typ
+    types               = each.value.types
+    cpu                 = each.value.cpu
+    mem                 = each.value.mem
     ami_id              = each.value.ami_id
     private             = var.private
     private_subnets_ids = join("-", local.private_subnets_ids)
@@ -151,7 +160,16 @@ resource "aws_launch_template" "cluster_additional" {
     instance_metadata_tags      = var.imds_tags_enable ? "enabled" : "disabled"
   }
 
-  instance_type = random_id.additional_node_groups[each.key].keepers.node_type
+  dynamic "instance_requirements" {
+    for_each = random_id.additional_node_groups[each.key].keepers.cpu > 0 && random_id.additional_node_groups[each.key].keepers.mem > 0 ? [1] : []
+    content {
+      vcpu_count { min = random_id.additional_node_groups[each.key].keepers.cpu }
+      memory_mib { min = random_id.additional_node_groups[each.key].keepers.mem }
+      allowed_instance_types = random_id.additional_node_groups[each.key].keepers.types != null ? random_id.additional_node_groups[each.key].keepers.types : [random_id.additional_node_groups[each.key].keepers.node_type]
+    }
+  }
+
+  instance_type = random_id.additional_node_groups[each.key].keepers.cpu > 0 && random_id.additional_node_groups[each.key].keepers.mem > 0 ? null : random_id.additional_node_groups[each.key].keepers.node_type
 
   image_id = random_id.additional_node_groups[each.key].keepers.ami_id
 
@@ -202,6 +220,9 @@ resource "random_id" "build_node_additional" {
     id                  = each.value.id
     node_disk           = each.value.disk != null ? each.value.disk : var.node_disk
     node_type           = each.value.type
+    types               = each.value.types
+    cpu                 = each.value.cpu
+    mem                 = each.value.mem
     capacity_type       = each.value.capacity_type
     ami_id              = each.value.ami_id
     private_subnets_ids = join("-", local.private_subnets_ids)
@@ -273,7 +294,16 @@ resource "aws_launch_template" "build_additional" {
     }
   }
 
-  instance_type = random_id.build_node_additional[each.key].keepers.node_type
+  dynamic "instance_requirements" {
+    for_each = random_id.build_node_additional[each.key].keepers.cpu > 0 && random_id.build_node_additional[each.key].keepers.mem > 0 ? [1] : []
+    content {
+      vcpu_count { min = random_id.build_node_additional[each.key].keepers.cpu }
+      memory_mib { min = random_id.build_node_additional[each.key].keepers.mem }
+      allowed_instance_types = random_id.build_node_additional[each.key].keepers.types != null ? random_id.build_node_additional[each.key].keepers.types : [random_id.build_node_additional[each.key].keepers.node_type]
+    }
+  }
+
+  instance_type = random_id.build_node_additional[each.key].keepers.cpu > 0 && random_id.build_node_additional[each.key].keepers.mem > 0 ? null : random_id.build_node_additional[each.key].keepers.node_type
 
   image_id = random_id.build_node_additional[each.key].keepers.ami_id
 


### PR DESCRIPTION
### What is the feature/fix?

This allows for more flexible instance selection in additional node groups and additional build groups by utilising the "instance requirements" feature of launch templates rather than specific instance type.
In the node groups config json, `type` is now optional, but you should specify either that or both the `cpu` and `mem` fields.  That will determine which type of launch template is created.
If `cpu` and `mem` fields are set to define the minimum cpu and memory requirements of the instance, you are also able to specify the `types` field to set the "allowed instance types" configuration within the instance requirements block to further limit the instance types desired if required.

### Does it has a breaking change?

No.  Existing configurations will work just fine.

### How to use/test it?

See examples specified in the documentation changes.

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [x] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
