### PR TITLE
Add option to clean old releases

### DIFF
--- a/pkg/mock/engine.go
+++ b/pkg/mock/engine.go
@@ -78,3 +78,7 @@ func (*TestEngine) SystemStatus() (string, error) {
 func (*TestEngine) GPUIntanceList(instanceTypes []string) ([]string, error) {
 	return nil, nil
 }
+
+func (*TestEngine) RepositoryImagesBatchDelete(app string, tags []string) error {
+	return nil
+}

--- a/provider/aws/repository.go
+++ b/provider/aws/repository.go
@@ -1,6 +1,11 @@
 package aws
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	ecrTypes "github.com/aws/aws-sdk-go/service/ecr"
+)
 
 func (p *Provider) RepositoryAuth(app string) (string, string, error) {
 	host, _, err := p.RepositoryHost(app)
@@ -22,4 +27,20 @@ func (p *Provider) RepositoryHost(app string) (string, bool, error) {
 
 func (p *Provider) RepositoryPrefix() string {
 	return fmt.Sprintf("%s/", p.Name)
+}
+
+func (p *Provider) RepositoryImagesBatchDelete(app string, tags []string) error {
+	imageIds := []*ecrTypes.ImageIdentifier{}
+
+	for _, tag := range tags {
+		imageIds = append(imageIds, &ecrTypes.ImageIdentifier{ImageTag: aws.String(tag)})
+	}
+
+	repo := aws.String(fmt.Sprintf("%s%s", p.RepositoryPrefix(), app))
+	_, err := p.ECR.BatchDeleteImage(&ecrTypes.BatchDeleteImageInput{
+		RepositoryName: repo,
+		ImageIds:       imageIds,
+	})
+
+	return err
 }

--- a/provider/azure/repository.go
+++ b/provider/azure/repository.go
@@ -15,3 +15,7 @@ func (p *Provider) RepositoryHost(app string) (string, bool, error) {
 func (p *Provider) RepositoryPrefix() string {
 	return ""
 }
+
+func (p *Provider) RepositoryImagesBatchDelete(app string, tags []string) error {
+	return fmt.Errorf("not implemented")
+}

--- a/provider/do/repository.go
+++ b/provider/do/repository.go
@@ -13,3 +13,7 @@ func (p *Provider) RepositoryHost(app string) (string, bool, error) {
 func (p *Provider) RepositoryPrefix() string {
 	return ""
 }
+
+func (p *Provider) RepositoryImagesBatchDelete(app string, tags []string) error {
+	return fmt.Errorf("not implemented")
+}

--- a/provider/gcp/repository.go
+++ b/provider/gcp/repository.go
@@ -15,3 +15,7 @@ func (p *Provider) RepositoryHost(app string) (string, bool, error) {
 func (p *Provider) RepositoryPrefix() string {
 	return ""
 }
+
+func (p *Provider) RepositoryImagesBatchDelete(app string, tags []string) error {
+	return fmt.Errorf("not implemented")
+}

--- a/provider/k8s/app.go
+++ b/provider/k8s/app.go
@@ -299,6 +299,9 @@ func (p *Provider) appFromNamespace(ns ac.Namespace) (*structs.App, error) {
 		Release:    release,
 		Router:     p.Router,
 		Status:     status,
+		Tags: map[string]string{
+			"namespace": ns.Name,
+		},
 	}
 
 	var params map[string]string
@@ -355,6 +358,9 @@ func (p *Provider) appFromNamespaceOnly(ns ac.Namespace) (*structs.App, error) {
 		Release:    ns.Annotations["convox.com/app-release"],
 		Router:     p.Router,
 		Status:     status,
+		Tags: map[string]string{
+			"namespace": ns.Name,
+		},
 	}
 
 	var params map[string]string

--- a/provider/k8s/engine.go
+++ b/provider/k8s/engine.go
@@ -21,6 +21,7 @@ type Engine interface {
 	RepositoryHost(app string) (string, bool, error)
 	RepositoryPrefix() string
 	ResolverHost() (string, error)
+	RepositoryImagesBatchDelete(app string, tags []string) error
 	ServiceHost(app string, s manifest.Service) string
 	SystemHost() string
 	SystemStatus() (string, error)

--- a/provider/k8s/k8s.go
+++ b/provider/k8s/k8s.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
+	"strconv"
 	"time"
 
 	"github.com/convox/convox/pkg/atom"
@@ -45,43 +46,45 @@ const (
 )
 
 type Provider struct {
-	Atom                             atom.Interface
-	BuildkitEnabled                  string
-	BuildNodeEnabled                 string
-	CertManager                      bool
-	CertManagerRoleArn               string
-	Cluster                          kubernetes.Interface
-	Config                           *rest.Config
-	Convox                           cv.Interface
-	ConvoxDomainTLSCertDisable       bool
-	CertManagerClient                cmclient.Interface
-	DiscoveryClient                  discovery.DiscoveryInterface
-	DockerUsername                   string
-	DockerPassword                   string
-	Domain                           string
-	DomainInternal                   string
-	DynamicClient                    dynamic.Interface
-	EfsFileSystemId                  string
-	Engine                           Engine
-	Image                            string
-	JwtMngr                          *jwt.JwtManager
-	Name                             string
-	MetricScraper                    *MetricScraperClient
-	MetricsClient                    metricsclientset.Interface
-	Namespace                        string
-	Password                         string
-	PdbDefaultMinAvailablePercentage string
-	Provider                         string
-	RackName                         string
-	Resolver                         string
-	BuildDisableResolver             bool
-	RestClient                       rest.Interface
-	Router                           string
-	Socket                           string
-	Storage                          string
-	SubnetIDs                        string
-	Version                          string
-	VpcID                            string
+	Atom                                atom.Interface
+	BuildkitEnabled                     string
+	BuildNodeEnabled                    string
+	CertManager                         bool
+	CertManagerRoleArn                  string
+	Cluster                             kubernetes.Interface
+	Config                              *rest.Config
+	Convox                              cv.Interface
+	ConvoxDomainTLSCertDisable          bool
+	CertManagerClient                   cmclient.Interface
+	DiscoveryClient                     discovery.DiscoveryInterface
+	DockerUsername                      string
+	DockerPassword                      string
+	Domain                              string
+	DomainInternal                      string
+	DynamicClient                       dynamic.Interface
+	EfsFileSystemId                     string
+	Engine                              Engine
+	Image                               string
+	JwtMngr                             *jwt.JwtManager
+	Name                                string
+	ReleasesToRetainAfterActive         int
+	ReleasesToRetainTaskRunIntervalHour int
+	MetricScraper                       *MetricScraperClient
+	MetricsClient                       metricsclientset.Interface
+	Namespace                           string
+	Password                            string
+	PdbDefaultMinAvailablePercentage    string
+	Provider                            string
+	RackName                            string
+	Resolver                            string
+	BuildDisableResolver                bool
+	RestClient                          rest.Interface
+	Router                              string
+	Socket                              string
+	Storage                             string
+	SubnetIDs                           string
+	Version                             string
+	VpcID                               string
 
 	nc                 *NodeController
 	namespaceInformer  informerv1.NamespaceInformer
@@ -192,6 +195,9 @@ func FromEnv() (*Provider, error) {
 		DockerUsername:                   os.Getenv("DOCKER_HUB_USERNAME"),
 		DockerPassword:                   os.Getenv("DOCKER_HUB_PASSWORD"),
 	}
+
+	p.ReleasesToRetainAfterActive, _ = strconv.Atoi(os.Getenv("RELEASES_TO_RETAIN_AFTER_ACTIVE"))
+	p.ReleasesToRetainTaskRunIntervalHour, _ = strconv.Atoi(os.Getenv("RELEASES_TO_RETAIN_TASK_RUN_INTERVAL_HOUR"))
 
 	p.RdsProvisioner = rds.NewProvisioner(p)
 	p.ElasticacheProvisioner = elasticache.NewProvisioner(p)

--- a/provider/k8s/task_release_cleanup.go
+++ b/provider/k8s/task_release_cleanup.go
@@ -1,0 +1,219 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/convox/convox/pkg/common"
+	"github.com/convox/convox/pkg/manifest"
+	"github.com/convox/convox/pkg/structs"
+	convoxv1 "github.com/convox/convox/provider/k8s/pkg/apis/convox/v1"
+	cv "github.com/convox/convox/provider/k8s/pkg/client/clientset/versioned"
+	"github.com/convox/logger"
+	am "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+const cleanupAnnotationKey = "convox.io/last-release-build-cleanup"
+
+type providerForReleaseCleaner interface {
+	AppList() (structs.Apps, error)
+	AppNamespace(appName string) string
+}
+
+type releaseCleaner struct {
+	provider                        providerForReleaseCleaner
+	engine                          Engine
+	convox                          cv.Interface
+	logger                          *logger.Logger
+	cluster                         kubernetes.Interface
+	systemNamespace                 string
+	ctx                             context.Context
+	releasesToRetainAfterActive     int
+	releaseBuildCleanupIntervalHour int
+}
+
+func (a *releaseCleaner) Run() error {
+	a.logger.Logf("starting release build cleanup task...")
+	if a.releaseBuildCleanupIntervalHour <= 0 {
+		a.releaseBuildCleanupIntervalHour = 24
+	}
+	if err := a.waitUntilScheduledForCleanup(); err != nil {
+		return err
+	}
+	return a.cleanupReleasesAndBuilds()
+}
+
+func (a *releaseCleaner) waitUntilScheduledForCleanup() error {
+	sysNs, err := a.cluster.CoreV1().Namespaces().Get(a.ctx, a.systemNamespace, v1.GetOptions{})
+	if err != nil {
+		a.logger.Errorf("failed to get system namespace: %s", err)
+		return err
+	}
+
+	if sysNs.Annotations[cleanupAnnotationKey] != "" {
+		t, err := time.Parse(time.RFC3339, sysNs.Annotations[cleanupAnnotationKey])
+		if err == nil && t.Add(time.Duration(a.releaseBuildCleanupIntervalHour)*time.Hour).After(time.Now().UTC()) {
+			a.logger.Logf("release build cleanup already run in last %d hours, skipping", a.releaseBuildCleanupIntervalHour)
+			time.Sleep(t.Add(time.Duration(a.releaseBuildCleanupIntervalHour)*time.Hour).Sub(time.Now().UTC()) + (10 * time.Second))
+		}
+	}
+	return nil
+}
+
+func (a *releaseCleaner) cleanupReleasesAndBuilds() error {
+	a.logger.Logf("running release build cleanup...")
+
+	appList, err := a.provider.AppList()
+	if err != nil {
+		a.logger.Errorf("failed to list apps: %s", err)
+		time.Sleep(3 * time.Second)
+		return err
+	}
+
+	for _, app := range appList {
+		if app.Release == "" {
+			continue
+		}
+
+		if err := a.appReleaseAndBuildCleanup(&app); err != nil {
+			a.logger.Errorf("failed to cleanup release builds for app '%s': %s", app.Name, err)
+		}
+		time.Sleep(3 * time.Second)
+	}
+
+	patchBytes, err := patchBytes(map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]string{
+				cleanupAnnotationKey: time.Now().UTC().Format(time.RFC3339),
+			},
+		},
+	})
+	if err != nil {
+		a.logger.Errorf("failed to create patch bytes err=%q\n", err)
+		return err
+	}
+	_, err = a.cluster.CoreV1().Namespaces().Patch(a.ctx, a.systemNamespace, types.MergePatchType, patchBytes, am.PatchOptions{})
+	if err != nil {
+		a.logger.Errorf("failed to patch namespace '%s' err=%q\n", a.systemNamespace, err)
+	}
+	return err
+}
+
+func (a *releaseCleaner) toTime(t string) time.Time {
+	parsedTime, _ := time.Parse(common.SortableTime, t)
+	return parsedTime
+}
+
+func (a *releaseCleaner) appReleaseAndBuildCleanup(app *structs.App) error {
+	listOpts := am.ListOptions{}
+	bs := []convoxv1.Build{}
+
+	appNamespace := ""
+	if app.Tags != nil && app.Tags["namespace"] != "" {
+		appNamespace = app.Tags["namespace"]
+	} else {
+		appNamespace = a.provider.AppNamespace(app.Name)
+	}
+
+	for {
+		bList, err := a.convox.ConvoxV1().Builds(appNamespace).List(listOpts)
+		if err != nil {
+			return err
+		}
+
+		bs = append(bs, bList.Items...)
+
+		if bList.GetContinue() == "" {
+			break
+		}
+		listOpts.Continue = bList.GetContinue()
+	}
+
+	listOpts = am.ListOptions{}
+	rs := []convoxv1.Release{}
+
+	for {
+		rList, err := a.convox.ConvoxV1().Releases(appNamespace).List(listOpts)
+		if err != nil {
+			return err
+		}
+
+		rs = append(rs, rList.Items...)
+
+		if rList.GetContinue() == "" {
+			break
+		}
+		listOpts.Continue = rList.GetContinue()
+	}
+
+	sort.Slice(rs, func(i, j int) bool {
+		// sort by creation time, so that the newest release comes first
+		return a.toTime(rs[i].Spec.Created).After(a.toTime(rs[j].Spec.Created))
+	})
+
+	foundActiveIndex := -1
+	for i, r := range rs {
+		if r.Name == strings.ToLower(app.Release) {
+			foundActiveIndex = i
+			break
+		}
+	}
+
+	if foundActiveIndex == -1 {
+		a.logger.Logf("active release '%s' not found for app '%s', skipping build cleanup", app.Release, app.Name)
+		return nil
+	}
+
+	buildToKeep := map[string]struct{}{}
+	for i := 0; i < (foundActiveIndex+a.releasesToRetainAfterActive+1) && i < len(rs); i++ {
+		if rs[i].Spec.Build != "" {
+			buildToKeep[strings.ToLower(rs[i].Spec.Build)] = struct{}{}
+		}
+	}
+
+	for i := foundActiveIndex + a.releasesToRetainAfterActive + 1; i < len(rs); i++ {
+		a.convox.ConvoxV1().Releases(appNamespace).Delete(rs[i].Name, &am.DeleteOptions{})
+		time.Sleep(50 * time.Millisecond) // to avoid rate limit
+	}
+
+	oldReleaseTime := a.toTime(rs[min(foundActiveIndex+a.releasesToRetainAfterActive, len(rs)-1)].Spec.Created)
+	oldestReleaseTimeToKeep := oldReleaseTime.Add(-1 * time.Minute)
+	buildToDelete := []string{}
+	buildTagsToDelete := []string{}
+	for _, b := range bs {
+		// also ensure we don't delete builds that are newer than the oldest release we are keeping
+		if _, ok := buildToKeep[b.Name]; !ok && a.toTime(b.Spec.Started).Before(oldestReleaseTimeToKeep) {
+			buildToDelete = append(buildToDelete, b.Name)
+			m, err := manifest.Load([]byte(b.Spec.Manifest), structs.Environment{})
+			if err != nil {
+				a.logger.Errorf("failed to load manifest for build '%s' of app '%s': %s", b.Name, app.Name, err)
+				continue
+			}
+			for _, svc := range m.Services {
+				if svc.Name != "" {
+					buildTagsToDelete = append(buildTagsToDelete, fmt.Sprintf("%s.%s", svc.Name, strings.ToUpper(b.Name)))
+				}
+			}
+		}
+	}
+
+	for _, b := range buildToDelete {
+		a.convox.ConvoxV1().Builds(appNamespace).Delete(b, &am.DeleteOptions{})
+		time.Sleep(50 * time.Millisecond) // to avoid rate limit
+	}
+
+	batchSize := 50
+	for i := 0; i < len(buildTagsToDelete); i = i + batchSize {
+		batch := buildTagsToDelete[i:min(i+batchSize, len(buildTagsToDelete))]
+		if err := a.engine.RepositoryImagesBatchDelete(app.Name, batch); err != nil {
+			a.logger.Errorf("failed to delete images for builds '%s': %s", strings.Join(batch, ","), err)
+		}
+	}
+	return nil
+}

--- a/provider/k8s/task_release_cleanup_test.go
+++ b/provider/k8s/task_release_cleanup_test.go
@@ -1,0 +1,421 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/convox/convox/pkg/common"
+	"github.com/convox/convox/pkg/manifest"
+	"github.com/convox/convox/pkg/structs"
+	convoxv1 "github.com/convox/convox/provider/k8s/pkg/apis/convox/v1"
+	cvfake "github.com/convox/convox/provider/k8s/pkg/client/clientset/versioned/fake"
+	"github.com/convox/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// MockProviderForReleaseCleaner is a mock implementation of providerForReleaseCleaner
+type MockProviderForReleaseCleaner struct {
+	mock.Mock
+}
+
+func (m *MockProviderForReleaseCleaner) AppList() (structs.Apps, error) {
+	args := m.Called()
+	return args.Get(0).(structs.Apps), args.Error(1)
+}
+
+func (m *MockProviderForReleaseCleaner) AppNamespace(appName string) string {
+	args := m.Called(appName)
+	return args.String(0)
+}
+
+// MockEngine is a mock implementation of Engine for testing
+type MockEngine struct {
+	mock.Mock
+}
+
+func (m *MockEngine) RepositoryImagesBatchDelete(app string, builds []string) error {
+	args := m.Called(app, builds)
+	return args.Error(0)
+}
+
+// Add stub implementations for all Engine interface methods
+func (m *MockEngine) AppIdles(app string) (bool, error) {
+	return false, nil
+}
+
+func (m *MockEngine) AppParameters() map[string]string {
+	return nil
+}
+
+func (m *MockEngine) GPUIntanceList(instanceTypes []string) ([]string, error) {
+	return nil, nil
+}
+
+func (m *MockEngine) Heartbeat() (map[string]interface{}, error) {
+	return nil, nil
+}
+
+func (m *MockEngine) IngressAnnotations(certDuration string) (map[string]string, error) {
+	return nil, nil
+}
+
+func (m *MockEngine) IngressClass() string {
+	return ""
+}
+
+func (m *MockEngine) IngressInternalClass() string {
+	return ""
+}
+
+func (m *MockEngine) Log(app, stream string, ts time.Time, message string) error {
+	return nil
+}
+
+func (m *MockEngine) ManifestValidate(manifest *manifest.Manifest) error {
+	args := m.Called(manifest)
+	return args.Error(0)
+}
+
+func (m *MockEngine) RegistryAuth(host, username, password string) (string, string, error) {
+	return "", "", nil
+}
+
+func (m *MockEngine) RepositoryAuth(app string) (string, string, error) {
+	return "", "", nil
+}
+
+func (m *MockEngine) RepositoryHost(app string) (string, bool, error) {
+	return "", false, nil
+}
+
+func (m *MockEngine) RepositoryPrefix() string {
+	return ""
+}
+
+func (m *MockEngine) ResolverHost() (string, error) {
+	return "", nil
+}
+
+func (m *MockEngine) ServiceHost(app string, s manifest.Service) string {
+	args := m.Called(app, s)
+	return args.String(0)
+}
+
+func (m *MockEngine) SystemHost() string {
+	return ""
+}
+
+func (m *MockEngine) SystemStatus() (string, error) {
+	return "", nil
+}
+
+// Helper function to create a releaseCleaner for testing
+func createReleaseCleaner(
+	provider providerForReleaseCleaner,
+	engine Engine,
+	convox cvfake.Clientset,
+	cluster *fake.Clientset,
+	systemNamespace string,
+	releasesToRetainAfterActive int,
+) *releaseCleaner {
+	log := logger.New("test")
+
+	return &releaseCleaner{
+		provider:                    provider,
+		engine:                      engine,
+		convox:                      &convox,
+		logger:                      log,
+		cluster:                     cluster,
+		systemNamespace:             systemNamespace,
+		ctx:                         context.Background(),
+		releasesToRetainAfterActive: releasesToRetainAfterActive,
+	}
+}
+
+// Helper functions for creating test data
+func createTestRelease(name, ns, build, created string) convoxv1.Release {
+	return convoxv1.Release{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: convoxv1.ReleaseSpec{
+			Build:   build,
+			Created: created,
+		},
+	}
+}
+
+func createTestBuild(name, ns, started string) convoxv1.Build {
+	return convoxv1.Build{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: convoxv1.BuildSpec{
+			Started: started,
+		},
+	}
+}
+
+// Create a namespace for testing
+func createNamespace(cluster *fake.Clientset, name string, annotations map[string]string) error {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Annotations: annotations,
+		},
+	}
+	_, err := cluster.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+	return err
+}
+
+// Test for the waitUntilScheduledForCleanup method
+func TestWaitUntilScheduledForCleanup(t *testing.T) {
+	systemNamespace := "test-namespace"
+
+	testCases := []struct {
+		name        string
+		annotation  string
+		expectError bool
+	}{
+		{
+			name:        "No annotation",
+			annotation:  "",
+			expectError: false,
+		},
+		{
+			name:        "Recent annotation",
+			annotation:  time.Now().Add((-24 * time.Hour) + (5 * time.Second)).Format(time.RFC3339),
+			expectError: false,
+		},
+		{
+			name:        "Old annotation",
+			annotation:  time.Now().Add(-48 * time.Hour).Format(time.RFC3339),
+			expectError: false,
+		},
+		{
+			name:        "Invalid date format",
+			annotation:  "invalid-date-format",
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create mock objects for each test case
+			provider := &MockProviderForReleaseCleaner{}
+			engine := &MockEngine{}
+			convox := cvfake.NewSimpleClientset()
+			cluster := fake.NewSimpleClientset()
+
+			// Create namespace with annotation
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: systemNamespace,
+				},
+			}
+
+			if tc.annotation != "" {
+				ns.Annotations = map[string]string{
+					cleanupAnnotationKey: tc.annotation,
+				}
+			}
+
+			_, err := cluster.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			// Create the cleaner
+			cleaner := createReleaseCleaner(provider, engine, *convox, cluster, systemNamespace, 3)
+
+			// Override the context with a canceled one to avoid long sleeps in tests
+			cancelCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+			defer cancel()
+			cleaner.ctx = cancelCtx
+
+			// Call the method
+			err = cleaner.waitUntilScheduledForCleanup()
+
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// Test for appReleaseAndBuildCleanup method
+func TestAppReleaseAndBuildCleanup(t *testing.T) {
+	// Define test cases
+	testCases := []struct {
+		name                        string
+		app                         structs.App
+		releases                    []convoxv1.Release
+		builds                      []convoxv1.Build
+		releasesToRetainAfterActive int
+		deleteImagesError           error
+		expectError                 bool
+		expectedDeletedBuilds       []string
+		expectedDeletedReleases     []string
+	}{
+		{
+			name: "No active release found",
+			app: structs.App{
+				Name:    "app1",
+				Release: "release-not-found",
+			},
+			releases: []convoxv1.Release{
+				createTestRelease("release1", "app1-namespace", "build1", time.Now().Add(-3*time.Hour).Format(common.SortableTime)),
+				createTestRelease("release2", "app1-namespace", "build2", time.Now().Add(-2*time.Hour).Format(common.SortableTime)),
+			},
+			builds: []convoxv1.Build{
+				createTestBuild("build1", "app1-namespace", time.Now().Add(-4*time.Hour).Format(common.SortableTime)),
+				createTestBuild("build2", "app1-namespace", time.Now().Add(-3*time.Hour).Format(common.SortableTime)),
+			},
+			releasesToRetainAfterActive: 3,
+			expectError:                 false,
+		},
+		{
+			name: "empty releases list",
+			app: structs.App{
+				Name:    "app1",
+				Release: "release1",
+			},
+			releasesToRetainAfterActive: 3,
+			expectError:                 false,
+		},
+		{
+			name: "empty builds list",
+			app: structs.App{
+				Name:    "app1",
+				Release: "release1",
+			},
+			releases: []convoxv1.Release{
+				createTestRelease("release1", "app1-namespace", "build1", time.Now().Add(-3*time.Hour).Format(common.SortableTime)),
+			},
+			releasesToRetainAfterActive: 3,
+			expectError:                 false,
+		},
+		{
+			name: "Normal cleanup",
+			app: structs.App{
+				Name:    "app1",
+				Release: "release1",
+			},
+			releases: []convoxv1.Release{
+				createTestRelease("release1", "app1-namespace", "build1", time.Now().Add(-1*time.Hour).Format(common.SortableTime)),
+				createTestRelease("release2", "app1-namespace", "build2", time.Now().Add(-2*time.Hour).Format(common.SortableTime)),
+				createTestRelease("release3", "app1-namespace", "build3", time.Now().Add(-3*time.Hour).Format(common.SortableTime)),
+				createTestRelease("release4", "app1-namespace", "build4", time.Now().Add(-4*time.Hour).Format(common.SortableTime)),
+				createTestRelease("release5", "app1-namespace", "build5", time.Now().Add(-5*time.Hour).Format(common.SortableTime)),
+			},
+			builds: []convoxv1.Build{
+				createTestBuild("build1", "app1-namespace", time.Now().Add(-7*time.Hour).Format(common.SortableTime)),
+				createTestBuild("build2", "app1-namespace", time.Now().Add(-6*time.Hour).Format(common.SortableTime)),
+				createTestBuild("build3", "app1-namespace", time.Now().Add(-5*time.Hour).Format(common.SortableTime)),
+				createTestBuild("build4", "app1-namespace", time.Now().Add(-4*time.Hour).Format(common.SortableTime)),
+				createTestBuild("build5", "app1-namespace", time.Now().Add(-3*time.Hour).Format(common.SortableTime)), // same time as last old release to keep
+				createTestBuild("build6", "app1-namespace", time.Now().Add(-8*time.Hour).Format(common.SortableTime)),
+				createTestBuild("build7", "app1-namespace", time.Now().Add(-9*time.Hour).Format(common.SortableTime)),
+				createTestBuild("build8", "app1-namespace", time.Now().Add(1*time.Hour).Format(common.SortableTime)),
+			},
+			releasesToRetainAfterActive: 2, // Keep release1, release2, release3
+			expectError:                 false,
+			expectedDeletedBuilds:       []string{"build4", "build6", "build7"},
+			expectedDeletedReleases:     []string{"release4", "release5"},
+		},
+		{
+			name: "Normal cleanup",
+			app: structs.App{
+				Name:    "app1",
+				Release: "release2",
+			},
+			releases: []convoxv1.Release{
+				createTestRelease("release1", "app1-namespace", "build1", time.Now().Add(-1*time.Hour).Format(common.SortableTime)),
+				createTestRelease("release2", "app1-namespace", "build2", time.Now().Add(-2*time.Hour).Format(common.SortableTime)),
+				createTestRelease("release3", "app1-namespace", "build3", time.Now().Add(-3*time.Hour).Format(common.SortableTime)),
+				createTestRelease("release4", "app1-namespace", "build4", time.Now().Add(-4*time.Hour).Format(common.SortableTime)),
+				createTestRelease("release5", "app1-namespace", "build5", time.Now().Add(-5*time.Hour).Format(common.SortableTime)),
+			},
+			builds: []convoxv1.Build{
+				createTestBuild("build1", "app1-namespace", time.Now().Add(-7*time.Hour).Format(common.SortableTime)),
+				createTestBuild("build2", "app1-namespace", time.Now().Add(-6*time.Hour).Format(common.SortableTime)),
+				createTestBuild("build3", "app1-namespace", time.Now().Add(-5*time.Hour).Format(common.SortableTime)),
+				createTestBuild("build4", "app1-namespace", time.Now().Add(-4*time.Hour).Format(common.SortableTime)), // same time as last old release to keep
+				createTestBuild("build5", "app1-namespace", time.Now().Add(-3*time.Hour).Format(common.SortableTime)),
+				createTestBuild("build6", "app1-namespace", time.Now().Add(-8*time.Hour).Format(common.SortableTime)),
+				createTestBuild("build7", "app1-namespace", time.Now().Add(-9*time.Hour).Format(common.SortableTime)),
+				createTestBuild("build8", "app1-namespace", time.Now().Add(1*time.Hour).Format(common.SortableTime)),
+			},
+			releasesToRetainAfterActive: 2, // Keep release1, release2, release3
+			expectError:                 false,
+			expectedDeletedBuilds:       []string{"build6", "build7"},
+			expectedDeletedReleases:     []string{"release5"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create mock objects
+			mockProvider := &MockProviderForReleaseCleaner{}
+			mockEngine := &MockEngine{}
+			convox := cvfake.NewSimpleClientset()
+			cluster := fake.NewSimpleClientset()
+
+			// Mock the AppNamespace method
+			mockProvider.On("AppNamespace", tc.app.Name).Return(tc.app.Name + "-namespace")
+
+			// Setup test data
+			// In a real test, you would actually create these objects in the fake client
+			// But since we'll mock the List calls, we don't need to do that here
+			for _, r := range tc.releases {
+				convox.ConvoxV1().Releases(r.Namespace).Create(&r)
+			}
+
+			for _, b := range tc.builds {
+				convox.ConvoxV1().Builds(b.Namespace).Create(&b)
+			}
+
+			// Create the cleaner
+			cleaner := createReleaseCleaner(mockProvider, mockEngine, *convox, cluster, "test-namespace", tc.releasesToRetainAfterActive)
+
+			// Call the method
+			err := cleaner.appReleaseAndBuildCleanup(&tc.app)
+
+			// Verify results
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			mockProvider.AssertExpectations(t)
+			mockEngine.AssertExpectations(t)
+
+			for _, b := range tc.builds {
+				_, err := convox.ConvoxV1().Builds(b.Namespace).Get(b.Name, metav1.GetOptions{})
+				if common.ContainsInStringSlice(tc.expectedDeletedBuilds, b.Name) {
+					assert.Error(t, err, "Expected build %s to be deleted", b.Name)
+				} else {
+					assert.NoError(t, err, "Expected build %s to exist", b.Name)
+				}
+			}
+
+			for _, r := range tc.releases {
+				_, err := convox.ConvoxV1().Releases(r.Namespace).Get(r.Name, metav1.GetOptions{})
+				if common.ContainsInStringSlice(tc.expectedDeletedReleases, r.Name) {
+					assert.Error(t, err, "Expected release %s to be deleted", r.Name)
+				} else {
+					assert.NoError(t, err, "Expected release %s to exist", r.Name)
+				}
+			}
+		})
+	}
+}

--- a/provider/local/repository.go
+++ b/provider/local/repository.go
@@ -13,3 +13,7 @@ func (p *Provider) RepositoryHost(app string) (string, bool, error) {
 func (p *Provider) RepositoryPrefix() string {
 	return ""
 }
+
+func (p *Provider) RepositoryImagesBatchDelete(app string, tags []string) error {
+	return fmt.Errorf("not implemented")
+}

--- a/provider/metal/repository.go
+++ b/provider/metal/repository.go
@@ -13,3 +13,7 @@ func (p *Provider) RepositoryHost(app string) (string, bool, error) {
 func (p *Provider) RepositoryPrefix() string {
 	return ""
 }
+
+func (p *Provider) RepositoryImagesBatchDelete(app string, tags []string) error {
+	return fmt.Errorf("not implemented")
+}

--- a/terraform/api/aws/iam.tf
+++ b/terraform/api/aws/iam.tf
@@ -167,8 +167,8 @@ data "aws_iam_policy_document" "rds_provisioner" {
   }
 
   statement {
-    effect = "Allow"
-    actions = ["iam:CreateServiceLinkedRole"]
+    effect    = "Allow"
+    actions   = ["iam:CreateServiceLinkedRole"]
     resources = ["arn:${data.aws_partition.current.partition}:iam::*:role/aws-service-role/rds.amazonaws.com/AWSServiceRoleForRDS"]
     condition {
       test     = "StringLike"

--- a/terraform/api/aws/main.tf
+++ b/terraform/api/aws/main.tf
@@ -41,20 +41,22 @@ module "k8s" {
   }
 
   env = {
-    AWS_REGION                           = data.aws_region.current.name
-    BUCKET                               = var.custom_provided_bucket != "" ? data.aws_s3_bucket.custom_bucket[0].id : aws_s3_bucket.storage.id
-    CERT_MANAGER                         = "true"
-    CERT_MANAGER_ROLE_ARN                = aws_iam_role.cert-manager.arn
-    EFS_FILE_SYSTEM_ID                   = var.efs_file_system_id
-    BUILD_DISABLE_CONVOX_RESOLVER        = var.build_disable_convox_resolver
-    PDB_DEFAULT_MIN_AVAILABLE_PERCENTAGE = var.pdb_default_min_available_percentage
-    PROVIDER                             = "aws"
-    RESOLVER                             = var.disable_convox_resolver ? "" : var.resolver
-    ROUTER                               = var.router
-    SOCKET                               = "/var/run/docker.sock"
-    ECR_SCAN_ON_PUSH_ENABLE              = var.ecr_scan_on_push_enable
-    SUBNET_IDS                           = join(",", var.subnets)
-    VPC_ID                               = var.vpc_id
+    AWS_REGION                                = data.aws_region.current.name
+    BUCKET                                    = var.custom_provided_bucket != "" ? data.aws_s3_bucket.custom_bucket[0].id : aws_s3_bucket.storage.id
+    CERT_MANAGER                              = "true"
+    CERT_MANAGER_ROLE_ARN                     = aws_iam_role.cert-manager.arn
+    EFS_FILE_SYSTEM_ID                        = var.efs_file_system_id
+    BUILD_DISABLE_CONVOX_RESOLVER             = var.build_disable_convox_resolver
+    PDB_DEFAULT_MIN_AVAILABLE_PERCENTAGE      = var.pdb_default_min_available_percentage
+    PROVIDER                                  = "aws"
+    RESOLVER                                  = var.disable_convox_resolver ? "" : var.resolver
+    ROUTER                                    = var.router
+    SOCKET                                    = "/var/run/docker.sock"
+    ECR_SCAN_ON_PUSH_ENABLE                   = var.ecr_scan_on_push_enable
+    SUBNET_IDS                                = join(",", var.subnets)
+    VPC_ID                                    = var.vpc_id
+    RELEASES_TO_RETAIN_AFTER_ACTIVE           = var.releases_to_retain_after_active
+    RELEASES_TO_RETAIN_TASK_RUN_INTERVAL_HOUR = var.releases_to_retain_task_run_interval_hour
   }
 }
 
@@ -65,18 +67,18 @@ resource "kubernetes_persistent_volume_claim_v1" "efs-pvc-system-root" {
   count = var.efs_csi_driver_enable ? 1 : 0
 
   metadata {
-    name = "efs-pvc-system-root"
+    name      = "efs-pvc-system-root"
     namespace = var.namespace
   }
 
   spec {
-    access_modes = [ "ReadWriteMany" ]
+    access_modes = ["ReadWriteMany"]
     resources {
       requests = {
         storage = "2Gi"
       }
     }
-    volume_name = "efs-pv-root"
+    volume_name        = "efs-pv-root"
     storage_class_name = "efs-sc-base"
   }
 }

--- a/terraform/api/aws/s3.tf
+++ b/terraform/api/aws/s3.tf
@@ -31,6 +31,6 @@ resource "aws_s3_bucket_acl" "storage" {
 
 
 data "aws_s3_bucket" "custom_bucket" {
-  count = var.custom_provided_bucket != "" ? 1 : 0
+  count  = var.custom_provided_bucket != "" ? 1 : 0
   bucket = var.custom_provided_bucket
 }

--- a/terraform/api/aws/variables.tf
+++ b/terraform/api/aws/variables.tf
@@ -115,6 +115,16 @@ variable "release" {
   type = string
 }
 
+variable "releases_to_retain_after_active" {
+  type    = number
+  default = 0
+}
+
+variable "releases_to_retain_task_run_interval_hour" {
+  type    = number
+  default = 24
+}
+
 variable "resolver" {
   type = string
 }

--- a/terraform/cluster/aws/efs.tf
+++ b/terraform/cluster/aws/efs.tf
@@ -7,9 +7,9 @@ resource "aws_eks_addon" "aws_efs_csi_driver" {
 
   count = var.efs_csi_driver_enable ? 1 : 0
 
-  cluster_name      = aws_eks_cluster.cluster.name
-  addon_name        = "aws-efs-csi-driver"
-  addon_version     = var.efs_csi_driver_version
+  cluster_name                = aws_eks_cluster.cluster.name
+  addon_name                  = "aws-efs-csi-driver"
+  addon_version               = var.efs_csi_driver_version
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "OVERWRITE"
 }

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -181,7 +181,7 @@ resource "aws_eks_node_group" "cluster-build" {
     aws_iam_openid_connect_provider.cluster,
   ]
 
-  count = var.build_node_enabled ? 1 : 0
+  count           = var.build_node_enabled ? 1 : 0
   ami_type        = var.build_gpu_type ? "AL2023_x86_64_NVIDIA" : var.build_arm_type ? "AL2023_ARM_64_STANDARD" : "AL2023_x86_64_STANDARD"
   capacity_type   = "ON_DEMAND"
   cluster_name    = aws_eks_cluster.cluster.name
@@ -423,9 +423,9 @@ resource "aws_eks_addon" "vpc_cni" {
     null_resource.wait_k8s_api
   ]
 
-  cluster_name      = aws_eks_cluster.cluster.name
-  addon_name        = "vpc-cni"
-  addon_version     = var.vpc_cni_version
+  cluster_name                = aws_eks_cluster.cluster.name
+  addon_name                  = "vpc-cni"
+  addon_version               = var.vpc_cni_version
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "OVERWRITE"
 }
@@ -435,9 +435,9 @@ resource "aws_eks_addon" "coredns" {
     null_resource.wait_k8s_api
   ]
 
-  cluster_name      = aws_eks_cluster.cluster.name
-  addon_name        = "coredns"
-  addon_version     = var.coredns_version
+  cluster_name                = aws_eks_cluster.cluster.name
+  addon_name                  = "coredns"
+  addon_version               = var.coredns_version
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "OVERWRITE"
 }
@@ -447,9 +447,9 @@ resource "aws_eks_addon" "kube_proxy" {
     null_resource.wait_k8s_api
   ]
 
-  cluster_name      = aws_eks_cluster.cluster.name
-  addon_name        = "kube-proxy"
-  addon_version     = var.kube_proxy_version
+  cluster_name                = aws_eks_cluster.cluster.name
+  addon_name                  = "kube-proxy"
+  addon_version               = var.kube_proxy_version
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "OVERWRITE"
 }
@@ -461,9 +461,9 @@ resource "aws_eks_addon" "eks_pod_identity_agent" {
 
   count = var.pod_identity_agent_enable ? 1 : 0
 
-  cluster_name      = aws_eks_cluster.cluster.name
-  addon_name        = "eks-pod-identity-agent"
-  addon_version     = var.pod_identity_agent_version
+  cluster_name                = aws_eks_cluster.cluster.name
+  addon_name                  = "eks-pod-identity-agent"
+  addon_version               = var.pod_identity_agent_version
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "OVERWRITE"
 }

--- a/terraform/rack/aws/main.tf
+++ b/terraform/rack/aws/main.tf
@@ -24,35 +24,37 @@ module "api" {
     kubernetes = kubernetes
   }
 
-  buildkit_enabled                     = var.buildkit_enabled
-  build_disable_convox_resolver        = var.build_disable_convox_resolver
-  build_node_enabled                   = var.build_node_enabled
-  convox_domain_tls_cert_disable       = var.convox_domain_tls_cert_disable
-  custom_provided_bucket               = var.custom_provided_bucket
-  docker_hub_authentication            = module.k8s.docker_hub_authentication
-  docker_hub_username                  = var.docker_hub_username
-  docker_hub_password                  = var.docker_hub_password
-  domain                               = try(module.router.endpoint, "") # terraform destroy sometimes failes to resolve the value
-  domain_internal                      = module.router.endpoint_internal
-  disable_image_manifest_cache         = var.disable_image_manifest_cache
-  ecr_scan_on_push_enable              = var.ecr_scan_on_push_enable
-  efs_csi_driver_enable                = var.efs_csi_driver_enable
-  efs_file_system_id                   = var.efs_file_system_id
-  high_availability                    = var.high_availability
-  metrics_scraper_host                 = module.metrics.metrics_scraper_host
-  image                                = var.image
-  name                                 = var.name
-  rack_name                            = var.rack_name
-  namespace                            = module.k8s.namespace
-  oidc_arn                             = var.oidc_arn
-  oidc_sub                             = var.oidc_sub
-  pdb_default_min_available_percentage = var.pdb_default_min_available_percentage
-  release                              = var.release
-  disable_convox_resolver              = var.disable_convox_resolver
-  resolver                             = module.resolver.endpoint
-  router                               = module.router.endpoint
-  subnets                              = var.subnets
-  vpc_id                               = var.vpc_id
+  buildkit_enabled                          = var.buildkit_enabled
+  build_disable_convox_resolver             = var.build_disable_convox_resolver
+  build_node_enabled                        = var.build_node_enabled
+  convox_domain_tls_cert_disable            = var.convox_domain_tls_cert_disable
+  custom_provided_bucket                    = var.custom_provided_bucket
+  docker_hub_authentication                 = module.k8s.docker_hub_authentication
+  docker_hub_username                       = var.docker_hub_username
+  docker_hub_password                       = var.docker_hub_password
+  domain                                    = try(module.router.endpoint, "") # terraform destroy sometimes failes to resolve the value
+  domain_internal                           = module.router.endpoint_internal
+  disable_image_manifest_cache              = var.disable_image_manifest_cache
+  ecr_scan_on_push_enable                   = var.ecr_scan_on_push_enable
+  efs_csi_driver_enable                     = var.efs_csi_driver_enable
+  efs_file_system_id                        = var.efs_file_system_id
+  high_availability                         = var.high_availability
+  metrics_scraper_host                      = module.metrics.metrics_scraper_host
+  image                                     = var.image
+  name                                      = var.name
+  rack_name                                 = var.rack_name
+  namespace                                 = module.k8s.namespace
+  oidc_arn                                  = var.oidc_arn
+  oidc_sub                                  = var.oidc_sub
+  pdb_default_min_available_percentage      = var.pdb_default_min_available_percentage
+  release                                   = var.release
+  disable_convox_resolver                   = var.disable_convox_resolver
+  resolver                                  = module.resolver.endpoint
+  router                                    = module.router.endpoint
+  releases_to_retain_after_active           = var.releases_to_retain_after_active
+  releases_to_retain_task_run_interval_hour = var.releases_to_retain_task_run_interval_hour
+  subnets                                   = var.subnets
+  vpc_id                                    = var.vpc_id
 }
 
 module "metrics" {

--- a/terraform/rack/aws/variables.tf
+++ b/terraform/rack/aws/variables.tf
@@ -132,6 +132,16 @@ variable "release" {
   type = string
 }
 
+variable "releases_to_retain_after_active" {
+  type    = number
+  default = 0
+}
+
+variable "releases_to_retain_task_run_interval_hour" {
+  type    = number
+  default = 24
+}
+
 variable "tags" {
   default = {}
 }

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -185,6 +185,8 @@ module "rack" {
   pdb_default_min_available_percentage = var.pdb_default_min_available_percentage
   proxy_protocol                       = var.proxy_protocol
   release                              = local.release
+  releases_to_retain_after_active      = var.releases_to_retain_after_active
+  releases_to_retain_task_run_interval_hour = var.releases_to_retain_task_run_interval_hour
   ssl_ciphers                          = var.ssl_ciphers
   ssl_protocols                        = var.ssl_protocols
   subnets                              = module.cluster.subnets

--- a/terraform/system/aws/telemetry.tf
+++ b/terraform/system/aws/telemetry.tf
@@ -67,6 +67,8 @@ locals {
     rack_name = var.rack_name
     region = var.region
     release = var.release
+    releases_to_retain_after_active = var.releases_to_retain_after_active
+    releases_to_retain_task_run_interval_hour = var.releases_to_retain_task_run_interval_hour
     schedule_rack_scale_down = var.schedule_rack_scale_down
     schedule_rack_scale_up = var.schedule_rack_scale_up
     settings = var.settings
@@ -147,6 +149,8 @@ locals {
     rack_name = ""
     region = "us-east-1"
     release = ""
+    releases_to_retain_after_active = "0"
+    releases_to_retain_task_run_interval_hour = "24"
     schedule_rack_scale_down = ""
     schedule_rack_scale_up = ""
     settings = ""

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -296,6 +296,16 @@ variable "release" {
   default = ""
 }
 
+variable "releases_to_retain_after_active" {
+  type = number
+  default = 0
+}
+
+variable "releases_to_retain_task_run_interval_hour" {
+  type = number
+  default = 24
+}
+
 variable "region" {
   default = "us-east-1"
 }


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: Automatic Cleanup of Old Releases and ECR Images**

We have introduced an automatic cleanup feature that removes old application releases and their associated ECR (Elastic Container Registry) images. This feature helps manage storage costs and maintain a cleaner deployment history by automatically removing releases that are no longer needed, while preserving a configurable number of releases after the currently active release.

The cleanup process counts releases based on the **active release** (not the latest release), ensuring that your production deployments and their recent history are always preserved. If an application has no active release, the cleanup operation will be skipped for that application.

---

### Why is this important?

- **Reduced Storage Costs:**
  - Automatically removes old ECR images that can accumulate significant storage costs over time
  - Helps manage AWS storage expenses by cleaning up unused container images

- **Improved Resource Management:**
  - Prevents unlimited growth of release history
  - Maintains a clean and manageable deployment history
  - Reduces clutter in your ECR repositories

- **Flexible Configuration:**
  - Fully configurable retention policy based on your needs
  - Can be enabled or disabled per rack
  - Automated scheduling reduces manual maintenance tasks

---

### How to use this feature?

To enable automatic cleanup of old releases, configure the following rack parameters:

1. **Set the number of releases to retain after the active release:**
   ```
   $ convox rack params set releases_to_retain_after_active=100 -r rackName
   ```
   This parameter determines how many releases to keep after the currently active release. For example, if set to 100, the system will retain the active release plus the 100 most recent releases after it.

2. **Configure the cleanup task interval (optional):**
   ```
   $ convox rack params set releases_to_retain_task_run_interval_hour=24 -r rackName
   ```
   This parameter sets how often the cleanup task runs, specified in hours. The default is 24 hours (once daily).

#### **Default Values:**
- `releases_to_retain_after_active`: **Unset** (no automatic cleanup)
- `releases_to_retain_task_run_interval_hour`: **24** hours

#### **Important Notes:**
- The feature is **disabled by default** - no releases will be removed automatically unless `releases_to_retain_after_active` is explicitly set
- The cleanup counts from the **active release**, not the latest release
- Applications without an active release will be skipped during cleanup
- Both application releases and their corresponding ECR images will be removed

#### **Example Configuration:**
To retain only the active release plus 50 recent releases, with cleanup running every 12 hours:
```
$ convox rack params set releases_to_retain_after_active=50 -r rackName
$ convox rack params set releases_to_retain_task_run_interval_hour=12 -r rackName
```

---

### Does it have a breaking change?

**No breaking changes** are introduced with this update. The feature is disabled by default and requires explicit configuration to activate.

---

### Requirements

To use this fix, you must be on at least version `3.22.3`.

For a minor version update, you must state the version with the command `convox rack update 3.22.3 -r rackName`.  
**_You must be on at least rack version `3.21.0` to perform this update._**

_If you are unfamiliar with v3 rack versioning, we advise checking the documentation [Updating a Rack](https://docs.convox.com/management/cli-rack-management/)_