### PR TITLE
Fix Terraform drift for rack resources

### DIFF
--- a/terraform/api/aws/iam.tf
+++ b/terraform/api/aws/iam.tf
@@ -23,6 +23,10 @@ resource "aws_iam_role" "api" {
   assume_role_policy = data.aws_iam_policy_document.assume_api.json
   path               = "/convox/"
   tags               = local.tags
+
+  lifecycle {
+    ignore_changes = [assume_role_policy]
+  }
 }
 
 data "aws_iam_policy_document" "iam_role_manage" {
@@ -229,6 +233,11 @@ resource "aws_iam_role_policy_attachment" "api_ecr_full_access" {
   count      = var.ecr_full_access ? 1 : 0
   role       = aws_iam_role.api.name
   policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess"
+
+  lifecycle {
+    ignore_changes       = [policy_arn]
+    replace_triggered_by = [terraform_data.release_sentinel.id]
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "api_ecr_additional" {
@@ -241,36 +250,66 @@ resource "aws_iam_role_policy" "api_ec2_key_pair" {
   name   = "ec2_key_pair"
   role   = aws_iam_role.api.name
   policy = data.aws_iam_policy_document.ec2_key_pair.json
+
+  lifecycle {
+    ignore_changes       = [policy]
+    replace_triggered_by = [terraform_data.release_sentinel.id]
+  }
 }
 
 resource "aws_iam_role_policy" "api_logs" {
   name   = "logs"
   role   = aws_iam_role.api.name
   policy = data.aws_iam_policy_document.logs.json
+
+  lifecycle {
+    ignore_changes       = [policy]
+    replace_triggered_by = [terraform_data.release_sentinel.id]
+  }
 }
 
 resource "aws_iam_role_policy" "api_storage" {
   name   = "storage"
   role   = aws_iam_role.api.name
   policy = data.aws_iam_policy_document.storage.json
+
+  lifecycle {
+    ignore_changes       = [policy]
+    replace_triggered_by = [terraform_data.release_sentinel.id]
+  }
 }
 
 resource "aws_iam_role_policy" "api_iam_manage" {
   name   = "api-iam-manage"
   role   = aws_iam_role.api.name
   policy = data.aws_iam_policy_document.iam_role_manage.json
+
+  lifecycle {
+    ignore_changes       = [policy]
+    replace_triggered_by = [terraform_data.release_sentinel.id]
+  }
 }
 
 resource "aws_iam_role_policy" "api_eks_pod_identity" {
   name   = "api-eks-pod-identity"
   role   = aws_iam_role.api.name
   policy = data.aws_iam_policy_document.eks_pod_identitiy.json
+
+  lifecycle {
+    ignore_changes       = [policy]
+    replace_triggered_by = [terraform_data.release_sentinel.id]
+  }
 }
 
 resource "aws_iam_role_policy" "rds_provisioner" {
   name   = "api-rds-provisioner"
   role   = aws_iam_role.api.name
   policy = data.aws_iam_policy_document.rds_provisioner.json
+
+  lifecycle {
+    ignore_changes       = [policy]
+    replace_triggered_by = [terraform_data.release_sentinel.id]
+  }
 }
 
 data "aws_iam_policy_document" "assume_cert_manager" {
@@ -296,4 +335,8 @@ resource "aws_iam_role" "cert-manager" {
   assume_role_policy = data.aws_iam_policy_document.assume_cert_manager.json
   path               = "/convox/"
   tags               = local.tags
+
+  lifecycle {
+    ignore_changes = [assume_role_policy]
+  }
 }

--- a/terraform/api/aws/main.tf
+++ b/terraform/api/aws/main.tf
@@ -1,6 +1,10 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
+resource "terraform_data" "release_sentinel" {
+  input = var.release
+}
+
 locals {
   tags = {
     System = "convox"

--- a/terraform/api/k8s/atom.tf
+++ b/terraform/api/k8s/atom.tf
@@ -165,4 +165,11 @@ resource "kubernetes_deployment" "atom" {
     }
   }
   depends_on = [kubernetes_resource_quota.gcp-critical-pods]
+
+  lifecycle {
+    ignore_changes = [
+      spec[0].template[0].metadata[0].annotations["convox.com/triggered-reschedule-for-node"],
+      spec[0].template[0].metadata[0].annotations["convox.com/restart"]
+    ]
+  }
 }

--- a/terraform/api/k8s/main.tf
+++ b/terraform/api/k8s/main.tf
@@ -107,13 +107,13 @@ resource "kubernetes_cluster_role_binding" "api" {
   role_ref {
     api_group = "rbac.authorization.k8s.io"
     kind      = "ClusterRole"
-    name      = kubernetes_cluster_role.api.metadata.0.name
+    name      = kubernetes_cluster_role.api.metadata[0].name
   }
 
   subject {
     kind      = "ServiceAccount"
-    name      = kubernetes_service_account.api.metadata.0.name
-    namespace = kubernetes_service_account.api.metadata.0.namespace
+    name      = kubernetes_service_account.api.metadata[0].name
+    namespace = kubernetes_service_account.api.metadata[0].namespace
   }
 }
 
@@ -184,7 +184,7 @@ resource "kubernetes_deployment" "api" {
 
       spec {
         automount_service_account_token = true
-        service_account_name            = kubernetes_service_account.api.metadata.0.name
+        service_account_name            = kubernetes_service_account.api.metadata[0].name
         share_process_namespace         = true
         priority_class_name             = "system-cluster-critical"
         node_selector                   = var.karpenter_enabled ? { "convox.io/system-node" = "true" } : {}

--- a/terraform/api/k8s/main.tf
+++ b/terraform/api/k8s/main.tf
@@ -477,7 +477,8 @@ resource "kubernetes_deployment" "api" {
     ignore_changes = [
       spec[0].template[0].metadata[0].annotations["convox.com/triggered-reschedule-for-node"],
       spec[0].template[0].metadata[0].annotations["convox.com/restartAt"],
-      spec[0].template[0].metadata[0].annotations["convox.com/restart"]
+      spec[0].template[0].metadata[0].annotations["convox.com/restart"],
+      spec[0].template[0].metadata[0].annotations["convox.com/config-hash"]
     ]
   }
 

--- a/terraform/api/k8s/main.tf
+++ b/terraform/api/k8s/main.tf
@@ -473,6 +473,14 @@ resource "kubernetes_deployment" "api" {
       }
     }
   }
+  lifecycle {
+    ignore_changes = [
+      spec[0].template[0].metadata[0].annotations["convox.com/triggered-reschedule-for-node"],
+      spec[0].template[0].metadata[0].annotations["convox.com/restartAt"],
+      spec[0].template[0].metadata[0].annotations["convox.com/restart"]
+    ]
+  }
+
   depends_on = [
     kubernetes_resource_quota.gcp-critical-pods,
     kubernetes_secret_v1.webhook_signing_key,

--- a/terraform/cluster/aws/autoscaler.tf
+++ b/terraform/cluster/aws/autoscaler.tf
@@ -423,6 +423,12 @@ resource "kubernetes_deployment" "autoscaler" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      spec[0].template[0].metadata[0].annotations["convox.com/triggered-reschedule-for-node"]
+    ]
+  }
 }
 
 resource "kubernetes_cluster_role" "hpa_external_metrics" {

--- a/terraform/elasticsearch/k8s/outputs.tf
+++ b/terraform/elasticsearch/k8s/outputs.tf
@@ -1,9 +1,9 @@
 output "host" {
   depends_on = [kubernetes_stateful_set.elasticsearch]
-  value      = "${kubernetes_service.elasticsearch.metadata.0.name}.${var.namespace}.svc.cluster.local"
+  value      = "${kubernetes_service.elasticsearch.metadata[0].name}.${var.namespace}.svc.cluster.local"
 }
 
 output "url" {
   depends_on = [kubernetes_stateful_set.elasticsearch]
-  value      = "http://${kubernetes_service.elasticsearch.metadata.0.name}.${var.namespace}.svc.cluster.local:9200"
+  value      = "http://${kubernetes_service.elasticsearch.metadata[0].name}.${var.namespace}.svc.cluster.local:9200"
 }

--- a/terraform/fluentd/aws/iam.tf
+++ b/terraform/fluentd/aws/iam.tf
@@ -23,6 +23,10 @@ resource "aws_iam_role" "fluentd" {
   assume_role_policy = data.aws_iam_policy_document.assume_fluentd.json
   path               = "/convox/"
   tags               = local.tags
+
+  lifecycle {
+    ignore_changes = [assume_role_policy]
+  }
 }
 
 data "aws_iam_policy_document" "fluentd" {
@@ -52,4 +56,8 @@ resource "aws_iam_role_policy" "fluentd" {
   name   = "fluentd"
   role   = aws_iam_role.fluentd.name
   policy = data.aws_iam_policy_document.fluentd.json
+
+  lifecycle {
+    ignore_changes = [policy]
+  }
 }

--- a/terraform/fluentd/k8s/main.tf
+++ b/terraform/fluentd/k8s/main.tf
@@ -18,13 +18,13 @@ resource "kubernetes_cluster_role_binding" "fluentd" {
   role_ref {
     api_group = "rbac.authorization.k8s.io"
     kind      = "ClusterRole"
-    name      = kubernetes_cluster_role.fluentd.metadata.0.name
+    name      = kubernetes_cluster_role.fluentd.metadata[0].name
   }
 
   subject {
     kind      = "ServiceAccount"
-    name      = kubernetes_service_account.fluentd.metadata.0.name
-    namespace = kubernetes_service_account.fluentd.metadata.0.namespace
+    name      = kubernetes_service_account.fluentd.metadata[0].name
+    namespace = kubernetes_service_account.fluentd.metadata[0].namespace
   }
 }
 

--- a/terraform/fluentd/k8s/main.tf
+++ b/terraform/fluentd/k8s/main.tf
@@ -239,4 +239,10 @@ resource "kubernetes_daemonset" "fluentd" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      spec[0].template[0].metadata[0].annotations["convox.com/restart"]
+    ]
+  }
 }

--- a/terraform/metrics/k8s/main.tf
+++ b/terraform/metrics/k8s/main.tf
@@ -202,6 +202,13 @@ resource "kubernetes_deployment" "metrics" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      spec[0].template[0].metadata[0].annotations["convox.com/triggered-reschedule-for-node"],
+      spec[0].template[0].metadata[0].annotations["convox.com/restart"]
+    ]
+  }
 }
 
 resource "kubernetes_service" "metrics" {

--- a/terraform/metrics/k8s/metric_scraper.tf
+++ b/terraform/metrics/k8s/metric_scraper.tf
@@ -18,13 +18,13 @@ resource "kubernetes_cluster_role_binding" "metrics_scraper" {
   role_ref {
     api_group = "rbac.authorization.k8s.io"
     kind      = "ClusterRole"
-    name      = kubernetes_cluster_role.metrics_scraper.metadata.0.name
+    name      = kubernetes_cluster_role.metrics_scraper.metadata[0].name
   }
 
   subject {
     kind      = "ServiceAccount"
-    name      = kubernetes_service_account.metrics_scraper.metadata.0.name
-    namespace = kubernetes_service_account.metrics_scraper.metadata.0.namespace
+    name      = kubernetes_service_account.metrics_scraper.metadata[0].name
+    namespace = kubernetes_service_account.metrics_scraper.metadata[0].namespace
   }
 }
 
@@ -64,7 +64,7 @@ resource "kubernetes_deployment" "metrics_scraper" {
 
       spec {
         automount_service_account_token = true
-        service_account_name            = kubernetes_service_account.metrics_scraper.metadata.0.name
+        service_account_name            = kubernetes_service_account.metrics_scraper.metadata[0].name
         node_selector                   = var.karpenter_enabled ? { "convox.io/system-node" = "true" } : {}
 
         dynamic "toleration" {

--- a/terraform/metrics/k8s/metric_scraper.tf
+++ b/terraform/metrics/k8s/metric_scraper.tf
@@ -142,6 +142,13 @@ resource "kubernetes_deployment" "metrics_scraper" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      spec[0].template[0].metadata[0].annotations["convox.com/triggered-reschedule-for-node"],
+      spec[0].template[0].metadata[0].annotations["convox.com/restart"]
+    ]
+  }
 }
 
 resource "kubernetes_service" "metrics_scraper" {

--- a/terraform/metrics/k8s/outputs.tf
+++ b/terraform/metrics/k8s/outputs.tf
@@ -1,3 +1,3 @@
 output "metrics_scraper_host" {
-  value = "http://${kubernetes_service.metrics_scraper.metadata.0.name}.${kubernetes_service.metrics_scraper.metadata.0.namespace}.svc.cluster.local:8000"
+  value = "http://${kubernetes_service.metrics_scraper.metadata[0].name}.${kubernetes_service.metrics_scraper.metadata[0].namespace}.svc.cluster.local:8000"
 }

--- a/terraform/rack/do/registry.tf
+++ b/terraform/rack/do/registry.tf
@@ -131,6 +131,13 @@ resource "kubernetes_deployment" "registry" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      spec[0].template[0].metadata[0].annotations["convox.com/triggered-reschedule-for-node"],
+      spec[0].template[0].metadata[0].annotations["convox.com/restart"]
+    ]
+  }
 }
 
 resource "kubernetes_persistent_volume_claim" "registry" {

--- a/terraform/rack/do/registry.tf
+++ b/terraform/rack/do/registry.tf
@@ -125,7 +125,7 @@ resource "kubernetes_deployment" "registry" {
           name = "registry"
 
           persistent_volume_claim {
-            claim_name = kubernetes_persistent_volume_claim.registry.metadata.0.name
+            claim_name = kubernetes_persistent_volume_claim.registry.metadata[0].name
           }
         }
       }
@@ -209,7 +209,7 @@ resource "kubernetes_ingress_v1" "registry" {
         path {
           backend {
             service {
-              name = kubernetes_service.registry.metadata.0.name
+              name = kubernetes_service.registry.metadata[0].name
               port {
                 number = 80
               }

--- a/terraform/rack/k8s/main.tf
+++ b/terraform/rack/k8s/main.tf
@@ -17,6 +17,12 @@ resource "kubernetes_namespace" "system" {
   timeouts {
     delete = "30m"
   }
+
+  lifecycle {
+    ignore_changes = [
+      metadata[0].annotations["convox.io/last-release-build-cleanup"]
+    ]
+  }
 }
 
 resource "kubernetes_config_map" "rack" {

--- a/terraform/rack/local/registry.tf
+++ b/terraform/rack/local/registry.tf
@@ -82,6 +82,13 @@ resource "kubernetes_deployment" "registry" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      spec[0].template[0].metadata[0].annotations["convox.com/triggered-reschedule-for-node"],
+      spec[0].template[0].metadata[0].annotations["convox.com/restart"]
+    ]
+  }
 }
 
 resource "kubernetes_persistent_volume_claim" "registry" {
@@ -166,4 +173,3 @@ resource "kubernetes_ingress_v1" "registry" {
     }
   }
 }
-

--- a/terraform/rack/local/registry.tf
+++ b/terraform/rack/local/registry.tf
@@ -76,7 +76,7 @@ resource "kubernetes_deployment" "registry" {
           name = "registry"
 
           persistent_volume_claim {
-            claim_name = kubernetes_persistent_volume_claim.registry.metadata.0.name
+            claim_name = kubernetes_persistent_volume_claim.registry.metadata[0].name
           }
         }
       }
@@ -162,7 +162,7 @@ resource "kubernetes_ingress_v1" "registry" {
         path {
           backend {
             service {
-              name = kubernetes_service.registry.metadata.0.name
+              name = kubernetes_service.registry.metadata[0].name
               port {
                 number = 80
               }

--- a/terraform/rack/metal/registry.tf
+++ b/terraform/rack/metal/registry.tf
@@ -85,6 +85,13 @@ resource "kubernetes_deployment" "registry" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      spec[0].template[0].metadata[0].annotations["convox.com/triggered-reschedule-for-node"],
+      spec[0].template[0].metadata[0].annotations["convox.com/restart"]
+    ]
+  }
 }
 
 resource "kubernetes_persistent_volume_claim" "registry" {
@@ -168,4 +175,3 @@ resource "kubernetes_ingress_v1" "registry" {
     }
   }
 }
-

--- a/terraform/rack/metal/registry.tf
+++ b/terraform/rack/metal/registry.tf
@@ -79,7 +79,7 @@ resource "kubernetes_deployment" "registry" {
           name = "registry"
 
           persistent_volume_claim {
-            claim_name = kubernetes_persistent_volume_claim.registry.metadata.0.name
+            claim_name = kubernetes_persistent_volume_claim.registry.metadata[0].name
           }
         }
       }
@@ -164,7 +164,7 @@ resource "kubernetes_ingress_v1" "registry" {
         path {
           backend {
             service {
-              name = kubernetes_service.registry.metadata.0.name
+              name = kubernetes_service.registry.metadata[0].name
               port {
                 number = 80
               }

--- a/terraform/resolver/k8s/main.tf
+++ b/terraform/resolver/k8s/main.tf
@@ -212,6 +212,13 @@ resource "kubernetes_deployment" "resolver" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      spec[0].template[0].metadata[0].annotations["convox.com/triggered-reschedule-for-node"],
+      spec[0].template[0].metadata[0].annotations["convox.com/restart"]
+    ]
+  }
 }
 
 resource "kubernetes_service" "resolver" {

--- a/terraform/router/nginx/main.tf
+++ b/terraform/router/nginx/main.tf
@@ -403,7 +403,11 @@ resource "kubernetes_deployment" "ingress-nginx" {
   }
 
   lifecycle {
-    ignore_changes = [spec[0].replicas]
+    ignore_changes = [
+      spec[0].replicas,
+      spec[0].template[0].metadata[0].annotations["convox.com/triggered-reschedule-for-node"],
+      spec[0].template[0].metadata[0].annotations["convox.com/restart"]
+    ]
   }
 }
 
@@ -602,7 +606,11 @@ resource "kubernetes_deployment" "ingress-nginx-internal" {
   }
 
   lifecycle {
-    ignore_changes = [spec[0].replicas]
+    ignore_changes = [
+      spec[0].replicas,
+      spec[0].template[0].metadata[0].annotations["convox.com/triggered-reschedule-for-node"],
+      spec[0].template[0].metadata[0].annotations["convox.com/restart"]
+    ]
   }
 }
 


### PR DESCRIPTION
This has been annoying me for many years, so I finally fixed the Terraform drift issue!

# Before

```
  Plan: 1 to add, 21 to change, 1 to destroy.
```

(Even with no changes to terraform.)

# After

```
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
Releasing state lock. This may take a few moments...

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```

### What is the feature/fix?

  - Silence Terraform drift caused by Convox-managed values: ignore the per-release namespace cleanup annotation and the convox.com/* restart/reschedule hints that Convox writes onto deployments/daemonsets.
  - Keep EKS node groups pinned to aws_launch_template.<name>.latest_version so real launch-template changes still roll out, while routine $Latest churn disappears.
  - Refresh IAM inline policies and the ECR attachment exactly when a rack release changes via the release sentinel, making plans deterministic without hiding real changes.

### Terraform apply is much faster

This also makes `terraform apply` way faster even when something changes. The EKS node group update would always takes a while when using `$Latest` instead of a fixed release.

Now, we only need to update what has actually changed (e.g. when updating a test release version):

```
Plan: 0 to add, 4 to change, 0 to destroy.

Changes to Outputs:
  ~ release  = "docspring-001" -> "docspring-002"
module.system.module.rack.module.api.terraform_data.release_sentinel: Modifying... [id=ddf8cddc-0e34-fee6-a944-d4ff72026136]
module.system.module.rack.module.api.terraform_data.release_sentinel: Modifications complete after 0s [id=ddf8cddc-0e34-fee6-a944-d4ff72026136]
module.system.module.rack.module.api.module.k8s.kubernetes_deployment.atom: Modifying... [id=staging-system/atom]
module.system.module.rack.module.resolver.module.k8s.kubernetes_deployment.resolver: Modifying... [id=staging-system/resolver]
module.system.module.rack.module.api.module.k8s.kubernetes_deployment.api: Modifying... [id=staging-system/api]
module.system.module.rack.module.api.module.k8s.kubernetes_deployment.atom: Still modifying... [id=staging-system/atom, 00m10s elapsed]
module.system.module.rack.module.resolver.module.k8s.kubernetes_deployment.resolver: Still modifying... [id=staging-system/resolver, 00m10s elapsed]
module.system.module.rack.module.api.module.k8s.kubernetes_deployment.api: Still modifying... [id=staging-system/api, 00m10s elapsed]
module.system.module.rack.module.api.module.k8s.kubernetes_deployment.atom: Modifications complete after 10s [id=staging-system/atom]
module.system.module.rack.module.resolver.module.k8s.kubernetes_deployment.resolver: Modifications complete after 10s [id=staging-system/resolver]
module.system.module.rack.module.api.module.k8s.kubernetes_deployment.api: Still modifying... [id=staging-system/api, 00m20s elapsed]
module.system.module.rack.module.api.module.k8s.kubernetes_deployment.api: Modifications complete after 29s [id=staging-system/api]
Releasing state lock. This may take a few moments...

Apply complete! Resources: 0 added, 4 changed, 0 destroyed.
```

### Terraform apply is also much safer

Now I can see exactly what is changing when I upgrade Convox, instead of having to sift through all the noise and sometimes missing very important changes. e.g. I accidentally deployed a release a while ago that wiped all our logs older than 7 days because I hadn't set `awsLogs.cwRetention`. I now read the release notes way more carefully, but I would have also been more likely to spot that change in the plan without all the unrelated changes.

### Add screenshot or video (optional)

- Not applicable (Terraform/config change only).

### Does it have a breaking change?

- No breaking changes. All updates are backward-compatible; policies and roles keep their names, and resources are updated in place.

Check the boxes you actually completed:

- [ ] New coverage tests
- [ ] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [ ] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov