### PR TITLE
Fix stale bearer token in ServiceLogs

### DIFF
--- a/provider/k8s/log.go
+++ b/provider/k8s/log.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/convox/convox/pkg/options"
@@ -126,7 +128,18 @@ func (p *Provider) newlogsConfigFlags(ns string) *genericclioptions.ConfigFlags 
 	cf.Insecure = options.Bool(true)
 	cf.KubeConfig = nil
 	cf.APIServer = options.String(p.Config.Host)
-	cf.BearerToken = options.String(p.Config.BearerToken)
+	// Read token fresh from disk to handle EKS projected service account
+	// token rotation. The BearerTokenFile is updated by the kubelet when
+	// the token is rotated, but BearerToken is a static string from startup.
+	if p.Config.BearerTokenFile != "" {
+		if token, err := os.ReadFile(p.Config.BearerTokenFile); err == nil {
+			cf.BearerToken = options.String(strings.TrimSpace(string(token)))
+		} else {
+			cf.BearerToken = options.String(p.Config.BearerToken)
+		}
+	} else {
+		cf.BearerToken = options.String(p.Config.BearerToken)
+	}
 	cf.CAFile = options.String(p.Config.CAFile)
 	cf.CertFile = options.String(p.Config.CertFile)
 	cf.DisableCompression = options.Bool(p.Config.DisableCompression)


### PR DESCRIPTION
### What is the feature/update/fix?

**Fix: Stale Bearer Token in `convox logs` Streaming**

Fixed an issue where `convox logs` (and other log streaming commands) would fail with HTTP 401 errors after approximately one hour of rack uptime. The rack's API server was using a static bearer token captured at startup when creating the internal Kubernetes client for log streaming. After EKS rotates the projected service account token (~1 hour), this static token became invalid and all log streaming requests were rejected by the Kubernetes API.

**Changes:**

| Component | Before | After |
|-----------|--------|-------|
| Token source in `ServiceLogs` | Static `BearerToken` from startup | Fresh read from `BearerTokenFile` at each request |
| Token rotation handling | Not handled; token expired after ~1 hour | Reads rotated token from disk, matching kubelet behavior |
| Fallback behavior | N/A | Falls back to static token if `BearerTokenFile` is empty or unreadable (out-of-cluster environments) |

---

### Why is this important?

EKS uses projected service account tokens with automatic rotation for security. The main rack Kubernetes client handled this transparently via its transport layer, but the separate client created for log streaming (`ConfigFlags`-based) only accepted a token string and had no rotation mechanism.

**Benefits:**

- **Reliable log streaming.** `convox logs` and service log streaming no longer fail after token rotation, regardless of rack uptime.
- **Transparent to users.** No configuration changes needed. The fix reads the same token file the kubelet maintains.
- **Safe fallback.** Out-of-cluster environments (local development, testing) continue to work with the existing static token.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this fix.

The fix only changes the token source for one internal code path (`ServiceLogs`). Out-of-cluster environments and racks where `BearerTokenFile` is not set fall back to the previous behavior. No new configuration, no API changes, no interface changes.

---

### Requirements

This fix requires version `3.24.2` or later for the rack.

**Update the Rack:** Run `convox rack update 3.24.2 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.23.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
