### PR TITLE
Update eks join scripts for custom amis as it is changed in AL2023

### DIFF
--- a/terraform/cluster/aws/files/custom_ami_userdata_al2.sh
+++ b/terraform/cluster/aws/files/custom_ami_userdata_al2.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -ex
+
+/etc/eks/bootstrap.sh ${name} \
+  --kubelet-extra-args '--node-labels=eks.amazonaws.com/nodegroup=${var.name}-additional-${each.key}-${random_id.additional_node_groups[each.key].hex}' \
+  --b64-cluster-ca ${api_server_ca} \
+  --apiserver-endpoint ${api_server_endpoint} --use-max-pods true --dns-cluster-ip ${cluster_dns}
+
+# Custom user data script
+${user_data}

--- a/terraform/cluster/aws/files/custom_ami_userdata_al2023.sh
+++ b/terraform/cluster/aws/files/custom_ami_userdata_al2023.sh
@@ -1,0 +1,32 @@
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="//"
+
+--//
+Content-Type: application/node.eks.aws
+
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    apiServerEndpoint: ${api_server_endpoint}
+    certificateAuthority: ${api_server_ca}
+    name: ${name}
+    cidr: ${cidr}
+  kubelet:
+    config:
+      clusterDNS:
+      - ${cluster_dns}
+    maxPodsExpression: "((default_enis - 1) * (ips_per_eni - 1)) + 2"
+    flags:
+    - "--node-labels=${node_labels}"
+--//
+
+Content-Type: text/x-shellscript
+
+---
+#!/bin/bash
+# Custom user data script
+${user_data}
+
+--//--


### PR DESCRIPTION
### What is the feature/update/fix?

**Fix: Alternate Node Group AMI Configurations for Amazon Linux 2023**

We have resolved an issue with custom AMI configurations for alternate node groups by updating the EKS join scripts to properly support Amazon Linux 2023. This fix ensures that custom AMIs based on AL2023 can correctly join EKS clusters when used in additional node groups.

**Important:** As Amazon Linux 2 is no longer supported by Kubernetes 1.33 and onward, we have discontinued support for custom AMIs based on AL2. All custom AMIs must now be based on Amazon Linux 2023 or Ubuntu.

---

### Why is this important?

**Restored Custom AMI Functionality:**

- **Custom AMI Support** - Properly configure and use custom AMIs based on Amazon Linux 2023 in your additional node groups
- **Kubernetes 1.33+ Compatibility** - Ensures compatibility with current and future Kubernetes versions that no longer support AL2
- **Security and Compliance** - Use hardened or specialized AMIs that meet your organization's security requirements
- **Specialized Workloads** - Deploy pre-configured AMIs with specific tools, libraries, or configurations for your workloads

This fix is critical for organizations that:
- Use custom AMIs for security hardening or compliance requirements
- Need pre-installed software or configurations on their node groups
- Want to standardize their infrastructure with golden AMIs
- Are running Kubernetes 1.33 or later versions

**Migration Notice:**
If you are currently using custom AMIs based on Amazon Linux 2, you must migrate to Amazon Linux 2023-based AMIs before updating to Kubernetes 1.33 or later. The EKS join scripts have been updated to work with the new AL2023 bootstrap process.

---

### Does it have a breaking change?

**Yes, this update contains a breaking change for users with custom AL2 AMIs.**

If you are using custom AMIs based on Amazon Linux 2 in your additional node groups, you must:
1. Create new custom AMIs based on Amazon Linux 2023
2. Update your node group configurations to use the new AMI IDs
3. Apply the rack update

Existing node groups using standard EKS-optimized AMIs or AL2023-based custom AMIs are not affected by this change.

---

### Requirements

To use this fix, you must be on at least version `3.22.5`.

For a minor version update, you must state the version during with the command `convox rack update 3.22.5 -r rackName`.  
**_You must be on at least rack version `3.21.0` to perform this update._**

If you are using custom AMIs in your additional node groups, ensure they are based on Amazon Linux 2023 before applying this update. You can specify custom AMIs in your node group configuration using the `ami_id` field as documented in [Workload Placement](https://docs.convox.com/configuration/workload-placement).

_If you are unfamiliar with v3 rack versioning, we advise checking the documentation [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) for more information before applying any updates._