### PR TITLE
dependancy fixes for karpenter alt node groups

### DIFF
--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -356,7 +356,7 @@ func (an AdditionalNodeGroups) Validate() error {
 
 	if idCnt == 0 {
 		for i := range an {
-			an[i].Id = options.Int(i + 1)
+			an[i].Id = options.Int(i)
 		}
 	}
 	return nil
@@ -588,6 +588,41 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 			nCfgs := AdditionalNodeGroups{}
 			if err := json.Unmarshal(cfgData, &nCfgs); err != nil {
 				return err
+			}
+
+			// Preserve existing ids from currentParams when new config omits them.
+			// This prevents Terraform for_each key changes (destroy+create cycles)
+			// when a user modifies config without specifying ids.
+			hasNilId := false
+			for _, ng := range nCfgs {
+				if ng.Id == nil {
+					hasNilId = true
+					break
+				}
+			}
+			if hasNilId && currentParams[k] != "" {
+				var existingData []byte
+				if decoded, err := base64.StdEncoding.DecodeString(currentParams[k]); err == nil {
+					existingData = decoded
+				} else {
+					existingData = []byte(currentParams[k])
+				}
+				var existing AdditionalNodeGroups
+				if err := json.Unmarshal(existingData, &existing); err == nil {
+					for i := range nCfgs {
+						if nCfgs[i].Id != nil {
+							continue
+						}
+						if i < len(existing) {
+							if existing[i].Id != nil {
+								nCfgs[i].Id = existing[i].Id
+							} else {
+								// Legacy entry without id — use 0-based index to match Terraform's idx default
+								nCfgs[i].Id = options.Int(i)
+							}
+						}
+					}
+				}
 			}
 
 			if err := nCfgs.Validate(); err != nil {

--- a/pkg/cli/rack_karpenter_test.go
+++ b/pkg/cli/rack_karpenter_test.go
@@ -1625,3 +1625,93 @@ func TestCheckRackNameRegex(t *testing.T) {
 		})
 	}
 }
+
+func TestAdditionalNodeGroups_Validate_AutoAssignIdsFromZero(t *testing.T) {
+	ngs := AdditionalNodeGroups{
+		{Type: "m5.large"},
+		{Type: "c5.xlarge"},
+	}
+	if err := ngs.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if ngs[0].Id == nil || *ngs[0].Id != 0 {
+		t.Errorf("expected first id=0, got %v", ngs[0].Id)
+	}
+	if ngs[1].Id == nil || *ngs[1].Id != 1 {
+		t.Errorf("expected second id=1, got %v", ngs[1].Id)
+	}
+}
+
+func TestValidateAndMutateParams_PreserveExistingNodeGroupIds(t *testing.T) {
+	id5 := 5
+	lbl := "gpu"
+	existingWithId := AdditionalNodeGroups{{Type: "g6.xlarge", Id: &id5, Dedicated: boolPtr(true), Label: &lbl}}
+	existingWithIdJSON, _ := json.Marshal(existingWithId)
+	existingWithIdB64 := base64.StdEncoding.EncodeToString(existingWithIdJSON)
+
+	existingNoId := `[{"type":"g6.xlarge","dedicated":true,"label":"gpu"}]`
+	existingNoIdB64 := base64.StdEncoding.EncodeToString([]byte(existingNoId))
+
+	tests := []struct {
+		name          string
+		newConfig     string
+		currentConfig string
+		wantId        int
+	}{
+		{
+			"preserves existing id from currentParams",
+			`[{"type":"g6.xlarge","dedicated":true,"label":"gpu"}]`,
+			existingWithIdB64,
+			5,
+		},
+		{
+			"legacy config without id gets 0-based index",
+			`[{"type":"g6.xlarge","dedicated":true,"label":"gpu"}]`,
+			existingNoIdB64,
+			0,
+		},
+		{
+			"no currentParams — auto-assigns 0-based",
+			`[{"type":"g6.xlarge","dedicated":true,"label":"gpu"}]`,
+			"",
+			0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := map[string]string{
+				"additional_node_groups_config": tt.newConfig,
+			}
+			currentParams := map[string]string{}
+			if tt.currentConfig != "" {
+				currentParams["additional_node_groups_config"] = tt.currentConfig
+			}
+
+			if err := validateAndMutateParams(params, "aws", currentParams); err != nil {
+				t.Fatal(err)
+			}
+
+			// Decode the result
+			decoded, err := base64.StdEncoding.DecodeString(params["additional_node_groups_config"])
+			if err != nil {
+				t.Fatal(err)
+			}
+			var result AdditionalNodeGroups
+			if err := json.Unmarshal(decoded, &result); err != nil {
+				t.Fatal(err)
+			}
+			if len(result) != 1 {
+				t.Fatalf("expected 1 node group, got %d", len(result))
+			}
+			if result[0].Id == nil {
+				t.Fatal("expected non-nil id")
+			}
+			if *result[0].Id != tt.wantId {
+				t.Errorf("expected id=%d, got id=%d", tt.wantId, *result[0].Id)
+			}
+		})
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }

--- a/terraform/cluster/aws/autoscaler.tf
+++ b/terraform/cluster/aws/autoscaler.tf
@@ -320,7 +320,6 @@ resource "kubernetes_deployment" "autoscaler" {
   depends_on = [
     aws_iam_role_policy.autoscaler_autoscale,
     null_resource.wait_eks_addons,
-    kubectl_manifest.karpenter_nodepool_workload,
   ]
 
   metadata {

--- a/terraform/cluster/aws/node_groups.tf
+++ b/terraform/cluster/aws/node_groups.tf
@@ -67,10 +67,20 @@ resource "random_id" "additional_node_groups" {
   }
 }
 
-module "amitype" {
-  source    = "../../helpers/aws"
-  for_each  = { for ng in local.additional_node_groups_with_defaults : ng.id => ng }
-  node_type = each.value.type
+data "aws_ec2_instance_type" "additional_node_type" {
+  for_each      = { for ng in local.additional_node_groups_with_defaults : ng.id => ng }
+  instance_type = each.value.type
+}
+
+locals {
+  additional_node_ami_type = {
+    for key, inst in data.aws_ec2_instance_type.additional_node_type : key => (
+      (substr(inst.instance_type, 0, 1) == "g" || substr(inst.instance_type, 0, 1) == "p" ||
+        substr(inst.instance_type, 0, 3) == "inf" || substr(inst.instance_type, 0, 3) == "trn")
+      ? "AL2023_x86_64_NVIDIA"
+      : contains(inst.supported_architectures, "arm64") ? "AL2023_ARM_64_STANDARD" : "AL2023_x86_64_STANDARD"
+    )
+  }
 }
 
 resource "aws_eks_node_group" "cluster_additional" {
@@ -81,7 +91,7 @@ resource "aws_eks_node_group" "cluster_additional" {
 
   for_each = { for ng in local.additional_node_groups_with_defaults : ng.id => ng }
 
-  ami_type        = random_id.additional_node_groups[each.key].keepers.ami_id != null ? "CUSTOM" : module.amitype[each.key].ami_type
+  ami_type        = random_id.additional_node_groups[each.key].keepers.ami_id != null ? "CUSTOM" : local.additional_node_ami_type[each.key]
   capacity_type   = random_id.additional_node_groups[each.key].keepers.node_capacity_type
   cluster_name    = aws_eks_cluster.cluster.name
   node_group_name = "${var.name}-additional-${each.key}-${random_id.additional_node_groups[each.key].hex}"
@@ -109,8 +119,7 @@ resource "aws_eks_node_group" "cluster_additional" {
   }
 
   lifecycle {
-    create_before_destroy = true
-    ignore_changes        = [scaling_config[0].desired_size]
+    ignore_changes = [scaling_config[0].desired_size]
   }
 
   labels = {
@@ -211,12 +220,21 @@ resource "random_id" "build_node_additional" {
   }
 }
 
-module "build_amitype" {
-  source    = "../../helpers/aws"
-  for_each  = { for ng in local.additional_build_groups_with_defaults : ng.id => ng }
-  node_type = each.value.type
+data "aws_ec2_instance_type" "build_node_type" {
+  for_each      = { for ng in local.additional_build_groups_with_defaults : ng.id => ng }
+  instance_type = each.value.type
 }
 
+locals {
+  build_node_ami_type = {
+    for key, inst in data.aws_ec2_instance_type.build_node_type : key => (
+      (substr(inst.instance_type, 0, 1) == "g" || substr(inst.instance_type, 0, 1) == "p" ||
+        substr(inst.instance_type, 0, 3) == "inf" || substr(inst.instance_type, 0, 3) == "trn")
+      ? "AL2023_x86_64_NVIDIA"
+      : contains(inst.supported_architectures, "arm64") ? "AL2023_ARM_64_STANDARD" : "AL2023_x86_64_STANDARD"
+    )
+  }
+}
 
 resource "aws_eks_node_group" "build_additional" {
   depends_on = [
@@ -226,7 +244,7 @@ resource "aws_eks_node_group" "build_additional" {
 
   for_each = { for idx, ng in local.additional_build_groups_with_defaults : ng.id => ng }
 
-  ami_type        = random_id.build_node_additional[each.key].keepers.ami_id != null ? "CUSTOM" : module.build_amitype[each.key].ami_type
+  ami_type        = random_id.build_node_additional[each.key].keepers.ami_id != null ? "CUSTOM" : local.build_node_ami_type[each.key]
   capacity_type   = random_id.build_node_additional[each.key].keepers.capacity_type != null ? random_id.build_node_additional[each.key].keepers.capacity_type : "ON_DEMAND"
   cluster_name    = aws_eks_cluster.cluster.name
   node_group_name = "${var.name}-build-additional-${each.key}-${random_id.build_node_additional[each.key].hex}"
@@ -263,9 +281,6 @@ resource "aws_eks_node_group" "build_additional" {
     create = "1h"
   }
 
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 resource "aws_launch_template" "build_additional" {


### PR DESCRIPTION
### What is the feature/update/fix?

**Fix: Additional Node Group Terraform Destroy/Create Cycle**

Fixed an edge case where racks configured with `additional_node_groups_config` before version 3.21.1 (when the `id` field was introduced) experienced Terraform destroy+create cycles when updating the node group configuration.

**Root cause:** Pre-3.21.1 racks had node groups stored in Terraform state with 0-based index keys (`"0"`, `"1"`, ...) from the default `lookup(ng, "id", idx)`. When the CLI's auto-assignment logic assigned IDs starting from 1, Terraform saw a key change from `"0"` to `"1"`, triggering a destroy+create. On Karpenter-enabled racks with additional node groups, this created a dependency cycle through the autoscaler's node group references.

**Changes:**

| Aspect | Before | After |
|--------|--------|-------|
| ID auto-assignment base | Started from 1 | Starts from 0 (matches Terraform default) |
| Existing ID preservation | Not preserved | CLI reads existing IDs from current params and preserves them |
| AMI type module | External `module.amitype` wrapper | Inline `data.aws_ec2_instance_type` lookup (eliminates implicit TF dependencies) |
| Additional node group lifecycle | `create_before_destroy = true` | Removed (prevents dependency cycle during key transitions) |
| Autoscaler → Karpenter dependency | Explicit `depends_on` to karpenter nodepool | Removed (breaks dependency cycle) |

---

### Why is this important?

A Terraform destroy+create cycle on an EKS node group is a disruptive event — it drains all pods from the node group, destroys the instances, and creates new ones. For racks that have been running since before 3.21.1 and have never re-set their `additional_node_groups_config`, this could be triggered unexpectedly by any rack update that touched the configuration.

**Benefits:**

- **No surprise node group replacements.** Existing node group IDs are preserved, preventing Terraform key changes.
- **Safe for legacy racks.** Racks configured before 3.21.1 can now update their additional node group configuration without triggering destroy+create cycles.
- **Karpenter compatibility.** Eliminates the dependency cycle that blocked Terraform applies on Karpenter-enabled racks with additional node groups.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this fix.

- Customers who set up after 3.21.1 already have explicit IDs — the auto-assignment change does not affect them
- The ID preservation logic only activates when new config entries have no IDs
- Removing `create_before_destroy` from additional node groups means a brief capacity gap is possible during rare full-replacement operations (keeper changes), but this tradeoff prevents the more severe destroy+create cycle

---

### Requirements

This fix requires version `3.24.3` or later for the rack.

**Update the Rack:** Run `convox rack update 3.24.3 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.23.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
