### PR TITLE
Fix Karpenter consolidation: PDB eviction, pin controller

### DIFF
--- a/provider/k8s/controller_deployment.go
+++ b/provider/k8s/controller_deployment.go
@@ -189,6 +189,8 @@ func (c *DeployController) SyncPDB(d *apps.Deployment, remove bool) error {
 			pdb.Spec.MinAvailable = pdbMinAvailable
 			pdb.Spec.Selector = d.Spec.Selector
 			pdb.Spec.Selector.MatchLabels["type"] = "service"
+			alwaysAllow := policyv1.AlwaysAllow
+			pdb.Spec.UnhealthyPodEvictionPolicy = &alwaysAllow
 			return pdb
 		}, metav1.PatchOptions{
 			FieldManager: "convox",

--- a/terraform/cluster/aws/lbc.tf
+++ b/terraform/cluster/aws/lbc.tf
@@ -93,4 +93,44 @@ resource "helm_release" "aws_lbc" {
     name  = "enableServiceMutatorWebhook"
     value = "false"
   }
+
+  dynamic "set" {
+    for_each = var.karpenter_enabled ? [1] : []
+    content {
+      name  = "nodeSelector.convox\\.io/system-node"
+      value = "true"
+    }
+  }
+
+  dynamic "set" {
+    for_each = var.karpenter_enabled ? [1] : []
+    content {
+      name  = "tolerations[0].key"
+      value = "convox.io/system-node"
+    }
+  }
+
+  dynamic "set" {
+    for_each = var.karpenter_enabled ? [1] : []
+    content {
+      name  = "tolerations[0].operator"
+      value = "Equal"
+    }
+  }
+
+  dynamic "set" {
+    for_each = var.karpenter_enabled ? [1] : []
+    content {
+      name  = "tolerations[0].value"
+      value = "true"
+    }
+  }
+
+  dynamic "set" {
+    for_each = var.karpenter_enabled ? [1] : []
+    content {
+      name  = "tolerations[0].effect"
+      value = "NoSchedule"
+    }
+  }
 }

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -592,13 +592,39 @@ resource "aws_eks_addon" "aws_ebs_csi_driver" {
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "OVERWRITE"
 
-  configuration_values = jsonencode({
-    sidecars = {
-      snapshotter = {
-        forceEnable = false
+  configuration_values = jsonencode(merge(
+    {
+      sidecars = {
+        snapshotter = {
+          forceEnable = false
+        }
       }
-    }
-  })
+    },
+    var.karpenter_enabled ? {
+      controller = {
+        nodeSelector = {
+          "convox.io/system-node" = "true"
+        }
+        tolerations = [
+          {
+            key      = "CriticalAddonsOnly"
+            operator = "Exists"
+          },
+          {
+            operator          = "Exists"
+            effect            = "NoExecute"
+            tolerationSeconds = 300
+          },
+          {
+            key      = "convox.io/system-node"
+            operator = "Equal"
+            value    = "true"
+            effect   = "NoSchedule"
+          },
+        ]
+      }
+    } : {}
+  ))
 }
 
 resource "null_resource" "wait_eks_addons" {


### PR DESCRIPTION
### What is the feature/update/fix?

**Fix: Karpenter Node Consolidation Blocked by Unhealthy Pods and Controller Placement**

Fixed three issues that prevented Karpenter from consolidating underutilized nodes:

1. **Unhealthy pods blocking PDB eviction.** When a pod enters CrashLoopBackOff, its PodDisruptionBudget reports `disruptionsAllowed: 0` because `currentHealthy` drops to 0. All Convox-managed PDBs now set `unhealthyPodEvictionPolicy: AlwaysAllow`, allowing unhealthy pods to be evicted during consolidation. This applies to all racks — both Karpenter and Cluster Autoscaler.

2. **EBS CSI controller on workload nodes.** The EKS addon's controller was landing on Karpenter workload nodes. Fixed by adding conditional `nodeSelector` and system-node toleration to the addon's `configuration_values` when Karpenter is enabled.

3. **AWS Load Balancer Controller on workload nodes.** Added conditional `nodeSelector` and system-node toleration via Helm dynamic set blocks when Karpenter is enabled.

---

### Why is this important?

Karpenter node consolidation is a key cost-saving feature — it moves pods to fewer, better-utilized nodes and terminates the empty ones. When consolidation is blocked, users pay for underutilized EC2 instances indefinitely. These three issues could each independently prevent consolidation, and they were difficult to diagnose because Karpenter produces no user-visible error.

**Benefits:**

- **Stuck pods no longer block scale-down.** A service in CrashLoopBackOff won't prevent its node from being consolidated or replaced.
- **Controllers stay on system nodes.** EBS CSI and AWS LBC controllers are pinned to system nodes when Karpenter is enabled, preventing them from blocking consolidation of workload nodes.
- **Applies to all racks.** The PDB eviction policy improvement benefits Cluster Autoscaler racks equally — unhealthy pods no longer block CAS scale-down.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this fix.

- The PDB eviction policy is purely additive — healthy pods continue to be protected by PDBs as before
- Controller pinning is conditional on `karpenter_enabled` — non-Karpenter racks are unaffected
- No new rack parameters or API changes

---

### Requirements

This fix requires version `3.24.3` or later for the rack.

**Update the Rack:** Run `convox rack update 3.24.3 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.23.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
