### PR TITLE
Allow overriding rack release without GitHub lookup

### DIFF
--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -65,6 +65,8 @@ data "aws_eks_cluster_auth" "cluster" {
 }
 
 data "http" "releases" {
+  count = var.release == "" ? 1 : 0
+
   url = "https://api.github.com/repos/${var.image}/releases/latest"
   request_headers = {
     User-Agent = "convox"
@@ -80,11 +82,11 @@ locals {
   build_node_type = var.build_node_type != "" ? var.build_node_type : local.node_type
   arm_type        = module.node_arch.is_arm
   build_arm_type  = module.build_node_arch.is_arm
-  current         = jsondecode(data.http.releases.response_body).tag_name
+  desired_release = var.release != "" ? var.release : jsondecode(data.http.releases[0].response_body).tag_name
   gpu_type        = substr(local.node_type, 0, 1) == "g" || substr(local.node_type, 0, 1) == "p"
   build_gpu_type  = substr(local.build_node_type, 0, 1) == "g" || substr(local.build_node_type, 0, 1) == "p"
   image           = var.image
-  release         = coalesce(var.release, local.current)
+  release         = local.desired_release
   tag_map = length(var.tags) == 0 ? {} : {
     for v in split(",", var.tags) :
     "${split("=", v)[0]}" => split("=", v)[1]

--- a/terraform/system/azure/main.tf
+++ b/terraform/system/azure/main.tf
@@ -11,7 +11,12 @@ provider "kubernetes" {
 }
 
 data "http" "releases" {
+  count = var.release == "" ? 1 : 0
+
   url = "https://api.github.com/repos/${var.image}/releases/latest"
+  request_headers = {
+    User-Agent = "convox"
+  }
 }
 
 locals {

--- a/terraform/system/do/main.tf
+++ b/terraform/system/do/main.tf
@@ -11,14 +11,19 @@ provider "kubernetes" {
 }
 
 data "http" "releases" {
+  count = var.release == "" ? 1 : 0
+
   url = "https://api.github.com/repos/${var.image}/releases/latest"
+  request_headers = {
+    User-Agent = "convox"
+  }
 }
 
 locals {
-  name      = lower(var.name)
-  rack_name = lower(var.rack_name)
-  current   = jsondecode(data.http.releases.response_body).tag_name
-  release   = coalesce(var.release, local.current)
+  name            = lower(var.name)
+  rack_name       = lower(var.rack_name)
+  desired_release = var.release != "" ? var.release : jsondecode(data.http.releases[0].response_body).tag_name
+  release         = local.desired_release
 }
 
 module "cluster" {

--- a/terraform/system/gcp/main.tf
+++ b/terraform/system/gcp/main.tf
@@ -16,14 +16,19 @@ module "project" {
 }
 
 data "http" "releases" {
+  count = var.release == "" ? 1 : 0
+
   url = "https://api.github.com/repos/${var.image}/releases/latest"
+  request_headers = {
+    User-Agent = "convox"
+  }
 }
 
 locals {
-  name      = lower(var.name)
-  rack_name = lower(var.rack_name)
-  current   = jsondecode(data.http.releases.response_body).tag_name
-  release   = coalesce(var.release, local.current)
+  name            = lower(var.name)
+  rack_name       = lower(var.rack_name)
+  desired_release = var.release != "" ? var.release : jsondecode(data.http.releases[0].response_body).tag_name
+  release         = local.desired_release
 
   # a malformed non-empty value must fail the plan, not silently become [] and destroy the pools
   additional_node_groups = var.additional_node_groups_config == "" ? [] : try(jsondecode(var.additional_node_groups_config), jsondecode(base64decode(var.additional_node_groups_config)))

--- a/terraform/system/local/main.tf
+++ b/terraform/system/local/main.tf
@@ -1,12 +1,17 @@
 data "http" "releases" {
+  count = var.release == "" ? 1 : 0
+
   url = "https://api.github.com/repos/${var.image}/releases/latest"
+  request_headers = {
+    User-Agent = "convox"
+  }
 }
 
 locals {
-  name      = lower(var.name)
-  rack_name = lower(var.rack_name)
-  current   = jsondecode(data.http.releases.response_body).tag_name
-  release   = coalesce(var.release, local.current)
+  name            = lower(var.name)
+  rack_name       = lower(var.rack_name)
+  desired_release = var.release != "" ? var.release : jsondecode(data.http.releases[0].response_body).tag_name
+  release         = local.desired_release
 }
 
 provider "kubernetes" {

--- a/terraform/system/metal/main.tf
+++ b/terraform/system/metal/main.tf
@@ -1,12 +1,17 @@
 data "http" "releases" {
+  count = var.release == "" ? 1 : 0
+
   url = "https://api.github.com/repos/${var.image}/releases/latest"
+  request_headers = {
+    User-Agent = "convox"
+  }
 }
 
 locals {
-  name      = lower(var.name)
-  rack_name = lower(var.rack_name)
-  current   = jsondecode(data.http.releases.response_body).tag_name
-  release   = coalesce(var.release, local.current)
+  name            = lower(var.name)
+  rack_name       = lower(var.rack_name)
+  desired_release = var.release != "" ? var.release : jsondecode(data.http.releases[0].response_body).tag_name
+  release         = local.desired_release
 }
 
 provider "kubernetes" {}
@@ -30,4 +35,3 @@ module "rack" {
   webhook_signing_key = var.webhook_signing_key
   whitelist           = split(",", var.whitelist)
 }
-


### PR DESCRIPTION
### What is the feature/fix?

This was needed during the development of https://github.com/convox/convox/pull/925 so that I could test my changes on our staging rack.

- Task & goal: allow racks that set `var.release` (or `var.image`) to skip the GitHub “latest release” lookup. Terraform will now only hit the GitHub API when release is empty, keeping our private fork from breaking during terraform plan/apply while we test changes.
- Bug & solution: previously, Convox’s module always queried https://api.github.com/repos/${var.image}/releases/latest, which fails for private/forked repos. Each cloud module (terraform/system/*/main.tf) now guards the lookup with count =
  var.release == "" ? 1 : 0, so providing var.release short-circuits the request.
- Additional info: Applicable to AWS, GCP, Azure, DO, Metal, and Local modules; behavior is unchanged for users relying on the official public repo.

### Add screenshot or video (optional)

- N/A

### Does it has a breaking change?

- No. If var.release is unset, the modules behave exactly as before (still fetching the latest release). Setting var.release just avoids the GitHub call.

### How to use/test it?

- Set module "system" { release = "cloudflare-dns01-support" } (or any tag you publish) in your rack Terraform.
- Run terraform plan / terraform apply; notice no GitHub API call is made and the apply succeeds with the supplied release.
- Leaving release blank continues to fetch the Convox release as before.

### Checklist

- [ ] New coverage tests
- [x] Unit tests passing (terraform fmt / terraform plan locally)
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [x] No warnings or errors on Deepsource/Codecov