### PR TITLE
Add support for additional nginx configurations

### DIFF
--- a/terraform/api/aws/main.tf
+++ b/terraform/api/aws/main.tf
@@ -57,7 +57,7 @@ module "k8s" {
     VPC_ID                                    = var.vpc_id
     RELEASES_TO_RETAIN_AFTER_ACTIVE           = var.releases_to_retain_after_active
     RELEASES_TO_RETAIN_TASK_RUN_INTERVAL_HOUR = var.releases_to_retain_task_run_interval_hour
-    FEATURE_GATES                        = var.api_feature_gates
+    FEATURE_GATES                             = var.api_feature_gates
   }
 }
 

--- a/terraform/api/aws/variables.tf
+++ b/terraform/api/aws/variables.tf
@@ -1,5 +1,5 @@
 variable "api_feature_gates" {
-  type = string
+  type    = string
   default = ""
 }
 

--- a/terraform/api/azure/storage.tf
+++ b/terraform/api/azure/storage.tf
@@ -11,7 +11,7 @@ resource "azurerm_storage_account" "storage" {
 }
 
 resource "azurerm_storage_share" "storage" {
-  name                 = "storage"
-  quota                = 50
-  storage_account_id   = azurerm_storage_account.storage.id
+  name               = "storage"
+  quota              = 50
+  storage_account_id = azurerm_storage_account.storage.id
 }

--- a/terraform/api/gcp/main.tf
+++ b/terraform/api/gcp/main.tf
@@ -63,7 +63,7 @@ module "k8s" {
     PROJECT      = data.google_client_config.current.project,
     PROVIDER     = "gcp"
     REGION       = data.google_client_config.current.region
-    REGISTRY     ="${var.region}-docker.pkg.dev/${var.project_id}/${var.name}"
+    REGISTRY     = "${var.region}-docker.pkg.dev/${var.project_id}/${var.name}"
     RESOLVER     = var.resolver
     ROUTER       = var.router
     SOCKET       = "/var/run/docker.sock"

--- a/terraform/api/k8s/atom.tf
+++ b/terraform/api/k8s/atom.tf
@@ -113,5 +113,5 @@ resource "kubernetes_deployment" "atom" {
       }
     }
   }
-  depends_on = [ kubernetes_resource_quota.gcp-critical-pods ]
+  depends_on = [kubernetes_resource_quota.gcp-critical-pods]
 }

--- a/terraform/api/k8s/main.tf
+++ b/terraform/api/k8s/main.tf
@@ -5,7 +5,7 @@ resource "random_string" "password" {
 
 resource "kubernetes_resource_quota" "gcp-critical-pods" {
   metadata {
-    name = "gcp-critical-pods"
+    name      = "gcp-critical-pods"
     namespace = var.namespace
   }
   spec {
@@ -15,8 +15,8 @@ resource "kubernetes_resource_quota" "gcp-critical-pods" {
     scope_selector {
       match_expression {
         scope_name = "PriorityClass"
-        operator = "In"
-        values = ["system-node-critical", "system-cluster-critical"]
+        operator   = "In"
+        values     = ["system-node-critical", "system-cluster-critical"]
       }
     }
   }
@@ -305,7 +305,7 @@ resource "kubernetes_deployment" "api" {
       }
     }
   }
-  depends_on = [ kubernetes_resource_quota.gcp-critical-pods ]
+  depends_on = [kubernetes_resource_quota.gcp-critical-pods]
 }
 
 resource "kubernetes_service" "api" {

--- a/terraform/api/metal/main.tf
+++ b/terraform/api/metal/main.tf
@@ -37,12 +37,12 @@ module "k8s" {
   }
 
   docker_hub_authentication = var.docker_hub_authentication
-  domain    = var.domain
-  image     = var.image
-  namespace = var.namespace
-  rack      = var.name
-  release   = var.release
-  resolver  = var.resolver
+  domain                    = var.domain
+  image                     = var.image
+  namespace                 = var.namespace
+  rack                      = var.name
+  release                   = var.release
+  resolver                  = var.resolver
 
   annotations = {
     "cert-manager.io/cluster-issuer" = "self-signed"

--- a/terraform/cluster/do/variables.tf
+++ b/terraform/cluster/do/variables.tf
@@ -3,7 +3,7 @@ variable "high_availability" {
 }
 
 variable "k8s_version" {
-  type = string
+  type    = string
   default = "1.33"
 }
 

--- a/terraform/fluentd/aws/main.tf
+++ b/terraform/fluentd/aws/main.tf
@@ -15,7 +15,7 @@ module "k8s" {
     kubernetes = kubernetes
   }
 
-  fluentd_disable  = var.fluentd_disable
+  fluentd_disable = var.fluentd_disable
 
   cluster   = var.cluster
   image     = var.arm_type ? "convox/fluentd:1.13-arm64" : "convox/fluentd:1.13"

--- a/terraform/fluentd/aws/variables.tf
+++ b/terraform/fluentd/aws/variables.tf
@@ -1,6 +1,6 @@
 variable "access_log_retention_in_days" {
   default = "7"
-  type = string
+  type    = string
 }
 
 variable "arm_type" {

--- a/terraform/helpers/aws-asg-tag/main.tf
+++ b/terraform/helpers/aws-asg-tag/main.tf
@@ -7,15 +7,15 @@ variable "asg_tags" {
 }
 
 variable "propagate_at_launch" {
-  type = bool
+  type    = bool
   default = true
 }
 
 resource "aws_autoscaling_group_tag" "cluster_additional" {
   for_each = var.asg_tags
-  
+
   autoscaling_group_name = var.asg_name
-  
+
   tag {
     key                 = each.key
     value               = each.value

--- a/terraform/rack/aws/main.tf
+++ b/terraform/rack/aws/main.tf
@@ -101,6 +101,7 @@ module "router" {
   namespace                 = module.k8s.namespace
   nlb_security_group        = var.nlb_security_group
   nginx_image               = var.nginx_image
+  nginx_additional_config   = var.nginx_additional_config
   oidc_arn                  = var.oidc_arn
   oidc_sub                  = var.oidc_sub
   proxy_protocol            = var.proxy_protocol

--- a/terraform/rack/aws/variables.tf
+++ b/terraform/rack/aws/variables.tf
@@ -1,5 +1,5 @@
 variable "api_feature_gates" {
-  type = string
+  type    = string
   default = ""
 }
 
@@ -114,6 +114,12 @@ variable "nlb_security_group" {
 variable "nginx_image" {
   type    = string
   default = "registry.k8s.io/ingress-nginx/controller:v1.12.0@sha256:e6b8de175acda6ca913891f0f727bca4527e797d52688cbe9fec9040d6f6b6fa"
+}
+
+variable "nginx_additional_config" {
+  description = "Comma-separated key=value pairs (e.g., 'key1=value1,key2=value2')"
+  type        = string
+  default     = ""
 }
 
 variable "oidc_arn" {

--- a/terraform/rack/gcp/main.tf
+++ b/terraform/rack/gcp/main.tf
@@ -67,6 +67,7 @@ module "router" {
   name                      = var.name
   namespace                 = module.k8s.namespace
   network                   = var.network
+  nginx_additional_config   = var.nginx_additional_config
   release                   = var.release
   whitelist                 = var.whitelist
 }

--- a/terraform/rack/gcp/variables.tf
+++ b/terraform/rack/gcp/variables.tf
@@ -39,6 +39,12 @@ variable "nodes_account" {
   type = string
 }
 
+variable "nginx_additional_config" {
+  description = "Comma-separated key=value pairs (e.g., 'key1=value1,key2=value2')"
+  type        = string
+  default     = ""
+}
+
 variable "project_id" {
   type = string
 }

--- a/terraform/resolver/azure/main.tf
+++ b/terraform/resolver/azure/main.tf
@@ -6,9 +6,9 @@ module "k8s" {
   }
 
   docker_hub_authentication = var.docker_hub_authentication
-  image     = var.image
-  namespace = var.namespace
-  rack      = var.rack
-  release   = var.release
+  image                     = var.image
+  namespace                 = var.namespace
+  rack                      = var.rack
+  release                   = var.release
 
 }

--- a/terraform/resolver/gcp/main.tf
+++ b/terraform/resolver/gcp/main.tf
@@ -6,9 +6,9 @@ module "k8s" {
   }
 
   docker_hub_authentication = var.docker_hub_authentication
-  image     = var.image
-  namespace = var.namespace
-  rack      = var.rack
-  release   = var.release
+  image                     = var.image
+  namespace                 = var.namespace
+  rack                      = var.rack
+  release                   = var.release
 
 }

--- a/terraform/resolver/k8s/main.tf
+++ b/terraform/resolver/k8s/main.tf
@@ -127,10 +127,10 @@ resource "kubernetes_deployment" "resolver" {
           }
         }
         container {
-          name               = "system"
-          args               = ["resolver"]
-          image              = "${var.image}:${var.release}"
-          image_pull_policy  = "IfNotPresent"
+          name              = "system"
+          args              = ["resolver"]
+          image             = "${var.image}:${var.release}"
+          image_pull_policy = "IfNotPresent"
 
           env {
             name = "NAMESPACE"

--- a/terraform/resolver/k8s/variables.tf
+++ b/terraform/resolver/k8s/variables.tf
@@ -1,15 +1,15 @@
 variable "annotations" {
-  type    = map
+  type    = map(any)
   default = {}
 }
 
 variable "docker_hub_authentication" {
-  type = string
+  type    = string
   default = null
 }
 
 variable "env" {
-  type    = map
+  type    = map(any)
   default = {}
 }
 

--- a/terraform/resolver/metal/main.tf
+++ b/terraform/resolver/metal/main.tf
@@ -6,9 +6,9 @@ module "k8s" {
   }
 
   docker_hub_authentication = var.docker_hub_authentication
-  image     = var.image
-  namespace = var.namespace
-  rack      = var.rack
-  release   = var.release
+  image                     = var.image
+  namespace                 = var.namespace
+  rack                      = var.rack
+  release                   = var.release
 
 }

--- a/terraform/router/aws/variables.tf
+++ b/terraform/router/aws/variables.tf
@@ -53,6 +53,12 @@ variable "nginx_image" {
   default = "registry.k8s.io/ingress-nginx/controller:v1.12.0@sha256:e6b8de175acda6ca913891f0f727bca4527e797d52688cbe9fec9040d6f6b6fa"
 }
 
+variable "nginx_additional_config" {
+  description = "Comma-separated key=value pairs (e.g., 'key1=value1,key2=value2')"
+  type        = string
+  default     = ""
+}
+
 variable "oidc_arn" {
   type = string
 }

--- a/terraform/router/gcp/main.tf
+++ b/terraform/router/gcp/main.tf
@@ -12,6 +12,7 @@ module "nginx" {
     kubernetes = kubernetes
   }
 
+  nginx_additional_config   = var.nginx_additional_config
   docker_hub_authentication = var.docker_hub_authentication
   namespace                 = var.namespace
   rack                      = var.name

--- a/terraform/router/gcp/variables.tf
+++ b/terraform/router/gcp/variables.tf
@@ -19,6 +19,12 @@ variable "network" {
   type = string
 }
 
+variable "nginx_additional_config" {
+  description = "Comma-separated key=value pairs (e.g., 'key1=value1,key2=value2')"
+  type        = string
+  default     = ""
+}
+
 variable "release" {
   type = string
 }

--- a/terraform/router/local/main.tf
+++ b/terraform/router/local/main.tf
@@ -31,7 +31,7 @@ resource "kubernetes_config_map_v1_data" "ingress-nginx-controller-configmap" {
     namespace = "ingress-nginx"
   }
   data = {
-    "hsts" =  "false"
+    "hsts"            = "false"
     "proxy-body-size" = "0"
   }
 }

--- a/terraform/router/nginx/variables.tf
+++ b/terraform/router/nginx/variables.tf
@@ -1,5 +1,5 @@
 variable "docker_hub_authentication" {
-  type = string
+  type    = string
   default = null
 }
 
@@ -16,6 +16,12 @@ variable "nginx_image" {
 variable "nginx_user" {
   type    = string
   default = "101"
+}
+
+variable "nginx_additional_config" {
+  description = "Comma-separated key=value pairs (e.g., 'key1=value1,key2=value2')"
+  type        = string
+  default     = ""
 }
 
 variable "namespace" {

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -185,6 +185,7 @@ module "rack" {
   rack_name                                 = local.rack_name
   nlb_security_group                        = var.nlb_security_group
   nginx_image                               = var.nginx_image
+  nginx_additional_config                   = var.nginx_additional_config
   oidc_arn                                  = module.cluster.oidc_arn
   oidc_sub                                  = module.cluster.oidc_sub
   pdb_default_min_available_percentage      = var.pdb_default_min_available_percentage

--- a/terraform/system/aws/telemetry.tf
+++ b/terraform/system/aws/telemetry.tf
@@ -29,6 +29,7 @@ locals {
     ecr_scan_on_push_enable = var.ecr_scan_on_push_enable
     efs_csi_driver_enable = var.efs_csi_driver_enable
     efs_csi_driver_version = var.efs_csi_driver_version
+    eks_api_server_public_access_cidrs = var.eks_api_server_public_access_cidrs
     enable_private_access = var.enable_private_access
     fluentd_disable = var.fluentd_disable
     gpu_tag_enable = var.gpu_tag_enable
@@ -48,6 +49,7 @@ locals {
     max_on_demand_count = var.max_on_demand_count
     min_on_demand_count = var.min_on_demand_count
     name = var.name
+    nginx_additional_config = var.nginx_additional_config
     nginx_image = var.nginx_image
     nlb_security_group = var.nlb_security_group
     node_capacity_type = var.node_capacity_type
@@ -113,6 +115,7 @@ locals {
     ecr_scan_on_push_enable = "false"
     efs_csi_driver_enable = "false"
     efs_csi_driver_version = "v2.1.13-eksbuild.1"
+    eks_api_server_public_access_cidrs = "0.0.0.0/0"
     enable_private_access = "false"
     fluentd_disable = "false"
     gpu_tag_enable = "false"
@@ -132,6 +135,7 @@ locals {
     max_on_demand_count = "100"
     min_on_demand_count = "1"
     name = ""
+    nginx_additional_config = ""
     nginx_image = "registry.k8s.io/ingress-nginx/controller:v1.12.6@sha256:c371fbf42b4f23584ce879d99303463131f4f31612f0875482b983354eeca7e6"
     nlb_security_group = ""
     node_capacity_type = "on_demand"

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -132,8 +132,9 @@ variable "efs_csi_driver_version" {
 }
 
 variable "eks_api_server_public_access_cidrs" {
-  type    = string
-  default = "0.0.0.0/0"
+  type        = string
+  description = "comma separated cidr"
+  default     = "0.0.0.0/0"
 }
 
 variable "gpu_tag_enable" {
@@ -251,6 +252,12 @@ variable "node_type" {
 variable "nginx_image" {
   type    = string
   default = "registry.k8s.io/ingress-nginx/controller:v1.12.6@sha256:c371fbf42b4f23584ce879d99303463131f4f31612f0875482b983354eeca7e6"
+}
+
+variable "nginx_additional_config" {
+  description = "Comma-separated key=value pairs (e.g., 'key1=value1,key2=value2')"
+  type        = string
+  default     = ""
 }
 
 variable "nvidia_device_plugin_enable" {

--- a/terraform/system/gcp/main.tf
+++ b/terraform/system/gcp/main.tf
@@ -49,21 +49,22 @@ module "rack" {
     google     = google
   }
 
-  buildkit_enabled      = var.buildkit_enabled
-  cluster               = module.cluster.id
-  docker_hub_username   = var.docker_hub_username
-  docker_hub_password   = var.docker_hub_password
-  image                 = var.image
-  name                  = local.name
-  rack_name             = local.rack_name
-  network               = module.cluster.network
-  nodes_account         = module.cluster.nodes_account
-  project_id            = module.project.id
-  region                = var.region
-  release               = local.release
-  syslog                = var.syslog
-  telemetry             = var.telemetry
-  telemetry_map         = local.telemetry_map
-  telemetry_default_map = local.telemetry_default_map
-  whitelist             = split(",", var.whitelist)
+  buildkit_enabled        = var.buildkit_enabled
+  cluster                 = module.cluster.id
+  docker_hub_username     = var.docker_hub_username
+  docker_hub_password     = var.docker_hub_password
+  image                   = var.image
+  name                    = local.name
+  rack_name               = local.rack_name
+  network                 = module.cluster.network
+  nodes_account           = module.cluster.nodes_account
+  nginx_additional_config = var.nginx_additional_config
+  project_id              = module.project.id
+  region                  = var.region
+  release                 = local.release
+  syslog                  = var.syslog
+  telemetry               = var.telemetry
+  telemetry_map           = local.telemetry_map
+  telemetry_default_map   = local.telemetry_default_map
+  whitelist               = split(",", var.whitelist)
 }

--- a/terraform/system/gcp/telemetry.tf
+++ b/terraform/system/gcp/telemetry.tf
@@ -10,6 +10,7 @@ locals {
     image = var.image
     k8s_version = var.k8s_version
     name = var.name
+    nginx_additional_config = var.nginx_additional_config
     node_disk = var.node_disk
     node_type = var.node_type
     preemptible = var.preemptible
@@ -30,6 +31,7 @@ locals {
     image = "convox/convox"
     k8s_version = "1.33"
     name = ""
+    nginx_additional_config = ""
     node_disk = "100"
     node_type = "n1-standard-2"
     preemptible = "true"

--- a/terraform/system/gcp/variables.tf
+++ b/terraform/system/gcp/variables.tf
@@ -41,6 +41,12 @@ variable "node_type" {
   default = "n1-standard-2"
 }
 
+variable "nginx_additional_config" {
+  description = "Comma-separated key=value pairs (e.g., 'key1=value1,key2=value2')"
+  type        = string
+  default     = ""
+}
+
 variable "preemptible" {
   default = true
 }

--- a/terraform/system/local/telemetry.tf
+++ b/terraform/system/local/telemetry.tf
@@ -5,24 +5,24 @@ locals {
   telemetry_map = {
     docker_hub_password = var.docker_hub_password
     docker_hub_username = var.docker_hub_username
-    image               = var.image
-    name                = var.name
-    os                  = var.os
-    rack_name           = var.rack_name
-    release             = var.release
-    settings            = var.settings
-    telemetry           = var.telemetry
-  }
+    image = var.image
+    name = var.name
+    os = var.os
+    rack_name = var.rack_name
+    release = var.release
+    settings = var.settings
+    telemetry = var.telemetry
+    }
 
   telemetry_default_map = {
     docker_hub_password = ""
     docker_hub_username = ""
-    image               = "convox/convox"
-    name                = ""
-    os                  = "ubuntu"
-    rack_name           = ""
-    release             = ""
-    settings            = ""
-    telemetry           = "false"
-  }
+    image = "convox/convox"
+    name = ""
+    os = "ubuntu"
+    rack_name = ""
+    release = ""
+    settings = ""
+    telemetry = "false"
+    }
 }


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: Additional Nginx Configuration Support**

This release introduces support for custom Nginx configurations through a new rack parameter `nginx_additional_config`. This feature allows you to fine-tune Nginx ingress controller settings directly through rack parameters, providing greater control over request handling, buffering, timeouts, and other critical HTTP/HTTPS behaviors for your applications on AWS and GCP racks.

---

### Why is this important?

**Enhanced Control Over Ingress Behavior:**

- **Custom Buffer Sizes** - Configure proxy buffer sizes to handle large headers or request bodies, preventing 502 errors for applications with extensive authentication tokens or cookies
- **Timeout Adjustments** - Fine-tune client header and body timeouts to accommodate slow clients or long-running uploads without modifying application code
- **Performance Optimization** - Adjust Nginx settings to optimize for your specific workload patterns, improving overall application performance
- **Compatibility Requirements** - Meet specific application requirements that need non-default Nginx configurations without rebuilding the entire ingress controller

This feature is particularly valuable for:
- Applications processing large file uploads or downloads
- Services requiring extended timeout periods for slow clients or complex operations
- APIs with large authentication headers or extensive cookie data
- Workloads that need specific Nginx tuning for optimal performance
- Teams migrating from custom Nginx setups who need to maintain specific configurations

#### Configuration Examples

Set custom Nginx configurations using the rack parameter:

```bash
# Configure proxy buffer size and client header timeout
convox rack params set nginx_additional_config="proxy-buffer-size=256k,client-header-timeout=70" -r rackName

# Multiple configuration options for handling large requests
convox rack params set nginx_additional_config="proxy-body-size=50m,proxy-buffer-size=256k,proxy-buffers=8 256k" -r rackName

# WebSocket and long-polling optimizations
convox rack params set nginx_additional_config="proxy-read-timeout=3600,proxy-send-timeout=3600,proxy-connect-timeout=75" -r rackName

# Clear custom configurations (return to defaults)
convox rack params set nginx_additional_config="" -r rackName
```

**Supported Configuration Options:**

You can configure any parameter from the [Nginx Ingress Controller ConfigMap documentation](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/). The most impactful and commonly used options include:

**Request/Response Handling:**
- `proxy-body-size` - Maximum allowed size of client request body (default: "1m"). Increase for file uploads
- `proxy-buffer-size` - Buffer size for reading response headers (default: "4k"). Increase for apps with large headers/cookies
- `proxy-buffers` - Number and size of buffers for proxy responses (default: "4 8k")
- `client-body-buffer-size` - Buffer size for reading client request body (default: "8k")
- `client-max-body-size` - Maximum allowed size of client request body, similar to proxy-body-size

**Timeout Configuration:**
- `proxy-connect-timeout` - Timeout for establishing connection to upstream (default: "75s")
- `proxy-send-timeout` - Timeout for transmitting request to upstream (default: "60s")
- `proxy-read-timeout` - Timeout for reading response from upstream (default: "60s")
- `client-header-timeout` - Timeout for reading client request headers (default: "60s")
- `client-body-timeout` - Timeout for reading client request body (default: "60s")
- `keepalive-timeout` - Timeout for keep-alive connections (default: "75s")

**Performance Tuning:**
- `keep-alive-requests` - Maximum requests per keep-alive connection (default: "100")
- `upstream-keepalive-connections` - Number of idle keepalive connections to upstream (default: "32")
- `worker-processes` - Number of worker processes (default: "auto")
- `worker-connections` - Maximum number of simultaneous connections per worker (default: "16384")
- `use-gzip` - Enable/disable gzip compression (default: "true")
- `gzip-level` - Gzip compression level 1-9 (default: "5")

**Security and Limits:**
- `ssl-protocols` - SSL protocols to enable (default: "TLSv1.2 TLSv1.3")
- `ssl-ciphers` - SSL ciphers to enable
- `limit-req-status-code` - Status code for rate-limited requests (default: "503")
- `limit-conn-status-code` - Status code for connection-limited requests (default: "503")

**Default Behavior:**
When `nginx_additional_config` is empty or not set, Nginx uses its default configurations based on the provider (AWS or GCP) and the installed Nginx ingress controller version, along with any Convox-managed values. These defaults are optimized for general use cases but may not suit all applications. Any value provided in the `nginx_additional_config` parameter will override the corresponding default values.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this update.

Existing racks will continue to operate with default Nginx configurations. The `nginx_additional_config` parameter is optional and only applies custom settings when explicitly configured. All existing applications and ingress behaviors remain unchanged unless you actively set this parameter.

---

### Requirements

To use this feature, you must be on at least version `3.23.1`.

For a minor version update, you must state the version with the command `convox rack update 3.23.1 -r rackName`.  
**_You must be on at least rack version `3.22.0` to perform this update._**

_If you are unfamiliar with v3 rack versioning, we advise checking the documentation [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) for more information before applying any updates._