### PR TITLE
Add options to use service volumes

### DIFF
--- a/pkg/structs/process.go
+++ b/pkg/structs/process.go
@@ -38,21 +38,22 @@ type ProcessListOptions struct {
 }
 
 type ProcessRunOptions struct {
-	Command        *string           `header:"Command"`
-	Cpu            *int              `flag:"cpu" header:"Cpu"`
-	CpuLimit       *int              `flag:"cpu-limit" header:"Cpu-Limit"`
-	Environment    map[string]string `header:"Environment"`
-	Gpu            *int              `flag:"gpu" header:"Gpu"`
-	Height         *int              `header:"Height"`
-	Image          *string           `header:"Image"`
-	Memory         *int              `flag:"memory" header:"Memory"`
-	MemoryLimit    *int              `flag:"memory-limit" header:"Memory-Limit"`
-	Release        *string           `flag:"release" header:"Release"`
-	Volumes        map[string]string `header:"Volumes"`
-	Width          *int              `header:"Width"`
-	Privileged     *bool             `header:"Privileged"`
-	NodeLabels     *string           `flag:"node-labels" header:"Node-Labels"`
-	SystemCritical *bool             `flag:"system-critical" header:"System-Critical"`
+	Command          *string           `header:"Command"`
+	Cpu              *int              `flag:"cpu" header:"Cpu"`
+	CpuLimit         *int              `flag:"cpu-limit" header:"Cpu-Limit"`
+	Environment      map[string]string `header:"Environment"`
+	Gpu              *int              `flag:"gpu" header:"Gpu"`
+	Height           *int              `header:"Height"`
+	Image            *string           `header:"Image"`
+	Memory           *int              `flag:"memory" header:"Memory"`
+	MemoryLimit      *int              `flag:"memory-limit" header:"Memory-Limit"`
+	Release          *string           `flag:"release" header:"Release"`
+	Volumes          map[string]string `header:"Volumes"`
+	UseServiceVolume *bool             `flag:"use-service-volume" header:"Use-Service-Volume"`
+	Width            *int              `header:"Width"`
+	Privileged       *bool             `header:"Privileged"`
+	NodeLabels       *string           `flag:"node-labels" header:"Node-Labels"`
+	SystemCritical   *bool             `flag:"system-critical" header:"System-Critical"`
 }
 
 func (p *Process) sortKey() string {

--- a/provider/k8s/service.go
+++ b/provider/k8s/service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/convox/convox/pkg/manifest"
 	"github.com/convox/convox/pkg/structs"
 	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	resource "k8s.io/apimachinery/pkg/api/resource"
 	am "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -214,6 +215,16 @@ func (p *Provider) ServiceUpdate(app, name string, opts structs.ServiceUpdateOpt
 	}
 
 	return nil
+}
+
+func (p *Provider) serviceDaemonset(app, name string) (*appsv1.DaemonSet, error) {
+	ds := p.Cluster.AppsV1().DaemonSets(p.AppNamespace(app))
+	return ds.Get(context.TODO(), name, am.GetOptions{})
+}
+
+func (p *Provider) serviceDeployment(app, name string) (*appsv1.Deployment, error) {
+	ds := p.Cluster.AppsV1().Deployments(p.AppNamespace(app))
+	return ds.Get(context.TODO(), name, am.GetOptions{})
 }
 
 func serviceContainerPorts(c v1.Container, internal bool) []structs.ServicePort {


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: Service Volume Support for `convox run` Command**

We have added support for attaching service volumes when using the `convox run` command. This feature introduces a new `--use-service-volume` flag that automatically maps all volumes configured for a service to the run pod, ensuring that one-off processes have access to the same persistent storage as their parent service.

This resolves an issue where services scaled to zero that were executed with `convox run` would not properly attach to configured volumes, particularly EFS volumes. Now, when you run a one-off command with the `--use-service-volume` flag, the pod will inherit all volume configurations from the service definition.

**Usage Example:**
```
$ convox run web sh -a myapp --use-service-volume
```

---

### Why is this important?

- **Data Consistency**: One-off processes can now access the same persistent volumes as regular service processes, ensuring data consistency across all operations
- **Maintenance Operations**: Enables running maintenance scripts, migrations, or data manipulation tasks with full access to persistent storage
- **Debugging Capabilities**: Allows developers to inspect and troubleshoot volume-mounted data through interactive shells
- **Zero-Scale Services**: Fixes the critical issue where services scaled to zero couldn't access their configured volumes when run as one-off processes

This feature is particularly valuable for:
- Running database migrations that need access to shared configuration files
- Executing batch jobs that process data stored on EFS volumes
- Debugging production issues by inspecting persistent volume contents
- Managing content in shared storage across multiple service instances

---

### Does it have a breaking change?

**No breaking changes** are introduced with this update. 

The feature is opt-in through the `--use-service-volume` flag. Existing `convox run` commands will continue to work as before without volume attachments unless the new flag is explicitly added.

---

### Requirements

To use this feature, you must be on at least version `3.22.3` for both the CLI and the rack.

**Update the CLI**: Run `convox update` to update your CLI to the latest version. You can verify your CLI version with `convox version`.

For a minor version update, you must state the version with the command `convox rack update 3.22.3 -r rackName`.  
**_You must be on at least rack version `3.21.0` to perform this update._**

_If you are unfamiliar with v3 rack versioning, we advise checking the documentation [Updating a Rack](https://docs.convox.com/management/cli-rack-management/)_