### PR TITLE
fix ecr cleanup manifest env validation

### DIFF
--- a/provider/k8s/task_release_cleanup.go
+++ b/provider/k8s/task_release_cleanup.go
@@ -8,16 +8,20 @@ import (
 	"time"
 
 	"github.com/convox/convox/pkg/common"
-	"github.com/convox/convox/pkg/manifest"
 	"github.com/convox/convox/pkg/structs"
 	convoxv1 "github.com/convox/convox/provider/k8s/pkg/apis/convox/v1"
 	cv "github.com/convox/convox/provider/k8s/pkg/client/clientset/versioned"
 	"github.com/convox/logger"
+	yaml "gopkg.in/yaml.v2"
 	am "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 )
+
+type cleanupManifest struct {
+	Services map[string]interface{} `yaml:"services"`
+}
 
 const cleanupAnnotationKey = "convox.io/last-release-build-cleanup"
 
@@ -192,28 +196,32 @@ func (a *releaseCleaner) appReleaseAndBuildCleanup(app *structs.App) error {
 	for _, b := range bs {
 		// also ensure we don't delete builds that are newer than the oldest release we are keeping
 		if _, ok := buildToKeep[b.Name]; !ok && a.toTime(b.Spec.Started).Before(oldestReleaseTimeToKeep) {
-			buildToDelete[b.Name] = []string{}
-			m, err := manifest.Load([]byte(b.Spec.Manifest), structs.Environment{})
-			if err != nil {
-				a.logger.Errorf("failed to load manifest for build '%s' of app '%s': %s", b.Name, app.Name, err)
-				return err
+			var cm cleanupManifest
+			if err := yaml.Unmarshal([]byte(b.Spec.Manifest), &cm); err != nil {
+				a.logger.Errorf("failed to parse manifest for build '%s' of app '%s': %s, skipping build", b.Name, app.Name, err)
+				continue
 			}
-			for _, svc := range m.Services {
-				if svc.Name != "" {
-					buildToDelete[b.Name] = append(buildToDelete[b.Name], fmt.Sprintf("%s.%s", svc.Name, strings.ToUpper(b.Name)))
+
+			tags := []string{}
+			for svcName := range cm.Services {
+				if svcName != "" {
+					tags = append(tags, fmt.Sprintf("%s.%s", svcName, strings.ToUpper(b.Name)))
 				}
 			}
+			buildToDelete[b.Name] = tags
 		}
 	}
 
 	for bName, tags := range buildToDelete {
-		if err := a.engine.RepositoryImagesBatchDelete(app.Name, tags); err != nil {
-			a.logger.Errorf("failed to delete images for builds '%s': %s", strings.Join(tags, ","), err)
-			return err
+		if len(tags) > 0 {
+			if err := a.engine.RepositoryImagesBatchDelete(app.Name, tags); err != nil {
+				a.logger.Errorf("failed to delete images for build '%s': %s", bName, err)
+				continue
+			}
 		}
 		if err := a.convox.ConvoxV1().Builds(appNamespace).Delete(bName, &am.DeleteOptions{}); err != nil {
 			a.logger.Errorf("failed to delete build '%s': %s", bName, err)
-			return err
+			continue
 		}
 		time.Sleep(50 * time.Millisecond) // to avoid rate limit
 	}


### PR DESCRIPTION
### What is the feature/update/fix?

**Fix: ECR Image Cleanup Failing for Apps with Required Environment Variables**

Fixed a bug where the automated release cleanup process failed to delete old builds and ECR images for any app that declares required environment variables in its `convox.yml`.

The release cleaner was using `manifest.Load()` with an empty environment map to extract service names for ECR image tag construction. `manifest.Load()` runs the full validation pipeline including environment variable checking, which fails with `"required env: ..."` for any manifest declaring required variables without defaults. This blocked all build and ECR image cleanup for affected apps.

A second issue compounded the problem: when cleanup failed for one build, the error caused an immediate return, halting cleanup for all remaining builds in that app.

**Changes:**

| Aspect | Before | After |
|--------|--------|-------|
| Manifest parsing | Full `manifest.Load()` with env validation | Minimal YAML unmarshal that extracts only service names |
| Error handling (manifest) | `return err`, stops all cleanup | `continue`, skips the failing build and continues with the rest |
| Error handling (ECR delete) | `return err`, stops all cleanup | `continue`, logs the error and continues with remaining builds |
| Error handling (build delete) | `return err`, stops all cleanup | `continue`, logs the error and continues with remaining builds |
| Empty service list | Called ECR API with empty tag list | Skips the ECR API call entirely (no-op for builds with no services) |

---

### Why is this important?

Any app with required environment variables (a common and recommended pattern) had its build and ECR image cleanup silently broken. Over time, this leads to:

- **Accumulating orphaned ECR images** consuming storage and incurring costs
- **Accumulating orphaned build records** in the Kubernetes API
- **A single bad build blocking cleanup for the entire app.** One unparseable manifest prevented deletion of all other eligible builds.

**Benefits:**

- **Cleanup works for all apps.** Apps with required env vars (`DATABASE_URL`, `API_KEY`, etc.) now have their old builds and ECR images cleaned up correctly.
- **Resilient error handling.** One failing build no longer blocks cleanup for the entire app. Each build is processed independently.
- **No unnecessary API calls.** Builds with no services (e.g., failed builds with empty manifests) skip the ECR batch delete call entirely.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this fix.

The cleanup feature is opt-in via the `releases_to_retain_after_active` rack parameter. The fix only changes how the cleaner extracts service names from build manifests and how it handles errors. The selection logic for which builds and releases to delete is unchanged.

---

### Requirements

This fix requires version `3.24.2` or later for the rack.

**Update the Rack:** Run `convox rack update 3.24.2 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.23.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
