### PR TITLE
Fix timer placement for alternate node groups

### DIFF
--- a/provider/k8s/template/app/timer.yml.tmpl
+++ b/provider/k8s/template/app/timer.yml.tmpl
@@ -51,6 +51,23 @@ spec:
             {{ range keyValue .Service.NodeSelectorLabels }}
             {{.Key}}: "{{.Value}}"
             {{ end }}
+          {{ $hasTolerations := false }}
+          {{ range keyValue .Service.NodeSelectorLabels }}
+            {{ if eq .Key "convox.io/label" }}
+              {{ $hasTolerations = true }}
+            {{ end }}
+          {{ end }}
+          {{ if $hasTolerations }}
+          tolerations:
+            {{ range keyValue .Service.NodeSelectorLabels }}
+            {{ if eq .Key "convox.io/label" }}
+            - key: "dedicated-node"
+              operator: "Equal"
+              value: "{{.Value}}"
+              effect: "NoSchedule"
+            {{ end }}
+            {{ end }}
+          {{ end }}
           {{ end }}
           {{ if or (.Resolver) (gt .Service.DnsConfig.Ndots 0) }}
           dnsPolicy: "None"


### PR DESCRIPTION
### What is the feature/update/fix?

**Fix: Timer Placement for Alternate Node Groups**

We have fixed an issue where timers configured to run on alternate node groups were incorrectly being scheduled on standard rack nodes. This fix ensures that timers now properly respect node selector labels and are scheduled on the designated node groups as specified in your configuration.

Previously, even when a timer's service was configured with `nodeSelectorLabels` to target specific node groups created via `additional_node_groups_config`, the timer pods would still run on the default nodes. This has been corrected to honor the node placement configuration.

---

### Why is this important?

- **Resource Optimization**: Ensures timers run on appropriately sized or configured nodes, preventing resource contention on standard nodes
- **Cost Management**: Allows timers to run on spot instances or specialized node groups, reducing operational costs
- **Workload Isolation**: Maintains proper separation between different workload types as intended by your infrastructure design
- **Consistent Behavior**: Timers now behave consistently with other services regarding node placement rules

This fix is particularly important for organizations using custom node groups to:
- Run batch jobs on cost-effective spot instances
- Isolate periodic tasks from production workloads
- Utilize nodes with specific resource profiles for timer-based operations

---

### Does it have a breaking change?

**No breaking changes** are introduced with this update. 

However, after updating, timers that were previously running on standard nodes will begin scheduling on their configured alternate node groups. Ensure that:
- Your alternate node groups have sufficient capacity for timer workloads
- The node groups specified in your timer service configurations exist and are properly labeled
- Any dependencies or resources needed by timers are accessible from the alternate node groups

---

### Requirements

To use this fix, you must be on at least version `3.22.3`.

For a minor version update, you must state the version with the command `convox rack update 3.22.3 -r rackName`.  
**_You must be on at least rack version `3.21.0` to perform this update._**

_If you are unfamiliar with v3 rack versioning, we advise checking the documentation [Updating a Rack](https://docs.convox.com/management/cli-rack-management/)_