### PR TITLE
Add support for eks api server public access cidr block

### DIFF
--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -79,6 +79,7 @@ resource "aws_eks_cluster" "cluster" {
     endpoint_public_access = var.disable_public_access ? false : true
     // if public access is disabled, then private access must be true
     endpoint_private_access = var.disable_public_access ? true : var.enable_private_access
+    public_access_cidrs     = var.public_access_cidrs
     security_group_ids      = [aws_security_group.cluster.id]
     subnet_ids              = concat(local.public_subnets_ids)
   }

--- a/terraform/cluster/aws/variables.tf
+++ b/terraform/cluster/aws/variables.tf
@@ -197,6 +197,11 @@ variable "private_eks_pass" {
   default = ""
 }
 
+variable "public_access_cidrs" {
+  type    = list(string)
+  default = ["0.0.0.0/0"]
+}
+
 variable "schedule_rack_scale_down" {
   type    = string
   default = ""

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -52,6 +52,8 @@ locals {
 
   additional_node_groups  = try(jsondecode(var.additional_node_groups_config), jsondecode(base64decode(var.additional_node_groups_config)), [])
   additional_build_groups = try(jsondecode(var.additional_build_groups_config), jsondecode(base64decode(var.additional_build_groups_config)), [])
+
+  public_access_cidrs = var.eks_api_server_public_access_cidrs == "" ? ["0.0.0.0/0"] : split(",", var.eks_api_server_public_access_cidrs)
 }
 
 module "cluster" {
@@ -105,6 +107,7 @@ module "cluster" {
   private_eks_host                    = var.private_eks_host
   private_eks_user                    = var.private_eks_user
   private_eks_pass                    = var.private_eks_pass
+  public_access_cidrs                 = local.public_access_cidrs
   kubelet_registry_pull_qps           = var.kubelet_registry_pull_qps
   kubelet_registry_burst              = var.kubelet_registry_burst
   schedule_rack_scale_down            = var.schedule_rack_scale_down

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -13,7 +13,7 @@ variable "additional_build_groups_config" {
 }
 
 variable "api_feature_gates" {
-  type = string
+  type    = string
   default = ""
 }
 
@@ -129,6 +129,11 @@ variable "efs_csi_driver_enable" {
 variable "efs_csi_driver_version" {
   type    = string
   default = "v2.1.13-eksbuild.1"
+}
+
+variable "eks_api_server_public_access_cidrs" {
+  type    = string
+  default = "0.0.0.0/0"
 }
 
 variable "gpu_tag_enable" {


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: EKS API Server Public Access CIDR Block Configuration**

This release adds support for configuring public access CIDR blocks for the EKS API server when using the `public-private` endpoint security mode. This feature provides enhanced security controls by allowing you to restrict which IP ranges can access your EKS cluster's API server from the public internet while maintaining private VPC access for internal resources.

---

### Why is this important?

**Enhanced Security Control for Hybrid Access Patterns:**

- **Granular Access Control** - Restrict public API server access to specific IP ranges (e.g., your office networks, CI/CD systems) while maintaining full private access within the VPC
- **Improved Security Posture** - Reduce the attack surface by limiting public access to only trusted CIDR blocks instead of allowing access from anywhere on the internet
- **Compliance Requirements** - Meet security compliance standards that require IP whitelisting for management interfaces while maintaining operational flexibility
- **Zero-Trust Implementation** - Implement zero-trust network principles by explicitly defining allowed source IP ranges for cluster management

This feature is particularly valuable for organizations that:
- Need to access the EKS API server from specific external locations (offices, remote sites)
- Want to maintain strict security controls while using the `public-private` endpoint mode
- Require audit compliance for restricted management plane access
- Use external CI/CD systems that need cluster access from known IP ranges

#### How It Works

When the EKS endpoint security mode is set to `public-private`, you can now configure specific CIDR blocks through the Convox Console:

1. Navigate to **Rack Settings** in the Convox Console
2. Locate the **EKS Endpoint Security Setting**
3. Select `public-private` mode
4. Configure your allowed CIDR blocks in the new **Public Access CIDR** field
5. Apply the changes to update your rack

Example CIDR configurations:
- Single office: `203.0.113.0/24`
- Multiple locations: `203.0.113.0/24,198.51.100.0/24`
- Specific IPs: `203.0.113.42/32,198.51.100.15/32`

**Important Notes:**
- **Only public IP ranges are valid** - Private IP ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) and other reserved IP ranges cannot be used for public endpoint access
- If no CIDR blocks are specified, the default behavior allows access from `0.0.0.0/0` (anywhere)
- In-VPC resources always maintain access through the private endpoint regardless of public CIDR restrictions
- Changes to CIDR blocks are applied without cluster downtime

---

### Does it have a breaking change?

**No breaking changes** are introduced with this update.

Existing racks with `public-private` endpoint mode will continue to function with their current access patterns. The CIDR block configuration is optional and defaults to allowing all public access if not specified, maintaining backward compatibility.

---

### Requirements

To use this feature, you must be on at least version `3.23.1`.

For a minor version update, you must state the version with the command `convox rack update 3.23.1 -r rackName`.  
**_You must be on at least rack version `3.22.0` to perform this update._**

_If you are unfamiliar with v3 rack versioning, we advise checking the documentation [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) for more information before applying any updates._