### PR TITLE
Add ami_id rack parameter for custom AMIs

### DIFF
--- a/assets/provider/aws/params.yaml
+++ b/assets/provider/aws/params.yaml
@@ -188,6 +188,19 @@ Groups:
         description: AWS EC2 (Instance type)[https://aws.amazon.com/ec2/instance-types/]
           used for cluster nodes. Supports comma-separated list for mixed instance
           configurations.
+      - name: ami_id
+        default: "null"
+        sideNote: EKS-optimized AL2023 AMI used by default
+        optional: true
+        type: string
+        regex: ^ami-[a-f0-9]{8,17}$
+        description: |
+          &b Advanced Configuration &b &l Custom AMI ID for the core EKS node
+          groups (primary and build). Overrides the default EKS-optimized AL2023
+          AMI. &l &l &b Warning: &b Setting or changing this parameter will trigger
+          a rolling replacement of all core node groups. &l &l AMIs are
+          region-specific and must be AL2023-based and compatible with the
+          cluster's Kubernetes version. &l
       - name: build_node_enabled
         default: "false"
         type: boolean

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -130,14 +130,14 @@ resource "aws_eks_node_group" "cluster" {
 
   count = var.high_availability ? 3 : 1
 
-  ami_type        = var.gpu_type ? "AL2023_x86_64_NVIDIA" : var.arm_type ? "AL2023_ARM_64_STANDARD" : "AL2023_x86_64_STANDARD"
+  ami_type        = var.ami_id != "" ? "CUSTOM" : var.gpu_type ? "AL2023_x86_64_NVIDIA" : var.arm_type ? "AL2023_ARM_64_STANDARD" : "AL2023_x86_64_STANDARD"
   capacity_type   = var.node_capacity_type == "MIXED" ? count.index == 0 ? "ON_DEMAND" : "SPOT" : var.node_capacity_type
   cluster_name    = aws_eks_cluster.cluster.name
   node_group_name = "${var.name}-${var.private ? data.aws_subnet.private_subnet_details[count.index].availability_zone : data.aws_subnet.public_subnet_details[count.index].availability_zone}-${count.index}${random_id.node_group.hex}"
   node_role_arn   = random_id.node_group.keepers.role_arn
   subnet_ids      = [var.private ? local.private_subnets_ids[count.index] : local.public_subnets_ids[count.index]]
   tags            = local.tags
-  version         = var.k8s_version
+  version         = var.ami_id != "" ? null : var.k8s_version
 
   launch_template {
     id      = aws_launch_template.cluster.id
@@ -185,7 +185,7 @@ resource "aws_eks_node_group" "cluster-build" {
   ]
 
   count           = var.build_node_enabled ? 1 : 0
-  ami_type        = var.build_gpu_type ? "AL2023_x86_64_NVIDIA" : var.build_arm_type ? "AL2023_ARM_64_STANDARD" : "AL2023_x86_64_STANDARD"
+  ami_type        = var.ami_id != "" ? "CUSTOM" : var.build_gpu_type ? "AL2023_x86_64_NVIDIA" : var.build_arm_type ? "AL2023_ARM_64_STANDARD" : "AL2023_x86_64_STANDARD"
   capacity_type   = "ON_DEMAND"
   cluster_name    = aws_eks_cluster.cluster.name
   instance_types  = split(",", random_id.build_node_group[0].keepers.node_type)
@@ -193,7 +193,7 @@ resource "aws_eks_node_group" "cluster-build" {
   node_role_arn   = random_id.build_node_group[0].keepers.role_arn
   subnet_ids      = [var.private ? local.private_subnets_ids[count.index] : local.public_subnets_ids[count.index]]
   tags            = local.tags
-  version         = var.k8s_version
+  version         = var.ami_id != "" ? null : var.k8s_version
 
   labels = {
     "convox-build" : "true"
@@ -311,6 +311,7 @@ resource "aws_launch_template" "cluster" {
     instance_metadata_tags      = var.imds_tags_enable ? "enabled" : "disabled"
   }
 
+  image_id      = var.ami_id != "" ? var.ami_id : null
   instance_type = split(",", random_id.node_group.keepers.node_type)[0]
 
   dynamic "tag_specifications" {
@@ -324,12 +325,20 @@ resource "aws_launch_template" "cluster" {
     }
   }
 
-  user_data = var.user_data_url != "" || var.user_data != "" || var.kubelet_registry_pull_qps != 5 || var.kubelet_registry_burst != 10 ? base64encode(templatefile("${path.module}/files/custom_user_data.sh", {
+  user_data = var.ami_id != "" ? base64encode(templatefile("${path.module}/files/custom_ami_userdata_al2023.sh", {
+    api_server_endpoint = aws_eks_cluster.cluster.endpoint,
+    api_server_ca       = aws_eks_cluster.cluster.certificate_authority[0].data,
+    name                = aws_eks_cluster.cluster.name,
+    cidr                = var.cidr,
+    cluster_dns         = local.kube_dns_ip,
+    node_labels         = "eks.amazonaws.com/nodegroup=${var.name}",
+    user_data           = local.launch_template_user_data_raw,
+  })) : (var.user_data_url != "" || var.user_data != "" || var.kubelet_registry_pull_qps != 5 || var.kubelet_registry_burst != 10 ? base64encode(templatefile("${path.module}/files/custom_user_data.sh", {
     kubelet_registry_pull_qps = var.kubelet_registry_pull_qps
     kubelet_registry_burst    = var.kubelet_registry_burst
     user_data_script_file     = var.user_data_url != "" ? data.http.user_data_content[0].response_body : ""
     user_data                 = var.user_data
-  })) : ""
+  })) : "")
 
   key_name = var.key_pair_name != "" ? var.key_pair_name : null
 }
@@ -343,6 +352,8 @@ resource "aws_launch_template" "cluster-build" {
       encrypted   = var.ebs_volume_encryption_enabled
     }
   }
+
+  image_id = var.ami_id != "" ? var.ami_id : null
 
   metadata_options {
     http_tokens                 = var.imds_http_tokens
@@ -361,6 +372,16 @@ resource "aws_launch_template" "cluster-build" {
       tags          = local.tags
     }
   }
+
+  user_data = var.ami_id != "" ? base64encode(templatefile("${path.module}/files/custom_ami_userdata_al2023.sh", {
+    api_server_endpoint = aws_eks_cluster.cluster.endpoint,
+    api_server_ca       = aws_eks_cluster.cluster.certificate_authority[0].data,
+    name                = aws_eks_cluster.cluster.name,
+    cidr                = var.cidr,
+    cluster_dns         = local.kube_dns_ip,
+    node_labels         = "eks.amazonaws.com/nodegroup=${var.name}-build",
+    user_data           = "",
+  })) : null
 
   key_name = var.key_pair_name != "" ? var.key_pair_name : null
 }

--- a/terraform/cluster/aws/variables.tf
+++ b/terraform/cluster/aws/variables.tf
@@ -8,6 +8,11 @@ variable "additional_build_groups" {
   default = []
 }
 
+variable "ami_id" {
+  type    = string
+  default = ""
+}
+
 variable "arm_type" {
   default = false
 }

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -75,6 +75,7 @@ module "cluster" {
 
   additional_node_groups              = local.additional_node_groups
   additional_build_groups             = local.additional_build_groups
+  ami_id                              = var.ami_id
   arm_type                            = local.arm_type
   aws_ebs_csi_driver_version          = var.aws_ebs_csi_driver_version
   build_arm_type                      = local.build_arm_type

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -2,6 +2,11 @@ variable "access_log_retention_in_days" {
   default = "7"
 }
 
+variable "ami_id" {
+  type    = string
+  default = ""
+}
+
 variable "additional_node_groups_config" {
   type    = string
   default = ""


### PR DESCRIPTION
## Summary

- Adds `ami_id` rack parameter for AWS provider, allowing customers to specify a custom AMI for core EKS node groups (primary + build)
- Defaults to empty/null -- zero impact on existing racks; EKS-optimized AL2023 AMI continues to be used unless explicitly overridden
- When set, node groups switch to `ami_type = "CUSTOM"` with AL2023 bootstrap userdata, following the same pattern already used by `additional_node_groups_config`

## Details

**Files changed:**
- `assets/provider/aws/params.yaml` -- New `ami_id` parameter in Performance & Scaling group
- `terraform/system/aws/variables.tf` -- Variable declaration at system level
- `terraform/system/aws/main.tf` -- Pass-through to cluster module
- `terraform/cluster/aws/variables.tf` -- Variable declaration at cluster level
- `terraform/cluster/aws/main.tf` -- Conditional logic on node groups + launch templates

**Behavior when `ami_id` is empty (default -- all existing customers):**
- No change whatsoever. `ami_type` remains `AL2023_x86_64_STANDARD` (or ARM/GPU variant), launch templates have no `image_id`, EKS manages AMI selection.

**Behavior when `ami_id` is set:**
- `ami_type` becomes `"CUSTOM"` on primary and build node groups
- `version` becomes `null` (EKS cannot manage k8s version for custom AMIs)
- Launch templates get `image_id` set to the provided AMI
- AL2023 bootstrap userdata is injected (same template as additional_node_groups)
- `ami_type` is `ForceNew` on `aws_eks_node_group`, so toggling between default and custom AMI triggers create-before-destroy node group replacement automatically; changing from one custom AMI to another triggers an EKS rolling update via launch template versioning
- `ami_id` is intentionally **not** added to `random_id` keepers -- adding a new keeper key would force node group replacement for every existing rack on upgrade, even those not using the parameter
- Existing `user_data` / `user_data_url` / kubelet settings are preserved and included in the bootstrap

