### PR TITLE
feat: Add securityContext support to services and timers

### DIFF
--- a/docs/reference/primitives/app/service.md
+++ b/docs/reference/primitives/app/service.md
@@ -92,6 +92,14 @@ services:
         external:
           - name: "datadogmetric@default:web-requests"
             averageValue: 200
+    securityContext:
+      runAsNonRoot: true
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      seccompProfile: RuntimeDefault
     singleton: false
     sticky: true
     termination:
@@ -135,6 +143,7 @@ services:
 | **privileged**  | boolean    | false               | Set to **true** to allow [Processes](/reference/primitives/app/process) of this Service to run as root inside their container. Use with caution as this grants elevated permissions |
 | **resources**   | list       |                     | A list of [Resources](/reference/primitives/app/resource) to make available to this Service (e.g. databases) |
 | **scale**       | map        | 1                   | Define scaling parameters (see below)                                                                                                      |
+| **securityContext** | map   |                     | Container security settings including capabilities, read-only filesystem, and seccomp profiles (see below)                               |
 | **singleton**   | boolean    | false               | Set to **true** to prevent extra [Processes](/reference/primitives/app/process) of this Service from being started during deployments                               |
 | **sticky**      | boolean    | false               | Set to **true** to enable sticky sessions                                                                                                    |
 | **termination** | map        |                     | Termination related configuration                                                                                                          |
@@ -443,6 +452,70 @@ services:
 ```
 
 
+
+### securityContext
+
+Container-level security settings. These settings control Linux security features for the container. Any field left unset is omitted from the rendered pod spec, leaving the Kubernetes default in effect.
+
+| Attribute                    | Type    | Default | Description                                                                                                 |
+| ---------------------------- | ------- | ------- | ----------------------------------------------------------------------------------------------------------- |
+| **runAsNonRoot**             | boolean |         | Require the container to run as a non-root user                                                             |
+| **runAsUser**                | number  |         | The UID to run the container as                                                                             |
+| **runAsGroup**               | number  |         | The GID to run the container as                                                                             |
+| **readOnlyRootFilesystem**   | boolean |         | Mount the root filesystem as read-only                                                                      |
+| **allowPrivilegeEscalation** | boolean |         | Whether a process can gain more privileges than its parent process. Set to **false** for security hardening |
+| **capabilities**             | map     |         | Linux capabilities to add or drop (see below)                                                               |
+| **seccompProfile**           | string  |         | The seccomp profile to apply. Allowed values: `RuntimeDefault`, `Unconfined`                                |
+
+```yaml
+services:
+  web:
+    build: .
+    port: 3000
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      seccompProfile: RuntimeDefault
+```
+
+Notes:
+
+- These settings apply to the service's Deployment pods, its Timer CronJob pods, and one-off containers created by `convox run <service>`. Build containers retain Convox's existing build-time security context (unconfined seccomp, optionally privileged) regardless of manifest configuration.
+- The legacy top-level `privileged: true` flag still renders as `privileged: true` in the pod's security context. When `privileged: true` is set, Kubernetes grants the container all Linux capabilities at runtime; `capabilities.drop` has no effect in that mode. Do not mix `privileged: true` with `securityContext` hardening unless you understand that precedence.
+- `seccompProfile: Localhost` is not currently supported because Convox does not expose the required `localhostProfile` path field.
+- Namespaces with restrictive Kubernetes [Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/) labels may reject pods that use `privileged: true` or that omit `runAsNonRoot` / `seccompProfile`. Configure `securityContext` to match the namespace's enforced profile.
+- `seccompProfile: RuntimeDefault` requires the kubelet to provide a default seccomp profile. All managed providers Convox supports (EKS, GKE, AKS, DOKS) ship this profile; self-managed bare-metal clusters must provision it themselves.
+- `readOnlyRootFilesystem: true` prevents the container from writing anywhere outside explicitly mounted volumes. Processes that cache to `$HOME` (AWS CLI credential cache, CUDA kernel cache at `~/.nv/ComputeCache`, many language runtimes) need a writable mount. Use `volumeOptions.emptyDir` with a `mountPath` targeting the cache directory.
+
+### securityContext.capabilities
+
+| Attribute | Type | Default | Description                                                                                       |
+| --------- | ---- | ------- | ------------------------------------------------------------------------------------------------- |
+| **drop**  | list |         | List of Linux capabilities to drop. Use `ALL` to drop all capabilities                            |
+| **add**   | list |         | List of Linux capabilities to add back (typically after dropping `ALL`)                           |
+
+Capability names are case-sensitive and must omit the `CAP_` prefix (use `NET_BIND_SERVICE`, not `CAP_NET_BIND_SERVICE`).
+
+```yaml
+services:
+  web:
+    build: .
+    port: 3000
+    securityContext:
+      capabilities:
+        drop:
+          - ALL
+        add:
+          - NET_BIND_SERVICE
+```
+
+&nbsp;
 
 ### termination
 

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -10,6 +10,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Helper functions for pointer values in tests
+func ptrBool(b bool) *bool {
+	return &b
+}
+
+func ptrInt64(i int64) *int64 {
+	return &i
+}
+
 func TestManifestLoad(t *testing.T) {
 	n := &manifest.Manifest{
 		Balancers: manifest.Balancers{
@@ -413,6 +422,51 @@ func TestManifestLoad(t *testing.T) {
 					Redirect: true,
 				},
 			},
+			manifest.Service{
+				Name: "secured",
+				Build: manifest.ServiceBuild{
+					Manifest: "Dockerfile",
+					Path:     ".",
+				},
+				Deployment: manifest.ServiceDeployment{
+					Minimum: 50,
+					Maximum: 200,
+				},
+				Drain: 30,
+				Health: manifest.ServiceHealth{
+					Grace:    5,
+					Path:     "/",
+					Interval: 5,
+					Timeout:  4,
+				},
+				Init: true,
+				Port: manifest.ServicePortScheme{Port: 8080, Scheme: "http"},
+				Scale: manifest.ServiceScale{
+					Count:  manifest.ServiceScaleCount{Min: 1, Max: 1},
+					Cpu:    250,
+					Memory: 512,
+				},
+				SecurityContext: manifest.ServiceSecurityContext{
+					RunAsNonRoot:             ptrBool(true),
+					RunAsUser:                ptrInt64(1000),
+					RunAsGroup:               ptrInt64(1000),
+					ReadOnlyRootFilesystem:   ptrBool(true),
+					AllowPrivilegeEscalation: ptrBool(false),
+					Capabilities: &manifest.ServiceSecurityContextCapabilities{
+						Drop: []string{"ALL"},
+						Add:  []string{"NET_BIND_SERVICE"},
+					},
+					SeccompProfile: "RuntimeDefault",
+				},
+				Sticky: false,
+				Termination: manifest.ServiceTermination{
+					Grace: 30,
+				},
+				Timeout: 60,
+				Tls: manifest.ServiceTls{
+					Redirect: true,
+				},
+			},
 		},
 		Timers: manifest.Timers{
 			manifest.Timer{
@@ -543,6 +597,19 @@ func TestManifestLoad(t *testing.T) {
 		"services.scaler.scale.targets.custom.AWS/SQS/ApproximateNumberOfMessagesVisible.value",
 		"services.scaler.scale.targets.memory",
 		"services.scaler.scale.targets.requests",
+		"services.secured",
+		"services.secured.build",
+		"services.secured.port",
+		"services.secured.securityContext",
+		"services.secured.securityContext.allowPrivilegeEscalation",
+		"services.secured.securityContext.capabilities",
+		"services.secured.securityContext.capabilities.add",
+		"services.secured.securityContext.capabilities.drop",
+		"services.secured.securityContext.readOnlyRootFilesystem",
+		"services.secured.securityContext.runAsGroup",
+		"services.secured.securityContext.runAsNonRoot",
+		"services.secured.securityContext.runAsUser",
+		"services.secured.securityContext.seccompProfile",
 		"timers",
 		"timers.alpha",
 		"timers.alpha.command",

--- a/pkg/manifest/security_context_test.go
+++ b/pkg/manifest/security_context_test.go
@@ -1,0 +1,196 @@
+package manifest_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/convox/convox/pkg/manifest"
+)
+
+func i64ptr(i int64) *int64 { return &i }
+
+func TestServiceSecurityContextValidate(t *testing.T) {
+	t.Run("empty is valid", func(t *testing.T) {
+		sc := manifest.ServiceSecurityContext{}
+		if err := sc.Validate(); err != nil {
+			t.Errorf("expected no error for empty, got %v", err)
+		}
+	})
+
+	t.Run("RuntimeDefault seccomp ok", func(t *testing.T) {
+		sc := manifest.ServiceSecurityContext{SeccompProfile: "RuntimeDefault"}
+		if err := sc.Validate(); err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("Unconfined seccomp ok", func(t *testing.T) {
+		sc := manifest.ServiceSecurityContext{SeccompProfile: "Unconfined"}
+		if err := sc.Validate(); err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("Localhost seccomp rejected with specific message", func(t *testing.T) {
+		sc := manifest.ServiceSecurityContext{SeccompProfile: "Localhost"}
+		err := sc.Validate()
+		if err == nil {
+			t.Fatal("expected error for Localhost, got nil")
+		}
+		if !strings.Contains(err.Error(), "Localhost is not supported") {
+			t.Errorf("expected Localhost-specific error, got %v", err)
+		}
+	})
+
+	t.Run("unknown seccomp rejected", func(t *testing.T) {
+		sc := manifest.ServiceSecurityContext{SeccompProfile: "Runitme"}
+		err := sc.Validate()
+		if err == nil {
+			t.Fatal("expected error for typo, got nil")
+		}
+		if !strings.Contains(err.Error(), "allowed: RuntimeDefault, Unconfined") {
+			t.Errorf("expected allowed-values hint, got %v", err)
+		}
+	})
+
+	t.Run("valid capability names accepted", func(t *testing.T) {
+		sc := manifest.ServiceSecurityContext{
+			Capabilities: &manifest.ServiceSecurityContextCapabilities{
+				Add:  []string{"NET_BIND_SERVICE", "SYS_PTRACE"},
+				Drop: []string{"ALL"},
+			},
+		}
+		if err := sc.Validate(); err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("CAP_ prefix rejected with fix hint", func(t *testing.T) {
+		sc := manifest.ServiceSecurityContext{
+			Capabilities: &manifest.ServiceSecurityContextCapabilities{
+				Add: []string{"CAP_NET_BIND_SERVICE"},
+			},
+		}
+		err := sc.Validate()
+		if err == nil {
+			t.Fatal("expected error for CAP_ prefix, got nil")
+		}
+		if !strings.Contains(err.Error(), `use "NET_BIND_SERVICE"`) {
+			t.Errorf("expected fix hint, got %v", err)
+		}
+	})
+
+	t.Run("lowercase capability rejected", func(t *testing.T) {
+		sc := manifest.ServiceSecurityContext{
+			Capabilities: &manifest.ServiceSecurityContextCapabilities{
+				Drop: []string{"all"},
+			},
+		}
+		if err := sc.Validate(); err == nil {
+			t.Error("expected error for lowercase cap")
+		}
+	})
+
+	t.Run("runAsNonRoot true + runAsUser 0 rejected", func(t *testing.T) {
+		sc := manifest.ServiceSecurityContext{
+			RunAsNonRoot: boolptr(true),
+			RunAsUser:    i64ptr(0),
+		}
+		err := sc.Validate()
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "runAsNonRoot=true is incompatible with runAsUser=0") {
+			t.Errorf("expected specific error, got %v", err)
+		}
+	})
+
+	t.Run("runAsNonRoot true + runAsUser non-zero ok", func(t *testing.T) {
+		sc := manifest.ServiceSecurityContext{
+			RunAsNonRoot: boolptr(true),
+			RunAsUser:    i64ptr(1000),
+		}
+		if err := sc.Validate(); err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("runAsNonRoot false + runAsUser 0 ok", func(t *testing.T) {
+		sc := manifest.ServiceSecurityContext{
+			RunAsNonRoot: boolptr(false),
+			RunAsUser:    i64ptr(0),
+		}
+		if err := sc.Validate(); err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+}
+
+func TestServiceSecurityContextCapabilitiesHasCapabilities(t *testing.T) {
+	t.Run("nil receiver", func(t *testing.T) {
+		var c *manifest.ServiceSecurityContextCapabilities
+		if c.HasCapabilities() {
+			t.Error("nil should return false")
+		}
+	})
+
+	t.Run("empty struct", func(t *testing.T) {
+		c := &manifest.ServiceSecurityContextCapabilities{}
+		if c.HasCapabilities() {
+			t.Error("empty should return false")
+		}
+	})
+
+	t.Run("empty slices", func(t *testing.T) {
+		c := &manifest.ServiceSecurityContextCapabilities{Add: []string{}, Drop: []string{}}
+		if c.HasCapabilities() {
+			t.Error("empty slices should return false")
+		}
+	})
+
+	t.Run("add only", func(t *testing.T) {
+		c := &manifest.ServiceSecurityContextCapabilities{Add: []string{"NET_BIND_SERVICE"}}
+		if !c.HasCapabilities() {
+			t.Error("add non-empty should return true")
+		}
+	})
+
+	t.Run("drop only", func(t *testing.T) {
+		c := &manifest.ServiceSecurityContextCapabilities{Drop: []string{"ALL"}}
+		if !c.HasCapabilities() {
+			t.Error("drop non-empty should return true")
+		}
+	})
+}
+
+func TestServiceSecurityContextHasSecurityContext(t *testing.T) {
+	t.Run("empty returns false", func(t *testing.T) {
+		sc := manifest.ServiceSecurityContext{}
+		if sc.HasSecurityContext() {
+			t.Error("empty should return false")
+		}
+	})
+
+	t.Run("empty capabilities pointer returns false", func(t *testing.T) {
+		sc := manifest.ServiceSecurityContext{
+			Capabilities: &manifest.ServiceSecurityContextCapabilities{},
+		}
+		if sc.HasSecurityContext() {
+			t.Error("empty Capabilities struct should not count as configured")
+		}
+	})
+
+	t.Run("seccomp only returns true", func(t *testing.T) {
+		sc := manifest.ServiceSecurityContext{SeccompProfile: "RuntimeDefault"}
+		if !sc.HasSecurityContext() {
+			t.Error("seccomp set should return true")
+		}
+	})
+
+	t.Run("runAsNonRoot false counts as configured", func(t *testing.T) {
+		sc := manifest.ServiceSecurityContext{RunAsNonRoot: boolptr(false)}
+		if !sc.HasSecurityContext() {
+			t.Error("explicit false is still configuration")
+		}
+	})
+}

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -25,47 +26,48 @@ const (
 type Service struct {
 	Name string `yaml:"-"`
 
-	Agent              ServiceAgent          `yaml:"agent,omitempty"`
-	Annotations        Annotations           `yaml:"annotations,omitempty"`
-	Build              ServiceBuild          `yaml:"build,omitempty"`
-	Certificate        Certificate           `yaml:"certificate,omitempty"`
-	Command            string                `yaml:"command,omitempty"`
-	ConfigMounts       ConfigMounts          `yaml:"configMounts,omitempty"`
-	Deployment         ServiceDeployment     `yaml:"deployment,omitempty"`
-	DnsConfig          ServiceDnsConfig      `yaml:"dnsConfig,omitempty"`
-	Domains            ServiceDomains        `yaml:"domain,omitempty"`
-	Drain              int                   `yaml:"drain,omitempty"`
-	DisableHostUsers   bool                  `yaml:"disableHostUsers,omitempty"`
-	Environment        Environment           `yaml:"environment,omitempty"`
-	GrpcHealthEnabled  bool                  `yaml:"grpcHealthEnabled,omitempty"`
-	Health             ServiceHealth         `yaml:"health,omitempty"`
-	Liveness           ServiceLiveness       `yaml:"liveness,omitempty"`
-	StartupProbe       ServiceStartupProbe   `yaml:"startupProbe,omitempty"`
-	Image              string                `yaml:"image,omitempty"`
-	Init               bool                  `yaml:"init,omitempty"`
-	InitContainer      *InitContainer        `yaml:"initContainer,omitempty"`
-	Internal           bool                  `yaml:"internal,omitempty"`
-	InternalRouter     bool                  `yaml:"internalRouter,omitempty"`
-	IngressAnnotations Annotations           `yaml:"ingressAnnotations,omitempty"`
-	Labels             Labels                `yaml:"labels,omitempty"`
-	NodeAffinityLabels Affinities            `yaml:"nodeAffinityLabels,omitempty"`
-	NodeSelectorLabels Labels                `yaml:"nodeSelectorLabels,omitempty"`
-	Lifecycle          ServiceLifecycle      `yaml:"lifecycle,omitempty"`
-	Port               ServicePortScheme     `yaml:"port,omitempty"`
-	Ports              []ServicePortProtocol `yaml:"ports,omitempty"`
-	Privileged         bool                  `yaml:"privileged,omitempty"`
-	Resources          []string              `yaml:"resources,omitempty"`
-	Scale              ServiceScale          `yaml:"scale,omitempty"`
-	Singleton          bool                  `yaml:"singleton,omitempty"`
-	Sticky             bool                  `yaml:"sticky,omitempty"`
-	Termination        ServiceTermination    `yaml:"termination,omitempty"`
-	Test               string                `yaml:"test,omitempty"`
-	Timeout            int                   `yaml:"timeout,omitempty"`
-	Tls                ServiceTls            `yaml:"tls,omitempty"`
-	Volumes            []string              `yaml:"volumes,omitempty"`
-	VolumeOptions      []VolumeOption        `yaml:"volumeOptions,omitempty"`
-	Whitelist          string                `yaml:"whitelist,omitempty"`
-	AccessControl      AccessControlOptions  `yaml:"accessControl,omitempty"`
+	Agent              ServiceAgent           `yaml:"agent,omitempty"`
+	Annotations        Annotations            `yaml:"annotations,omitempty"`
+	Build              ServiceBuild           `yaml:"build,omitempty"`
+	Certificate        Certificate            `yaml:"certificate,omitempty"`
+	Command            string                 `yaml:"command,omitempty"`
+	ConfigMounts       ConfigMounts           `yaml:"configMounts,omitempty"`
+	Deployment         ServiceDeployment      `yaml:"deployment,omitempty"`
+	DnsConfig          ServiceDnsConfig       `yaml:"dnsConfig,omitempty"`
+	Domains            ServiceDomains         `yaml:"domain,omitempty"`
+	Drain              int                    `yaml:"drain,omitempty"`
+	DisableHostUsers   bool                   `yaml:"disableHostUsers,omitempty"`
+	Environment        Environment            `yaml:"environment,omitempty"`
+	GrpcHealthEnabled  bool                   `yaml:"grpcHealthEnabled,omitempty"`
+	Health             ServiceHealth          `yaml:"health,omitempty"`
+	Liveness           ServiceLiveness        `yaml:"liveness,omitempty"`
+	StartupProbe       ServiceStartupProbe    `yaml:"startupProbe,omitempty"`
+	Image              string                 `yaml:"image,omitempty"`
+	Init               bool                   `yaml:"init,omitempty"`
+	InitContainer      *InitContainer         `yaml:"initContainer,omitempty"`
+	Internal           bool                   `yaml:"internal,omitempty"`
+	InternalRouter     bool                   `yaml:"internalRouter,omitempty"`
+	IngressAnnotations Annotations            `yaml:"ingressAnnotations,omitempty"`
+	Labels             Labels                 `yaml:"labels,omitempty"`
+	NodeAffinityLabels Affinities             `yaml:"nodeAffinityLabels,omitempty"`
+	NodeSelectorLabels Labels                 `yaml:"nodeSelectorLabels,omitempty"`
+	Lifecycle          ServiceLifecycle       `yaml:"lifecycle,omitempty"`
+	Port               ServicePortScheme      `yaml:"port,omitempty"`
+	Ports              []ServicePortProtocol  `yaml:"ports,omitempty"`
+	Privileged         bool                   `yaml:"privileged,omitempty"`
+	Resources          []string               `yaml:"resources,omitempty"`
+	SecurityContext    ServiceSecurityContext `yaml:"securityContext,omitempty"`
+	Scale              ServiceScale           `yaml:"scale,omitempty"`
+	Singleton          bool                   `yaml:"singleton,omitempty"`
+	Sticky             bool                   `yaml:"sticky,omitempty"`
+	Termination        ServiceTermination     `yaml:"termination,omitempty"`
+	Test               string                 `yaml:"test,omitempty"`
+	Timeout            int                    `yaml:"timeout,omitempty"`
+	Tls                ServiceTls             `yaml:"tls,omitempty"`
+	Volumes            []string               `yaml:"volumes,omitempty"`
+	VolumeOptions      []VolumeOption         `yaml:"volumeOptions,omitempty"`
+	Whitelist          string                 `yaml:"whitelist,omitempty"`
+	AccessControl      AccessControlOptions   `yaml:"accessControl,omitempty"`
 }
 
 type Affinities []Affinity
@@ -571,6 +573,94 @@ type ServiceTermination struct {
 
 type ServiceTls struct {
 	Redirect bool
+}
+
+// ServiceSecurityContext defines container security settings
+type ServiceSecurityContext struct {
+	RunAsNonRoot             *bool                               `yaml:"runAsNonRoot,omitempty"`
+	RunAsUser                *int64                              `yaml:"runAsUser,omitempty"`
+	RunAsGroup               *int64                              `yaml:"runAsGroup,omitempty"`
+	ReadOnlyRootFilesystem   *bool                               `yaml:"readOnlyRootFilesystem,omitempty"`
+	AllowPrivilegeEscalation *bool                               `yaml:"allowPrivilegeEscalation,omitempty"`
+	Capabilities             *ServiceSecurityContextCapabilities `yaml:"capabilities,omitempty"`
+	SeccompProfile           string                              `yaml:"seccompProfile,omitempty"`
+}
+
+// ServiceSecurityContextCapabilities defines Linux capabilities to add or drop
+type ServiceSecurityContextCapabilities struct {
+	Add  []string `yaml:"add,omitempty"`
+	Drop []string `yaml:"drop,omitempty"`
+}
+
+// HasCapabilities returns true if any add or drop capability is configured.
+// Pointer receiver is nil-safe so this is usable from templates without a wrapper check.
+func (c *ServiceSecurityContextCapabilities) HasCapabilities() bool {
+	if c == nil {
+		return false
+	}
+	return len(c.Add) > 0 || len(c.Drop) > 0
+}
+
+// HasSecurityContext returns true if any security context settings are configured
+func (s ServiceSecurityContext) HasSecurityContext() bool {
+	return s.RunAsNonRoot != nil ||
+		s.RunAsUser != nil ||
+		s.RunAsGroup != nil ||
+		s.ReadOnlyRootFilesystem != nil ||
+		s.AllowPrivilegeEscalation != nil ||
+		s.Capabilities.HasCapabilities() ||
+		s.SeccompProfile != ""
+}
+
+var (
+	validSeccompProfile = map[string]bool{
+		"RuntimeDefault": true,
+		"Unconfined":     true,
+	}
+	validCapabilityName = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
+)
+
+// Validate checks manifest-level security context configuration for shape and
+// internal consistency. It catches errors that would otherwise only surface at
+// kubelet pod admission (seccomp enum, capability names) and flags combinations
+// that render a manifest self-contradictory (privileged + capabilities drop,
+// runAsNonRoot with runAsUser=0).
+func (s ServiceSecurityContext) Validate() error {
+	if s.SeccompProfile != "" && !validSeccompProfile[s.SeccompProfile] {
+		if s.SeccompProfile == "Localhost" {
+			return fmt.Errorf("securityContext.seccompProfile: Localhost is not supported (no localhostProfile field); use RuntimeDefault or Unconfined")
+		}
+		return fmt.Errorf("securityContext.seccompProfile: %q is not a supported value; allowed: RuntimeDefault, Unconfined", s.SeccompProfile)
+	}
+
+	if s.Capabilities != nil {
+		for _, c := range s.Capabilities.Add {
+			if err := validateCapabilityName(c); err != nil {
+				return fmt.Errorf("securityContext.capabilities.add: %s", err)
+			}
+		}
+		for _, c := range s.Capabilities.Drop {
+			if err := validateCapabilityName(c); err != nil {
+				return fmt.Errorf("securityContext.capabilities.drop: %s", err)
+			}
+		}
+	}
+
+	if s.RunAsNonRoot != nil && *s.RunAsNonRoot && s.RunAsUser != nil && *s.RunAsUser == 0 {
+		return fmt.Errorf("securityContext: runAsNonRoot=true is incompatible with runAsUser=0")
+	}
+
+	return nil
+}
+
+func validateCapabilityName(c string) error {
+	if strings.HasPrefix(c, "CAP_") {
+		return fmt.Errorf("%q must not include CAP_ prefix (use %q)", c, strings.TrimPrefix(c, "CAP_"))
+	}
+	if !validCapabilityName.MatchString(c) {
+		return fmt.Errorf("%q is not a valid capability name (expected uppercase letters, digits, underscores)", c)
+	}
+	return nil
 }
 
 // skipcq

--- a/pkg/manifest/testdata/full.yml
+++ b/pkg/manifest/testdata/full.yml
@@ -116,6 +116,21 @@ services:
       - 5000/udp
       - 5001
       - 5002/tcp
+  secured:
+    build: .
+    port: 8080
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+        add:
+          - NET_BIND_SERVICE
+      seccompProfile: RuntimeDefault
 timers:
   alpha:
     command: bin/alpha

--- a/pkg/manifest/validate.go
+++ b/pkg/manifest/validate.go
@@ -144,6 +144,10 @@ func (m *Manifest) validateServices() []error {
 			}
 		}
 
+		if err := s.SecurityContext.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("service %s: %s", s.Name, err))
+		}
+
 		for i := range s.ConfigMounts {
 			cm := &s.ConfigMounts[i]
 			if err := cm.Validate(); err != nil {

--- a/provider/k8s/helpers.go
+++ b/provider/k8s/helpers.go
@@ -444,3 +444,54 @@ func parseResourceSubstitutionId(id string) (string, string, string) {
 func patchBytes(patch map[string]interface{}) ([]byte, error) {
 	return gojson.Marshal(patch)
 }
+
+// serviceSecurityContext maps a manifest service's Privileged flag and
+// ServiceSecurityContext block to a Kubernetes container SecurityContext.
+// Returns nil when no settings are configured so callers can leave the
+// container SecurityContext unset. Mirrors the rendering logic in
+// provider/k8s/template/app/{service,timer}.yml.tmpl so one-off `convox run`
+// pods apply the same hardening as Deployment and CronJob pods.
+func serviceSecurityContext(s *manifest.Service) *ac.SecurityContext {
+	if s == nil {
+		return nil
+	}
+	if !s.Privileged && !s.SecurityContext.HasSecurityContext() {
+		return nil
+	}
+
+	sc := &ac.SecurityContext{}
+
+	if s.Privileged {
+		sc.Privileged = options.Bool(true)
+	}
+	if s.SecurityContext.RunAsNonRoot != nil {
+		sc.RunAsNonRoot = options.Bool(*s.SecurityContext.RunAsNonRoot)
+	}
+	if s.SecurityContext.RunAsUser != nil {
+		sc.RunAsUser = options.Int64(*s.SecurityContext.RunAsUser)
+	}
+	if s.SecurityContext.RunAsGroup != nil {
+		sc.RunAsGroup = options.Int64(*s.SecurityContext.RunAsGroup)
+	}
+	if s.SecurityContext.ReadOnlyRootFilesystem != nil {
+		sc.ReadOnlyRootFilesystem = options.Bool(*s.SecurityContext.ReadOnlyRootFilesystem)
+	}
+	if s.SecurityContext.AllowPrivilegeEscalation != nil {
+		sc.AllowPrivilegeEscalation = options.Bool(*s.SecurityContext.AllowPrivilegeEscalation)
+	}
+	if s.SecurityContext.Capabilities.HasCapabilities() {
+		caps := &ac.Capabilities{}
+		for _, c := range s.SecurityContext.Capabilities.Add {
+			caps.Add = append(caps.Add, ac.Capability(c))
+		}
+		for _, c := range s.SecurityContext.Capabilities.Drop {
+			caps.Drop = append(caps.Drop, ac.Capability(c))
+		}
+		sc.Capabilities = caps
+	}
+	if s.SecurityContext.SeccompProfile != "" {
+		sc.SeccompProfile = &ac.SeccompProfile{Type: ac.SeccompProfileType(s.SecurityContext.SeccompProfile)}
+	}
+
+	return sc
+}

--- a/provider/k8s/process.go
+++ b/provider/k8s/process.go
@@ -580,6 +580,10 @@ func (p *Provider) podSpecFromService(app, service, release string, isBuild bool
 			}
 
 			nodeSelectorLabels = s.NodeSelectorLabels
+
+			if sc := serviceSecurityContext(s); sc != nil {
+				c.SecurityContext = sc
+			}
 		}
 
 		for k, v := range env {

--- a/provider/k8s/security_context_test.go
+++ b/provider/k8s/security_context_test.go
@@ -1,0 +1,141 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/convox/convox/pkg/manifest"
+	ac "k8s.io/api/core/v1"
+)
+
+func TestServiceSecurityContextHelper(t *testing.T) {
+	b := func(v bool) *bool { return &v }
+	i := func(v int64) *int64 { return &v }
+
+	t.Run("nil service returns nil", func(t *testing.T) {
+		if sc := serviceSecurityContext(nil); sc != nil {
+			t.Errorf("expected nil, got %+v", sc)
+		}
+	})
+
+	t.Run("no config returns nil", func(t *testing.T) {
+		s := &manifest.Service{}
+		if sc := serviceSecurityContext(s); sc != nil {
+			t.Errorf("expected nil, got %+v", sc)
+		}
+	})
+
+	t.Run("privileged only", func(t *testing.T) {
+		s := &manifest.Service{Privileged: true}
+		sc := serviceSecurityContext(s)
+		if sc == nil {
+			t.Fatal("expected non-nil")
+		}
+		if sc.Privileged == nil || !*sc.Privileged {
+			t.Error("expected Privileged=true")
+		}
+	})
+
+	t.Run("full securityContext maps all fields", func(t *testing.T) {
+		s := &manifest.Service{
+			SecurityContext: manifest.ServiceSecurityContext{
+				RunAsNonRoot:             b(true),
+				RunAsUser:                i(1000),
+				RunAsGroup:               i(1001),
+				ReadOnlyRootFilesystem:   b(true),
+				AllowPrivilegeEscalation: b(false),
+				Capabilities: &manifest.ServiceSecurityContextCapabilities{
+					Add:  []string{"NET_BIND_SERVICE"},
+					Drop: []string{"ALL"},
+				},
+				SeccompProfile: "RuntimeDefault",
+			},
+		}
+		sc := serviceSecurityContext(s)
+		if sc == nil {
+			t.Fatal("expected non-nil")
+		}
+		if sc.RunAsNonRoot == nil || !*sc.RunAsNonRoot {
+			t.Error("RunAsNonRoot not mapped")
+		}
+		if sc.RunAsUser == nil || *sc.RunAsUser != 1000 {
+			t.Error("RunAsUser not mapped")
+		}
+		if sc.RunAsGroup == nil || *sc.RunAsGroup != 1001 {
+			t.Error("RunAsGroup not mapped")
+		}
+		if sc.ReadOnlyRootFilesystem == nil || !*sc.ReadOnlyRootFilesystem {
+			t.Error("ReadOnlyRootFilesystem not mapped")
+		}
+		if sc.AllowPrivilegeEscalation == nil || *sc.AllowPrivilegeEscalation {
+			t.Error("AllowPrivilegeEscalation should be false")
+		}
+		if sc.Capabilities == nil {
+			t.Fatal("Capabilities should be set")
+		}
+		if len(sc.Capabilities.Add) != 1 || sc.Capabilities.Add[0] != ac.Capability("NET_BIND_SERVICE") {
+			t.Errorf("Capabilities.Add not mapped: %+v", sc.Capabilities.Add)
+		}
+		if len(sc.Capabilities.Drop) != 1 || sc.Capabilities.Drop[0] != ac.Capability("ALL") {
+			t.Errorf("Capabilities.Drop not mapped: %+v", sc.Capabilities.Drop)
+		}
+		if sc.SeccompProfile == nil || sc.SeccompProfile.Type != ac.SeccompProfileTypeRuntimeDefault {
+			t.Errorf("SeccompProfile not mapped: %+v", sc.SeccompProfile)
+		}
+	})
+
+	t.Run("explicit zero values preserved", func(t *testing.T) {
+		s := &manifest.Service{
+			SecurityContext: manifest.ServiceSecurityContext{
+				RunAsNonRoot:             b(false),
+				ReadOnlyRootFilesystem:   b(false),
+				AllowPrivilegeEscalation: b(false),
+				RunAsUser:                i(0),
+			},
+		}
+		sc := serviceSecurityContext(s)
+		if sc == nil {
+			t.Fatal("expected non-nil")
+		}
+		if sc.RunAsNonRoot == nil || *sc.RunAsNonRoot {
+			t.Error("RunAsNonRoot=false should be preserved")
+		}
+		if sc.ReadOnlyRootFilesystem == nil || *sc.ReadOnlyRootFilesystem {
+			t.Error("ReadOnlyRootFilesystem=false should be preserved")
+		}
+		if sc.AllowPrivilegeEscalation == nil || *sc.AllowPrivilegeEscalation {
+			t.Error("AllowPrivilegeEscalation=false should be preserved")
+		}
+		if sc.RunAsUser == nil || *sc.RunAsUser != 0 {
+			t.Error("RunAsUser=0 should be preserved")
+		}
+	})
+
+	t.Run("empty capabilities does not produce Capabilities field", func(t *testing.T) {
+		s := &manifest.Service{
+			SecurityContext: manifest.ServiceSecurityContext{
+				Capabilities:   &manifest.ServiceSecurityContextCapabilities{},
+				SeccompProfile: "RuntimeDefault",
+			},
+		}
+		sc := serviceSecurityContext(s)
+		if sc == nil {
+			t.Fatal("expected non-nil because seccomp is set")
+		}
+		if sc.Capabilities != nil {
+			t.Errorf("empty Capabilities should not produce non-nil field: %+v", sc.Capabilities)
+		}
+	})
+
+	t.Run("seccomp Unconfined maps", func(t *testing.T) {
+		s := &manifest.Service{
+			SecurityContext: manifest.ServiceSecurityContext{SeccompProfile: "Unconfined"},
+		}
+		sc := serviceSecurityContext(s)
+		if sc == nil || sc.SeccompProfile == nil {
+			t.Fatal("expected seccomp set")
+		}
+		if sc.SeccompProfile.Type != ac.SeccompProfileTypeUnconfined {
+			t.Errorf("expected Unconfined, got %s", sc.SeccompProfile.Type)
+		}
+	})
+}

--- a/provider/k8s/template.go
+++ b/provider/k8s/template.go
@@ -40,6 +40,12 @@ func (p *Provider) templateHelpers() template.FuncMap {
 		"coalesce": func(ss ...string) string {
 			return common.CoalesceString(ss...)
 		},
+		"deref": func(b *bool) bool {
+			if b == nil {
+				return false
+			}
+			return *b
+		},
 		"domains": func(app string, s manifest.Service) []string {
 			ds := []string{
 				p.ServiceHost(app, s),

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -353,6 +353,46 @@ spec:
             {{ with .Service.Scale.Memory }}
             memory: "{{.}}Mi"
             {{ end }}
+        {{ if or .Service.Privileged .Service.SecurityContext.HasSecurityContext }}
+        securityContext:
+          {{ if .Service.Privileged }}
+          privileged: true
+          {{ end }}
+          {{ with .Service.SecurityContext.RunAsNonRoot }}
+          runAsNonRoot: {{ . }}
+          {{ end }}
+          {{ with .Service.SecurityContext.RunAsUser }}
+          runAsUser: {{ . }}
+          {{ end }}
+          {{ with .Service.SecurityContext.RunAsGroup }}
+          runAsGroup: {{ . }}
+          {{ end }}
+          {{ with .Service.SecurityContext.ReadOnlyRootFilesystem }}
+          readOnlyRootFilesystem: {{ . }}
+          {{ end }}
+          {{ if ne .Service.SecurityContext.AllowPrivilegeEscalation nil }}
+          allowPrivilegeEscalation: {{ deref .Service.SecurityContext.AllowPrivilegeEscalation }}
+          {{ end }}
+          {{ if .Service.SecurityContext.Capabilities.HasCapabilities }}
+          capabilities:
+            {{ with .Service.SecurityContext.Capabilities.Drop }}
+            drop:
+            {{ range . }}
+              - {{ . }}
+            {{ end }}
+            {{ end }}
+            {{ with .Service.SecurityContext.Capabilities.Add }}
+            add:
+            {{ range . }}
+              - {{ . }}
+            {{ end }}
+            {{ end }}
+          {{ end }}
+          {{ with .Service.SecurityContext.SeccompProfile }}
+          seccompProfile:
+            type: {{ . }}
+          {{ end }}
+        {{ end }}
         volumeMounts:
         - name: ca
           mountPath: /etc/convox

--- a/provider/k8s/template/app/timer.yml.tmpl
+++ b/provider/k8s/template/app/timer.yml.tmpl
@@ -188,6 +188,46 @@ spec:
                 {{ with .Service.Scale.Memory }}
                 memory: "{{.}}Mi"
                 {{ end }}
+            {{ if or .Service.Privileged .Service.SecurityContext.HasSecurityContext }}
+            securityContext:
+              {{ if .Service.Privileged }}
+              privileged: true
+              {{ end }}
+              {{ with .Service.SecurityContext.RunAsNonRoot }}
+              runAsNonRoot: {{ . }}
+              {{ end }}
+              {{ with .Service.SecurityContext.RunAsUser }}
+              runAsUser: {{ . }}
+              {{ end }}
+              {{ with .Service.SecurityContext.RunAsGroup }}
+              runAsGroup: {{ . }}
+              {{ end }}
+              {{ with .Service.SecurityContext.ReadOnlyRootFilesystem }}
+              readOnlyRootFilesystem: {{ . }}
+              {{ end }}
+              {{ if ne .Service.SecurityContext.AllowPrivilegeEscalation nil }}
+              allowPrivilegeEscalation: {{ deref .Service.SecurityContext.AllowPrivilegeEscalation }}
+              {{ end }}
+              {{ if .Service.SecurityContext.Capabilities.HasCapabilities }}
+              capabilities:
+                {{ with .Service.SecurityContext.Capabilities.Drop }}
+                drop:
+                {{ range . }}
+                  - {{ . }}
+                {{ end }}
+                {{ end }}
+                {{ with .Service.SecurityContext.Capabilities.Add }}
+                add:
+                {{ range . }}
+                  - {{ . }}
+                {{ end }}
+                {{ end }}
+              {{ end }}
+              {{ with .Service.SecurityContext.SeccompProfile }}
+              seccompProfile:
+                type: {{ . }}
+              {{ end }}
+            {{ end }}
             volumeMounts:
             - name: ca
               mountPath: /etc/convox

--- a/provider/k8s/template_test.go
+++ b/provider/k8s/template_test.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/convox/convox/pkg/manifest"
@@ -45,6 +46,117 @@ func TestRenderTemplate(t *testing.T) {
 		t.Fatal(err)
 	}
 	fmt.Println(string(data))
+}
+
+func TestRenderTemplateServiceSecurityContext(t *testing.T) {
+	a := &structs.App{Name: "test-app"}
+
+	d, err := os.ReadFile("./testdata/securitycontext.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m, err := manifest.Load(d, map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := Provider{Engine: &mock.TestEngine{}}
+	p.templater = templater.New(template.TemplatesFS)
+
+	render := func(tmpl string, svc manifest.Service) string {
+		params := map[string]interface{}{
+			"Annotations":    svc.AnnotationsMap(),
+			"App":            a,
+			"Environment":    map[string]string{},
+			"MaxSurge":       100,
+			"MaxUnavailable": 100,
+			"Namespace":      "ns",
+			"Password":       "pass",
+			"Rack":           "rack",
+			"Release":        &structs.Release{Id: "r1"},
+			"Replicas":       2,
+			"Resources":      svc.ResourceMap(),
+			"Service":        svc,
+			"Timer":          m.Timers[0],
+		}
+		data, err := p.RenderTemplate(tmpl, params)
+		if err != nil {
+			t.Fatalf("%s render: %v", svc.Name, err)
+		}
+		return string(data)
+	}
+
+	mustService := func(name string) manifest.Service {
+		for _, s := range m.Services {
+			if s.Name == name {
+				return s
+			}
+		}
+		t.Fatalf("service %q not in fixture", name)
+		return manifest.Service{}
+	}
+
+	t.Run("full securityContext renders all fields", func(t *testing.T) {
+		out := render("app/service", mustService("secured"))
+		for _, want := range []string{
+			"securityContext:",
+			"runAsNonRoot: true",
+			"runAsUser: 1000",
+			"runAsGroup: 1000",
+			"readOnlyRootFilesystem: true",
+			"allowPrivilegeEscalation: false",
+			"capabilities:",
+			"drop:",
+			"- ALL",
+			"add:",
+			"- NET_BIND_SERVICE",
+			"seccompProfile:",
+			"type: RuntimeDefault",
+		} {
+			if !strings.Contains(out, want) {
+				t.Errorf("expected %q in output\n---\n%s", want, out)
+			}
+		}
+	})
+
+	t.Run("plain service renders no securityContext block", func(t *testing.T) {
+		out := render("app/service", mustService("plain"))
+		if strings.Contains(out, "securityContext:") {
+			t.Errorf("did not expect securityContext in output for plain service\n---\n%s", out)
+		}
+	})
+
+	t.Run("legacy privileged renders securityContext.privileged", func(t *testing.T) {
+		out := render("app/service", mustService("legacy"))
+		if !strings.Contains(out, "securityContext:") || !strings.Contains(out, "privileged: true") {
+			t.Errorf("expected privileged rendering for legacy\n---\n%s", out)
+		}
+	})
+
+	t.Run("empty capabilities struct is suppressed", func(t *testing.T) {
+		out := render("app/service", mustService("emptycaps"))
+		if strings.Contains(out, "capabilities:") {
+			t.Errorf("empty capabilities should not render\n---\n%s", out)
+		}
+	})
+
+	t.Run("explicit zero values render", func(t *testing.T) {
+		out := render("app/service", mustService("zerouid"))
+		if !strings.Contains(out, "runAsUser: 0") {
+			t.Errorf("expected runAsUser: 0 to render\n---\n%s", out)
+		}
+		if !strings.Contains(out, "readOnlyRootFilesystem: false") {
+			t.Errorf("expected readOnlyRootFilesystem: false to render\n---\n%s", out)
+		}
+	})
+
+	t.Run("timer inherits service securityContext", func(t *testing.T) {
+		out := render("app/timer", mustService("secured"))
+		if !strings.Contains(out, "seccompProfile:") || !strings.Contains(out, "type: RuntimeDefault") {
+			t.Errorf("expected timer to render securityContext from referenced service\n---\n%s", out)
+		}
+	})
 }
 
 func TestRenderTemplateService(t *testing.T) {

--- a/provider/k8s/testdata/securitycontext.yml
+++ b/provider/k8s/testdata/securitycontext.yml
@@ -1,0 +1,39 @@
+services:
+  secured:
+    build: .
+    port: 8080
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+        add:
+          - NET_BIND_SERVICE
+      seccompProfile: RuntimeDefault
+  plain:
+    build: .
+    port: 8080
+  legacy:
+    build: .
+    port: 8080
+    privileged: true
+  emptycaps:
+    build: .
+    port: 8080
+    securityContext:
+      capabilities: {}
+  zerouid:
+    build: .
+    port: 8080
+    securityContext:
+      runAsUser: 0
+      readOnlyRootFilesystem: false
+timers:
+  secured-timer:
+    service: secured
+    schedule: "*/5 * * * *"
+    command: ./run.sh


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: Container-level `securityContext` for services and timers**

3.24.5 adds a `securityContext:` block to `convox.yml` that maps directly to Kubernetes container-level security settings. Services and timers can now enforce non-root execution, read-only root filesystems, restricted capabilities, seccomp profiles, and privilege-escalation prevention without custom Kubernetes templating.

The feature targets Pod Security Standards, CIS benchmark compliance, and regulatory requirements (PCI DSS, SOC 2, HIPAA). The block is purely additive. Services without `securityContext:` render identically to prior releases.

#### Supported options

| Field                     | Type                | Description                                                                 |
|---------------------------|---------------------|-----------------------------------------------------------------------------|
| `runAsNonRoot`            | boolean             | Require the container to run as a non-root user                             |
| `runAsUser`               | integer             | Set the UID for the container                                               |
| `runAsGroup`              | integer             | Set the GID for the container                                               |
| `readOnlyRootFilesystem`  | boolean             | Mount the root filesystem as read-only                                      |
| `allowPrivilegeEscalation`| boolean             | Whether a process can gain more privileges than its parent                  |
| `capabilities.drop`       | list of strings     | Linux capabilities to drop (for example `ALL`)                              |
| `capabilities.add`        | list of strings     | Linux capabilities to add back (typically after dropping `ALL`)             |
| `seccompProfile`          | `RuntimeDefault` / `Unconfined` | Seccomp profile type (the `Localhost` profile is not yet supported) |

#### Where the block renders

| Pod creation path                | Applies `securityContext`? |
|----------------------------------|----------------------------|
| Service Deployment pods          | Yes                        |
| CronJob pods (timers)            | Yes                        |
| `convox run <service>` one-off pods | Yes                     |
| `convox exec` attach pods        | Yes                        |
| Build containers                 | No (build needs writable mounts and full capability surface for BuildKit) |

The block renders into the pod's container-level `securityContext`. Build containers retain their existing unconfined seccomp plus optional `privileged` override regardless of manifest `securityContext` config.

#### Validation at deploy time

`ServiceSecurityContext.Validate()` runs as part of `validateServices()`, producing clear errors at `convox deploy` time instead of opaque kubelet rejection later. Rejected conditions:

| Condition                                           | Error                                        |
|-----------------------------------------------------|----------------------------------------------|
| `seccompProfile: Localhost`                         | Localhost profile not yet supported          |
| `seccompProfile: <other>`                           | Only `RuntimeDefault` and `Unconfined` allowed |
| `capabilities.add/drop` with `CAP_` prefix          | Use bare capability name (no `CAP_` prefix)  |
| Lowercase capability name                           | Capabilities must be uppercase (for example `NET_BIND_SERVICE`) |
| `runAsNonRoot: true` combined with `runAsUser: 0`   | Explicit conflict, rejected at validate time |

---

### Why is this important?

Kubernetes Pod Security Standards and compliance frameworks (CIS, PCI DSS, SOC 2, HIPAA) all prescribe container-level hardening: non-root execution, read-only root filesystems, capability drops, and seccomp profiles. Users running Convox on regulated workloads currently have to fork the service template or layer mutating admission webhooks to meet these requirements. 3.24.5 makes the hardening first-class in `convox.yml`.

**Benefits:**

| Benefit | Description |
|---------|-------------|
| Compliance without custom templating. | Pod Security Standards (restricted profile), CIS benchmarks, and PCI/SOC 2/HIPAA all express their container-hardening requirements in the fields added here. |
| Errors caught at deploy time. | Invalid seccomp values, malformed capabilities, and `runAsNonRoot`+`runAsUser: 0` conflicts fail fast at `convox deploy` rather than at pod admission. |
| Consistent across pod types. | Services, timers, and one-off pods (`convox run`, `convox exec`) all render the same `securityContext`, so hardening applied to the service manifest is not bypassed by ad-hoc commands. |
| Backward compatible. | Services without `securityContext:` parse and render identically. Zero rolling restart for users not opting in. |

---

### How to use it?

Full hardening example for a non-root service:

```yaml
services:
  web:
    build: .
    port: 3000
    securityContext:
      runAsNonRoot: true
      runAsUser: 1000
      runAsGroup: 1000
      readOnlyRootFilesystem: true
      allowPrivilegeEscalation: false
      capabilities:
        drop:
          - ALL
        add:
          - NET_BIND_SERVICE
      seccompProfile: RuntimeDefault
```

This renders into the Kubernetes container spec as:

```yaml
securityContext:
  runAsNonRoot: true
  runAsUser: 1000
  runAsGroup: 1000
  readOnlyRootFilesystem: true
  allowPrivilegeEscalation: false
  capabilities:
    drop:
      - ALL
    add:
      - NET_BIND_SERVICE
  seccompProfile:
    type: RuntimeDefault
```

Minimal hardening (just drop all capabilities):

```yaml
services:
  worker:
    build: .
    securityContext:
      capabilities:
        drop:
          - ALL
      readOnlyRootFilesystem: true
```

Apply the same block to a timer-backed service. Timers inherit the service's `securityContext` automatically:

```yaml
services:
  cron-worker:
    build: .
    securityContext:
      runAsNonRoot: true
      runAsUser: 1000
      readOnlyRootFilesystem: true

timers:
  nightly-report:
    service: cron-worker
    schedule: "0 3 * * *"
    command: bin/report
```

#### Recommended minimum for compliance

| Compliance target | Recommended minimum `securityContext` |
|-------------------|---------------------------------------|
| PCI DSS, SOC 2    | `runAsNonRoot: true`, `readOnlyRootFilesystem: true`, `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, `seccompProfile: RuntimeDefault` |
| CIS Kubernetes Benchmark 5.7.2 | `allowPrivilegeEscalation: false` on every container |
| Pod Security Standards "restricted" | `runAsNonRoot: true`, `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, `seccompProfile: RuntimeDefault`, `readOnlyRootFilesystem: true` |

#### Gotchas

| Situation | What to do |
|-----------|------------|
| Application writes to `/tmp` or caches, but you set `readOnlyRootFilesystem: true` | Mount an `emptyDir` volume at the writable path (for example `/tmp`, or SDK-specific cache paths) |
| Application needs to bind to port < 1024 as non-root | Add `NET_BIND_SERVICE` to `capabilities.add` |
| CUDA kernel cache warnings with `readOnlyRootFilesystem: true` | Mount an `emptyDir` at `/root/.nv` or set `CUDA_CACHE_PATH` to a writable location |
| Kubelet rejects `seccompProfile: RuntimeDefault` | Your kubelet must be launched with `--seccomp-default=true` (default on modern kubelets); check node runtime config |

---

### Does it have a breaking change?

**No breaking changes** are introduced to existing services, but one pre-existing semantic quirk is now consistent across pod types.

**Behavior change: `privileged: true` now renders into Deployment and CronJob pod specs.**

The top-level `privileged: true` service flag was previously honored only by `convox run` on V3 (`provider/k8s/process.go`). Deployment and CronJob pods silently dropped it. V2 racks (ECS) have always honored it via the TaskDefinition. This release brings V3 Deployment and CronJob rendering in line with V2 semantics and the V3 `convox run` path.

**Action required for users with a stale `privileged: true` flag:** if you have `privileged: true` in a `convox.yml` and do not actually want a privileged pod, remove the flag before upgrading. On first deploy after 3.24.5, a pod-spec diff will trigger one rolling restart on affected services.

| Compatibility item | Status |
|--------------------|--------|
| Existing manifests without `securityContext:` | Parse and render identically. Zero rolling restart. |
| New manifest with `securityContext:` deployed to a pre-3.24.5 rack | Old rack silently drops the unknown field during non-strict YAML unmarshal. No parse failure, no stuck deploy. Pods render without the block. |
| Downgrade from 3.24.5 to 3.24.4 with apps using `securityContext:` | Running pods retain their existing container-level `securityContext`. Next release promotes pods rendered without the block. Expected downgrade behavior. |
| Terraform, CloudFormation, API route, struct, CLI flag changes | None. No TF state fingertrap risk. |

---

### Requirements

This feature requires version `3.24.5` or later for the rack.

**Update the Rack:** Run `convox rack update 3.24.5 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.23.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
