### PR TITLE
Add CI linting and other tooling

### DIFF
--- a/.checkov.yml
+++ b/.checkov.yml
@@ -42,3 +42,8 @@ skip-check:
   - CKV_AWS_144   # S3 cross-region replication
   # Internal traffic — default SG needed for intra-cluster communication
   - CKV2_AWS_12   # default security group
+  # --- Deferred security hardening (enable when non-downgradeable version ships) ---
+  # EKS secrets-at-rest encryption requires KMS key + encryption_config on
+  # aws_eks_cluster. Non-downgradeable once enabled, so gated on a version
+  # boundary. Plan ready in 2026-04-08-eks-secrets-encryption/.
+  - CKV_AWS_58    # EKS secrets encryption

--- a/.checkov.yml
+++ b/.checkov.yml
@@ -1,0 +1,44 @@
+framework:
+  - terraform
+directory:
+  - terraform
+output:
+  - cli
+soft-fail: true
+skip-check:
+  # --- Kubernetes deployment checks (not applicable) ---
+  # Convox generates K8s resources dynamically at deploy time.
+  # These TF-defined deployments are system scaffolding, not customer workloads.
+  - CKV_K8S_8   # liveness probe
+  - CKV_K8S_9   # readiness probe
+  - CKV_K8S_10  # CPU requests
+  - CKV_K8S_11  # CPU limits
+  - CKV_K8S_12  # memory limits
+  - CKV_K8S_13  # memory requests
+  - CKV_K8S_14  # image tag fixed
+  - CKV_K8S_15  # image pull policy always
+  - CKV_K8S_22  # read-only filesystem
+  - CKV_K8S_25  # added capabilities
+  - CKV_K8S_27  # docker daemon socket
+  - CKV_K8S_28  # NET_RAW capability
+  - CKV_K8S_29  # pod security context
+  - CKV_K8S_30  # container security context
+  - CKV_K8S_43  # image digest
+  - CKV_K8S_49  # wildcard roles — platform needs broad cluster access
+  # --- Intentional architecture decisions ---
+  # Public endpoints required for Convox CLI access
+  - CKV_AWS_39    # EKS public endpoint
+  - CKV_AZURE_115 # AKS private cluster
+  - CKV_GCP_25    # GKE private cluster
+  - CKV_GCP_64    # GKE private nodes
+  # Platform needs broad IAM access to manage customer workloads
+  - CKV_AWS_356   # IAM wildcard resources
+  # Customer flexibility — can't restrict legacy usage patterns
+  - CKV_AWS_79    # IMDSv1 — customers may need it
+  - CKV_AZURE_44  # TLS version — older client compatibility
+  # Cost — not justified for every customer rack
+  - CKV_AWS_18    # S3 access logging
+  - CKV_AWS_37    # EKS control plane logging
+  - CKV_AWS_144   # S3 cross-region replication
+  # Internal traffic — default SG needed for intra-cluster communication
+  - CKV2_AWS_12   # default security group

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,78 @@
+name: lint
+on: pull_request
+
+jobs:
+  golangci-lint:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+          cache: false
+      - name: Install libudev-dev
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          args: --timeout 5m --new-from-rev=${{ github.event.pull_request.base.sha }}
+
+  govulncheck:
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+          cache: false
+      - name: Install libudev-dev
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev
+      - name: install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - name: govulncheck
+        run: govulncheck ./...
+
+  terraform-lint:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: setup terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+      - name: setup tflint
+        uses: terraform-linters/setup-tflint@v4
+      - name: init tflint
+        run: tflint --init
+      - name: terraform validate
+        continue-on-error: true
+        run: |
+          for dir in $(find terraform -name '*.tf' -not -path '*/.terraform/*' -exec dirname {} \; | sort -u); do
+            echo "==> terraform validate $dir"
+            (cd "$dir" && terraform init -backend=false -input=false > /dev/null 2>&1 && terraform validate) || echo "  ⚠ validate failed for $dir (pre-existing)"
+          done
+      - name: tflint
+        run: |
+          for dir in $(find terraform -name '*.tf' -not -path '*/.terraform/*' -exec dirname {} \; | sort -u); do
+            echo "==> tflint $dir"
+            (cd "$dir" && tflint --config "$(git rev-parse --show-toplevel)/.tflint.hcl")
+          done
+
+  terraform-security:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: install checkov
+        run: pip install checkov
+      - name: checkov
+        run: checkov -d terraform --framework terraform --config-file .checkov.yml

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,47 @@
+run:
+  timeout: 5m
+  modules-download-mode: vendor
+
+linters:
+  enable:
+    - errcheck
+    - staticcheck
+    - gosec
+    - govet
+    - bodyclose
+    - nilerr
+    - exhaustive
+    - gocritic
+    - goimports
+    - ineffassign
+    - unused
+  disable:
+    - lll
+    - wsl
+    - funlen
+    - gocognit
+    - godot
+    - godox
+    - wrapcheck
+
+linters-settings:
+  errcheck:
+    check-type-assertions: true
+    check-blank: false
+  gosec:
+    excludes:
+      - G104
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - performance
+    disabled-tags:
+      - style
+      - opinionated
+  exhaustive:
+    default-signifies-exhaustive: true
+
+issues:
+  exclude-use-default: true
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v2.1.6
+    hooks:
+      - id: golangci-lint
+        args: ["--timeout", "5m", "--new-from-rev=HEAD"]
+
+  - repo: https://github.com/dnephin/pre-commit-golang
+    rev: v0.5.1
+    hooks:
+      - id: go-fmt
+
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.96.3
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_validate
+        args: ["-backend=false"]
+      - id: terraform_tflint
+        args: ["--args=--config __GIT_WORKING_DIR__/.tflint.hcl"]
+
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ["--baseline", ".secrets.baseline"]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,535 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "vendor/",
+        ".terraform/"
+      ]
+    }
+  ],
+  "results": {
+    "ci/assets/example.org.key": [
+      {
+        "type": "Private Key",
+        "filename": "ci/assets/example.org.key",
+        "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
+        "is_verified": false,
+        "line_number": 1
+      }
+    ],
+    "docs/cloud/cli-reference.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/cloud/cli-reference.md",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 635
+      }
+    ],
+    "docs/cloud/databases/README.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/cloud/databases/README.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 80
+      }
+    ],
+    "docs/cloud/databases/mariadb.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/cloud/databases/mariadb.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 172
+      }
+    ],
+    "docs/cloud/databases/mysql.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/cloud/databases/mysql.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 154
+      }
+    ],
+    "docs/cloud/databases/postgres.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/cloud/databases/postgres.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 174
+      }
+    ],
+    "docs/cloud/getting-started.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/cloud/getting-started.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 191
+      }
+    ],
+    "docs/installation/production-rack/azure.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/installation/production-rack/azure.md",
+        "hashed_secret": "f4d22918a78f46a1e865a6122d49a282fd26bb80",
+        "is_verified": false,
+        "line_number": 88
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/installation/production-rack/azure.md",
+        "hashed_secret": "c303df00cd0a72b21c62900b758b06fc541664ce",
+        "is_verified": false,
+        "line_number": 256
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/installation/production-rack/azure.md",
+        "hashed_secret": "da221c445c9be54099777a1d68df7f5da4230d7a",
+        "is_verified": false,
+        "line_number": 306
+      }
+    ],
+    "docs/reference/cli/instances.md": [
+      {
+        "type": "Private Key",
+        "filename": "docs/reference/cli/instances.md",
+        "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
+        "is_verified": false,
+        "line_number": 55
+      }
+    ],
+    "docs/reference/cli/rack.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/reference/cli/rack.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 269
+      }
+    ],
+    "docs/reference/cli/registries.md": [
+      {
+        "type": "AWS Access Key",
+        "filename": "docs/reference/cli/registries.md",
+        "hashed_secret": "171d9259808305e4eb83b2063acf9a4ffe7b38ae",
+        "is_verified": false,
+        "line_number": 20
+      }
+    ],
+    "docs/reference/cli/resources.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/reference/cli/resources.md",
+        "hashed_secret": "c685fb0942562abf747649b7943b30e23f48f544",
+        "is_verified": false,
+        "line_number": 20
+      }
+    ],
+    "docs/reference/primitives/app/resource/README.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/reference/primitives/app/resource/README.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 58
+      }
+    ],
+    "docs/reference/primitives/app/resource/mariadb.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/reference/primitives/app/resource/mariadb.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 98
+      }
+    ],
+    "docs/reference/primitives/app/resource/mysql.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/reference/primitives/app/resource/mysql.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 98
+      }
+    ],
+    "docs/reference/primitives/app/resource/postgis.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/reference/primitives/app/resource/postgis.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 50
+      }
+    ],
+    "docs/reference/primitives/app/resource/postgres.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/reference/primitives/app/resource/postgres.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 98
+      }
+    ],
+    "docs/reference/primitives/rack/README.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/reference/primitives/rack/README.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 47
+      }
+    ],
+    "pkg/api/api.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/api/api.go",
+        "hashed_secret": "9c1122bc82893da2b155453a7363fcfa3eadf815",
+        "is_verified": false,
+        "line_number": 91
+      }
+    ],
+    "pkg/api/auth_test.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "pkg/api/auth_test.go",
+        "hashed_secret": "f0578f1e7174b1a41c4ea8c6e17f7a8a3b88c92a",
+        "is_verified": false,
+        "line_number": 26
+      }
+    ],
+    "pkg/build/build_docker_test.go": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/build/build_docker_test.go",
+        "hashed_secret": "8cc73f9b530d68945cf90d1ae79e16827179d1f4",
+        "is_verified": false,
+        "line_number": 44
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "pkg/build/build_docker_test.go",
+        "hashed_secret": "07671453fe4c33acb4b7ef9099ce14251c39eb60",
+        "is_verified": false,
+        "line_number": 283
+      }
+    ],
+    "pkg/cli/rack.go": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "pkg/cli/rack.go",
+        "hashed_secret": "347cd9c53ff77d41a7b22aa56c7b4efaf54658e3",
+        "is_verified": false,
+        "line_number": 872
+      }
+    ],
+    "pkg/rack/test.go": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "pkg/rack/test.go",
+        "hashed_secret": "62cdb7020ff920e5aa642c3d4066950dd1f01f4d",
+        "is_verified": false,
+        "line_number": 39
+      }
+    ],
+    "provider/aws/provisioner/rds/params.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "provider/aws/provisioner/rds/params.go",
+        "hashed_secret": "c16c80937690561ea93178b0984265adbb382817",
+        "is_verified": false,
+        "line_number": 19
+      }
+    ],
+    "provider/k8s/api.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "provider/k8s/api.go",
+        "hashed_secret": "3e9ae7cc7bf078162aa38185a21c087103e7f172",
+        "is_verified": false,
+        "line_number": 71
+      }
+    ],
+    "provider/k8s/controller_secret.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "provider/k8s/controller_secret.go",
+        "hashed_secret": "9457fbde5202d38b9893ac78f8c66904f4c5c764",
+        "is_verified": false,
+        "line_number": 25
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "provider/k8s/controller_secret.go",
+        "hashed_secret": "55639e19bdcae077d5b2d7bb1a86e392ff67ec0b",
+        "is_verified": false,
+        "line_number": 142
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "provider/k8s/controller_secret.go",
+        "hashed_secret": "afaab76344e1b9396dd5ae02b98ce31824c31923",
+        "is_verified": false,
+        "line_number": 144
+      }
+    ],
+    "provider/k8s/instance.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "provider/k8s/instance.go",
+        "hashed_secret": "91979944dd6e261292b5a481c611e63622c6f819",
+        "is_verified": false,
+        "line_number": 112
+      }
+    ],
+    "provider/k8s/instance_test.go": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "provider/k8s/instance_test.go",
+        "hashed_secret": "d3dbbdd6654a8f2b556665e8f913f7c5b69191c9",
+        "is_verified": false,
+        "line_number": 105
+      }
+    ],
+    "provider/k8s/resource.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "provider/k8s/resource.go",
+        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
+        "is_verified": false,
+        "line_number": 388
+      }
+    ],
+    "provider/k8s/system.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "provider/k8s/system.go",
+        "hashed_secret": "86b39741fc52b6101bd391579dec8fa3eeb7e7e9",
+        "is_verified": false,
+        "line_number": 27
+      }
+    ],
+    "provider/k8s/telemetry_test.go": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "provider/k8s/telemetry_test.go",
+        "hashed_secret": "8b82e17fba8100c25c1c02f205bd551489ea0ee9",
+        "is_verified": false,
+        "line_number": 44
+      }
+    ],
+    "provider/k8s/template/system/cert-manager.yml.tmpl": [
+      {
+        "type": "Secret Keyword",
+        "filename": "provider/k8s/template/system/cert-manager.yml.tmpl",
+        "hashed_secret": "11f0b6aad889e6e3d00a24835dbbd060fcd0ca4d",
+        "is_verified": false,
+        "line_number": 5425
+      }
+    ],
+    "provider/k8s/testdata/release-basic-app.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "provider/k8s/testdata/release-basic-app.yml",
+        "hashed_secret": "2813201c0a91a1cdbf0010355fd5b4cff21864bc",
+        "is_verified": false,
+        "line_number": 100
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "provider/k8s/testdata/release-basic-app.yml",
+        "hashed_secret": "6c83f2c91274e83ffcc184807acb122a705505e4",
+        "is_verified": false,
+        "line_number": 145
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "provider/k8s/testdata/release-basic-app.yml",
+        "hashed_secret": "ba3ab4090becf66ab6edc2867ea6f89438b25406",
+        "is_verified": false,
+        "line_number": 153
+      }
+    ],
+    "sdk/methods.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "sdk/methods.go",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 756
+      }
+    ],
+    "terraform/api/k8s/main.tf": [
+      {
+        "type": "Secret Keyword",
+        "filename": "terraform/api/k8s/main.tf",
+        "hashed_secret": "e9214a72c3369987b6c07460a0672f3ce2ce7e56",
+        "is_verified": false,
+        "line_number": 384
+      }
+    ],
+    "terraform/cluster/aws/main.tf": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "terraform/cluster/aws/main.tf",
+        "hashed_secret": "83c1003f406f34fba4d6279a948fee3abc802884",
+        "is_verified": false,
+        "line_number": 114
+      }
+    ],
+    "terraform/rack/do/registry.tf": [
+      {
+        "type": "Secret Keyword",
+        "filename": "terraform/rack/do/registry.tf",
+        "hashed_secret": "01a888f2df5feda29933bf02eb1dba21f089ca83",
+        "is_verified": false,
+        "line_number": 195
+      }
+    ],
+    "terraform/rack/local/registry.tf": [
+      {
+        "type": "Secret Keyword",
+        "filename": "terraform/rack/local/registry.tf",
+        "hashed_secret": "01a888f2df5feda29933bf02eb1dba21f089ca83",
+        "is_verified": false,
+        "line_number": 148
+      }
+    ],
+    "terraform/rack/metal/registry.tf": [
+      {
+        "type": "Secret Keyword",
+        "filename": "terraform/rack/metal/registry.tf",
+        "hashed_secret": "01a888f2df5feda29933bf02eb1dba21f089ca83",
+        "is_verified": false,
+        "line_number": 150
+      }
+    ]
+  },
+  "generated_at": "2026-04-08T17:29:29Z"
+}

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,14 @@
+plugin "aws" {
+  enabled = true
+  version = "0.36.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}
+
+# Disable all built-in Terraform style/convention rules.
+# The existing codebase predates these rules and enforcing them
+# would require touching every .tf file. Only the AWS plugin
+# rules remain — those catch real infrastructure mistakes like
+# invalid resource types and deprecated attributes.
+plugin "terraform" {
+  enabled = false
+}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build clean clean-package compress dev generate generate-k8s generate-provider mocks package release test tools vendor
+.PHONY: all build clean clean-package compress dev generate generate-k8s generate-provider lint lint-new lint-tf lint-security lint-all mocks package release setup test tools validate vendor
 
 commands = api atom build convox docs resolver
 
@@ -60,6 +60,35 @@ release:
 
 test:
 	env TEST=true go test -covermode atomic -coverprofile coverage.txt -mod=vendor ./...
+
+lint:
+	golangci-lint run --timeout 5m ./...
+
+lint-new:
+	golangci-lint run --timeout 5m --new-from-rev=$$(git merge-base HEAD master) ./...
+
+lint-tf:
+	@for dir in $$(find terraform -name '*.tf' -not -path './vendor/*' -not -path '*/.terraform/*' -exec dirname {} \; | sort -u); do \
+		echo "==> tflint $$dir"; \
+		(cd $$dir && tflint --config $$(git rev-parse --show-toplevel)/.tflint.hcl) || exit 1; \
+		echo "==> terraform validate $$dir"; \
+		(cd $$dir && terraform init -backend=false -input=false > /dev/null 2>&1 && terraform validate) || exit 1; \
+	done
+
+validate:
+	@for dir in $$(find terraform -name '*.tf' -not -path './vendor/*' -not -path '*/.terraform/*' -exec dirname {} \; | sort -u); do \
+		echo "==> terraform validate $$dir"; \
+		(cd $$dir && terraform init -backend=false -input=false > /dev/null 2>&1 && terraform validate) || exit 1; \
+	done
+
+lint-security:
+	checkov -d terraform --framework terraform --compact
+
+lint-all: lint lint-tf lint-security
+
+setup:
+	pip install pre-commit
+	pre-commit install
 
 tools:
 	go install -mod=vendor ./vendor/github.com/crazy-max/xgo


### PR DESCRIPTION
## Summary

- Add golangci-lint config (`.golangci.yml`) with linters tuned for catching dangerous patterns in infrastructure code: unchecked errors, security issues, nil pointer risks, exhaustive switch handling
- Add tflint config (`.tflint.hcl`) with AWS ruleset for Terraform validation
- Add checkov config (`.checkov.yml`) for Terraform security scanning (open security groups, unencrypted storage, overly permissive IAM)
- Add GitHub Actions CI workflow (`lint.yml`) running all of the above on every PR, plus govulncheck for Go CVE detection
- Add pre-commit hooks (`.pre-commit-config.yaml`) for local developer safety
- Add Makefile targets: `lint`, `lint-new`, `lint-tf`, `lint-security`, `lint-all`, `validate`, `setup`
- Uses `--new-from-rev` to lint only changed code — no legacy noise blocking PRs