### PR TITLE
Fix param downgrade compat potential issues

### DIFF
--- a/pkg/rack/terraform.go
+++ b/pkg/rack/terraform.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -310,6 +311,10 @@ func (t Terraform) UpdateParams(params map[string]string) error {
 		return err
 	}
 
+	if err := t.reconcileVarsWithModule(release); err != nil {
+		return err
+	}
+
 	if err := t.apply(); err != nil {
 		return err
 	}
@@ -345,6 +350,10 @@ func (t Terraform) UpdateVersion(version string, force bool) error {
 		return err
 	}
 
+	if err := t.reconcileVarsWithModule(version); err != nil {
+		return err
+	}
+
 	if err := t.apply(); err != nil {
 		return err
 	}
@@ -363,6 +372,109 @@ func (t Terraform) apply() error {
 	}
 
 	return nil
+}
+
+// moduleVarNames returns the set of variable names declared by the downloaded
+// system module after terraform init. It reads the Terraform modules manifest
+// to locate the module directory, then scans .tf files for variable blocks.
+func (t Terraform) moduleVarNames() (map[string]bool, error) {
+	dir, err := t.settingsDirectory()
+	if err != nil {
+		return nil, err
+	}
+
+	manifestPath := filepath.Join(dir, ".terraform", "modules", "modules.json")
+	data, err := ioutil.ReadFile(manifestPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var manifest struct {
+		Modules []struct {
+			Key string `json:"Key"`
+			Dir string `json:"Dir"`
+		} `json:"Modules"`
+	}
+
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, err
+	}
+
+	moduleDir := ""
+	for _, m := range manifest.Modules {
+		if m.Key == "system" {
+			moduleDir = filepath.Join(dir, m.Dir)
+			break
+		}
+	}
+
+	if moduleDir == "" {
+		return nil, fmt.Errorf("system module not found in manifest")
+	}
+
+	files, err := filepath.Glob(filepath.Join(moduleDir, "*.tf"))
+	if err != nil {
+		return nil, err
+	}
+
+	varNames := map[string]bool{}
+	re := regexp.MustCompile(`(?m)^variable\s+"([^"]+)"`)
+
+	for _, f := range files {
+		content, err := ioutil.ReadFile(f)
+		if err != nil {
+			continue
+		}
+		for _, match := range re.FindAllStringSubmatch(string(content), -1) {
+			varNames[match[1]] = true
+		}
+	}
+
+	return varNames, nil
+}
+
+// reconcileVarsWithModule filters rack parameters to only those accepted by
+// the target module version. When a rack changes versions, previously-set
+// parameters may not exist in the new version's module. Without filtering,
+// Terraform errors with "argument not expected." This scans the downloaded
+// module for declared variables and removes any unrecognized parameters from
+// both main.tf and vars.json before apply.
+func (t Terraform) reconcileVarsWithModule(release string) error {
+	accepted, err := t.moduleVarNames()
+	if err != nil {
+		return nil
+	}
+
+	// sanity check: every version should declare name and release
+	if !accepted["name"] || !accepted["release"] {
+		return nil
+	}
+
+	vars, err := t.vars()
+	if err != nil {
+		return err
+	}
+
+	var removed []string
+	for k := range vars {
+		if !accepted[k] {
+			removed = append(removed, k)
+		}
+	}
+
+	if len(removed) == 0 {
+		return nil
+	}
+
+	sort.Strings(removed)
+	fmt.Fprintf(os.Stderr, "NOTICE: removing parameters not supported by version %s: %s\n",
+		release, strings.Join(removed, ", "))
+
+	for _, k := range removed {
+		delete(vars, k)
+	}
+
+	return t.update(release, vars)
 }
 
 func (t Terraform) create(release string, vars map[string]string, state []byte) error {

--- a/pkg/rack/terraform.go
+++ b/pkg/rack/terraform.go
@@ -89,6 +89,10 @@ func InstallTerraform(c *stdcli.Context, provider, name, version string, options
 		return err
 	}
 
+	if err := t.reconcileVarsWithModule(version); err != nil {
+		return err
+	}
+
 	if err := t.apply(); err != nil {
 		return err
 	}


### PR DESCRIPTION
### What is the feature/update/fix?

**Update: Automatic Rack Parameter Reconciliation Across Version Transitions**

Rack parameter compatibility across version transitions is now handled automatically. When a rack changes versions (upgrade, downgrade, or version pin), a new reconciliation step scans the target version's Terraform module for declared variables and compares them against the rack's stored parameters. Any parameters not accepted by the target version are automatically removed before `terraform apply`, preventing failures from unrecognized arguments.

Previously, parameter compatibility required manual per-parameter coordination. Each new parameter needed careful gating logic to ensure it wouldn't break racks transitioning between versions. This was error-prone and required developers to anticipate every version transition path. The new approach replaces that with generic, automatic detection.

**How it works:**

1. After `terraform init` downloads the target version's module, the reconciliation step reads the module's `.tf` files and extracts all declared `variable` blocks
2. It compares these against the rack's stored parameters (`vars.json`)
3. Any parameters not declared by the target module are removed from `vars.json` and `main.tf`
4. A `NOTICE` is printed to stderr listing removed parameters, so operators have visibility into what was dropped

**Scope:**

| Operation | Covered | Description |
|-----------|---------|-------------|
| `convox rack update {version}` | Yes | Version upgrades and downgrades |
| `convox rack params set ...` | Yes | Safety net for stale stored params |
| `convox rack install ...` | Yes | Fresh installs (no-op, no stale params) |

---

### Why is this important?

Version transitions are one of the most common sources of unexpected Terraform failures. When a rack has stored a parameter that the target version doesn't declare, Terraform errors with `"argument not expected"` and the entire update fails. This can happen during:

- **Downgrades:** rolling back to a version that predates a parameter
- **Version pinning:** switching to a specific release that doesn't include a recently added parameter
- **Hotfix branches:** applying a patch built from an older code base

**Benefits:**

- **Safe version transitions.** Racks can move between any versions without parameter mismatch errors. No more Terraform failures from stale parameters.
- **Operator visibility.** Removed parameters are printed as a `NOTICE` so operators know exactly what was dropped during the transition.
- **Future-proof.** New parameters added in any future release are handled generically. No version-specific coordination or gating logic required.
- **Zero disruption for current behavior.** If no unrecognized parameters are found, the reconciliation is a no-op with no side effects.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this update.

Existing racks with parameters that match the target version are completely unaffected. The reconciliation step detects no mismatches and does nothing. Only racks with stale parameters from a different version will see any effect, and in those cases the alternative was a Terraform failure, so the automatic cleanup is strictly better.

---

### Requirements

This update requires version `3.24.2` or later for the rack.

**Update the Rack:** Run `convox rack update 3.24.2 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.23.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
