### PR TITLE
Fix build nodes error when cluster is public only

### DIFF
--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -116,6 +116,7 @@ resource "random_id" "build_node_group" {
     node_disk           = var.node_disk
     node_type           = var.build_node_type
     private_subnets_ids = join("-", local.private_subnets_ids)
+    public_subnets_ids  = join("-", local.public_subnets_ids)
     role_arn            = replace(aws_iam_role.nodes.arn, "role/convox/", "role/") # eks barfs on roles with paths
   }
 }
@@ -189,7 +190,7 @@ resource "aws_eks_node_group" "cluster-build" {
   instance_types  = split(",", random_id.build_node_group[0].keepers.node_type)
   node_group_name = "${var.name}-build-${data.aws_subnet.private_subnet_details[count.index].availability_zone}-${count.index}${random_id.build_node_group[0].hex}"
   node_role_arn   = random_id.build_node_group[0].keepers.role_arn
-  subnet_ids      = [local.private_subnets_ids[count.index]]
+  subnet_ids      = [var.private ? local.private_subnets_ids[count.index] : local.public_subnets_ids[count.index]]
   tags            = local.tags
   version         = var.k8s_version
 

--- a/terraform/cluster/aws/node_groups.tf
+++ b/terraform/cluster/aws/node_groups.tf
@@ -207,6 +207,7 @@ resource "random_id" "build_node_additional" {
     capacity_type       = each.value.capacity_type
     ami_id              = each.value.ami_id
     private_subnets_ids = join("-", local.private_subnets_ids)
+    public_subnets_ids  = join("-", local.public_subnets_ids)
     role_arn            = replace(aws_iam_role.nodes.arn, "role/convox/", "role/") # eks barfs on roles with paths
     tags                = try(jsonencode(each.value.tags), "")
   }
@@ -232,7 +233,7 @@ resource "aws_eks_node_group" "build_additional" {
   cluster_name    = aws_eks_cluster.cluster.name
   node_group_name = "${var.name}-build-additional-${each.key}-${random_id.build_node_additional[each.key].hex}"
   node_role_arn   = random_id.build_node_additional[each.key].keepers.role_arn
-  subnet_ids      = local.private_subnets_ids
+  subnet_ids      = var.private ? local.private_subnets_ids : local.public_subnets_ids
   tags            = each.value.tags == null ? local.tags : merge(local.tags, each.value.tags)
   version         = random_id.build_node_additional[each.key].keepers.ami_id != null ? null : var.k8s_version
 


### PR DESCRIPTION
### What is the feature/update/fix?

**Fix: Build Nodes Error on Public Racks**

We have resolved an issue that prevented build nodes from being properly activated on public racks (configured with rack parameter `private=false`). Previously, attempting to enable build nodes on public racks would result in an error, preventing the use of dedicated build infrastructure on these racks.

---

### Why is this important?

**Restored Build Node Functionality for Public Racks:**

- **Dedicated Build Infrastructure** - Build nodes can now be properly enabled on public racks, allowing you to isolate build processes from your application workloads
- **Resource Optimization** - Separate build nodes prevent resource contention between builds and running services
- **Cost Management** - Use spot instances or specialized instance types for builds without affecting production workloads
- **Improved Build Performance** - Dedicated build nodes with optimized configurations can significantly speed up build times

This fix is essential for teams that:
- Run public racks (`private=false`) for their environments
- Need dedicated build infrastructure on public racks
- Want to optimize costs by using different instance types for builds versus applications
- Experience resource constraints when builds run on the same nodes as services

---

### Does it have a breaking change?

**No breaking changes** are introduced with this fix.

Existing racks with build nodes already enabled are not affected. This fix only addresses the activation issue for new build node configurations on public racks.

---

### Requirements

To use this fix, you must be on at least version `3.22.4`.

For a minor version update, you must state the version with the command `convox rack update 3.22.4 -r rackName`.  
**_You must be on at least rack version `3.21.0` to perform this update._**

_If you are unfamiliar with v3 rack versioning, we advise checking the documentation [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) for more information before applying any updates._