### PR TITLE
Add --max-log-requests flag to logs commands

### DIFF
--- a/pkg/api/app_test.go
+++ b/pkg/api/app_test.go
@@ -190,14 +190,14 @@ func TestAppLogs(t *testing.T) {
 func TestAppLogsMaxLogRequests(t *testing.T) {
 	testServer(t, func(c *stdsdk.Client, p *structs.MockProvider) {
 		d1 := []byte("test")
-		r1 := ioutil.NopCloser(bytes.NewReader(d1))
+		r1 := io.NopCloser(bytes.NewReader(d1))
 		opts := structs.LogsOptions{Since: options.Duration(2 * time.Minute), MaxLogRequests: options.Int(50)}
 		p.On("AppLogs", "app1", opts).Return(r1, nil)
 		r2, err := c.Websocket("/apps/app1/logs", stdsdk.RequestOptions{
 			Headers: stdsdk.Headers{"Maxlogrequests": "50"},
 		})
 		require.NoError(t, err)
-		d2, err := ioutil.ReadAll(r2)
+		d2, err := io.ReadAll(r2)
 		require.NoError(t, err)
 		require.Equal(t, d1, d2)
 	})

--- a/pkg/api/app_test.go
+++ b/pkg/api/app_test.go
@@ -187,6 +187,22 @@ func TestAppLogs(t *testing.T) {
 	})
 }
 
+func TestAppLogsMaxLogRequests(t *testing.T) {
+	testServer(t, func(c *stdsdk.Client, p *structs.MockProvider) {
+		d1 := []byte("test")
+		r1 := ioutil.NopCloser(bytes.NewReader(d1))
+		opts := structs.LogsOptions{Since: options.Duration(2 * time.Minute), MaxLogRequests: options.Int(50)}
+		p.On("AppLogs", "app1", opts).Return(r1, nil)
+		r2, err := c.Websocket("/apps/app1/logs", stdsdk.RequestOptions{
+			Headers: stdsdk.Headers{"Maxlogrequests": "50"},
+		})
+		require.NoError(t, err)
+		d2, err := ioutil.ReadAll(r2)
+		require.NoError(t, err)
+		require.Equal(t, d1, d2)
+	})
+}
+
 func TestAppLogsError(t *testing.T) {
 	testServer(t, func(c *stdsdk.Client, p *structs.MockProvider) {
 		opts := structs.LogsOptions{Since: options.Duration(2 * time.Minute)}

--- a/pkg/cli/logs_test.go
+++ b/pkg/cli/logs_test.go
@@ -27,6 +27,36 @@ func TestLogs(t *testing.T) {
 	})
 }
 
+func TestLogsMaxLogRequests(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("AppLogs", "app1", structs.LogsOptions{Prefix: options.Bool(true), MaxLogRequests: options.Int(50)}).Return(testLogs(fxLogs()), nil)
+
+		res, err := testExecute(e, "logs -a app1 --max-log-requests 50", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		res.RequireStderr(t, []string{""})
+		res.RequireStdout(t, []string{
+			fxLogs()[0],
+			fxLogs()[1],
+		})
+	})
+}
+
+func TestLogsServiceMaxLogRequests(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("ServiceLogs", "app1", "web", structs.LogsOptions{Prefix: options.Bool(true), MaxLogRequests: options.Int(100)}).Return(testLogs(fxLogs()), nil)
+
+		res, err := testExecute(e, "logs -a app1 --service web --max-log-requests 100", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		res.RequireStderr(t, []string{""})
+		res.RequireStdout(t, []string{
+			fxLogs()[0],
+			fxLogs()[1],
+		})
+	})
+}
+
 func TestLogsError(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
 		// i.On("ClientType").Return("standard")

--- a/pkg/cli/rack_test.go
+++ b/pkg/cli/rack_test.go
@@ -305,6 +305,21 @@ func TestRackLogs(t *testing.T) {
 	})
 }
 
+func TestRackLogsMaxLogRequests(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("SystemLogs", structs.LogsOptions{Prefix: options.Bool(true), MaxLogRequests: options.Int(50)}).Return(testLogs(fxLogs()), nil)
+
+		res, err := testExecute(e, "rack logs --max-log-requests 50", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		res.RequireStderr(t, []string{""})
+		res.RequireStdout(t, []string{
+			fxLogs()[0],
+			fxLogs()[1],
+		})
+	})
+}
+
 func TestRackLogsError(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
 		i.On("SystemLogs", structs.LogsOptions{Prefix: options.Bool(true)}).Return(nil, fmt.Errorf("err1"))

--- a/pkg/structs/log.go
+++ b/pkg/structs/log.go
@@ -3,10 +3,11 @@ package structs
 import "time"
 
 type LogsOptions struct {
-	Filter   *string        `flag:"filter" header:"Filter"`
-	Follow   *bool          `header:"Follow"`
-	Prefix   *bool          `header:"Prefix"`
-	Since    *time.Duration `default:"2m" flag:"since" header:"Since"`
-	Previous *bool          `flag:"allow-previous" header:"Previous"`
-	Tail     *int           `flag:"tail" header:"Tail"`
+	Filter         *string        `flag:"filter" header:"Filter"`
+	Follow         *bool          `header:"Follow"`
+	MaxLogRequests *int           `flag:"max-log-requests" header:"Maxlogrequests"`
+	Prefix         *bool          `header:"Prefix"`
+	Since          *time.Duration `default:"2m" flag:"since" header:"Since"`
+	Previous       *bool          `flag:"allow-previous" header:"Previous"`
+	Tail           *int           `flag:"tail" header:"Tail"`
 }

--- a/provider/k8s/log.go
+++ b/provider/k8s/log.go
@@ -83,6 +83,9 @@ func (p *Provider) configureLogOptionsForService(app, name string, f cmdutil.Fac
 	}
 
 	o.MaxFollowConcurrency = 20
+	if logConfig.MaxLogRequests != nil {
+		o.MaxFollowConcurrency = *logConfig.MaxLogRequests
+	}
 
 	o.Namespace = p.AppNamespace(app)
 	o.ConsumeRequestFn = logs.DefaultConsumeRequest


### PR DESCRIPTION
### What is the feature/update/fix?

**Update: Add `--max-log-requests` flag to `convox logs` and `convox rack logs`**

`convox logs --service <name>` streams logs from every pod that matches the selector. The underlying kubectl plumbing caps concurrency at 20 follow streams. When a service runs with more than 20 pods, the command fails immediately with:

```
ERROR: you are attempting to follow 50 log streams, but maximum allowed concurrency is 20, use --max-log-requests to increase the limit
```

3.24.5 surfaces that cap as a user-settable flag. Pass `--max-log-requests N` to raise (or lower) the follow-stream concurrency on any of the logs commands.

| Command                                | Flag                     | Default | Behavior                                                      |
|----------------------------------------|--------------------------|---------|---------------------------------------------------------------|
| `convox logs`                          | `--max-log-requests N`   | `20`    | Raises the kubectl follow-stream concurrency cap to `N`.      |
| `convox logs --service <name>`         | `--max-log-requests N`   | `20`    | Same cap, applied when tailing a specific service by name.    |
| `convox rack logs`                     | `--max-log-requests N`   | `20`    | Same cap, applied when tailing rack-level system logs.        |

The flag is plumbed through the full CLI to SDK to HTTP to provider pipeline via the existing `stdcli.OptionFlags(LogsOptions{})` reflection pattern, so the field is automatically picked up without changes to individual command wiring.

---

### Why is this important?

The hardcoded `20` limit has been a friction point for any user running high-concurrency services. Tailing logs on a service that scales to dozens of pods currently requires tearing out the `--service` filter and paging through the full app stream, which buries the signal under chatter from unrelated services. The new flag removes that limit without changing default behavior for anyone running fewer than 20 pods per service.

**Benefits:**

| Benefit | Description |
|---------|-------------|
| Tail high-concurrency services. | Services with 20+ pods can now stream logs through `convox logs --service` without hitting the concurrency error. |
| Default behavior unchanged. | The default stays `20`, so existing tooling, scripts, and CI jobs that do not pass the flag behave identically to prior releases. |
| Works on rack logs too. | The flag is also wired into `convox rack logs`, covering the rack-level system log stream (kube-system, coredns, convox-system pods). |

---

### How to use it?

Raise the concurrency to 50 when tailing a high-pod-count service:

```
$ convox logs --rack prod-platform --service pii-worker --since 5m --max-log-requests 50
```

Raise the concurrency on the rack log stream:

```
$ convox rack logs --rack prod-platform --max-log-requests 50
```

Combine with other log flags (`--filter`, `--since`, `--tail`) as usual:

```
$ convox logs -a my-app --service web --since 10m --filter ERROR --max-log-requests 40
```

Picking a value: set `--max-log-requests` to at least the pod count of the target service. Log streams are persistent HTTP connections, so very large values (hundreds) put sustained load on the API server and fluentd; prefer filtering by `--service` and a modest concurrency (25 to 100) over tailing the full app stream without the flag.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this update.

- The default `MaxFollowConcurrency` remains `20` when `--max-log-requests` is not supplied.
- Existing invocations of `convox logs` and `convox rack logs` behave identically to prior releases.
- The `LogsOptions` struct gains an optional pointer field (`MaxLogRequests *int`); old API clients that do not send the header receive the same behavior as before.

---

### Requirements

This update requires version `3.24.5` or later for the rack.

**Update the Rack:** Run `convox rack update 3.24.5 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.23.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
