### PR TITLE
Add Affinities to give better placement flexibility

### DIFF
--- a/docs/configuration/workload-placement.md
+++ b/docs/configuration/workload-placement.md
@@ -177,6 +177,41 @@ services:
       convox.io/label: batch-workers
 ```
 
+You can also specify nodeAffinityLabels with weights to specify preferences of where to place services:
+
+```yaml
+services:
+  web:
+    nodeAffinityLabels:
+      - Weight: 1
+        Label: node.kubernetes.io/instance-type
+        Value: t3a.medium
+      - Weight: 10
+        Label: node.kubernetes.io/instance-type
+        Value: t3a.large
+```
+
+Weights will be summed for all matching labels and the node with the highest weight will have the service scheduled on it.
+
+You can combine the two options as well:
+
+```yaml
+services:
+  web:
+    nodeSelectorLabels:
+      convox.io/label: app-workers
+    nodeAffinityLabels:
+      - Weight: 1
+        Label: node.kubernetes.io/instance-type
+        Value: t3a.medium
+      - Weight: 10
+        Label: node.kubernetes.io/instance-type
+        Value: t3a.large
+```
+
+In this case, the service will definitely be scheduled on the `app-workers` group, preferably on a `t3a.large` instance, or if not on a `t3a.medium` instance, or if not, then any other instance in the group.
+
+
 ## Implementation Examples
 
 ### Optimizing for Cost and Performance

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -38,6 +38,7 @@ type Service struct {
 	InternalRouter     bool                  `yaml:"internalRouter,omitempty"`
 	IngressAnnotations Annotations           `yaml:"ingressAnnotations,omitempty"`
 	Labels             Labels                `yaml:"labels,omitempty"`
+	NodeAffinityLabels Affinities            `yaml:"nodeAffinityLabels,omitempty"`
 	NodeSelectorLabels Labels                `yaml:"nodeSelectorLabels,omitempty"`
 	Lifecycle          ServiceLifecycle      `yaml:"lifecycle,omitempty"`
 	Port               ServicePortScheme     `yaml:"port,omitempty"`
@@ -55,6 +56,14 @@ type Service struct {
 	VolumeOptions      []VolumeOption        `yaml:"volumeOptions,omitempty"`
 	Whitelist          string                `yaml:"whitelist,omitempty"`
 	AccessControl      AccessControlOptions  `yaml:"accessControl,omitempty"`
+}
+
+type Affinities []Affinity
+
+type Affinity struct {
+	Label  string `yaml:"label"`
+	Weight int    `yaml:"weight"`
+	Value  string `yaml:"value"`
 }
 
 type Annotations []Annotation

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -85,11 +85,30 @@ spec:
         {{.Key}}: "{{.Value}}"
         {{ end }}
     spec:
-      {{ if .Service.NodeSelectorLabels }}
-      nodeSelector:
-        {{ range keyValue .Service.NodeSelectorLabels }}
-        {{.Key}}: "{{.Value}}"
-        {{ end }}
+      {{ if or (.Service.NodeSelectorLabels) (.Service.NodeAffinityLabels) }}
+      affinity:
+        nodeAffinity:
+          {{ if .Service.NodeSelectorLabels }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              {{ range keyValue .Service.NodeSelectorLabels }}
+              - key: {{ .Key }}
+                operator: In
+                values:
+                - {{ .Value }}
+              {{ end }}
+          {{ if .Service.NodeAffinityLabels }}
+          preferredDuringSchedulingIgnoredDuringExecution:
+          {{ range .Service.NodeAffinityLabels }}
+          - weight: {{ .Weight }}
+            preference:
+              matchExpressions:
+              - key: {{ .Label }}
+                operator: In
+                values:
+                - {{ .Value }}
+          {{ end }}
       {{ $hasTolerations := false }}
       {{ range keyValue .Service.NodeSelectorLabels }}
         {{ if eq .Key "convox.io/label" }}


### PR DESCRIPTION
### What is the feature/fix?

This PR adds nodeAffinityLabels support to allow for better preferences when scheduled services onto nodes.  It maintains support for nodeSelectorLabels through the use of the `requiredDuringSchedulingIgnoredDuringExecution` config which functions the same, just with a more expressive syntax.

Affinities have a weight associated with them to allow for preferences to be stated.  

### Does it has a breaking change?

No, nodeSelectorLabels should still function the same.

### How to use/test it?

** Describe how to test or use the feature **

### Checklist
- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [x] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov
