### PR TITLE
Add support to run multiple timer replica in parallel

### DIFF
--- a/pkg/manifest/timer.go
+++ b/pkg/manifest/timer.go
@@ -6,10 +6,11 @@ type Timer struct {
 	Name        string             `yaml:"-"`
 	Annotations ServiceAnnotations `yaml:"annotations,omitempty"`
 
-	Command     string `yaml:"command,omitempty"`
-	Schedule    string `yaml:"schedule"`
-	Service     string `yaml:"service"`
-	Concurrency string `yaml:"concurrency,omitempty"`
+	Command       string `yaml:"command,omitempty"`
+	Schedule      string `yaml:"schedule"`
+	Service       string `yaml:"service"`
+	Concurrency   string `yaml:"concurrency,omitempty"`
+	ParallelCount int    `yaml:"parallelCount,omitempty"`
 }
 
 type Timers []Timer

--- a/provider/k8s/template/app/timer.yml.tmpl
+++ b/provider/k8s/template/app/timer.yml.tmpl
@@ -27,6 +27,11 @@ spec:
     spec:
       backoffLimit: 0
       # ttlSecondsAfterFinished: 60
+      {{ if gt .Timer.ParallelCount 1 }}
+      completionMode: "Indexed"
+      completions: {{ .Timer.ParallelCount }}
+      parallelism: {{ .Timer.ParallelCount }}
+      {{ end }}
       template:
         metadata:
           annotations:
@@ -102,6 +107,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            {{ if gt .Timer.ParallelCount 1 }}
+            - name: TIMER_INDEX
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['batch.kubernetes.io/job-completion-index']
+            {{ end }}
             {{ range $.Resources }}
             - name: "{{.Env}}"
               valueFrom:


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: Support for Running Multiple Timer Replicas in Parallel**

We have added support for running multiple parallel replicas of a timer, enabling concurrent execution of scheduled tasks. This feature allows you to scale your timer-based workloads horizontally by running multiple instances of the same timer simultaneously, which is particularly useful for high-throughput batch processing or distributed cron jobs.

When `parallelCount` is set to a value greater than 1, each timer container receives a unique `TIMER_INDEX` environment variable (starting from 0) that can be used to partition work or identify specific replica instances.

---

### Why is this important?

**Benefits of Parallel Timer Execution:**

- **Increased Throughput** - Process larger volumes of scheduled work by running multiple timer instances concurrently
- **Work Distribution** - Use the `TIMER_INDEX` environment variable to partition tasks across replicas (e.g., process different data shards)
- **Improved Reliability** - Reduce the impact of single instance failures on your scheduled workloads
- **Scalable Batch Processing** - Handle growing workloads without modifying your timer schedule
- **Resource Optimization** - Better utilize available compute resources by parallelizing time-sensitive batch operations

This feature is especially valuable for:
- Data processing pipelines that need to handle increasing volumes
- Cleanup operations that can be parallelized across different data partitions
- Report generation that can be split across multiple workers
- Any scheduled task where horizontal scaling improves performance

---

### How to use it?

To enable parallel timer execution, add the `parallelCount` attribute to your timer definition in `convox.yml`:

```yaml
environment:
  - PORT=3000
services:
  web:
    build: .
    port: 3000

timers:
  cleanup:
    command: ./cleanup.sh
    schedule: "*/10 * * * *"
    service: web
    parallelCount: 3
```

In this configuration:
- The `cleanup` timer will spawn **3 parallel replicas** every 10 minutes
- Each replica receives a unique `TIMER_INDEX` environment variable:
  - First container: `TIMER_INDEX=0`
  - Second container: `TIMER_INDEX=1`
  - Third container: `TIMER_INDEX=2`

#### Using TIMER_INDEX for Work Distribution

You can use the `TIMER_INDEX` environment variable in your timer scripts to partition work:

```bash
#!/bin/bash
# cleanup.sh example

TOTAL_REPLICAS=3
PARTITION=$TIMER_INDEX

echo "Processing partition $PARTITION of $TOTAL_REPLICAS"

# Example: Process different database shards based on replica index
case $TIMER_INDEX in
  0)
    echo "Processing users A-H"
    # Process first shard
    ;;
  1)
    echo "Processing users I-P"
    # Process second shard
    ;;
  2)
    echo "Processing users Q-Z"
    # Process third shard
    ;;
esac
```

#### Configuration Options

- **parallelCount**: Integer value specifying the number of parallel replicas (default: 1)
- **TIMER_INDEX**: Automatically injected environment variable (0-based index)

#### Important Considerations

- Ensure your timer logic can handle concurrent execution safely
- Consider using the `TIMER_INDEX` to avoid processing conflicts between replicas
- Database operations should account for potential race conditions
- The `concurrency` policy still applies to the timer as a whole

---

### Does it have a breaking change?

**No breaking changes** are introduced with this update. 

Existing timers without the `parallelCount` attribute will continue to run as single instances (equivalent to `parallelCount: 1`).

---

### Requirements

To use this feature, you must be on at least version `3.22.4`.

For a minor version update, you must state the version with the command `convox rack update 3.22.4 -r rackName`.  
**_You must be on at least rack version `3.21.0` to perform this update._**

_If you are unfamiliar with v3 rack versioning, we advise checking the documentation [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) for more information before applying any updates._