### PR TITLE
Pin coredns and efs-csi to system nodes

### DIFF
--- a/terraform/cluster/aws/efs.tf
+++ b/terraform/cluster/aws/efs.tf
@@ -12,6 +12,22 @@ resource "aws_eks_addon" "aws_efs_csi_driver" {
   addon_version               = var.efs_csi_driver_version
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "OVERWRITE"
+
+  configuration_values = var.karpenter_enabled ? jsonencode({
+    controller = {
+      nodeSelector = {
+        "convox.io/system-node" = "true"
+      }
+      tolerations = [
+        {
+          key      = "convox.io/system-node"
+          operator = "Equal"
+          value    = "true"
+          effect   = "NoSchedule"
+        }
+      ]
+    }
+  }) : null
 }
 
 // setup iam permissions

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -548,6 +548,20 @@ resource "aws_eks_addon" "coredns" {
   addon_version               = var.coredns_version
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "OVERWRITE"
+
+  configuration_values = var.karpenter_enabled ? jsonencode({
+    nodeSelector = {
+      "convox.io/system-node" = "true"
+    }
+    tolerations = [
+      {
+        key      = "convox.io/system-node"
+        operator = "Equal"
+        value    = "true"
+        effect   = "NoSchedule"
+      }
+    ]
+  }) : null
 }
 
 resource "aws_eks_addon" "kube_proxy" {


### PR DESCRIPTION
### What is the feature/update/fix?

**Fix: CoreDNS and EFS CSI Controller Blocking Karpenter Consolidation**

Fixed two additional components that were landing on Karpenter workload nodes and silently preventing node consolidation.

**CoreDNS** has a `topologySpreadConstraint` with `whenUnsatisfiable: ScheduleAnyway` (preferred zone spread). When a CoreDNS pod landed on a Karpenter workload node, Karpenter's consolidation simulation respected the preferred topology spread and silently skipped the node — no event emitted, no log at INFO level. The node appeared permanently unconsolidatable.

**EFS CSI controller** had the same class of problem — it could land on workload nodes and add PDB/scheduling complexity that interfered with consolidation.

Both are now pinned to system nodes when Karpenter is enabled via EKS addon `configuration_values` with `nodeSelector` and system-node tolerations. When `karpenter_enabled=false`, no override is applied and addons schedule per EKS defaults.

---

### Why is this important?

CoreDNS landing on a workload node was particularly insidious — Karpenter would silently skip that node during consolidation with no visible indication. Users could observe nodes that never consolidated despite being underutilized, with no logs or events explaining why.

**Benefits:**

- **CoreDNS pinned to system nodes.** Eliminates the invisible consolidation blocker caused by CoreDNS topology spread preferences.
- **EFS CSI controller pinned to system nodes.** Prevents the controller from interfering with workload node consolidation.
- **No impact on non-Karpenter racks.** Pinning is conditional on `karpenter_enabled` — addons schedule normally on standard racks.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this fix.

- Controller pinning is conditional on `karpenter_enabled` — non-Karpenter racks are unaffected
- CoreDNS and EFS CSI DaemonSet pods (node-level) are NOT affected — only the controller pods are pinned
- No new rack parameters or API changes

---

### Requirements

This fix requires version `3.24.3` or later for the rack.

**Update the Rack:** Run `convox rack update 3.24.3 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.23.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
