### PR TITLE
Add Cloudflare DNS01 support

### DIFF
--- a/docs/deployment/ssl.md
+++ b/docs/deployment/ssl.md
@@ -41,11 +41,11 @@ $ convox certs delete cert-xxxxxxxxxxxxxx
 Deleting certificate cert-xxxxxxxxxxxxxx... OK
 ```
 
-## Advanced SSL Configuration: Let's Encrypt DNS-01 Challenge with Route53 (AWS)
+## Advanced SSL Configuration: Let's Encrypt DNS-01 Challenge
 
-> This configuration is currently available for AWS racks using Route53 for DNS management.
+Convox supports the Let's Encrypt DNS-01 challenge for SSL certificate generation, which is useful when HTTP endpoints are not exposed or when wildcard certificates are required. The DNS-01 challenge verifies domain ownership via DNS TXT records, and it is ideal for environments with strict security requirements.
 
-Convox also supports the Let's Encrypt DNS-01 challenge for SSL certificate generation, which is useful when HTTP endpoints are not exposed or when wildcard certificates are required. The DNS-01 challenge verifies domain ownership via DNS TXT records, and it is ideal for environments with strict security requirements.
+### Using AWS Route53
 
 ### Setting Up DNS-01 Challenge
 
@@ -129,6 +129,27 @@ convox letsencrypt dns route53 list
 ```
 
 This command will list your DNS zones and hosted zone IDs, confirming that the DNS-01 challenge is configured correctly.
+
+### Using Cloudflare
+
+If you manage DNS in Cloudflare, you can hand the token or API key value directly to Convox and it will manage the underlying secret for you.
+
+1. **Configure the DNS Solver**: Run the following command to register the Cloudflare solver with Convox. Supplying `--api-token` causes Convox to store the token in a secret named `cloudflare-dns-credential-<id>` under the `cert-manager` namespace automatically.
+
+```html
+convox letsencrypt dns cloudflare add --id 1 --dns-zones <your.zone> \
+  --api-token <your_api_token>
+```
+
+   To use an API key instead, swap `--api-token` for `--api-key <your_api_key>` and add `--email <cloudflare_account_email>`. Convox stores both the key and email alongside one another in the same secret so cert-manager can authenticate correctly.
+
+2. **Verify Configuration**: Check the configuration:
+
+```html
+convox letsencrypt dns cloudflare list
+```
+
+This command will list your Cloudflare-backed DNS zones and the referenced Kubernetes secrets, confirming that the DNS-01 challenge is configured correctly.
 
 ## Wildcard Certificates and Reuse
 

--- a/docs/reference/cli/letsencrypt.md
+++ b/docs/reference/cli/letsencrypt.md
@@ -35,7 +35,7 @@ Configure a new letsencrypt DNS-01 solver for a Route53 DNS zone
 
 ## letsencrypt dns route53 list
 
-List configured letsencrypt dns solvers for route53
+List configured Let's Encrypt DNS solvers for Route53.
 
 ### Usage
 ```bash
@@ -47,9 +47,25 @@ List configured letsencrypt dns solvers for route53
     ID  DNS-ZONES    HOSTED-ZONE-ID  REGION     ROLE
     1   example.com  XXXXXXXXXXXXX   us-east-1  arn:aws:iam::XXXXXXXXXXXX:role/dns-access
 ```
+
+## letsencrypt dns cloudflare list
+
+List configured Let's Encrypt DNS solvers for Cloudflare.
+
+### Usage
+```html
+    convox letsencrypt dns cloudflare list
+```
+### Examples
+```html
+    $ convox letsencrypt dns cloudflare list
+    ID  DNS-ZONES      TYPE       SECRET                         FIELDS          EMAIL
+    1   example.com    API Token  cloudflare-dns-credential-1   api-token
+```
+Supplying `--api-token` or `--api-key` causes Convox to create or update a secret in the `cert-manager` namespace automatically (defaulting to `cloudflare-dns-credential-<id>` for the solver). `api-token` is written for token-based auth; API key auth stores both `api-key` and `email` entries in the same secret.
 ## letsencrypt dns route53 update
 
-Update letsencrypt dns solvers for route53 dns zone
+Update Let's Encrypt DNS solvers for a Route53 hosted zone.
 
 ### Usage
 ```bash
@@ -74,7 +90,7 @@ Update letsencrypt dns solvers for route53 dns zone
 
 ## letsencrypt dns route53 delete
 
-Delete letsencrypt dns solvers for route53 dns zone
+Delete Let's Encrypt DNS solvers for a Route53 hosted zone.
 
 ### Usage
 ```bash
@@ -95,7 +111,7 @@ Delete letsencrypt dns solvers for route53 dns zone
 
 ## letsencrypt dns route53 role
 
-Letsencrypt route53 role
+Show the IAM role the rack uses for Route53 DNS-01 challenges.
 
 ### Usage
 ```bash
@@ -106,6 +122,59 @@ Letsencrypt route53 role
 ```bash
     $ convox letsencrypt dns route53 role
     arn:aws:iam::XXXXXXXXXXXX:role/xxx-cert-manager
+
+## letsencrypt dns cloudflare add
+
+Configure a Let's Encrypt DNS solver that uses a Cloudflare API token or API key secret stored in Kubernetes.
+
+### Usage
+```html
+    convox letsencrypt dns cloudflare add --id [id] --dns-zones [dns-zone] \
+      [--api-token token | --api-key key --email email]
+```
+
+### Examples
+```html
+    $ convox letsencrypt dns cloudflare add --id 1 --dns-zones example.com \
+        --api-token myCloudflareTokenValue
+    OK
+
+    $ convox letsencrypt dns cloudflare add --id 2 --dns-zones example.com \
+        --api-key abc123 --email ops@example.com
+    OK
+```
+
+## letsencrypt dns cloudflare update
+
+Update an existing Cloudflare DNS solver. All provided flags replace the stored values for that solver ID.
+
+### Usage
+```html
+    convox letsencrypt dns cloudflare update --id [id] [--dns-zones dns-zone] \
+      [--api-token token | --api-key key --email email]
+```
+
+### Examples
+```html
+    $ convox letsencrypt dns cloudflare update --id 1 --dns-zones example.com \
+        --api-token myNewCloudflareTokenValue
+    OK
+```
+
+## letsencrypt dns cloudflare delete
+
+Remove a Cloudflare DNS solver by ID.
+
+### Usage
+```html
+    convox letsencrypt dns cloudflare delete --id [id]
+```
+
+### Examples
+```html
+    $ convox letsencrypt dns cloudflare delete --id 1
+    OK
+```
 ```
 
 ## See Also

--- a/pkg/cli/certs.go
+++ b/pkg/cli/certs.go
@@ -92,6 +92,91 @@ func init() {
 		},
 		Validate: stdcli.Args(0),
 	})
+
+	register("letsencrypt dns cloudflare add", "configure letsencrypt dns cloudflare solver", CertLetsEncryptDnsCloudflareAdd, stdcli.CommandOptions{
+		Flags: []stdcli.Flag{
+			flagRack,
+			stdcli.IntFlag("id", "", "dns solver id"),
+			stdcli.StringFlag("dns-zones", "", "comma separated dns zones"),
+			stdcli.StringFlag("api-token", "", "cloudflare api token value"),
+			stdcli.StringFlag("api-key", "", "cloudflare api key value"),
+			stdcli.StringFlag("email", "", "cloudflare account email (required for api key auth)"),
+		},
+		Validate: stdcli.Args(0),
+	})
+
+	register("letsencrypt dns cloudflare update", "update letsencrypt dns cloudflare solver", CertLetsEncryptDnsCloudflareUpdate, stdcli.CommandOptions{
+		Flags: []stdcli.Flag{
+			flagRack,
+			stdcli.IntFlag("id", "", "dns solver id"),
+			stdcli.StringFlag("dns-zones", "", "comma separated dns zones"),
+			stdcli.StringFlag("api-token", "", "cloudflare api token value"),
+			stdcli.StringFlag("api-key", "", "cloudflare api key value"),
+			stdcli.StringFlag("email", "", "cloudflare account email (required for api key auth)"),
+		},
+		Validate: stdcli.Args(0),
+	})
+
+	register("letsencrypt dns cloudflare delete", "delete letsencrypt dns cloudflare solver", CertLetsEncryptDnsCloudflareDelete, stdcli.CommandOptions{
+		Flags: []stdcli.Flag{
+			flagRack,
+			stdcli.IntFlag("id", "", "dns solver id"),
+		},
+		Validate: stdcli.Args(0),
+	})
+
+	register("letsencrypt dns cloudflare list", "list letsencrypt dns cloudflare solver", CertLetsEncryptDnsCloudflareList, stdcli.CommandOptions{
+		Flags: []stdcli.Flag{
+			flagRack,
+		},
+		Validate: stdcli.Args(0),
+	})
+}
+
+func optionalString(v string) *string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return nil
+	}
+	return options.String(v)
+}
+
+func cloudflareCredentialFromCLI(id int, c *stdcli.Context) (*structs.Cloudflare, error) {
+	tokenValue := strings.TrimSpace(c.String("api-token"))
+	keyValue := strings.TrimSpace(c.String("api-key"))
+	emailValue := strings.TrimSpace(c.String("email"))
+
+	if tokenValue != "" && keyValue != "" {
+		return nil, fmt.Errorf("cloudflare api token and api key options are mutually exclusive")
+	}
+
+	if tokenValue == "" && keyValue == "" && emailValue == "" {
+		return nil, nil
+	}
+
+	if tokenValue == "" && keyValue == "" {
+		return nil, fmt.Errorf("either --api-token or --api-key must be provided")
+	}
+
+	secretName := fmt.Sprintf("cloudflare-dns-credential-%d", id)
+	cf := &structs.Cloudflare{}
+
+	if tokenValue != "" {
+		cf.ApiTokenValue = options.String(tokenValue)
+		cf.ApiTokenSecretRefName = options.String(secretName)
+		cf.ApiTokenSecretRefKey = options.String("api-token")
+		cf.Email = nil
+	} else {
+		if emailValue == "" {
+			return nil, fmt.Errorf("email is required when using --api-key")
+		}
+		cf.ApiKeyValue = options.String(keyValue)
+		cf.ApiKeySecretRefName = options.String(secretName)
+		cf.ApiKeySecretRefKey = options.String("api-key")
+		cf.Email = options.String(emailValue)
+	}
+
+	return cf, nil
 }
 
 func Certs(rack sdk.Interface, c *stdcli.Context) error {
@@ -258,7 +343,7 @@ func CertLetsEncryptDnsRoute53Add(rack sdk.Interface, c *stdcli.Context) error {
 	}
 
 	if exists[solver.Id] {
-		return fmt.Errorf("id required or provided id is already in use")
+		return fmt.Errorf("provided id is already in use")
 	}
 
 	config.Solvers = append(config.Solvers, solver)
@@ -267,6 +352,196 @@ func CertLetsEncryptDnsRoute53Add(rack sdk.Interface, c *stdcli.Context) error {
 		return err
 	}
 	return c.OK()
+}
+
+func CertLetsEncryptDnsCloudflareAdd(rack sdk.Interface, c *stdcli.Context) error {
+	solver := &structs.Dns01Solver{}
+	solver.Id = c.Int("id")
+	if solver.Id <= 0 {
+		return fmt.Errorf("invalid id or id is not provided")
+	}
+
+	zonesInput := strings.TrimSpace(c.String("dns-zones"))
+	if zonesInput == "" {
+		return fmt.Errorf("dns zones are required")
+	}
+
+	for _, d := range strings.Split(zonesInput, ",") {
+		dd := strings.TrimSpace(d)
+		if dd != "" {
+			solver.DnsZones = append(solver.DnsZones, dd)
+		}
+	}
+
+	if len(solver.DnsZones) == 0 {
+		return fmt.Errorf("dns zones are required")
+	}
+
+	cf, err := cloudflareCredentialFromCLI(solver.Id, c)
+	if err != nil {
+		return err
+	}
+	if cf == nil {
+		return fmt.Errorf("either --api-token or --api-key must be provided")
+	}
+	solver.Cloudflare = cf
+
+	if err := solver.Validate(); err != nil {
+		return err
+	}
+
+	config, err := rack.LetsEncryptConfigGet()
+	if err != nil {
+		return fmt.Errorf("failed to get config: %s", err)
+	}
+
+	exists := map[int]bool{}
+	for i := range config.Solvers {
+		exists[config.Solvers[i].Id] = true
+	}
+
+	if exists[solver.Id] {
+		return fmt.Errorf("provided id is already in use")
+	}
+
+	config.Solvers = append(config.Solvers, solver)
+
+	if err := rack.LetsEncryptConfigApply(*config); err != nil {
+		return err
+	}
+	return c.OK()
+}
+
+func CertLetsEncryptDnsCloudflareUpdate(rack sdk.Interface, c *stdcli.Context) error {
+	config, err := rack.LetsEncryptConfigGet()
+	if err != nil {
+		return fmt.Errorf("failed to get config: %s", err)
+	}
+
+	id := c.Int("id")
+	if id <= 0 {
+		return fmt.Errorf("invalid id or id is not provided")
+	}
+
+	var solver *structs.Dns01Solver
+	for _, s := range config.Solvers {
+		if s.Id == id {
+			solver = s
+			break
+		}
+	}
+
+	if solver == nil {
+		return fmt.Errorf("solver with id %d not found", id)
+	}
+
+	if dz := strings.TrimSpace(c.String("dns-zones")); dz != "" {
+		zones := []string{}
+		for _, d := range strings.Split(dz, ",") {
+			dd := strings.TrimSpace(d)
+			if dd != "" {
+				zones = append(zones, dd)
+			}
+		}
+		if len(zones) == 0 {
+			return fmt.Errorf("dns zones are required")
+		}
+		solver.DnsZones = zones
+	}
+
+	cf, err := cloudflareCredentialFromCLI(solver.Id, c)
+	if err != nil {
+		return err
+	}
+	if cf != nil {
+		solver.Cloudflare = cf
+	}
+
+	if err := solver.Validate(); err != nil {
+		return err
+	}
+
+	if err := rack.LetsEncryptConfigApply(*config); err != nil {
+		return err
+	}
+	return c.OK()
+}
+
+func CertLetsEncryptDnsCloudflareDelete(rack sdk.Interface, c *stdcli.Context) error {
+	id := c.Int("id")
+	if id <= 0 {
+		return fmt.Errorf("invalid id or id is not provided")
+	}
+
+	config, err := rack.LetsEncryptConfigGet()
+	if err != nil {
+		return fmt.Errorf("failed to get config: %s", err)
+	}
+
+	found := false
+	solvers := []*structs.Dns01Solver{}
+	for i := range config.Solvers {
+		if config.Solvers[i].Id == id {
+			found = true
+		} else {
+			solvers = append(solvers, config.Solvers[i])
+		}
+	}
+
+	if !found {
+		return fmt.Errorf("solver with id %d not found", id)
+	}
+
+	config.Solvers = solvers
+	if err := rack.LetsEncryptConfigApply(*config); err != nil {
+		return err
+	}
+	return c.OK()
+}
+
+func CertLetsEncryptDnsCloudflareList(rack sdk.Interface, c *stdcli.Context) error {
+	config, err := rack.LetsEncryptConfigGet()
+	if err != nil {
+		return fmt.Errorf("failed to get config: %s", err)
+	}
+
+	t := c.Table("ID", "DNS-ZONES", "TYPE", "SECRET", "FIELDS", "EMAIL")
+
+	for _, solver := range config.Solvers {
+		if solver.Cloudflare != nil {
+			cl := solver.Cloudflare
+
+			authType := ""
+			secretName := ""
+			fields := []string{}
+
+			if cl.ApiTokenSecretRefName != nil && *cl.ApiTokenSecretRefName != "" {
+				authType = "API Token"
+				secretName = *cl.ApiTokenSecretRefName
+				if cl.ApiTokenSecretRefKey != nil && *cl.ApiTokenSecretRefKey != "" {
+					fields = append(fields, *cl.ApiTokenSecretRefKey)
+				}
+			} else if cl.ApiKeySecretRefName != nil && *cl.ApiKeySecretRefName != "" {
+				authType = "API Key"
+				secretName = *cl.ApiKeySecretRefName
+				if cl.ApiKeySecretRefKey != nil && *cl.ApiKeySecretRefKey != "" {
+					fields = append(fields, *cl.ApiKeySecretRefKey)
+				}
+				fields = append(fields, "email")
+			}
+
+			t.AddRow(
+				strconv.Itoa(solver.Id),
+				strings.Join(solver.DnsZones, ","),
+				authType,
+				secretName,
+				strings.Join(fields, ", "),
+				options.StringValueSafe(cl.Email),
+			)
+		}
+	}
+
+	return t.Print()
 }
 
 func CertLetsEncryptDnsRoute53Update(rack sdk.Interface, c *stdcli.Context) error {

--- a/pkg/structs/dns.go
+++ b/pkg/structs/dns.go
@@ -22,20 +22,30 @@ func (l *LetsEncryptConfig) Defaults() {
 }
 
 type Dns01Solver struct {
-	Id       int      `json:"id" param:"id" flag:"id"`
-	DnsZones []string `json:"dns-zones" param:"dns-zones"`
-	Route53  *Route53 `json:"route53" param:"route53"`
+	Id         int         `json:"id" param:"id" flag:"id"`
+	DnsZones   []string    `json:"dns-zones" param:"dns-zones"`
+	Route53    *Route53    `json:"route53" param:"route53"`
+	Cloudflare *Cloudflare `json:"cloudflare" param:"cloudflare"`
 }
 
 func (d *Dns01Solver) Validate() error {
 	if len(d.DnsZones) == 0 {
 		return fmt.Errorf("dns zones are required")
 	}
-	if d.Route53 != nil {
-		if d.Route53.Role == nil || len(*d.Route53.Role) == 0 {
-			return fmt.Errorf("route53 access role is required")
+
+	switch {
+	case d.Route53 != nil:
+		if err := d.Route53.Validate(); err != nil {
+			return err
 		}
+	case d.Cloudflare != nil:
+		if err := d.Cloudflare.Validate(); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("route53 or cloudflare configuration is required")
 	}
+
 	return nil
 }
 
@@ -43,4 +53,42 @@ type Route53 struct {
 	HostedZoneID *string `json:"hosted-zone-id" param:"hosted-zone-id"`
 	Region       *string `json:"region" param:"region"`
 	Role         *string `json:"role" param:"role"`
+}
+
+func (r *Route53) Validate() error {
+	if r.Role == nil || len(*r.Role) == 0 {
+		return fmt.Errorf("route53 access role is required")
+	}
+	return nil
+}
+
+type Cloudflare struct {
+	ApiTokenSecretRefName *string `json:"api-token-secret-ref-name" param:"api-token-secret-ref-name"`
+	ApiTokenSecretRefKey  *string `json:"api-token-secret-ref-key" param:"api-token-secret-ref-key"`
+	ApiTokenValue         *string `json:"api-token,omitempty" param:"api-token"`
+	ApiKeySecretRefName   *string `json:"api-key-secret-ref-name" param:"api-key-secret-ref-name"`
+	ApiKeySecretRefKey    *string `json:"api-key-secret-ref-key" param:"api-key-secret-ref-key"`
+	ApiKeyValue           *string `json:"api-key,omitempty" param:"api-key"`
+	Email                 *string `json:"email" param:"email"`
+}
+
+func (c *Cloudflare) Validate() error {
+	hasTokenRef := c.ApiTokenSecretRefName != nil && *c.ApiTokenSecretRefName != "" && c.ApiTokenSecretRefKey != nil && *c.ApiTokenSecretRefKey != ""
+	hasTokenValue := c.ApiTokenValue != nil && *c.ApiTokenValue != ""
+	hasKeyRef := c.ApiKeySecretRefName != nil && *c.ApiKeySecretRefName != "" && c.ApiKeySecretRefKey != nil && *c.ApiKeySecretRefKey != ""
+	hasKeyValue := c.ApiKeyValue != nil && *c.ApiKeyValue != ""
+
+	if (hasTokenRef || hasTokenValue) && (hasKeyRef || hasKeyValue) {
+		return fmt.Errorf("cloudflare api token and api key secret references are mutually exclusive")
+	}
+
+	if !(hasTokenRef || hasTokenValue || hasKeyRef || hasKeyValue) {
+		return fmt.Errorf("cloudflare api token or api key secret reference is required")
+	}
+
+	if (hasKeyRef || hasKeyValue) && (c.Email == nil || *c.Email == "") {
+		return fmt.Errorf("cloudflare email is required when using api key secret")
+	}
+
+	return nil
 }

--- a/provider/k8s/certificate.go
+++ b/provider/k8s/certificate.go
@@ -320,7 +320,27 @@ func (p *Provider) renewCertificate(crt *cmapi.Certificate) error {
 
 func (p *Provider) LetsEncryptConfigApply(config structs.LetsEncryptConfig) error {
 	config.Defaults()
-	data, err := json.Marshal(config)
+	configForStorage := config
+	configForStorage.Solvers = make([]*structs.Dns01Solver, len(config.Solvers))
+
+	for i := range config.Solvers {
+		solver := config.Solvers[i]
+		solverCopy := *solver
+
+		if solver.Cloudflare != nil {
+			cf := *solver.Cloudflare
+
+			if err := p.ensureCloudflareSecrets(&cf); err != nil {
+				return err
+			}
+
+			solverCopy.Cloudflare = &cf
+		}
+
+		configForStorage.Solvers[i] = &solverCopy
+	}
+
+	data, err := json.Marshal(configForStorage)
 	if err != nil {
 		return err
 	}
@@ -351,6 +371,98 @@ func (p *Provider) LetsEncryptConfigApply(config structs.LetsEncryptConfig) erro
 		"Config":       config,
 		"IngressClass": p.Engine.IngressClass(),
 	})
+}
+
+func (p *Provider) ensureCloudflareSecrets(cf *structs.Cloudflare) error {
+	if cf == nil {
+		return nil
+	}
+
+	if cf.ApiTokenSecretRefName != nil && *cf.ApiTokenSecretRefName != "" && (cf.ApiTokenSecretRefKey == nil || *cf.ApiTokenSecretRefKey == "") {
+		cf.ApiTokenSecretRefKey = options.String("api-token")
+	}
+
+	if cf.ApiKeySecretRefName != nil && *cf.ApiKeySecretRefName != "" && (cf.ApiKeySecretRefKey == nil || *cf.ApiKeySecretRefKey == "") {
+		cf.ApiKeySecretRefKey = options.String("api-key")
+	}
+
+	secretName := ""
+	data := map[string][]byte{}
+
+	if cf.ApiTokenValue != nil && *cf.ApiTokenValue != "" {
+		if cf.ApiTokenSecretRefName == nil || *cf.ApiTokenSecretRefName == "" {
+			return fmt.Errorf("cloudflare api token secret name is required when providing a token value")
+		}
+
+		secretName = *cf.ApiTokenSecretRefName
+
+		key := "api-token"
+		if cf.ApiTokenSecretRefKey != nil && *cf.ApiTokenSecretRefKey != "" {
+			key = *cf.ApiTokenSecretRefKey
+		} else {
+			cf.ApiTokenSecretRefKey = options.String(key)
+		}
+
+		data[key] = []byte(*cf.ApiTokenValue)
+	}
+
+	if cf.ApiKeyValue != nil && *cf.ApiKeyValue != "" {
+		if cf.ApiKeySecretRefName == nil || *cf.ApiKeySecretRefName == "" {
+			return fmt.Errorf("cloudflare api key secret name is required when providing an api key value")
+		}
+
+		if secretName == "" {
+			secretName = *cf.ApiKeySecretRefName
+		} else if secretName != *cf.ApiKeySecretRefName {
+			return fmt.Errorf("cloudflare api credentials must reference the same secret")
+		}
+
+		key := "api-key"
+		if cf.ApiKeySecretRefKey != nil && *cf.ApiKeySecretRefKey != "" {
+			key = *cf.ApiKeySecretRefKey
+		} else {
+			cf.ApiKeySecretRefKey = options.String(key)
+		}
+
+		data[key] = []byte(*cf.ApiKeyValue)
+		if cf.Email != nil && *cf.Email != "" {
+			data["email"] = []byte(*cf.Email)
+		}
+	}
+
+	if len(data) > 0 {
+		if secretName == "" {
+			return fmt.Errorf("cloudflare secret name is required")
+		}
+
+		if err := p.ensureSecretData(secretName, data); err != nil {
+			return err
+		}
+
+		cf.ApiTokenValue = nil
+		cf.ApiKeyValue = nil
+	}
+
+	return nil
+}
+
+func (p *Provider) ensureSecretData(name string, data map[string][]byte) error {
+	secret := corev1.Secret(name, CERT_MANAGER_NAMESPACE)
+	secret.WithLabels(map[string]string{
+		"system": "convox",
+		"rack":   p.Name,
+	})
+	secret.WithData(data)
+	secret.WithType(ac.SecretTypeOpaque)
+
+	_, err := p.Cluster.CoreV1().Secrets(CERT_MANAGER_NAMESPACE).Apply(context.TODO(), secret, am.ApplyOptions{
+		FieldManager: "convox-system",
+	})
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
 }
 
 func (p *Provider) LetsEncryptConfigGet() (*structs.LetsEncryptConfig, error) {

--- a/provider/k8s/template/system/cert-manager-letsencrypt.yml.tmpl
+++ b/provider/k8s/template/system/cert-manager-letsencrypt.yml.tmpl
@@ -20,20 +20,43 @@ spec:
    {{ with .Config }}
    {{ range .Solvers }}
    - dns01:
-       {{ with .Route53 }}
+       {{- with .Route53 }}
        route53:
-         {{ with .HostedZoneID }}
+         {{- with .HostedZoneID }}
          hostedZoneID: {{ . }}
-         {{ end }}
+         {{- end }}
          region: {{ .Region }}
-         {{ with .Role }}
+         {{- with .Role }}
          role: {{ safe . }}
-         {{ end }}
-       {{ end }}
+         {{- end }}
+       {{- end }}
+      {{- with .Cloudflare }}
+      cloudflare:
+        {{- if and .ApiTokenSecretRefName .ApiTokenSecretRefKey }}
+        apiTokenSecretRef:
+          {{- with .ApiTokenSecretRefName }}
+          name: {{ . }}
+          {{- end }}
+          {{- with .ApiTokenSecretRefKey }}
+          key: {{ . }}
+          {{- end }}
+        {{- else if and .ApiKeySecretRefName .ApiKeySecretRefKey }}
+        apiKeySecretRef:
+          {{- with .ApiKeySecretRefName }}
+          name: {{ . }}
+          {{- end }}
+          {{- with .ApiKeySecretRefKey }}
+          key: {{ . }}
+          {{- end }}
+        {{- with .Email }}
+        email: {{ . }}
+        {{- end }}
+        {{- end }}
+      {{- end }}
      selector:
        dnsZones:
-       {{ range .DnsZones }}
+       {{- range .DnsZones }}
        - {{ safe . }}
-       {{ end }}
+       {{- end }}
    {{ end }}
    {{ end }}

--- a/provider/k8s/template_test.go
+++ b/provider/k8s/template_test.go
@@ -34,12 +34,12 @@ func TestRenderTemplate(t *testing.T) {
 					},
 				},
 				{
-					Id:       1,
-					DnsZones: []string{"test.com"},
-					Route53: &structs.Route53{
-						HostedZoneID: options.String("host"),
-						Region:       options.String("us"),
-						Role:         options.String("role"),
+					Id:       2,
+					DnsZones: []string{"example.org"},
+					Cloudflare: &structs.Cloudflare{
+						ApiKeySecretRefName: options.String("cloudflare-dns-credential-2"),
+						ApiKeySecretRefKey:  options.String("api-key"),
+						Email:               options.String("ops@example.com"),
 					},
 				},
 			},


### PR DESCRIPTION
### What is the feature/fix?

- Feature goal: add first-class Cloudflare DNS‑01 support so Convox manages the solver and the underlying Kubernetes secret automatically.
- Bug + solution: previously only Route53 solvers were supported and Cloudflare users had to hand-edit the ClusterIssuer, which Convox would overwrite. Now the CLI/API accept either a Cloudflare API token or an API key + email, create/update
  the `cert-manager/cloudflare-dns-credential-<id>` secret, strip raw credentials before storing the config, and render the solver correctly.
- Additional info: validation enforces “token xor key”, requires email for API key auth, and the CLI mirrors the Route53 commands (letsencrypt dns cloudflare add/update/delete/list).

### Add screenshot or video (optional)

N/A

### Does it has a breaking change?

No breaking changes; Route53 functionality is unchanged and Cloudflare support is additive.

### How to use/test it?

1. Configure the solver (Convox writes the secret automatically):

    ```
    convox letsencrypt dns cloudflare add \
      --id 1 \
      --dns-zones <zone> \
      --api-token <your-cloudflare-token>
    ```
   
    For legacy API key auth with email:

    ```
    convox letsencrypt dns cloudflare add \
      --id 2 \
      --dns-zones <zone> \
      --api-key <your-cloudflare-key> \
      --email you@example.com
    ```
    
2. Verify with `convox letsencrypt dns cloudflare list`; you should see the solver with the secret name `cloudflare-dns-credential-<id>`.
3. Run automated tests: `make test` (runs `TEST=true go test ./...`).

### Testing

I've pushed a Docker image here: https://hub.docker.com/repository/docker/docspringcom/convox
This is deployed to our staging rack and I've successfully set up the Cloudflare DNS-01 solver using the new convox CLI command.

### Checklist

- [ ] New coverage tests
- [x] Unit tests passing (make test)
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [x] Documentation updated
- [x] No warnings or errors on Deepsource/Codecov