### PR TITLE
Release/3.24.3

### DIFF
--- a/docs/configuration/scaling/karpenter.md
+++ b/docs/configuration/scaling/karpenter.md
@@ -239,6 +239,7 @@ Use this for dedicated GPU pools, tenant isolation, specialized instance require
 | `weight` | integer | _(unset)_ | no | Scheduling weight (0-100). Higher = preferred. |
 | `labels` | string | _(none)_ | no | Comma-separated `key=value`. `convox.io/nodepool` is reserved. |
 | `taints` | string | _(none)_ | no | Comma-separated `key=value:Effect`. Valid effects: `NoSchedule`, `PreferNoSchedule`, `NoExecute`. Prevents pods without matching tolerations from scheduling on these nodes. See [Using Taints to Protect Nodes](#using-taints-to-protect-nodes) below. |
+| `dedicated` | bool | `false` | no | When `true`, adds a `dedicated-node={name}:NoSchedule` taint automatically. Services with `nodeSelectorLabels: { convox.io/nodepool: {name} }` get the matching toleration injected. Simpler alternative to manual `taints` for pool isolation. |
 
 Every custom pool automatically gets a `convox.io/nodepool={name}` label. Target Services to a custom pool using `nodeSelectorLabels` in `convox.yml`:
 
@@ -250,7 +251,29 @@ services:
       convox.io/nodepool: gpu
 ```
 
-**Example: GPU pool and high-memory pool**
+**Example: Dedicated GPU pool (simple path)**
+
+```bash
+$ convox rack params set additional_karpenter_nodepools_config='[{"name":"gpu","instance_families":"g5,g6","dedicated":true}]' -r rackName
+Setting parameters... OK
+```
+
+```yaml
+# convox.yml
+services:
+  gpu-worker:
+    build: .
+    scale:
+      gpu:
+        count: 1
+        vendor: nvidia
+    nodeSelectorLabels:
+      convox.io/nodepool: gpu
+```
+
+With `dedicated: true`, only services targeting this pool (via `nodeSelectorLabels`) can schedule on it. No manual taint configuration needed. `convox run gpu-worker` also inherits the placement automatically.
+
+**Example: GPU pool and high-memory pool (advanced)**
 
 ```bash
 $ convox rack params set additional_karpenter_nodepools_config='[{"name":"gpu","instance_families":"g5,g6","capacity_types":"on-demand","cpu_limit":64,"memory_limit_gb":256,"taints":"nvidia.com/gpu=true:NoSchedule","disk":200},{"name":"high-mem","instance_families":"r5,r6i","instance_sizes":"xlarge,2xlarge,4xlarge","capacity_types":"on-demand,spot","cpu_limit":200,"memory_limit_gb":1600,"labels":"pool=high-mem"}]' -r rackName
@@ -288,9 +311,13 @@ $ convox rack params set nvidia_device_plugin_enable=true -r rackName
 Setting parameters... OK
 ```
 
-#### Non-GPU taints
+#### Dedicated pools
 
-For non-GPU custom taints (e.g., tenant isolation), Convox does not currently auto-inject tolerations. Pods targeting pools with non-GPU taints will need tolerations added through an external mechanism such as a Kubernetes mutating admission webhook. For most non-GPU use cases, using `labels` + `nodeSelectorLabels` without taints is the recommended approach — Karpenter only provisions nodes for pods that need them, so unwanted pods won't cause unnecessary GPU-class nodes to spin up.
+The simplest way to isolate a pool is `dedicated: true`. This auto-applies a `dedicated-node={name}:NoSchedule` taint and Convox auto-injects the matching toleration for any Service with `nodeSelectorLabels: { convox.io/nodepool: {name} }`. No external webhooks or manual taint configuration needed.
+
+#### Non-GPU custom taints
+
+For custom taints beyond `dedicated` (e.g., tenant isolation with specific taint keys), Convox does not auto-inject tolerations. Pods targeting pools with custom non-GPU taints will need tolerations added through an external mechanism such as a Kubernetes mutating admission webhook. For most non-GPU use cases, using `dedicated: true` or `labels` + `nodeSelectorLabels` without taints is the recommended approach — Karpenter only provisions nodes for pods that need them, so unwanted pods won't cause unnecessary scaling.
 
 #### DaemonSets on tainted nodes
 

--- a/pkg/api/controllers.go
+++ b/pkg/api/controllers.go
@@ -1747,6 +1747,19 @@ func (s *Server) SystemUpdate(c *stdapi.Context) error {
 	return c.RenderOK()
 }
 
+func (s *Server) KarpenterCleanup(c *stdapi.Context) error {
+	if err := s.hook("KarpenterCleanupValidate", c); err != nil {
+		return err
+	}
+
+	err := s.provider(c).WithContext(contextFrom(c)).KarpenterCleanup()
+	if err != nil {
+		return err
+	}
+
+	return c.RenderOK()
+}
+
 func (*Server) Workers(_ *stdapi.Context) error {
 	return stdapi.Errorf(404, "not available via api")
 }

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -91,6 +91,7 @@ func (s *Server) setupRoutes(r stdapi.Router) {
 	r.Route("PUT", "/resources/{name}", s.SystemResourceUpdate)
 	r.Route("", "", s.SystemUninstall)
 	r.Route("PUT", "/system", s.SystemUpdate)
+	r.Route("POST", "/system/karpenter/cleanup", s.KarpenterCleanup)
 	r.Route("", "", s.Workers)
 
 	r.Route("ANY", "/custom/http/proxy/{path:.*}", s.ProxyHttpService)

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -21,6 +21,7 @@ var (
 var (
 	flagApp           = stdcli.StringFlag("app", "a", "app name")
 	flagForce         = stdcli.BoolFlag("force", "", "force version update")
+	flagForceParams   = stdcli.BoolFlag("force", "f", "override known-key and managed-param guards")
 	flagId            = stdcli.BoolFlag("id", "", "put logs on stderr, release id on stdout")
 	flagNoFollow      = stdcli.BoolFlag("no-follow", "", "do not follow logs")
 	flagRack          = stdcli.StringFlag("rack", "r", "rack name")

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -199,6 +199,7 @@ type KarpenterNodePoolConfigParam struct {
 	VolumeType            *string `json:"volume_type,omitempty"`
 	Labels                *string `json:"labels,omitempty"`
 	Taints                *string `json:"taints,omitempty"`
+	Dedicated             *bool   `json:"dedicated,omitempty"`
 	Weight                *int    `json:"weight,omitempty"`
 }
 

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -379,8 +379,8 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 		return errors.New("to schedule your rack to turn on/off you need both ScheduleRackScaleDown and ScheduleRackScaleUp parameters")
 	}
 
-	// format: "key1=val1,key2=val2"
-	if tags, has := params["tags"]; has {
+	// format: "key1=val1,key2=val2" — empty string clears all tags
+	if tags, has := params["tags"]; has && tags != "" {
 		tList := strings.Split(tags, ",")
 		for _, p := range tList {
 			if len(strings.Split(p, "=")) != 2 {

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -370,8 +370,29 @@ func (an AdditionalNodeGroups) Validate() error {
 }
 
 func validateAndMutateParams(params map[string]string, provider string, currentParams map[string]string) error {
-	if params["high_availability"] != "" {
-		return errors.New("the high_availability parameter is only supported during rack installation")
+	// Install-only params — these define infrastructure that cannot be changed
+	// after rack creation without catastrophic consequences (network recreation,
+	// subnet destruction, cluster replacement). Block ANY post-install modification.
+	//
+	// MAINTENANCE: Keep in sync with immutableRackParams in console3
+	// api/controller/cli.go. Add any new TF variable here if changing it
+	// post-install would destroy or recreate core infrastructure.
+	installOnlyParams := map[string]bool{
+		"high_availability":  true,
+		"private":            true,
+		"cidr":               true,
+		"vpc_id":             true,
+		"internet_gateway_id": true,
+		"private_subnets_ids": true,
+		"public_subnets_ids": true,
+		"availability_zones": true,
+		"region":             true,
+	}
+
+	for k := range params {
+		if installOnlyParams[k] {
+			return fmt.Errorf("param '%s' can only be set during rack installation", k)
+		}
 	}
 
 	// Reject empty values for params that require explicit values.
@@ -393,6 +414,8 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 		"karpenter_build_consolidate_after": true,
 		"karpenter_node_expiry":             true,
 		"karpenter_disruption_budget_nodes": true,
+		"karpenter_auth_mode":              true, // one-way migration — empty would revert to "false"
+		"karpenter_enabled":                true, // stringly-typed bool — empty silently disables
 	}
 
 	for k, v := range params {
@@ -436,6 +459,7 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 	}
 
 	// karpenter_auth_mode: one-way migration (cannot be disabled once enabled)
+	// Empty string is caught by nonEmptyRequired above; this guards against explicit "false".
 	if params["karpenter_auth_mode"] == "false" && currentParams["karpenter_auth_mode"] == "true" {
 		return fmt.Errorf("karpenter_auth_mode cannot be disabled once enabled (AWS EKS access config migration is one-way)")
 	}

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -374,9 +374,36 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 		return errors.New("the high_availability parameter is only supported during rack installation")
 	}
 
-	srdown, srup := params["ScheduleRackScaleDown"], params["ScheduleRackScaleUp"]
+	// Reject empty values for params that require explicit values.
+	// Enum, numeric, and duration params have no valid "empty" state —
+	// empty strings cause TF type errors or silent default reversion.
+	//
+	// MAINTENANCE: When adding a new TF variable with type=number, type=bool,
+	// or type=string with a non-empty default (like "30s" or "on-demand"),
+	// add it here. See also preserveEmpty in pkg/rack/terraform.go.
+	nonEmptyRequired := map[string]bool{
+		"karpenter_arch":                    true,
+		"karpenter_capacity_types":          true,
+		"karpenter_build_capacity_types":    true,
+		"karpenter_cpu_limit":               true,
+		"karpenter_memory_limit_gb":         true,
+		"karpenter_build_cpu_limit":         true,
+		"karpenter_build_memory_limit_gb":   true,
+		"karpenter_consolidate_after":       true,
+		"karpenter_build_consolidate_after": true,
+		"karpenter_node_expiry":             true,
+		"karpenter_disruption_budget_nodes": true,
+	}
+
+	for k, v := range params {
+		if nonEmptyRequired[k] && strings.TrimSpace(v) == "" {
+			return fmt.Errorf("param '%s' requires an explicit value (omit to keep current)", k)
+		}
+	}
+
+	srdown, srup := params["schedule_rack_scale_down"], params["schedule_rack_scale_up"]
 	if (srdown == "" || srup == "") && (srdown != "" || srup != "") {
-		return errors.New("to schedule your rack to turn on/off you need both ScheduleRackScaleDown and ScheduleRackScaleUp parameters")
+		return errors.New("to schedule your rack to turn on/off you need both schedule_rack_scale_down and schedule_rack_scale_up parameters")
 	}
 
 	// format: "key1=val1,key2=val2" — empty string clears all tags

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -54,6 +54,12 @@ func init() {
 		Validate: stdcli.ArgsMin(2),
 	})
 
+	register("rack karpenter cleanup", "clean up orphaned Karpenter nodes after disabling Karpenter", RackKarpenterCleanup, stdcli.CommandOptions{
+		Flags:    []stdcli.Flag{flagRack},
+		Usage:    "",
+		Validate: stdcli.Args(0),
+	})
+
 	registerWithoutProvider("rack kubeconfig", "generate kubeconfig for rack", RackKubeconfig, stdcli.CommandOptions{
 		Flags:    []stdcli.Flag{flagRack},
 		Validate: stdcli.Args(0),
@@ -973,6 +979,16 @@ func RackInstall(_ sdk.Interface, c *stdcli.Context) error {
 	}
 
 	return nil
+}
+
+func RackKarpenterCleanup(rack sdk.Interface, c *stdcli.Context) error {
+	c.Startf("Cleaning up Karpenter nodes")
+
+	if err := rack.KarpenterCleanup(); err != nil {
+		return err
+	}
+
+	return c.OK()
 }
 
 func RackKubeconfig(_ sdk.Interface, c *stdcli.Context) error {

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -573,6 +573,17 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 		delete(params, rk)
 	}
 
+	// Normalize empty values for JSON config params — users clear with param= or param=""
+	// but TF needs valid base64-encoded JSON (empty array or empty object).
+	for _, k := range []string{"additional_node_groups_config", "additional_build_groups_config", "additional_karpenter_nodepools_config"} {
+		if v, ok := params[k]; ok && (v == "" || v == `""`) {
+			params[k] = base64.StdEncoding.EncodeToString([]byte("[]"))
+		}
+	}
+	if v, ok := params["karpenter_config"]; ok && (v == "" || v == `""`) {
+		params["karpenter_config"] = base64.StdEncoding.EncodeToString([]byte("{}"))
+	}
+
 	ngKeys := []string{"additional_node_groups_config", "additional_build_groups_config"}
 	for _, k := range ngKeys {
 		if params[k] != "" {
@@ -1127,8 +1138,8 @@ func RackParams(_ sdk.Interface, c *stdcli.Context) error {
 		keys = append(keys, k)
 	}
 
-	ngKeys := []string{"additional_node_groups_config", "additional_build_groups_config"}
-	for _, k := range ngKeys {
+	b64Keys := []string{"additional_node_groups_config", "additional_build_groups_config", "additional_karpenter_nodepools_config", "karpenter_config"}
+	for _, k := range b64Keys {
 		if params[k] != "" {
 			v, err := base64.StdEncoding.DecodeString(params[k])
 			if err == nil {

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -356,7 +356,7 @@ func (an AdditionalNodeGroups) Validate() error {
 
 	if idCnt == 0 {
 		for i := range an {
-			an[i].Id = options.Int(i + 1)
+			an[i].Id = options.Int(i)
 		}
 	}
 	return nil
@@ -588,6 +588,41 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 			nCfgs := AdditionalNodeGroups{}
 			if err := json.Unmarshal(cfgData, &nCfgs); err != nil {
 				return err
+			}
+
+			// Preserve existing ids from currentParams when new config omits them.
+			// This prevents Terraform for_each key changes (destroy+create cycles)
+			// when a user modifies config without specifying ids.
+			hasNilId := false
+			for _, ng := range nCfgs {
+				if ng.Id == nil {
+					hasNilId = true
+					break
+				}
+			}
+			if hasNilId && currentParams[k] != "" {
+				var existingData []byte
+				if decoded, err := base64.StdEncoding.DecodeString(currentParams[k]); err == nil {
+					existingData = decoded
+				} else {
+					existingData = []byte(currentParams[k])
+				}
+				var existing AdditionalNodeGroups
+				if err := json.Unmarshal(existingData, &existing); err == nil {
+					for i := range nCfgs {
+						if nCfgs[i].Id != nil {
+							continue
+						}
+						if i < len(existing) {
+							if existing[i].Id != nil {
+								nCfgs[i].Id = existing[i].Id
+							} else {
+								// Legacy entry without id — use 0-based index to match Terraform's idx default
+								nCfgs[i].Id = options.Int(i)
+							}
+						}
+					}
+				}
 			}
 
 			if err := nCfgs.Validate(); err != nil {

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -24,6 +24,131 @@ import (
 	"github.com/convox/stdcli"
 )
 
+var providerKnownParams = map[string]map[string]bool{
+	"aws":   awsKnownParams,
+	"gcp":   gcpKnownParams,
+	"azure": azureKnownParams,
+	"do":    doKnownParams,
+	"metal": metalKnownParams,
+	"local": localKnownParams,
+}
+
+var awsKnownParams = map[string]bool{
+	"access_log_retention_in_days": true, "additional_build_groups_config": true,
+	"additional_karpenter_nodepools_config": true, "additional_node_groups_config": true,
+	"api_feature_gates": true, "availability_zones": true,
+	"aws_ebs_csi_driver_version": true, "build_disable_convox_resolver": true,
+	"build_node_enabled": true, "build_node_min_count": true,
+	"build_node_type": true, "buildkit_host_path_cache_enable": true,
+	"cert_duration": true, "cidr": true,
+	"convox_domain_tls_cert_disable": true, "convox_rack_domain": true,
+	"coredns_version": true, "custom_provided_bucket": true,
+	"deploy_extra_nlb": true, "disable_convox_resolver": true,
+	"disable_image_manifest_cache": true, "disable_public_access": true,
+	"docker_hub_password": true, "docker_hub_username": true,
+	"ebs_volume_encryption_enabled": true, "ecr_scan_on_push_enable": true,
+	"efs_csi_driver_enable": true, "efs_csi_driver_version": true,
+	"eks_api_server_public_access_cidrs": true, "enable_private_access": true,
+	"fluentd_disable": true, "fluentd_memory": true,
+	"gpu_tag_enable": true, "high_availability": true,
+	"idle_timeout": true, "image": true,
+	"imds_http_hop_limit": true, "imds_http_tokens": true,
+	"imds_tags_enable": true, "internal_router": true,
+	"internet_gateway_id": true, "k8s_version": true,
+	"karpenter_arch": true, "karpenter_auth_mode": true,
+	"karpenter_build_capacity_types": true, "karpenter_build_consolidate_after": true,
+	"karpenter_build_cpu_limit": true, "karpenter_build_instance_families": true,
+	"karpenter_build_instance_sizes": true, "karpenter_build_memory_limit_gb": true,
+	"karpenter_build_node_labels": true, "karpenter_capacity_types": true,
+	"karpenter_config": true, "karpenter_consolidate_after": true,
+	"karpenter_consolidation_enabled": true, "karpenter_cpu_limit": true,
+	"karpenter_disruption_budget_nodes": true, "karpenter_enabled": true,
+	"karpenter_instance_families": true, "karpenter_instance_sizes": true,
+	"karpenter_memory_limit_gb": true, "karpenter_node_disk": true,
+	"karpenter_node_expiry": true, "karpenter_node_labels": true,
+	"karpenter_node_taints": true, "karpenter_node_volume_type": true,
+	"keda_enable": true, "key_pair_name": true,
+	"kube_proxy_version": true, "kubelet_registry_burst": true,
+	"kubelet_registry_pull_qps": true, "max_on_demand_count": true,
+	"min_on_demand_count": true, "name": true,
+	"nginx_additional_config": true, "nginx_image": true,
+	"nlb_security_group": true, "node_capacity_type": true,
+	"node_disk": true, "node_max_unavailable_percentage": true,
+	"node_type": true, "nvidia_device_plugin_enable": true,
+	"nvidia_device_time_slicing_replicas": true, "pdb_default_min_available_percentage": true,
+	"pod_identity_agent_enable": true, "pod_identity_agent_version": true,
+	"private": true, "private_eks_host": true,
+	"private_eks_pass": true, "private_eks_user": true,
+	"private_subnets_ids": true, "proxy_protocol": true,
+	"public_subnets_ids": true, "rack_name": true,
+	"region": true, "release": true,
+	"releases_to_retain_after_active": true, "releases_to_retain_task_run_interval_hour": true,
+	"schedule_rack_scale_down": true, "schedule_rack_scale_up": true,
+	"settings": true, "ssl_ciphers": true,
+	"ssl_protocols": true, "sync_tf_now": true,
+	"syslog": true, "tags": true,
+	"telemetry": true, "terraform_update_timeout": true,
+	"user_data": true, "user_data_url": true,
+	"vpa_enable": true, "vpc_cni_version": true,
+	"vpc_id": true, "whitelist": true,
+}
+
+var gcpKnownParams = map[string]bool{
+	"buildkit_enabled": true, "cert_duration": true, "docker_hub_password": true,
+	"docker_hub_username": true, "fluentd_memory": true, "image": true,
+	"k8s_version": true, "name": true, "nginx_additional_config": true,
+	"node_disk": true, "node_type": true, "preemptible": true,
+	"rack_name": true, "region": true, "release": true, "settings": true,
+	"sync_tf_now": true, "syslog": true, "telemetry": true,
+	"terraform_update_timeout": true, "whitelist": true,
+}
+
+var azureKnownParams = map[string]bool{
+	"additional_build_groups_config": true, "additional_node_groups_config": true,
+	"cert_duration": true, "docker_hub_password": true, "docker_hub_username": true,
+	"fluentd_memory": true, "high_availability": true, "idle_timeout": true,
+	"image": true, "k8s_version": true, "max_on_demand_count": true,
+	"min_on_demand_count": true, "name": true, "nginx_additional_config": true,
+	"nginx_image": true, "node_disk": true, "node_type": true,
+	"nvidia_device_plugin_enable": true, "nvidia_device_time_slicing_replicas": true,
+	"pdb_default_min_available_percentage": true, "rack_name": true, "region": true,
+	"release": true, "settings": true, "ssl_ciphers": true, "ssl_protocols": true,
+	"sync_tf_now": true, "syslog": true, "tags": true, "telemetry": true,
+	"terraform_update_timeout": true, "whitelist": true,
+}
+
+var doKnownParams = map[string]bool{
+	"access_id": true, "buildkit_enabled": true, "cert_duration": true,
+	"docker_hub_password": true, "docker_hub_username": true, "fluentd_memory": true,
+	"high_availability": true, "image": true, "k8s_version": true,
+	"name": true, "node_type": true, "rack_name": true, "region": true,
+	"registry_disk": true, "release": true, "secret_key": true,
+	"settings": true, "sync_tf_now": true, "syslog": true, "telemetry": true,
+	"terraform_update_timeout": true, "token": true, "whitelist": true,
+}
+
+var metalKnownParams = map[string]bool{
+	"docker_hub_password": true, "docker_hub_username": true, "domain": true,
+	"fluentd_memory": true, "image": true, "name": true, "rack_name": true,
+	"registry_disk": true, "release": true, "sync_tf_now": true,
+	"syslog": true, "whitelist": true,
+}
+
+var localKnownParams = map[string]bool{
+	"docker_hub_password": true, "docker_hub_username": true, "image": true,
+	"name": true, "os": true, "rack_name": true, "release": true,
+	"settings": true, "sync_tf_now": true, "telemetry": true,
+}
+
+var managedParams = map[string]bool{
+	"image": true, "name": true, "rack_name": true, "release": true, "settings": true,
+	"nginx_image": true, "k8s_version": true, "aws_ebs_csi_driver_version": true,
+	"coredns_version": true, "efs_csi_driver_version": true, "kube_proxy_version": true,
+	"pod_identity_agent_version": true, "vpc_cni_version": true,
+	"disable_public_access": true, "enable_private_access": true,
+	"eks_api_server_public_access_cidrs": true,
+}
+
 func init() {
 	register("rack", "get information about the rack", watch(Rack), stdcli.CommandOptions{
 		Flags:    []stdcli.Flag{flagRack, flagWatchInterval},
@@ -81,7 +206,7 @@ func init() {
 	})
 
 	registerWithoutProvider("rack params set", "set rack parameters", RackParamsSet, stdcli.CommandOptions{
-		Flags:    []stdcli.Flag{flagRack},
+		Flags:    []stdcli.Flag{flagRack, flagForceParams},
 		Usage:    "<Key=Value> [Key=Value]...",
 		Validate: stdcli.ArgsMin(1),
 	})
@@ -369,7 +494,53 @@ func (an AdditionalNodeGroups) Validate() error {
 	return nil
 }
 
-func validateAndMutateParams(params map[string]string, provider string, currentParams map[string]string) error {
+func levenshtein(a, b string) int {
+	la, lb := len(a), len(b)
+	if la == 0 {
+		return lb
+	}
+	if lb == 0 {
+		return la
+	}
+	prev := make([]int, lb+1)
+	for j := 0; j <= lb; j++ {
+		prev[j] = j
+	}
+	for i := 1; i <= la; i++ {
+		curr := make([]int, lb+1)
+		curr[0] = i
+		for j := 1; j <= lb; j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			ins := curr[j-1] + 1
+			del := prev[j] + 1
+			sub := prev[j-1] + cost
+			curr[j] = ins
+			if del < curr[j] {
+				curr[j] = del
+			}
+			if sub < curr[j] {
+				curr[j] = sub
+			}
+		}
+		prev = curr
+	}
+	return prev[lb]
+}
+
+func suggestParam(key string, known map[string]bool) string {
+	best, bestDist := "", 4
+	for k := range known {
+		if d := levenshtein(key, k); d < bestDist {
+			best, bestDist = k, d
+		}
+	}
+	return best
+}
+
+func validateAndMutateParams(params map[string]string, provider string, currentParams map[string]string, force bool) error {
 	// Install-only params — these define infrastructure that cannot be changed
 	// after rack creation without catastrophic consequences (network recreation,
 	// subnet destruction, cluster replacement). Block ANY post-install modification.
@@ -387,11 +558,78 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 		"public_subnets_ids": true,
 		"availability_zones": true,
 		"region":             true,
+		"access_id":          true,
+		"secret_key":         true,
+		"token":              true,
 	}
 
 	for k := range params {
 		if installOnlyParams[k] {
 			return fmt.Errorf("param '%s' can only be set during rack installation", k)
+		}
+	}
+
+	for k := range params {
+		if k == "" {
+			return fmt.Errorf("parameter name cannot be empty")
+		}
+	}
+
+	// V2 racks use PascalCase params (e.g. "HighAvailability", "BuildMemory").
+	// V3 racks use snake_case (e.g. "high_availability", "build_node_type").
+	// Detect V2 by checking if any currentParam key starts with an uppercase letter.
+	// Only check when provider is a known V3 provider — unknown providers (e.g. test
+	// fixtures) skip the known-key check via known==nil but should still run
+	// other validation (empty-value, terraform_update_timeout, etc.).
+	isV3Rack := true
+	if providerKnownParams[provider] != nil {
+		for k := range currentParams {
+			if len(k) > 0 && k[0] >= 'A' && k[0] <= 'Z' {
+				isV3Rack = false
+				break
+			}
+		}
+	}
+
+	if !isV3Rack {
+		return nil
+	}
+
+	known := providerKnownParams[provider]
+
+	if !force {
+		// Managed params are set automatically by `convox rack update` (image, release,
+		// k8s_version, etc.). Block direct modification unless --force is used.
+		for k := range params {
+			if managedParams[k] && (known == nil || known[k]) {
+				return fmt.Errorf("param '%s' is managed internally — to update it use 'convox rack update'. Use --force to override", k)
+			}
+		}
+
+		// Spellcheck: reject unknown keys with a suggestion when close to a known param.
+		if known != nil {
+			for k := range params {
+				// Karpenter params on non-AWS providers are caught later with a
+				// provider-specific error — don't shadow that with "unknown parameter".
+				if provider != "aws" && (strings.HasPrefix(k, "karpenter_") || k == "additional_karpenter_nodepools_config") {
+					continue
+				}
+				if !known[k] {
+					msg := fmt.Sprintf("unknown parameter '%s' for %s provider", k, provider)
+					if suggestion := suggestParam(k, known); suggestion != "" {
+						msg += fmt.Sprintf("\n       Did you mean '%s'?", suggestion)
+					}
+					msg += "\n       Run 'sudo convox update' to get the latest parameter support, or use --force to override."
+					return fmt.Errorf("%s", msg)
+				}
+			}
+		}
+	} else {
+		// --force bypasses managed and unknown-key guards, but still warn about managed params.
+		for k := range params {
+			if managedParams[k] && (known == nil || known[k]) {
+				fmt.Fprintf(os.Stderr, "WARNING: '%s' is a managed parameter — setting it directly may break your rack.\n", k)
+			}
 		}
 	}
 
@@ -479,6 +717,25 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 		}
 	}
 
+	if v, has := params["imds_http_tokens"]; has && v != "" {
+		if v != "optional" && v != "required" {
+			return fmt.Errorf("param 'imds_http_tokens' must be 'optional' or 'required'")
+		}
+	}
+
+	if v, has := params["node_capacity_type"]; has && v != "" {
+		lower := strings.ToLower(v)
+		if lower != "on_demand" && lower != "spot" && lower != "mixed" {
+			return fmt.Errorf("param 'node_capacity_type' must be 'on_demand', 'spot', or 'mixed'")
+		}
+	}
+
+	if v, has := params["access_log_retention_in_days"]; has && v != "" {
+		if _, err := strconv.Atoi(v); err != nil {
+			return fmt.Errorf("param 'access_log_retention_in_days' must be an integer")
+		}
+	}
+
 	// Reject karpenter_* params for non-AWS racks
 	if provider != "aws" {
 		for k := range params {
@@ -506,6 +763,13 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 	if params["karpenter_enabled"] == "true" && currentParams["karpenter_enabled"] != "true" {
 		if currentParams["karpenter_auth_mode"] != "true" && params["karpenter_auth_mode"] != "true" {
 			return fmt.Errorf("karpenter_enabled=true requires karpenter_auth_mode=true.\n  Either include both: convox rack params set karpenter_auth_mode=true karpenter_enabled=true\n  Or set karpenter_auth_mode=true first and wait for the update to complete")
+		}
+	}
+
+	if v, has := params["karpenter_node_volume_type"]; has && v != "" {
+		validVolTypes := map[string]bool{"gp2": true, "gp3": true, "io1": true, "io2": true}
+		if !validVolTypes[v] {
+			return fmt.Errorf("param 'karpenter_node_volume_type' must be gp2, gp3, io1, or io2")
 		}
 	}
 
@@ -1261,7 +1525,8 @@ func RackParamsSet(_ sdk.Interface, c *stdcli.Context) error {
 	}
 
 	params := argsToOptions(c.Args)
-	if err := validateAndMutateParams(params, r.Provider(), currentParams); err != nil {
+	force, _ := c.Value("force").(bool)
+	if err := validateAndMutateParams(params, r.Provider(), currentParams, force); err != nil {
 		return err
 	}
 

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -395,31 +395,61 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 		}
 	}
 
-	// Reject empty values for params that require explicit values.
-	// Enum, numeric, and duration params have no valid "empty" state —
-	// empty strings cause TF type errors or silent default reversion.
+	// Only these params accept empty strings — empty means "clear this setting."
+	// ALL other params require explicit values. Empty strings for non-clearable
+	// params cause TF type errors, silent default reversion, or state divergence
+	// between what convox rack params shows and what TF actually applies.
 	//
-	// MAINTENANCE: When adding a new TF variable with type=number, type=bool,
-	// or type=string with a non-empty default (like "30s" or "on-demand"),
-	// add it here. See also preserveEmpty in pkg/rack/terraform.go.
-	nonEmptyRequired := map[string]bool{
-		"karpenter_arch":                    true,
-		"karpenter_capacity_types":          true,
-		"karpenter_build_capacity_types":    true,
-		"karpenter_cpu_limit":               true,
-		"karpenter_memory_limit_gb":         true,
-		"karpenter_build_cpu_limit":         true,
-		"karpenter_build_memory_limit_gb":   true,
-		"karpenter_consolidate_after":       true,
-		"karpenter_build_consolidate_after": true,
-		"karpenter_node_expiry":             true,
-		"karpenter_disruption_budget_nodes": true,
-		"karpenter_auth_mode":              true, // one-way migration — empty would revert to "false"
-		"karpenter_enabled":                true, // stringly-typed bool — empty silently disables
+	// MAINTENANCE: When adding a new TF variable where users should be able to
+	// clear a previously-set value with param="", add it here AND to preserveEmpty
+	// in pkg/rack/terraform.go. Default is REJECT — only add if clearing makes sense.
+	clearableParams := map[string]bool{
+		// Labels/taints — clear means "remove all"
+		"karpenter_node_labels":             true,
+		"karpenter_node_taints":             true,
+		"karpenter_build_node_labels":       true,
+		// Instance restrictions — clear means "no restriction"
+		"karpenter_instance_families":       true,
+		"karpenter_instance_sizes":          true,
+		"karpenter_build_instance_families": true,
+		"karpenter_build_instance_sizes":    true,
+		// Schedule — clear means "disable schedule" (must be paired)
+		"schedule_rack_scale_down":          true,
+		"schedule_rack_scale_up":            true,
+		// Tags — clear means "remove all custom tags"
+		"tags":                              true,
+		// SSL — clear means "use defaults"
+		"ssl_ciphers":                       true,
+		"ssl_protocols":                     true,
+		// Optional overrides — clear means "use auto/default"
+		"build_node_type":                   true,
+		"key_pair_name":                     true,
+		"nginx_additional_config":           true,
+		// Credentials — clear means "remove auth"
+		"docker_hub_username":               true,
+		"docker_hub_password":               true,
+		// Logging — clear means "stop shipping"
+		"syslog":                            true,
+		// Domain — clear means "use auto-managed"
+		"convox_rack_domain":                true,
+		// Custom launch scripts — clear means "remove"
+		"user_data":                         true,
+		"user_data_url":                     true,
+		// Feature gates — clear means "disable all"
+		"api_feature_gates":                 true,
+		// Private EKS — cleared by console during mode changes
+		"private_eks_host":                  true,
+		"private_eks_user":                  true,
+		"private_eks_pass":                  true,
+		// JSON config — normalized to base64 later in this function
+		"additional_node_groups_config":         true,
+		"additional_build_groups_config":        true,
+		"additional_karpenter_nodepools_config": true,
+		"karpenter_config":                     true,
 	}
 
 	for k, v := range params {
-		if nonEmptyRequired[k] && strings.TrimSpace(v) == "" {
+		if strings.TrimSpace(v) == "" && !clearableParams[k] {
 			return fmt.Errorf("param '%s' requires an explicit value (omit to keep current)", k)
 		}
 	}
@@ -433,7 +463,7 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 	if tags, has := params["tags"]; has && tags != "" {
 		tList := strings.Split(tags, ",")
 		for _, p := range tList {
-			if len(strings.Split(p, "=")) != 2 {
+			if len(strings.SplitN(p, "=", 2)) != 2 {
 				return errors.New("invalid value for tags param")
 			}
 		}
@@ -458,8 +488,15 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 		}
 	}
 
+	// karpenter_auth_mode and karpenter_enabled are type=string in TF (not bool).
+	// Reject junk values — only "true" or "false" are valid.
+	for _, boolishParam := range []string{"karpenter_auth_mode", "karpenter_enabled"} {
+		if v, ok := params[boolishParam]; ok && v != "" && v != "true" && v != "false" {
+			return fmt.Errorf("param '%s' must be 'true' or 'false'", boolishParam)
+		}
+	}
+
 	// karpenter_auth_mode: one-way migration (cannot be disabled once enabled)
-	// Empty string is caught by nonEmptyRequired above; this guards against explicit "false".
 	if params["karpenter_auth_mode"] == "false" && currentParams["karpenter_auth_mode"] == "true" {
 		return fmt.Errorf("karpenter_auth_mode cannot be disabled once enabled (AWS EKS access config migration is one-way)")
 	}

--- a/pkg/cli/rack_karpenter_test.go
+++ b/pkg/cli/rack_karpenter_test.go
@@ -1405,6 +1405,13 @@ func TestValidateAndMutateParams_KarpenterAuthMode(t *testing.T) {
 			"",
 		},
 		{
+			"empty karpenter_auth_mode when enabled is blocked (one-way bypass prevention)",
+			map[string]string{"karpenter_auth_mode": ""},
+			map[string]string{"karpenter_auth_mode": "true"},
+			true,
+			"requires an explicit value",
+		},
+		{
 			"non-AWS rejection takes precedence over auth_mode check",
 			map[string]string{"karpenter_auth_mode": "true"},
 			map[string]string{},
@@ -1870,6 +1877,8 @@ func TestValidateAndMutateParams_EmptyParamRejection(t *testing.T) {
 		{"empty karpenter_build_consolidate_after", "karpenter_build_consolidate_after", "", true, "requires an explicit value"},
 		{"empty karpenter_node_expiry", "karpenter_node_expiry", "", true, "requires an explicit value"},
 		{"empty karpenter_disruption_budget_nodes", "karpenter_disruption_budget_nodes", "", true, "requires an explicit value"},
+		{"empty karpenter_auth_mode", "karpenter_auth_mode", "", true, "requires an explicit value"},
+		{"empty karpenter_enabled", "karpenter_enabled", "", true, "requires an explicit value"},
 		// Valid values still pass
 		{"valid karpenter_arch", "karpenter_arch", "amd64", false, ""},
 		{"valid karpenter_cpu_limit", "karpenter_cpu_limit", "100", false, ""},
@@ -1972,6 +1981,45 @@ func TestValidateAndMutateParams_SchedulePairValidation(t *testing.T) {
 				if !strings.Contains(err.Error(), tt.errMsg) {
 					t.Errorf("error %q does not contain %q", err.Error(), tt.errMsg)
 				}
+			}
+		})
+	}
+}
+
+func TestValidateAndMutateParams_InstallOnlyParams(t *testing.T) {
+	installOnly := []string{
+		"high_availability",
+		"private",
+		"cidr",
+		"vpc_id",
+		"internet_gateway_id",
+		"private_subnets_ids",
+		"public_subnets_ids",
+		"availability_zones",
+		"region",
+	}
+
+	for _, param := range installOnly {
+		t.Run(param, func(t *testing.T) {
+			params := map[string]string{param: "anything"}
+			err := validateAndMutateParams(params, "aws", map[string]string{})
+			if err == nil {
+				t.Errorf("param %s should be blocked post-install, got nil error", param)
+			}
+			if err != nil && !strings.Contains(err.Error(), "can only be set during rack installation") {
+				t.Errorf("error %q does not contain expected message", err.Error())
+			}
+		})
+
+		// Also test empty value — should still be blocked (install-only, not just non-empty)
+		t.Run(param+"_empty", func(t *testing.T) {
+			params := map[string]string{param: ""}
+			err := validateAndMutateParams(params, "aws", map[string]string{})
+			if err == nil {
+				t.Errorf("param %s=\"\" should be blocked post-install, got nil error", param)
+			}
+			if err != nil && !strings.Contains(err.Error(), "can only be set during rack installation") {
+				t.Errorf("error %q does not contain expected message", err.Error())
 			}
 		})
 	}

--- a/pkg/cli/rack_karpenter_test.go
+++ b/pkg/cli/rack_karpenter_test.go
@@ -412,6 +412,7 @@ func TestValidateAndMutateParams_KarpenterConfigProtectedFields(t *testing.T) {
 func TestKarpenterNodePoolConfigParam_Validate(t *testing.T) {
 	strPtr := func(s string) *string { return &s }
 	intPtr := func(i int) *int { return &i }
+	boolPtr := func(b bool) *bool { return &b }
 
 	tests := []struct {
 		name    string
@@ -422,6 +423,26 @@ func TestKarpenterNodePoolConfigParam_Validate(t *testing.T) {
 		{
 			"minimal valid",
 			KarpenterNodePoolConfigParam{Name: "test"},
+			false, "",
+		},
+		{
+			"dedicated true valid",
+			KarpenterNodePoolConfigParam{Name: "gpu", Dedicated: boolPtr(true)},
+			false, "",
+		},
+		{
+			"dedicated false valid",
+			KarpenterNodePoolConfigParam{Name: "gpu", Dedicated: boolPtr(false)},
+			false, "",
+		},
+		{
+			"dedicated nil valid",
+			KarpenterNodePoolConfigParam{Name: "gpu"},
+			false, "",
+		},
+		{
+			"dedicated true with taints valid",
+			KarpenterNodePoolConfigParam{Name: "gpu", Dedicated: boolPtr(true), Taints: strPtr("nvidia.com/gpu=true:NoSchedule")},
 			false, "",
 		},
 		{
@@ -1709,6 +1730,121 @@ func TestValidateAndMutateParams_PreserveExistingNodeGroupIds(t *testing.T) {
 			}
 			if *result[0].Id != tt.wantId {
 				t.Errorf("expected id=%d, got id=%d", tt.wantId, *result[0].Id)
+			}
+		})
+	}
+}
+
+func TestKarpenterNodePoolConfigParam_DedicatedJSONRoundtrip(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		wantDedicated *bool
+		wantJSON      string
+	}{
+		{
+			"dedicated true roundtrips",
+			`[{"name":"gpu","dedicated":true}]`,
+			boolPtr(true),
+			`true`,
+		},
+		{
+			"dedicated false roundtrips",
+			`[{"name":"gpu","dedicated":false}]`,
+			boolPtr(false),
+			`false`,
+		},
+		{
+			"dedicated absent stays nil",
+			`[{"name":"gpu"}]`,
+			nil,
+			"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var npCfgs KarpenterNodePools
+			if err := json.Unmarshal([]byte(tt.input), &npCfgs); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if len(npCfgs) != 1 {
+				t.Fatalf("expected 1 pool, got %d", len(npCfgs))
+			}
+
+			got := npCfgs[0].Dedicated
+			if tt.wantDedicated == nil {
+				if got != nil {
+					t.Errorf("expected nil Dedicated, got %v", *got)
+				}
+			} else {
+				if got == nil {
+					t.Fatalf("expected Dedicated=%v, got nil", *tt.wantDedicated)
+				}
+				if *got != *tt.wantDedicated {
+					t.Errorf("expected Dedicated=%v, got %v", *tt.wantDedicated, *got)
+				}
+			}
+
+			data, err := json.Marshal(npCfgs)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+
+			if tt.wantDedicated == nil {
+				if strings.Contains(string(data), `"dedicated"`) {
+					t.Errorf("nil dedicated should be omitted from JSON, got: %s", data)
+				}
+			} else {
+				if !strings.Contains(string(data), `"dedicated":`+tt.wantJSON) {
+					t.Errorf("expected JSON to contain dedicated:%s, got: %s", tt.wantJSON, data)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateAndMutateParams_KarpenterDedicatedNodepools(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  map[string]string
+		wantErr bool
+	}{
+		{
+			"dedicated true passes validation",
+			map[string]string{
+				"additional_karpenter_nodepools_config": `[{"name":"gpu","dedicated":true}]`,
+			},
+			false,
+		},
+		{
+			"dedicated false passes validation",
+			map[string]string{
+				"additional_karpenter_nodepools_config": `[{"name":"gpu","dedicated":false}]`,
+			},
+			false,
+		},
+		{
+			"dedicated absent passes validation",
+			map[string]string{
+				"additional_karpenter_nodepools_config": `[{"name":"gpu"}]`,
+			},
+			false,
+		},
+		{
+			"dedicated true with taints passes validation",
+			map[string]string{
+				"additional_karpenter_nodepools_config": `[{"name":"gpu","dedicated":true,"taints":"nvidia.com/gpu=true:NoSchedule"}]`,
+			},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAndMutateParams(tt.params, "aws", map[string]string{})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("got err=%v, wantErr=%v", err, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/cli/rack_karpenter_test.go
+++ b/pkg/cli/rack_karpenter_test.go
@@ -19,7 +19,7 @@ func TestValidateAndMutateParams_BudgetRegex(t *testing.T) {
 		{"hundred percent", "100%", false},
 		{"double percent", "10%%", true},
 		{"text", "abc", true},
-		{"empty", "", false}, // empty is allowed (not set)
+		{"empty", "", true}, // empty is now rejected (nonEmptyRequired guard)
 		{"negative", "-1", true},
 		{"decimal", "1.5", true},
 	}
@@ -658,7 +658,7 @@ func TestValidateAndMutateParams_Arch(t *testing.T) {
 		{"typo amd65", "amd65", true},
 		{"nonsense", "invalid", true},
 		{"mixed valid/invalid", "amd64,x86_64", true},
-		{"empty string", "", false},
+		{"empty string", "", true},
 		{"trailing comma", "amd64,", true},
 	}
 	for _, tt := range tests {
@@ -687,7 +687,7 @@ func TestValidateAndMutateParams_CapacityTypes(t *testing.T) {
 		{"valid with spaces", "karpenter_capacity_types", "on-demand, spot", false},
 		{"invalid type", "karpenter_capacity_types", "reserved", true},
 		{"mixed valid/invalid", "karpenter_capacity_types", "on-demand,invalid", true},
-		{"empty string", "karpenter_capacity_types", "", false},
+		{"empty string", "karpenter_capacity_types", "", true},
 		{"case sensitive On-Demand", "karpenter_capacity_types", "On-Demand", true},
 		{"trailing comma", "karpenter_capacity_types", "on-demand,", true},
 		{"leading comma", "karpenter_capacity_types", ",on-demand", true},
@@ -696,7 +696,7 @@ func TestValidateAndMutateParams_CapacityTypes(t *testing.T) {
 		{"build: valid spot", "karpenter_build_capacity_types", "spot", false},
 		{"build: valid both", "karpenter_build_capacity_types", "on-demand,spot", false},
 		{"build: invalid type", "karpenter_build_capacity_types", "reserved", true},
-		{"build: empty string", "karpenter_build_capacity_types", "", false},
+		{"build: empty string", "karpenter_build_capacity_types", "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -726,7 +726,7 @@ func TestValidateAndMutateParams_CpuLimit(t *testing.T) {
 		{"negative", "-1", true},
 		{"not a number", "abc", true},
 		{"decimal", "1.5", true},
-		{"empty string", "", false},
+		{"empty string", "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -756,7 +756,7 @@ func TestValidateAndMutateParams_BuildCpuLimit(t *testing.T) {
 		{"negative", "-1", true},
 		{"not a number", "abc", true},
 		{"decimal", "1.5", true},
-		{"empty string", "", false},
+		{"empty string", "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -786,7 +786,7 @@ func TestValidateAndMutateParams_BuildMemoryLimitGb(t *testing.T) {
 		{"negative", "-1", true},
 		{"not a number", "abc", true},
 		{"decimal", "1.5", true},
-		{"empty string", "", false},
+		{"empty string", "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -816,7 +816,7 @@ func TestValidateAndMutateParams_MemoryLimitGb(t *testing.T) {
 		{"negative", "-1", true},
 		{"not a number", "abc", true},
 		{"decimal", "1.5", true},
-		{"empty string", "", false},
+		{"empty string", "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -847,14 +847,14 @@ func TestValidateAndMutateParams_ConsolidateAfter(t *testing.T) {
 		{"invalid: no unit", "karpenter_consolidate_after", "30", true},
 		{"invalid: days", "karpenter_consolidate_after", "1d", true},
 		{"invalid: text", "karpenter_consolidate_after", "abc", true},
-		{"empty", "karpenter_consolidate_after", "", false},
+		{"empty", "karpenter_consolidate_after", "", true},
 		{"invalid: space", "karpenter_consolidate_after", "30 s", true},
 		{"invalid: decimal", "karpenter_consolidate_after", "1.5h", true},
 
 		{"build: valid 30s", "karpenter_build_consolidate_after", "30s", false},
 		{"build: valid 5m", "karpenter_build_consolidate_after", "5m", false},
 		{"build: invalid text", "karpenter_build_consolidate_after", "abc", true},
-		{"build: empty", "karpenter_build_consolidate_after", "", false},
+		{"build: empty", "karpenter_build_consolidate_after", "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -885,7 +885,7 @@ func TestValidateAndMutateParams_NodeExpiry(t *testing.T) {
 		{"invalid: seconds", "60s", true},
 		{"invalid: text", "abc", true},
 		{"invalid: never lowercase", "never", true},
-		{"empty", "", false},
+		{"empty", "", true},
 		{"invalid: no unit", "720", true},
 	}
 	for _, tt := range tests {
@@ -1845,6 +1845,133 @@ func TestValidateAndMutateParams_KarpenterDedicatedNodepools(t *testing.T) {
 			err := validateAndMutateParams(tt.params, "aws", map[string]string{})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("got err=%v, wantErr=%v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateAndMutateParams_EmptyParamRejection(t *testing.T) {
+	tests := []struct {
+		name    string
+		param   string
+		value   string
+		wantErr bool
+		errMsg  string
+	}{
+		{"empty karpenter_arch", "karpenter_arch", "", true, "requires an explicit value"},
+		{"whitespace karpenter_arch", "karpenter_arch", "  ", true, "requires an explicit value"},
+		{"empty karpenter_capacity_types", "karpenter_capacity_types", "", true, "requires an explicit value"},
+		{"empty karpenter_build_capacity_types", "karpenter_build_capacity_types", "", true, "requires an explicit value"},
+		{"empty karpenter_cpu_limit", "karpenter_cpu_limit", "", true, "requires an explicit value"},
+		{"empty karpenter_memory_limit_gb", "karpenter_memory_limit_gb", "", true, "requires an explicit value"},
+		{"empty karpenter_build_cpu_limit", "karpenter_build_cpu_limit", "", true, "requires an explicit value"},
+		{"empty karpenter_build_memory_limit_gb", "karpenter_build_memory_limit_gb", "", true, "requires an explicit value"},
+		{"empty karpenter_consolidate_after", "karpenter_consolidate_after", "", true, "requires an explicit value"},
+		{"empty karpenter_build_consolidate_after", "karpenter_build_consolidate_after", "", true, "requires an explicit value"},
+		{"empty karpenter_node_expiry", "karpenter_node_expiry", "", true, "requires an explicit value"},
+		{"empty karpenter_disruption_budget_nodes", "karpenter_disruption_budget_nodes", "", true, "requires an explicit value"},
+		// Valid values still pass
+		{"valid karpenter_arch", "karpenter_arch", "amd64", false, ""},
+		{"valid karpenter_cpu_limit", "karpenter_cpu_limit", "100", false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := map[string]string{tt.param: tt.value}
+			err := validateAndMutateParams(params, "aws", map[string]string{})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("param %s=%q: got err=%v, wantErr=%v", tt.param, tt.value, err, tt.wantErr)
+			}
+			if tt.wantErr && err != nil && tt.errMsg != "" {
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errMsg)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateAndMutateParams_EmptyClearableParams(t *testing.T) {
+	// These params have valid "clear to empty" semantics and must NOT be rejected.
+	clearable := []struct {
+		name  string
+		param string
+	}{
+		{"tags", "tags"},
+		{"schedule_rack_scale_down with pair", "schedule_rack_scale_down"},
+		{"karpenter_node_labels", "karpenter_node_labels"},
+		{"karpenter_node_taints", "karpenter_node_taints"},
+		{"karpenter_build_node_labels", "karpenter_build_node_labels"},
+		{"karpenter_instance_families", "karpenter_instance_families"},
+		{"karpenter_instance_sizes", "karpenter_instance_sizes"},
+		{"karpenter_build_instance_families", "karpenter_build_instance_families"},
+		{"karpenter_build_instance_sizes", "karpenter_build_instance_sizes"},
+	}
+
+	for _, tt := range clearable {
+		t.Run(tt.name, func(t *testing.T) {
+			params := map[string]string{tt.param: ""}
+			// Schedule params must be paired — send both empty
+			if tt.param == "schedule_rack_scale_down" {
+				params["schedule_rack_scale_up"] = ""
+			}
+			err := validateAndMutateParams(params, "aws", map[string]string{})
+			if err != nil {
+				t.Errorf("param %s=\"\" should be allowed (clearable), got err: %v", tt.param, err)
+			}
+		})
+	}
+}
+
+func TestValidateAndMutateParams_SchedulePairValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  map[string]string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			"both set",
+			map[string]string{
+				"schedule_rack_scale_down": "0 18 * * 5",
+				"schedule_rack_scale_up":   "0 0 * * 0",
+			},
+			false, "",
+		},
+		{
+			"both empty (clear schedule)",
+			map[string]string{
+				"schedule_rack_scale_down": "",
+				"schedule_rack_scale_up":   "",
+			},
+			false, "",
+		},
+		{
+			"only down set",
+			map[string]string{
+				"schedule_rack_scale_down": "0 18 * * 5",
+			},
+			true, "schedule_rack_scale_down",
+		},
+		{
+			"only up set",
+			map[string]string{
+				"schedule_rack_scale_up": "0 0 * * 0",
+			},
+			true, "schedule_rack_scale_up",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAndMutateParams(tt.params, "aws", map[string]string{})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("got err=%v, wantErr=%v", err, tt.wantErr)
+			}
+			if tt.wantErr && err != nil && tt.errMsg != "" {
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errMsg)
+				}
 			}
 		})
 	}

--- a/pkg/cli/rack_karpenter_test.go
+++ b/pkg/cli/rack_karpenter_test.go
@@ -19,7 +19,7 @@ func TestValidateAndMutateParams_BudgetRegex(t *testing.T) {
 		{"hundred percent", "100%", false},
 		{"double percent", "10%%", true},
 		{"text", "abc", true},
-		{"empty", "", true}, // empty is now rejected (nonEmptyRequired guard)
+		{"empty", "", true}, // empty is now rejected (clearableParams guard)
 		{"negative", "-1", true},
 		{"decimal", "1.5", true},
 	}
@@ -1879,9 +1879,18 @@ func TestValidateAndMutateParams_EmptyParamRejection(t *testing.T) {
 		{"empty karpenter_disruption_budget_nodes", "karpenter_disruption_budget_nodes", "", true, "requires an explicit value"},
 		{"empty karpenter_auth_mode", "karpenter_auth_mode", "", true, "requires an explicit value"},
 		{"empty karpenter_enabled", "karpenter_enabled", "", true, "requires an explicit value"},
+		// Non-karpenter params also rejected when empty
+		{"empty idle_timeout", "idle_timeout", "", true, "requires an explicit value"},
+		{"empty node_type", "node_type", "", true, "requires an explicit value"},
+		{"empty node_disk", "node_disk", "", true, "requires an explicit value"},
+		{"empty fluentd_memory", "fluentd_memory", "", true, "requires an explicit value"},
+		{"empty k8s_version", "k8s_version", "", true, "requires an explicit value"},
+		{"empty node_capacity_type", "node_capacity_type", "", true, "requires an explicit value"},
 		// Valid values still pass
 		{"valid karpenter_arch", "karpenter_arch", "amd64", false, ""},
 		{"valid karpenter_cpu_limit", "karpenter_cpu_limit", "100", false, ""},
+		{"valid idle_timeout", "idle_timeout", "7200", false, ""},
+		{"valid node_type", "node_type", "t3.large", false, ""},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cli/rack_karpenter_test.go
+++ b/pkg/cli/rack_karpenter_test.go
@@ -30,7 +30,7 @@ func TestValidateAndMutateParams_BudgetRegex(t *testing.T) {
 				"karpenter_enabled":              "true",
 				"karpenter_disruption_budget_nodes": tt.value,
 			}
-			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"})
+			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"}, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("budget=%q: got err=%v, wantErr=%v", tt.value, err, tt.wantErr)
 			}
@@ -63,7 +63,7 @@ func TestValidateAndMutateParams_TaintFormat(t *testing.T) {
 				"karpenter_enabled":    "true",
 				"karpenter_node_taints": tt.value,
 			}
-			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"})
+			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"}, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("taint=%q: got err=%v, wantErr=%v", tt.value, err, tt.wantErr)
 			}
@@ -97,7 +97,7 @@ func TestValidateAndMutateParams_ReservedLabels(t *testing.T) {
 				"karpenter_enabled": "true",
 				tt.param:            tt.value,
 			}
-			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"})
+			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"}, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("%s=%q: got err=%v, wantErr=%v", tt.param, tt.value, err, tt.wantErr)
 			}
@@ -133,7 +133,7 @@ func TestValidateAndMutateParams_KarpenterConfigBase64(t *testing.T) {
 			params := map[string]string{
 				"karpenter_config": tt.input,
 			}
-			err := validateAndMutateParams(params, "aws", map[string]string{})
+			err := validateAndMutateParams(params, "aws", map[string]string{}, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("config=%q: got err=%v, wantErr=%v", tt.input, err, tt.wantErr)
 			}
@@ -171,7 +171,7 @@ func TestValidateAndMutateParams_KarpenterConfigSizeLimit(t *testing.T) {
 			params := map[string]string{
 				"karpenter_config": config,
 			}
-			err := validateAndMutateParams(params, "aws", map[string]string{})
+			err := validateAndMutateParams(params, "aws", map[string]string{}, false)
 			if tt.wantErr && err == nil {
 				t.Errorf("size=%d: expected error, got nil", tt.size)
 			}
@@ -396,7 +396,7 @@ func TestValidateAndMutateParams_KarpenterConfigProtectedFields(t *testing.T) {
 			params := map[string]string{
 				"karpenter_config": string(raw),
 			}
-			err := validateAndMutateParams(params, "aws", map[string]string{})
+			err := validateAndMutateParams(params, "aws", map[string]string{}, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("got err=%v, wantErr=%v", err, tt.wantErr)
 			}
@@ -553,7 +553,7 @@ func TestValidateAndMutateParams_KarpenterDoubleQuoteRejection(t *testing.T) {
 				"karpenter_enabled": "true",
 				tt.param:            tt.value,
 			}
-			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"})
+			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"}, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("%s=%q: got err=%v, wantErr=%v", tt.param, tt.value, err, tt.wantErr)
 			}
@@ -590,7 +590,7 @@ func TestValidateAndMutateParams_KarpenterNotAWS(t *testing.T) {
 	params := map[string]string{
 		"karpenter_enabled": "true",
 	}
-	err := validateAndMutateParams(params, "gcp", map[string]string{})
+	err := validateAndMutateParams(params, "gcp", map[string]string{}, false)
 	if err == nil {
 		t.Error("expected error for non-AWS karpenter_enabled, got nil")
 	}
@@ -617,7 +617,7 @@ func TestValidateAndMutateParams_KarpenterEnabledGating(t *testing.T) {
 	}
 	for _, tt := range alwaysValidatedCases {
 		t.Run("validated/"+tt.name, func(t *testing.T) {
-			err := validateAndMutateParams(tt.params, "aws", map[string]string{})
+			err := validateAndMutateParams(tt.params, "aws", map[string]string{}, false)
 			if err == nil {
 				t.Errorf("expected error for invalid param, got nil")
 			}
@@ -627,7 +627,7 @@ func TestValidateAndMutateParams_KarpenterEnabledGating(t *testing.T) {
 	// karpenter_config is validated OUTSIDE the karpenter_enabled block
 	t.Run("karpenter_config still validated without enabled", func(t *testing.T) {
 		params := map[string]string{"karpenter_config": "{bad"}
-		err := validateAndMutateParams(params, "aws", map[string]string{})
+		err := validateAndMutateParams(params, "aws", map[string]string{}, false)
 		if err == nil {
 			t.Error("expected error: karpenter_config validated even without karpenter_enabled=true")
 		}
@@ -635,7 +635,7 @@ func TestValidateAndMutateParams_KarpenterEnabledGating(t *testing.T) {
 
 	t.Run("additional_karpenter_nodepools_config still validated without enabled", func(t *testing.T) {
 		params := map[string]string{"additional_karpenter_nodepools_config": "[bad]"}
-		err := validateAndMutateParams(params, "aws", map[string]string{})
+		err := validateAndMutateParams(params, "aws", map[string]string{}, false)
 		if err == nil {
 			t.Error("expected error: additional_karpenter_nodepools_config validated even without karpenter_enabled=true")
 		}
@@ -664,7 +664,7 @@ func TestValidateAndMutateParams_Arch(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			params := map[string]string{"karpenter_arch": tt.value}
-			err := validateAndMutateParams(params, "aws", map[string]string{})
+			err := validateAndMutateParams(params, "aws", map[string]string{}, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("karpenter_arch=%q: got err=%v, wantErr=%v", tt.value, err, tt.wantErr)
 			}
@@ -704,7 +704,7 @@ func TestValidateAndMutateParams_CapacityTypes(t *testing.T) {
 				"karpenter_enabled": "true",
 				tt.param:            tt.value,
 			}
-			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"})
+			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"}, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("%s=%q: got err=%v, wantErr=%v", tt.param, tt.value, err, tt.wantErr)
 			}
@@ -734,7 +734,7 @@ func TestValidateAndMutateParams_CpuLimit(t *testing.T) {
 				"karpenter_enabled":   "true",
 				"karpenter_cpu_limit": tt.value,
 			}
-			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"})
+			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"}, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("cpu_limit=%q: got err=%v, wantErr=%v", tt.value, err, tt.wantErr)
 			}
@@ -764,7 +764,7 @@ func TestValidateAndMutateParams_BuildCpuLimit(t *testing.T) {
 				"karpenter_enabled":        "true",
 				"karpenter_build_cpu_limit": tt.value,
 			}
-			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"})
+			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"}, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("build_cpu_limit=%q: got err=%v, wantErr=%v", tt.value, err, tt.wantErr)
 			}
@@ -794,7 +794,7 @@ func TestValidateAndMutateParams_BuildMemoryLimitGb(t *testing.T) {
 				"karpenter_enabled":               "true",
 				"karpenter_build_memory_limit_gb": tt.value,
 			}
-			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"})
+			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"}, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("build_memory_limit_gb=%q: got err=%v, wantErr=%v", tt.value, err, tt.wantErr)
 			}
@@ -824,7 +824,7 @@ func TestValidateAndMutateParams_MemoryLimitGb(t *testing.T) {
 				"karpenter_enabled":         "true",
 				"karpenter_memory_limit_gb": tt.value,
 			}
-			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"})
+			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"}, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("memory_limit_gb=%q: got err=%v, wantErr=%v", tt.value, err, tt.wantErr)
 			}
@@ -862,7 +862,7 @@ func TestValidateAndMutateParams_ConsolidateAfter(t *testing.T) {
 				"karpenter_enabled": "true",
 				tt.param:            tt.value,
 			}
-			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"})
+			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"}, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("%s=%q: got err=%v, wantErr=%v", tt.param, tt.value, err, tt.wantErr)
 			}
@@ -894,7 +894,7 @@ func TestValidateAndMutateParams_NodeExpiry(t *testing.T) {
 				"karpenter_enabled":     "true",
 				"karpenter_node_expiry": tt.value,
 			}
-			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"})
+			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"}, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("node_expiry=%q: got err=%v, wantErr=%v", tt.value, err, tt.wantErr)
 			}
@@ -1009,7 +1009,7 @@ func TestValidateAndMutateParams_KarpenterConfigMoreProtectedFields(t *testing.T
 			params := map[string]string{
 				"karpenter_config": string(raw),
 			}
-			err := validateAndMutateParams(params, "aws", map[string]string{})
+			err := validateAndMutateParams(params, "aws", map[string]string{}, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("got err=%v, wantErr=%v", err, tt.wantErr)
 			}
@@ -1031,7 +1031,7 @@ func TestValidateAndMutateParams_KarpenterConfigEdgeCases(t *testing.T) {
 		params := map[string]string{
 			"karpenter_config": encoded,
 		}
-		err := validateAndMutateParams(params, "aws", map[string]string{})
+		err := validateAndMutateParams(params, "aws", map[string]string{}, false)
 		if err == nil {
 			t.Error("expected error for JSON array, got nil")
 		}
@@ -1046,7 +1046,7 @@ func TestValidateAndMutateParams_KarpenterConfigEdgeCases(t *testing.T) {
 		config := `{"nodePool":{"d":"` + padding + `"}}`
 		if len(config) <= 64*1024 {
 			params := map[string]string{"karpenter_config": config}
-			err := validateAndMutateParams(params, "aws", map[string]string{})
+			err := validateAndMutateParams(params, "aws", map[string]string{}, false)
 			if err != nil && strings.Contains(err.Error(), "exceeds maximum size") {
 				t.Errorf("config at/under 64KB should not fail size check: %v", err)
 			}
@@ -1080,7 +1080,7 @@ func TestValidateAndMutateParams_AdditionalKarpenterNodepoolsConfig(t *testing.T
 			params := map[string]string{
 				"additional_karpenter_nodepools_config": tt.value,
 			}
-			err := validateAndMutateParams(params, "aws", map[string]string{})
+			err := validateAndMutateParams(params, "aws", map[string]string{}, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("got err=%v, wantErr=%v", err, tt.wantErr)
 			}
@@ -1110,7 +1110,7 @@ func TestValidateAndMutateParams_AdditionalKarpenterNodepoolsConfigBase64(t *tes
 	params := map[string]string{
 		"additional_karpenter_nodepools_config": encoded,
 	}
-	err := validateAndMutateParams(params, "aws", map[string]string{})
+	err := validateAndMutateParams(params, "aws", map[string]string{}, false)
 	if err != nil {
 		t.Errorf("expected no error for base64-encoded input, got: %v", err)
 	}
@@ -1139,7 +1139,7 @@ func TestValidateAndMutateParams_KarpenterNotAWS_AllParams(t *testing.T) {
 	for _, param := range karpenterParams {
 		t.Run(param, func(t *testing.T) {
 			params := map[string]string{param: "some-value"}
-			err := validateAndMutateParams(params, "gcp", map[string]string{})
+			err := validateAndMutateParams(params, "gcp", map[string]string{}, false)
 			if err == nil {
 				t.Errorf("expected error for %s on non-AWS, got nil", param)
 			}
@@ -1154,7 +1154,7 @@ func TestValidateAndMutateParams_KarpenterNotAWS_AllParams(t *testing.T) {
 		params := map[string]string{
 			"additional_karpenter_nodepools_config": `[{"name":"gpu"}]`,
 		}
-		err := validateAndMutateParams(params, "gcp", map[string]string{})
+		err := validateAndMutateParams(params, "gcp", map[string]string{}, false)
 		if err == nil {
 			t.Error("expected error for additional_karpenter_nodepools_config on non-AWS, got nil")
 		}
@@ -1427,7 +1427,7 @@ func TestValidateAndMutateParams_KarpenterAuthMode(t *testing.T) {
 			if tt.name == "non-AWS rejection takes precedence over auth_mode check" {
 				provider = "gcp"
 			}
-			err := validateAndMutateParams(tt.params, provider, tt.currentParams)
+			err := validateAndMutateParams(tt.params, provider, tt.currentParams, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("got err=%v, wantErr=%v", err, tt.wantErr)
 			}
@@ -1525,7 +1525,7 @@ func TestValidateAndMutateParams_KarpenterNonDedicatedNodeGroups(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateAndMutateParams(tt.params, "aws", tt.currentParams)
+			err := validateAndMutateParams(tt.params, "aws", tt.currentParams, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("got err=%v, wantErr=%v", err, tt.wantErr)
 			}
@@ -1590,7 +1590,7 @@ func TestValidateAndMutateParams_KarpenterReenableValidation(t *testing.T) {
 			for k, v := range tt.params {
 				paramsCopy[k] = v
 			}
-			err := validateAndMutateParams(paramsCopy, "aws", tt.currentParams)
+			err := validateAndMutateParams(paramsCopy, "aws", tt.currentParams, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("got err=%v, wantErr=%v", err, tt.wantErr)
 			}
@@ -1606,7 +1606,7 @@ func TestValidateAndMutateParams_KarpenterReenableValidation(t *testing.T) {
 	t.Run("injected keys cleaned up from params", func(t *testing.T) {
 		params := map[string]string{"karpenter_enabled": "true", "karpenter_auth_mode": "true"}
 		currentParams := map[string]string{"karpenter_auth_mode": "true", "karpenter_capacity_types": "on-demand", "karpenter_cpu_limit": "100"}
-		err := validateAndMutateParams(params, "aws", currentParams)
+		err := validateAndMutateParams(params, "aws", currentParams, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1716,7 +1716,7 @@ func TestValidateAndMutateParams_PreserveExistingNodeGroupIds(t *testing.T) {
 				currentParams["additional_node_groups_config"] = tt.currentConfig
 			}
 
-			if err := validateAndMutateParams(params, "aws", currentParams); err != nil {
+			if err := validateAndMutateParams(params, "aws", currentParams, false); err != nil {
 				t.Fatal(err)
 			}
 
@@ -1849,7 +1849,7 @@ func TestValidateAndMutateParams_KarpenterDedicatedNodepools(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateAndMutateParams(tt.params, "aws", map[string]string{})
+			err := validateAndMutateParams(tt.params, "aws", map[string]string{}, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("got err=%v, wantErr=%v", err, tt.wantErr)
 			}
@@ -1884,7 +1884,7 @@ func TestValidateAndMutateParams_EmptyParamRejection(t *testing.T) {
 		{"empty node_type", "node_type", "", true, "requires an explicit value"},
 		{"empty node_disk", "node_disk", "", true, "requires an explicit value"},
 		{"empty fluentd_memory", "fluentd_memory", "", true, "requires an explicit value"},
-		{"empty k8s_version", "k8s_version", "", true, "requires an explicit value"},
+		{"empty k8s_version", "k8s_version", "", true, "managed internally"},
 		{"empty node_capacity_type", "node_capacity_type", "", true, "requires an explicit value"},
 		// Valid values still pass
 		{"valid karpenter_arch", "karpenter_arch", "amd64", false, ""},
@@ -1896,7 +1896,7 @@ func TestValidateAndMutateParams_EmptyParamRejection(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			params := map[string]string{tt.param: tt.value}
-			err := validateAndMutateParams(params, "aws", map[string]string{})
+			err := validateAndMutateParams(params, "aws", map[string]string{}, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("param %s=%q: got err=%v, wantErr=%v", tt.param, tt.value, err, tt.wantErr)
 			}
@@ -1933,7 +1933,7 @@ func TestValidateAndMutateParams_EmptyClearableParams(t *testing.T) {
 			if tt.param == "schedule_rack_scale_down" {
 				params["schedule_rack_scale_up"] = ""
 			}
-			err := validateAndMutateParams(params, "aws", map[string]string{})
+			err := validateAndMutateParams(params, "aws", map[string]string{}, false)
 			if err != nil {
 				t.Errorf("param %s=\"\" should be allowed (clearable), got err: %v", tt.param, err)
 			}
@@ -1982,7 +1982,7 @@ func TestValidateAndMutateParams_SchedulePairValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateAndMutateParams(tt.params, "aws", map[string]string{})
+			err := validateAndMutateParams(tt.params, "aws", map[string]string{}, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("got err=%v, wantErr=%v", err, tt.wantErr)
 			}
@@ -2011,7 +2011,7 @@ func TestValidateAndMutateParams_InstallOnlyParams(t *testing.T) {
 	for _, param := range installOnly {
 		t.Run(param, func(t *testing.T) {
 			params := map[string]string{param: "anything"}
-			err := validateAndMutateParams(params, "aws", map[string]string{})
+			err := validateAndMutateParams(params, "aws", map[string]string{}, false)
 			if err == nil {
 				t.Errorf("param %s should be blocked post-install, got nil error", param)
 			}
@@ -2023,7 +2023,7 @@ func TestValidateAndMutateParams_InstallOnlyParams(t *testing.T) {
 		// Also test empty value — should still be blocked (install-only, not just non-empty)
 		t.Run(param+"_empty", func(t *testing.T) {
 			params := map[string]string{param: ""}
-			err := validateAndMutateParams(params, "aws", map[string]string{})
+			err := validateAndMutateParams(params, "aws", map[string]string{}, false)
 			if err == nil {
 				t.Errorf("param %s=\"\" should be blocked post-install, got nil error", param)
 			}

--- a/pkg/cli/rack_karpenter_test.go
+++ b/pkg/cli/rack_karpenter_test.go
@@ -1625,3 +1625,93 @@ func TestCheckRackNameRegex(t *testing.T) {
 		})
 	}
 }
+
+func TestAdditionalNodeGroups_Validate_AutoAssignIdsFromZero(t *testing.T) {
+	ngs := AdditionalNodeGroups{
+		{Type: "m5.large"},
+		{Type: "c5.xlarge"},
+	}
+	if err := ngs.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if ngs[0].Id == nil || *ngs[0].Id != 0 {
+		t.Errorf("expected first id=0, got %v", ngs[0].Id)
+	}
+	if ngs[1].Id == nil || *ngs[1].Id != 1 {
+		t.Errorf("expected second id=1, got %v", ngs[1].Id)
+	}
+}
+
+func TestValidateAndMutateParams_PreserveExistingNodeGroupIds(t *testing.T) {
+	id5 := 5
+	lbl := "gpu"
+	existingWithId := AdditionalNodeGroups{{Type: "g6.xlarge", Id: &id5, Dedicated: boolPtr(true), Label: &lbl}}
+	existingWithIdJSON, _ := json.Marshal(existingWithId)
+	existingWithIdB64 := base64.StdEncoding.EncodeToString(existingWithIdJSON)
+
+	existingNoId := `[{"type":"g6.xlarge","dedicated":true,"label":"gpu"}]`
+	existingNoIdB64 := base64.StdEncoding.EncodeToString([]byte(existingNoId))
+
+	tests := []struct {
+		name          string
+		newConfig     string
+		currentConfig string
+		wantId        int
+	}{
+		{
+			"preserves existing id from currentParams",
+			`[{"type":"g6.xlarge","dedicated":true,"label":"gpu"}]`,
+			existingWithIdB64,
+			5,
+		},
+		{
+			"legacy config without id gets 0-based index",
+			`[{"type":"g6.xlarge","dedicated":true,"label":"gpu"}]`,
+			existingNoIdB64,
+			0,
+		},
+		{
+			"no currentParams — auto-assigns 0-based",
+			`[{"type":"g6.xlarge","dedicated":true,"label":"gpu"}]`,
+			"",
+			0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := map[string]string{
+				"additional_node_groups_config": tt.newConfig,
+			}
+			currentParams := map[string]string{}
+			if tt.currentConfig != "" {
+				currentParams["additional_node_groups_config"] = tt.currentConfig
+			}
+
+			if err := validateAndMutateParams(params, "aws", currentParams); err != nil {
+				t.Fatal(err)
+			}
+
+			// Decode the result
+			decoded, err := base64.StdEncoding.DecodeString(params["additional_node_groups_config"])
+			if err != nil {
+				t.Fatal(err)
+			}
+			var result AdditionalNodeGroups
+			if err := json.Unmarshal(decoded, &result); err != nil {
+				t.Fatal(err)
+			}
+			if len(result) != 1 {
+				t.Fatalf("expected 1 node group, got %d", len(result))
+			}
+			if result[0].Id == nil {
+				t.Fatal("expected non-nil id")
+			}
+			if *result[0].Id != tt.wantId {
+				t.Errorf("expected id=%d, got id=%d", tt.wantId, *result[0].Id)
+			}
+		})
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }

--- a/pkg/cli/rack_test.go
+++ b/pkg/cli/rack_test.go
@@ -480,7 +480,7 @@ func TestRackParamsSetTerraformUpdateTimeoutEmpty(t *testing.T) {
 		res, err := testExecute(e, "rack params set terraform_update_timeout=", nil)
 		require.NoError(t, err)
 		require.Equal(t, 1, res.Code)
-		res.RequireStderr(t, []string{"ERROR: invalid value for terraform_update_timeout: must be a valid duration (e.g., '2h', '90m', '2h30m'): time: invalid duration \"\""})
+		res.RequireStderr(t, []string{"ERROR: param 'terraform_update_timeout' requires an explicit value (omit to keep current)"})
 	})
 }
 

--- a/pkg/cli/rack_validate_test.go
+++ b/pkg/cli/rack_validate_test.go
@@ -1,0 +1,309 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLevenshtein(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"abc", "", 3},
+		{"", "abc", 3},
+		{"abc", "abc", 0},
+		{"karpenter_enabled", "karpenter_enbled", 1},
+		{"node_type", "node_tyoe", 1},
+		{"tags", "tgas", 2},
+		{"idle_timeout", "banana", 12},
+	}
+	for _, tt := range tests {
+		t.Run(tt.a+"_"+tt.b, func(t *testing.T) {
+			got := levenshtein(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("levenshtein(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSuggestParam(t *testing.T) {
+	known := map[string]bool{
+		"karpenter_enabled": true,
+		"node_type":         true,
+		"idle_timeout":      true,
+		"tags":              true,
+	}
+	tests := []struct {
+		key  string
+		want string
+	}{
+		{"karpenter_enbled", "karpenter_enabled"},
+		{"node_tyoe", "node_type"},
+		{"tgas", "tags"},
+		{"banana", ""},
+		{"idle_timeoutt", "idle_timeout"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			got := suggestParam(tt.key, known)
+			if got != tt.want {
+				t.Errorf("suggestParam(%q) = %q, want %q", tt.key, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateAndMutateParams_V2RackSkipsValidation(t *testing.T) {
+	v2CurrentParams := map[string]string{
+		"HighAvailability": "true",
+		"Private":          "false",
+		"BuildMemory":      "2048",
+		"InstanceType":     "t3.medium",
+	}
+	params := map[string]string{"BuildMemory": "4096"}
+	err := validateAndMutateParams(params, "aws", v2CurrentParams, false)
+	if err != nil {
+		t.Errorf("V2 rack param should pass, got: %v", err)
+	}
+
+	params2 := map[string]string{"Release": "20260412"}
+	err2 := validateAndMutateParams(params2, "aws", v2CurrentParams, false)
+	if err2 != nil {
+		t.Errorf("V2 managed-equivalent param should pass, got: %v", err2)
+	}
+
+	v3CurrentParams := map[string]string{
+		"high_availability": "true",
+		"idle_timeout":      "3600",
+	}
+	params3 := map[string]string{"banana": "value"}
+	err3 := validateAndMutateParams(params3, "aws", v3CurrentParams, false)
+	if err3 == nil {
+		t.Fatal("V3 rack should still reject unknown params")
+	}
+}
+
+func TestValidateAndMutateParams_ManagedParam(t *testing.T) {
+	params := map[string]string{"image": "custom"}
+	err := validateAndMutateParams(params, "aws", map[string]string{}, false)
+	if err == nil {
+		t.Fatal("expected error for managed param without --force")
+	}
+	if !strings.Contains(err.Error(), "managed internally") {
+		t.Errorf("error %q should mention 'managed internally'", err.Error())
+	}
+
+	params2 := map[string]string{"image": "custom"}
+	err2 := validateAndMutateParams(params2, "aws", map[string]string{}, true)
+	if err2 != nil {
+		t.Errorf("--force should bypass managed guard, got: %v", err2)
+	}
+}
+
+func TestValidateAndMutateParams_UnknownParam(t *testing.T) {
+	params := map[string]string{"karpenter_enbled": "true"}
+	err := validateAndMutateParams(params, "aws", map[string]string{}, false)
+	if err == nil {
+		t.Fatal("expected error for unknown param")
+	}
+	if !strings.Contains(err.Error(), "unknown parameter") {
+		t.Errorf("error %q should mention 'unknown parameter'", err.Error())
+	}
+	if !strings.Contains(err.Error(), "karpenter_enabled") {
+		t.Errorf("error %q should suggest 'karpenter_enabled'", err.Error())
+	}
+
+	params2 := map[string]string{"totally_fake": "value"}
+	err2 := validateAndMutateParams(params2, "aws", map[string]string{}, true)
+	if err2 != nil {
+		t.Errorf("--force should bypass known-key check, got: %v", err2)
+	}
+}
+
+func TestValidateAndMutateParams_UnknownParamNoSuggestion(t *testing.T) {
+	params := map[string]string{"zzzzzzzzz": "value"}
+	err := validateAndMutateParams(params, "aws", map[string]string{}, false)
+	if err == nil {
+		t.Fatal("expected error for unknown param")
+	}
+	if strings.Contains(err.Error(), "Did you mean") {
+		t.Errorf("error should NOT have suggestion for distant match")
+	}
+	if !strings.Contains(err.Error(), "sudo convox update") {
+		t.Errorf("error should mention 'sudo convox update'")
+	}
+}
+
+func TestValidateAndMutateParams_EmptyKey(t *testing.T) {
+	params := map[string]string{"": "value"}
+	err := validateAndMutateParams(params, "aws", map[string]string{}, false)
+	if err == nil {
+		t.Fatal("expected error for empty key")
+	}
+	if !strings.Contains(err.Error(), "parameter name cannot be empty") {
+		t.Errorf("error %q should mention empty parameter name", err.Error())
+	}
+}
+
+func TestValidateAndMutateParams_SyncTfNow(t *testing.T) {
+	params := map[string]string{"sync_tf_now": "1"}
+	err := validateAndMutateParams(params, "aws", map[string]string{}, false)
+	if err != nil {
+		t.Errorf("sync_tf_now should be accepted, got: %v", err)
+	}
+}
+
+func TestValidateAndMutateParams_UnknownProvider(t *testing.T) {
+	params := map[string]string{"anything": "value"}
+	err := validateAndMutateParams(params, "", map[string]string{}, false)
+	if err != nil {
+		t.Errorf("empty provider should skip key check, got: %v", err)
+	}
+}
+
+func TestValidateAndMutateParams_KarpenterOnNonAWS_SkipsSpellcheck(t *testing.T) {
+	params := map[string]string{"karpenter_enabled": "true"}
+	err := validateAndMutateParams(params, "gcp", map[string]string{}, false)
+	if err == nil {
+		t.Fatal("expected error for karpenter on GCP")
+	}
+	if !strings.Contains(err.Error(), "only supported for AWS") {
+		t.Errorf("error %q should say 'only supported for AWS', not 'unknown parameter'", err.Error())
+	}
+}
+
+func TestValidateAndMutateParams_ManagedParamOnWrongProvider(t *testing.T) {
+	params := map[string]string{"k8s_version": "1.30"}
+	err := validateAndMutateParams(params, "metal", map[string]string{}, false)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if strings.Contains(err.Error(), "managed internally") {
+		t.Errorf("metal has no k8s_version — should get 'unknown parameter', not 'managed internally'")
+	}
+}
+
+func TestValidateAndMutateParams_DOInstallOnly(t *testing.T) {
+	for _, param := range []string{"access_id", "secret_key", "token"} {
+		params := map[string]string{param: "value"}
+		err := validateAndMutateParams(params, "do", map[string]string{}, false)
+		if err == nil {
+			t.Errorf("DO credential %s should be install-only", param)
+		}
+		if err != nil && !strings.Contains(err.Error(), "can only be set during rack installation") {
+			t.Errorf("error for %s: %q should mention install-only", param, err.Error())
+		}
+	}
+}
+
+func TestValidateAndMutateParams_ImdsHttpTokens(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+		errMsg  string
+	}{
+		{"optional is valid", "optional", false, ""},
+		{"required is valid", "required", false, ""},
+		{"junk rejected", "banana", true, "must be 'optional' or 'required'"},
+		{"OPTIONAL rejected (case-sensitive)", "OPTIONAL", true, "must be 'optional' or 'required'"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := map[string]string{"imds_http_tokens": tt.value}
+			err := validateAndMutateParams(params, "aws", map[string]string{}, false)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantErr && err != nil && !strings.Contains(err.Error(), tt.errMsg) {
+				t.Errorf("error %q should contain %q", err.Error(), tt.errMsg)
+			}
+		})
+	}
+}
+
+func TestValidateAndMutateParams_NodeCapacityType(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"on_demand valid", "on_demand", false},
+		{"spot valid", "spot", false},
+		{"mixed valid", "mixed", false},
+		{"ON_DEMAND valid (case-insensitive)", "ON_DEMAND", false},
+		{"MIXED valid (case-insensitive)", "MIXED", false},
+		{"junk rejected", "banana", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := map[string]string{"node_capacity_type": tt.value}
+			err := validateAndMutateParams(params, "aws", map[string]string{}, false)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateAndMutateParams_AccessLogRetention(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"7 valid", "7", false},
+		{"30 valid", "30", false},
+		{"junk rejected", "abc", true},
+		{"float rejected", "7.5", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := map[string]string{"access_log_retention_in_days": tt.value}
+			err := validateAndMutateParams(params, "aws", map[string]string{}, false)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateAndMutateParams_KarpenterNodeVolumeType(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"gp2 valid", "gp2", false},
+		{"gp3 valid", "gp3", false},
+		{"io1 valid", "io1", false},
+		{"io2 valid", "io2", false},
+		{"GP3 rejected (case-sensitive)", "GP3", true},
+		{"st1 rejected", "st1", true},
+		{"junk rejected", "banana", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := map[string]string{"karpenter_node_volume_type": tt.value}
+			err := validateAndMutateParams(params, "aws", map[string]string{}, false)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/mock/sdk/interface.go
+++ b/pkg/mock/sdk/interface.go
@@ -1001,6 +1001,20 @@ func (_m *Interface) InstanceTerminate(id string) error {
 	return r0
 }
 
+// KarpenterCleanup provides a mock function with given fields:
+func (_m *Interface) KarpenterCleanup() error {
+	ret := _m.Called()
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // LetsEncryptConfigApply provides a mock function with given fields: config
 func (_m *Interface) LetsEncryptConfigApply(config structs.LetsEncryptConfig) error {
 	ret := _m.Called(config)

--- a/pkg/rack/terraform.go
+++ b/pkg/rack/terraform.go
@@ -661,9 +661,11 @@ func (t Terraform) writeVars(vars map[string]string) error {
 	// Strip empties for everything else to prevent TF type errors on
 	// number/bool variables (e.g., idle_timeout="" would fail TF).
 	//
-	// MAINTENANCE: When adding a new TF variable with type=string and
-	// default="", add it here if users should be able to clear it after
-	// setting a value. See also nonEmptyRequired in pkg/cli/rack.go.
+	// MAINTENANCE: This list is a subset of clearableParams in pkg/cli/rack.go.
+	// JSON config params (additional_*_config, karpenter_config) are excluded
+	// because the CLI normalizes them to base64 before reaching writeVars.
+	// When adding a new clearable param to rack.go, add it here too unless
+	// it has similar pre-processing that prevents empty values at this point.
 	preserveEmpty := map[string]bool{
 		"tags":                              true,
 		"karpenter_node_labels":             true,

--- a/pkg/rack/terraform.go
+++ b/pkg/rack/terraform.go
@@ -656,8 +656,44 @@ func (t Terraform) varsFile() (string, error) {
 }
 
 func (t Terraform) writeVars(vars map[string]string) error {
+	// Preserve empty values for string-type TF variables where clearing
+	// is a valid operation (e.g., karpenter_node_labels="" to clear labels).
+	// Strip empties for everything else to prevent TF type errors on
+	// number/bool variables (e.g., idle_timeout="" would fail TF).
+	//
+	// MAINTENANCE: When adding a new TF variable with type=string and
+	// default="", add it here if users should be able to clear it after
+	// setting a value. See also nonEmptyRequired in pkg/cli/rack.go.
+	preserveEmpty := map[string]bool{
+		"tags":                              true,
+		"karpenter_node_labels":             true,
+		"karpenter_node_taints":             true,
+		"karpenter_build_node_labels":       true,
+		"karpenter_instance_families":       true,
+		"karpenter_instance_sizes":          true,
+		"karpenter_build_instance_families": true,
+		"karpenter_build_instance_sizes":    true,
+		"schedule_rack_scale_down":          true,
+		"schedule_rack_scale_up":            true,
+		"ssl_ciphers":                       true,
+		"ssl_protocols":                     true,
+		"build_node_type":                   true,
+		"key_pair_name":                     true,
+		"nginx_additional_config":           true,
+		"private_eks_host":                  true,
+		"private_eks_user":                  true,
+		"private_eks_pass":                  true,
+		"docker_hub_username":  true,
+		"docker_hub_password":  true,
+		"syslog":               true,
+		"convox_rack_domain":   true,
+		"user_data":            true,
+		"user_data_url":        true,
+		"api_feature_gates":    true,
+	}
+
 	for k, v := range vars {
-		if strings.TrimSpace(v) == "" {
+		if strings.TrimSpace(v) == "" && !preserveEmpty[k] {
 			delete(vars, k)
 		}
 	}

--- a/pkg/structs/mock_Provider.go
+++ b/pkg/structs/mock_Provider.go
@@ -1730,6 +1730,19 @@ func (_m *MockProvider) SystemUpdate(opts SystemUpdateOptions) error {
 	return r0
 }
 
+func (_m *MockProvider) KarpenterCleanup() error {
+	ret := _m.Called()
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // WithContext provides a mock function with given fields: ctx
 func (_m *MockProvider) WithContext(ctx context.Context) Provider {
 	ret := _m.Called(ctx)

--- a/pkg/structs/provider.go
+++ b/pkg/structs/provider.go
@@ -104,6 +104,8 @@ type Provider interface {
 	SystemUninstall(name string, w io.Writer, opts SystemUninstallOptions) error
 	SystemUpdate(opts SystemUpdateOptions) error
 
+	KarpenterCleanup() error
+
 	SystemResourceCreate(kind string, opts ResourceCreateOptions) (*Resource, error)
 	SystemResourceDelete(name string) error
 	SystemResourceGet(name string) (*Resource, error)

--- a/pkg/structs/routes.go
+++ b/pkg/structs/routes.go
@@ -80,6 +80,7 @@ func init() {
 	routes["SystemResourceUpdate"] = "PUT /resources/{name}"
 	routes["SystemUninstall"] = ""
 	routes["SystemUpdate"] = "PUT /system"
+	routes["KarpenterCleanup"] = "POST /system/karpenter/cleanup"
 	routes["Workers"] = ""
 }
 

--- a/provider/aws/karpenter.go
+++ b/provider/aws/karpenter.go
@@ -1,0 +1,62 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	k8s "github.com/convox/convox/provider/k8s"
+	"github.com/pkg/errors"
+	am "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (p *Provider) KarpenterCleanup() error {
+	ctx := p.Context()
+
+	nodes, err := p.Cluster.CoreV1().Nodes().List(ctx, am.ListOptions{
+		LabelSelector: k8s.KarpenterNodePoolLabel,
+	})
+	if err != nil {
+		return errors.WithStack(fmt.Errorf("failed to list karpenter nodes: %s", err))
+	}
+
+	if len(nodes.Items) == 0 {
+		return nil
+	}
+
+	var instanceIDs []*string
+	for _, node := range nodes.Items {
+		if id := parseInstanceID(node.Spec.ProviderID); id != "" {
+			instanceIDs = append(instanceIDs, aws.String(id))
+		}
+	}
+
+	if err := p.Provider.KarpenterCleanup(); err != nil {
+		return err
+	}
+
+	if len(instanceIDs) > 0 {
+		_, err := p.Ec2.TerminateInstances(&ec2.TerminateInstancesInput{
+			InstanceIds: instanceIDs,
+		})
+		if err != nil {
+			return errors.WithStack(fmt.Errorf("failed to terminate EC2 instances: %s", err))
+		}
+	}
+
+	return nil
+}
+
+func parseInstanceID(providerID string) string {
+	if !strings.HasPrefix(providerID, "aws://") {
+		return ""
+	}
+	id := strings.TrimPrefix(providerID, "aws://")
+	parts := strings.Split(id, "/")
+	instanceID := parts[len(parts)-1]
+	if !strings.HasPrefix(instanceID, "i-") {
+		return ""
+	}
+	return instanceID
+}

--- a/provider/aws/karpenter.go
+++ b/provider/aws/karpenter.go
@@ -32,10 +32,10 @@ func (p *Provider) KarpenterCleanup() error {
 		}
 	}
 
-	if err := p.Provider.KarpenterCleanup(); err != nil {
-		return err
-	}
-
+	// Terminate EC2 instances FIRST. If this fails (e.g., missing IAM permission),
+	// nodes remain in k8s (cordoned but intact) and the command can be retried.
+	// If we deleted k8s nodes first, a failed EC2 terminate would orphan instances
+	// with no node objects to track them.
 	if len(instanceIDs) > 0 {
 		_, err := p.Ec2.TerminateInstances(&ec2.TerminateInstancesInput{
 			InstanceIds: instanceIDs,
@@ -43,6 +43,13 @@ func (p *Provider) KarpenterCleanup() error {
 		if err != nil {
 			return errors.WithStack(fmt.Errorf("failed to terminate EC2 instances: %s", err))
 		}
+	}
+
+	// Now cordon, drain, and delete k8s node objects.
+	// EC2 instances are already terminating, so pods will be evicted naturally,
+	// but we drain explicitly to respect PDBs and ensure graceful shutdown.
+	if err := p.Provider.KarpenterCleanup(); err != nil {
+		return err
 	}
 
 	return nil

--- a/provider/aws/karpenter_test.go
+++ b/provider/aws/karpenter_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseInstanceID(t *testing.T) {
+	tests := []struct {
+		name       string
+		providerID string
+		want       string
+	}{
+		{"standard EKS format", "aws:///us-east-1a/i-0123456789abcdef0", "i-0123456789abcdef0"},
+		{"empty", "", ""},
+		{"no instance prefix", "aws:///us-east-1a/vol-123", ""},
+		{"just instance ID", "i-abc123", ""},
+		{"different region", "aws:///eu-west-1c/i-fffff", "i-fffff"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseInstanceID(tt.providerID)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/provider/k8s/controller_deployment.go
+++ b/provider/k8s/controller_deployment.go
@@ -189,6 +189,8 @@ func (c *DeployController) SyncPDB(d *apps.Deployment, remove bool) error {
 			pdb.Spec.MinAvailable = pdbMinAvailable
 			pdb.Spec.Selector = d.Spec.Selector
 			pdb.Spec.Selector.MatchLabels["type"] = "service"
+			alwaysAllow := policyv1.AlwaysAllow
+			pdb.Spec.UnhealthyPodEvictionPolicy = &alwaysAllow
 			return pdb
 		}, metav1.PatchOptions{
 			FieldManager: "convox",

--- a/provider/k8s/karpenter.go
+++ b/provider/k8s/karpenter.go
@@ -60,6 +60,12 @@ func (p *Provider) cleanupNode(ctx context.Context, node *ac.Node) error {
 		return errors.WithStack(fmt.Errorf("failed to drain: %s", err))
 	}
 
+	// Strip Karpenter finalizer — the controller that would process it is dead.
+	finalizerPatch := []byte(`{"metadata":{"finalizers":null}}`)
+	if _, err := p.Cluster.CoreV1().Nodes().Patch(ctx, node.Name, types.MergePatchType, finalizerPatch, am.PatchOptions{}); err != nil && !ae.IsNotFound(err) {
+		return errors.WithStack(fmt.Errorf("failed to strip finalizers: %s", err))
+	}
+
 	if err := p.Cluster.CoreV1().Nodes().Delete(ctx, node.Name, am.DeleteOptions{}); err != nil && !ae.IsNotFound(err) {
 		return errors.WithStack(fmt.Errorf("failed to delete node: %s", err))
 	}

--- a/provider/k8s/karpenter.go
+++ b/provider/k8s/karpenter.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -22,6 +23,9 @@ const (
 func (p *Provider) KarpenterCleanup() error {
 	ctx := p.Context()
 
+	var errs []error
+
+	// Clean up orphaned Karpenter nodes (cordon, drain, strip finalizers, delete)
 	nodes, err := p.Cluster.CoreV1().Nodes().List(ctx, am.ListOptions{
 		LabelSelector: KarpenterNodePoolLabel,
 	})
@@ -29,11 +33,6 @@ func (p *Provider) KarpenterCleanup() error {
 		return errors.WithStack(fmt.Errorf("failed to list karpenter nodes: %s", err))
 	}
 
-	if len(nodes.Items) == 0 {
-		return nil
-	}
-
-	var errs []error
 	for i := range nodes.Items {
 		node := &nodes.Items[i]
 		if err := p.cleanupNode(ctx, node); err != nil {
@@ -41,8 +40,66 @@ func (p *Provider) KarpenterCleanup() error {
 		}
 	}
 
+	// Delete stale NodePool and EC2NodeClass CRD instances.
+	// These survive disable because CRDs are intentionally kept installed.
+	// Clearing them ensures re-enable creates fresh objects without conflicts.
+	if err := p.deleteKarpenterCRDInstances(ctx); err != nil {
+		errs = append(errs, fmt.Errorf("CRD cleanup: %s", err))
+	}
+
 	if len(errs) > 0 {
 		return errors.WithStack(fmt.Errorf("cleanup errors: %v", errs))
+	}
+
+	return nil
+}
+
+func (p *Provider) deleteKarpenterCRDInstances(ctx context.Context) error {
+	// The REST client is used for CRD API paths that the typed client doesn't cover.
+	// In test environments (fake clientset), RESTClient() returns a typed nil that
+	// panics on use. Recover gracefully — CRD cleanup is best-effort.
+	defer func() {
+		recover()
+	}()
+
+	restClient := p.Cluster.CoreV1().RESTClient()
+
+	crdPaths := []string{
+		"/apis/karpenter.sh/v1/nodeclaims",
+		"/apis/karpenter.sh/v1/nodepools",
+		"/apis/karpenter.k8s.aws/v1/ec2nodeclasses",
+	}
+
+	for _, path := range crdPaths {
+		raw, err := restClient.Get().AbsPath(path).DoRaw(ctx)
+		if err != nil {
+			// CRDs might not be installed — skip silently
+			continue
+		}
+
+		var list struct {
+			Items []struct {
+				Metadata struct {
+					Name       string   `json:"name"`
+					Finalizers []string `json:"finalizers"`
+				} `json:"metadata"`
+			} `json:"items"`
+		}
+		if err := json.Unmarshal(raw, &list); err != nil {
+			continue
+		}
+
+		for _, item := range list.Items {
+			name := item.Metadata.Name
+
+			// Strip finalizers first (controller is dead, can't process them)
+			if len(item.Metadata.Finalizers) > 0 {
+				patch := []byte(`{"metadata":{"finalizers":null}}`)
+				_, _ = restClient.Patch(types.MergePatchType).AbsPath(path, name).Body(patch).DoRaw(ctx)
+			}
+
+			_, _ = restClient.Delete().AbsPath(path, name).DoRaw(ctx)
+		}
 	}
 
 	return nil

--- a/provider/k8s/karpenter.go
+++ b/provider/k8s/karpenter.go
@@ -1,0 +1,146 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+	ac "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	ae "k8s.io/apimachinery/pkg/api/errors"
+	am "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	KarpenterNodePoolLabel = "karpenter.sh/nodepool"
+	drainTimeout           = 5 * time.Minute
+	evictionRetryInterval  = 5 * time.Second
+)
+
+func (p *Provider) KarpenterCleanup() error {
+	ctx := p.Context()
+
+	nodes, err := p.Cluster.CoreV1().Nodes().List(ctx, am.ListOptions{
+		LabelSelector: KarpenterNodePoolLabel,
+	})
+	if err != nil {
+		return errors.WithStack(fmt.Errorf("failed to list karpenter nodes: %s", err))
+	}
+
+	if len(nodes.Items) == 0 {
+		return nil
+	}
+
+	var errs []error
+	for i := range nodes.Items {
+		node := &nodes.Items[i]
+		if err := p.cleanupNode(ctx, node); err != nil {
+			errs = append(errs, fmt.Errorf("node %s: %s", node.Name, err))
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.WithStack(fmt.Errorf("cleanup errors: %v", errs))
+	}
+
+	return nil
+}
+
+func (p *Provider) cleanupNode(ctx context.Context, node *ac.Node) error {
+	if !node.Spec.Unschedulable {
+		patch := []byte(`{"spec":{"unschedulable":true}}`)
+		if _, err := p.Cluster.CoreV1().Nodes().Patch(ctx, node.Name, types.StrategicMergePatchType, patch, am.PatchOptions{}); err != nil {
+			return errors.WithStack(fmt.Errorf("failed to cordon: %s", err))
+		}
+	}
+
+	if err := p.drainKarpenterNode(ctx, node.Name); err != nil {
+		return errors.WithStack(fmt.Errorf("failed to drain: %s", err))
+	}
+
+	if err := p.Cluster.CoreV1().Nodes().Delete(ctx, node.Name, am.DeleteOptions{}); err != nil && !ae.IsNotFound(err) {
+		return errors.WithStack(fmt.Errorf("failed to delete node: %s", err))
+	}
+
+	return nil
+}
+
+func (p *Provider) drainKarpenterNode(ctx context.Context, nodeName string) error {
+	pods, err := p.Cluster.CoreV1().Pods("").List(ctx, am.ListOptions{
+		FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
+	})
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	deadline := time.Now().Add(drainTimeout)
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+
+		if _, isMirror := pod.Annotations[ac.MirrorPodAnnotationKey]; isMirror {
+			continue
+		}
+		if isDaemonSetManaged(pod) {
+			continue
+		}
+
+		if err := p.evictPodWithRetry(ctx, pod, deadline); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func isDaemonSetManaged(pod *ac.Pod) bool {
+	for _, ref := range pod.OwnerReferences {
+		if ref.Kind == "DaemonSet" {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *Provider) evictPodWithRetry(ctx context.Context, pod *ac.Pod, deadline time.Time) error {
+	eviction := &policyv1.Eviction{
+		ObjectMeta: am.ObjectMeta{
+			Name:      pod.Name,
+			Namespace: pod.Namespace,
+		},
+	}
+
+	for {
+		err := p.Cluster.CoreV1().Pods(pod.Namespace).EvictV1(ctx, eviction)
+		if err == nil {
+			return nil
+		}
+
+		if ae.IsNotFound(err) {
+			return nil
+		}
+
+		if ae.IsTooManyRequests(err) {
+			if time.Now().After(deadline) {
+				return p.forceDeletePod(ctx, pod)
+			}
+			time.Sleep(evictionRetryInterval)
+			continue
+		}
+
+		return p.forceDeletePod(ctx, pod)
+	}
+}
+
+func (p *Provider) forceDeletePod(ctx context.Context, pod *ac.Pod) error {
+	grace := int64(0)
+	err := p.Cluster.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, am.DeleteOptions{
+		GracePeriodSeconds: &grace,
+	})
+	if err != nil && !ae.IsNotFound(err) {
+		return errors.WithStack(fmt.Errorf("failed to force-delete pod %s/%s: %s", pod.Namespace, pod.Name, err))
+	}
+	return nil
+}

--- a/provider/k8s/karpenter_test.go
+++ b/provider/k8s/karpenter_test.go
@@ -1,0 +1,148 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	"github.com/convox/convox/pkg/atom"
+	"github.com/convox/convox/pkg/mock"
+	"github.com/stretchr/testify/require"
+	ac "k8s.io/api/core/v1"
+	am "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	cvfake "github.com/convox/convox/provider/k8s/pkg/client/clientset/versioned/fake"
+	metricfake "k8s.io/metrics/pkg/client/clientset/versioned/fake"
+)
+
+func karpenterTestProvider() (*Provider, *fake.Clientset) {
+	c := fake.NewSimpleClientset()
+	cc := cvfake.NewSimpleClientset()
+	mc := metricfake.NewSimpleClientset()
+	a := &atom.MockInterface{}
+
+	p := &Provider{
+		Atom:          a,
+		Cluster:       c,
+		Convox:        cc,
+		Domain:        "domain1",
+		Engine:        &mock.TestEngine{},
+		MetricsClient: mc,
+		Name:          "rack1",
+		Namespace:     "ns1",
+		Provider:      "test",
+		ctx:           context.Background(),
+	}
+
+	return p, c
+}
+
+func TestKarpenterCleanupNoNodes(t *testing.T) {
+	p, _ := karpenterTestProvider()
+
+	err := p.KarpenterCleanup()
+	require.NoError(t, err)
+}
+
+func TestKarpenterCleanupRemovesKarpenterNodes(t *testing.T) {
+	p, c := karpenterTestProvider()
+
+	_, err := c.CoreV1().Nodes().Create(context.TODO(), &ac.Node{
+		ObjectMeta: am.ObjectMeta{
+			Name:   "karpenter-node-1",
+			Labels: map[string]string{"karpenter.sh/nodepool": "default"},
+		},
+		Spec: ac.NodeSpec{ProviderID: "aws:///us-east-1a/i-abc123"},
+		Status: ac.NodeStatus{
+			Conditions: []ac.NodeCondition{
+				{Type: ac.NodeReady, Status: ac.ConditionTrue},
+			},
+		},
+	}, am.CreateOptions{})
+	require.NoError(t, err)
+
+	err = p.KarpenterCleanup()
+	require.NoError(t, err)
+
+	_, err = c.CoreV1().Nodes().Get(context.TODO(), "karpenter-node-1", am.GetOptions{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+}
+
+func TestKarpenterCleanupSkipsDaemonSetPods(t *testing.T) {
+	p, c := karpenterTestProvider()
+
+	_, err := c.CoreV1().Nodes().Create(context.TODO(), &ac.Node{
+		ObjectMeta: am.ObjectMeta{
+			Name:   "karpenter-node-2",
+			Labels: map[string]string{"karpenter.sh/nodepool": "workload"},
+		},
+		Status: ac.NodeStatus{
+			Conditions: []ac.NodeCondition{
+				{Type: ac.NodeReady, Status: ac.ConditionTrue},
+			},
+		},
+	}, am.CreateOptions{})
+	require.NoError(t, err)
+
+	_, err = c.CoreV1().Pods("default").Create(context.TODO(), &ac.Pod{
+		ObjectMeta: am.ObjectMeta{Name: "app-pod", Namespace: "default"},
+		Spec:       ac.PodSpec{NodeName: "karpenter-node-2"},
+	}, am.CreateOptions{})
+	require.NoError(t, err)
+
+	_, err = c.CoreV1().Pods("kube-system").Create(context.TODO(), &ac.Pod{
+		ObjectMeta: am.ObjectMeta{
+			Name:      "ds-pod",
+			Namespace: "kube-system",
+			OwnerReferences: []am.OwnerReference{
+				{Kind: "DaemonSet", Name: "fluentd", APIVersion: "apps/v1"},
+			},
+		},
+		Spec: ac.PodSpec{NodeName: "karpenter-node-2"},
+	}, am.CreateOptions{})
+	require.NoError(t, err)
+
+	err = p.KarpenterCleanup()
+	require.NoError(t, err)
+
+	_, err = c.CoreV1().Nodes().Get(context.TODO(), "karpenter-node-2", am.GetOptions{})
+	require.Error(t, err)
+
+	_, err = c.CoreV1().Pods("kube-system").Get(context.TODO(), "ds-pod", am.GetOptions{})
+	require.NoError(t, err)
+}
+
+func TestKarpenterCleanupSkipsMirrorPods(t *testing.T) {
+	p, c := karpenterTestProvider()
+
+	_, err := c.CoreV1().Nodes().Create(context.TODO(), &ac.Node{
+		ObjectMeta: am.ObjectMeta{
+			Name:   "karpenter-node-3",
+			Labels: map[string]string{"karpenter.sh/nodepool": "workload"},
+		},
+		Status: ac.NodeStatus{
+			Conditions: []ac.NodeCondition{
+				{Type: ac.NodeReady, Status: ac.ConditionTrue},
+			},
+		},
+	}, am.CreateOptions{})
+	require.NoError(t, err)
+
+	_, err = c.CoreV1().Pods("kube-system").Create(context.TODO(), &ac.Pod{
+		ObjectMeta: am.ObjectMeta{
+			Name:      "kube-apiserver-mirror",
+			Namespace: "kube-system",
+			Annotations: map[string]string{
+				ac.MirrorPodAnnotationKey: "mirror-hash",
+			},
+		},
+		Spec: ac.PodSpec{NodeName: "karpenter-node-3"},
+	}, am.CreateOptions{})
+	require.NoError(t, err)
+
+	err = p.KarpenterCleanup()
+	require.NoError(t, err)
+
+	_, err = c.CoreV1().Pods("kube-system").Get(context.TODO(), "kube-apiserver-mirror", am.GetOptions{})
+	require.NoError(t, err)
+}

--- a/provider/k8s/process.go
+++ b/provider/k8s/process.go
@@ -509,6 +509,7 @@ func (p *Provider) podSpecFromService(app, service, release string, isBuild bool
 	})
 
 	serviceAccountName := ""
+	var nodeSelectorLabels map[string]string
 	if !isBuild && release != "" {
 		m, r, err := common.ReleaseManifest(p, app, release)
 		if err != nil {
@@ -577,6 +578,8 @@ func (p *Provider) podSpecFromService(app, service, release string, isBuild bool
 					MountPath: to,
 				})
 			}
+
+			nodeSelectorLabels = s.NodeSelectorLabels
 		}
 
 		for k, v := range env {
@@ -589,6 +592,40 @@ func (p *Provider) podSpecFromService(app, service, release string, isBuild bool
 		Containers:            []ac.Container{c},
 		ShareProcessNamespace: options.Bool(true),
 		Volumes:               vs,
+	}
+
+	if len(nodeSelectorLabels) > 0 {
+		matchExpressions := []ac.NodeSelectorRequirement{}
+		for k, v := range nodeSelectorLabels {
+			matchExpressions = append(matchExpressions, ac.NodeSelectorRequirement{
+				Key:      k,
+				Operator: ac.NodeSelectorOpIn,
+				Values:   []string{v},
+			})
+		}
+		ps.Affinity = &ac.Affinity{
+			NodeAffinity: &ac.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &ac.NodeSelector{
+					NodeSelectorTerms: []ac.NodeSelectorTerm{
+						{MatchExpressions: matchExpressions},
+					},
+				},
+			},
+		}
+
+		for k, v := range nodeSelectorLabels {
+			if k == "convox.io/label" || k == "convox.io/nodepool" {
+				if ps.Tolerations == nil {
+					ps.Tolerations = []ac.Toleration{}
+				}
+				ps.Tolerations = append(ps.Tolerations, ac.Toleration{
+					Key:      "dedicated-node",
+					Operator: ac.TolerationOpEqual,
+					Value:    v,
+					Effect:   ac.TaintEffectNoSchedule,
+				})
+			}
+		}
 	}
 
 	if !isBuild {
@@ -702,6 +739,8 @@ func (p *Provider) podSpecFromRunOptions(app, service string, opts structs.Proce
 	}
 
 	if opts.NodeLabels != nil {
+		s.Affinity = nil
+		s.Tolerations = nil
 		labelStrList := strings.Split(*opts.NodeLabels, ",")
 		for _, lb := range labelStrList {
 			parts := strings.SplitN(lb, "=", 2)

--- a/provider/k8s/process_nodeselector_test.go
+++ b/provider/k8s/process_nodeselector_test.go
@@ -1,0 +1,303 @@
+package k8s
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/convox/convox/pkg/atom"
+	"github.com/convox/convox/pkg/mock"
+	"github.com/convox/convox/pkg/options"
+	"github.com/convox/convox/pkg/structs"
+	ca "github.com/convox/convox/provider/k8s/pkg/apis/convox/v1"
+	cvfake "github.com/convox/convox/provider/k8s/pkg/client/clientset/versioned/fake"
+	"github.com/convox/logger"
+	"github.com/stretchr/testify/require"
+	ac "k8s.io/api/core/v1"
+	am "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	metricfake "k8s.io/metrics/pkg/client/clientset/versioned/fake"
+)
+
+// minimalProvider creates a Provider with fake clients and no informers.
+// Informer-based lookups fall back to direct API calls against the fakes.
+func minimalProvider(t *testing.T) (*Provider, *fake.Clientset, *cvfake.Clientset) {
+	t.Helper()
+	kk := fake.NewSimpleClientset()
+	kc := cvfake.NewSimpleClientset()
+	mc := metricfake.NewSimpleClientset()
+	aa := &atom.MockInterface{}
+	aa.On("Status", "rack1-app1", "app").Return("Running", "rel1", nil)
+
+	p := &Provider{
+		Atom:          aa,
+		Cluster:       kk,
+		Convox:        kc,
+		Engine:        &mock.TestEngine{},
+		MetricsClient: mc,
+		Name:          "rack1",
+		Namespace:     "ns1",
+		Provider:      "test",
+		logger:        logger.New("ns=k8s-test"),
+	}
+
+	return p, kk, kc
+}
+
+func createAppNamespace(t *testing.T, kk *fake.Clientset, rack, app string) {
+	t.Helper()
+	_, err := kk.CoreV1().Namespaces().Create(context.TODO(), &ac.Namespace{
+		ObjectMeta: am.ObjectMeta{
+			Name:        rack + "-" + app,
+			Annotations: map[string]string{"convox.com/lock": "false"},
+			Labels: map[string]string{
+				"app":    app,
+				"name":   app,
+				"rack":   rack,
+				"system": "convox",
+				"type":   "app",
+			},
+		},
+	}, am.CreateOptions{})
+	require.NoError(t, err)
+}
+
+func createBuild(t *testing.T, kc *cvfake.Clientset, ns, id string) {
+	t.Helper()
+	_, err := kc.ConvoxV1().Builds(ns).Create(&ca.Build{
+		ObjectMeta: am.ObjectMeta{
+			Name:   id,
+			Labels: map[string]string{"app": "app1"},
+		},
+		Spec: ca.BuildSpec{
+			Description: "test build",
+			Started:     "20200101.000000.000000000",
+			Ended:       "20200101.000000.000000000",
+			Manifest:    "services:\n  web:\n    build: .\n",
+		},
+	})
+	require.NoError(t, err)
+}
+
+func createRelease(t *testing.T, kc *cvfake.Clientset, ns, id, manifest string) {
+	t.Helper()
+	_, err := kc.ConvoxV1().Releases(ns).Create(&ca.Release{
+		ObjectMeta: am.ObjectMeta{Name: id},
+		Spec: ca.ReleaseSpec{
+			Build:    "build1",
+			Created:  "20200101.000000.000000000",
+			Manifest: manifest,
+		},
+	})
+	require.NoError(t, err)
+}
+
+// runAndGetPodSpec calls ProcessRun then retrieves the pod from the fake clientset.
+func runAndGetPodSpec(t *testing.T, p *Provider, kk *fake.Clientset, app, service string, opts structs.ProcessRunOptions) *ac.PodSpec {
+	t.Helper()
+	ps, err := p.ProcessRun(app, service, opts)
+	require.NoError(t, err)
+	require.NotNil(t, ps)
+
+	pod, err := kk.CoreV1().Pods(p.AppNamespace(app)).Get(context.TODO(), ps.Id, am.GetOptions{})
+	require.NoError(t, err)
+	return &pod.Spec
+}
+
+const manifestWithNodeSelectors = `services:
+  web:
+    build: .
+    port: 5000
+  gpu-worker:
+    build: .
+    nodeSelectorLabels:
+      convox.io/nodepool: gpu
+  labeled-worker:
+    build: .
+    nodeSelectorLabels:
+      convox.io/label: special
+  custom-label-worker:
+    build: .
+    nodeSelectorLabels:
+      team: ml
+`
+
+func TestProcessRun_InheritsNodeSelectorLabelsAffinity(t *testing.T) {
+	p, kk, kc := minimalProvider(t)
+	createAppNamespace(t, kk, "rack1", "app1")
+	createBuild(t, kc, "rack1-app1", "build1")
+	createRelease(t, kc, "rack1-app1", "rel1", manifestWithNodeSelectors)
+
+	spec := runAndGetPodSpec(t, p, kk, "app1", "gpu-worker", structs.ProcessRunOptions{
+		Release: options.String("rel1"),
+	})
+
+	// Should have required node affinity for convox.io/nodepool=gpu
+	require.NotNil(t, spec.Affinity, "expected Affinity to be set")
+	require.NotNil(t, spec.Affinity.NodeAffinity)
+	req := spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	require.NotNil(t, req)
+	require.Len(t, req.NodeSelectorTerms, 1)
+	require.Len(t, req.NodeSelectorTerms[0].MatchExpressions, 1)
+	require.Equal(t, "convox.io/nodepool", req.NodeSelectorTerms[0].MatchExpressions[0].Key)
+	require.Equal(t, ac.NodeSelectorOpIn, req.NodeSelectorTerms[0].MatchExpressions[0].Operator)
+	require.Equal(t, []string{"gpu"}, req.NodeSelectorTerms[0].MatchExpressions[0].Values)
+
+	// Should have dedicated-node toleration (Equal operator, exact value)
+	require.Len(t, spec.Tolerations, 1)
+	require.Equal(t, "dedicated-node", spec.Tolerations[0].Key)
+	require.Equal(t, ac.TolerationOpEqual, spec.Tolerations[0].Operator)
+	require.Equal(t, "gpu", spec.Tolerations[0].Value)
+	require.Equal(t, ac.TaintEffectNoSchedule, spec.Tolerations[0].Effect)
+}
+
+func TestProcessRun_InheritsConvoxLabelToleration(t *testing.T) {
+	p, kk, kc := minimalProvider(t)
+	createAppNamespace(t, kk, "rack1", "app1")
+	createBuild(t, kc, "rack1-app1", "build1")
+	createRelease(t, kc, "rack1-app1", "rel1", manifestWithNodeSelectors)
+
+	spec := runAndGetPodSpec(t, p, kk, "app1", "labeled-worker", structs.ProcessRunOptions{
+		Release: options.String("rel1"),
+	})
+
+	// convox.io/label should also trigger the dedicated-node toleration
+	require.NotNil(t, spec.Affinity)
+	require.Len(t, spec.Tolerations, 1)
+	require.Equal(t, "dedicated-node", spec.Tolerations[0].Key)
+	require.Equal(t, ac.TolerationOpEqual, spec.Tolerations[0].Operator)
+	require.Equal(t, "special", spec.Tolerations[0].Value)
+}
+
+func TestProcessRun_CustomLabelGetsAffinityButNoToleration(t *testing.T) {
+	p, kk, kc := minimalProvider(t)
+	createAppNamespace(t, kk, "rack1", "app1")
+	createBuild(t, kc, "rack1-app1", "build1")
+	createRelease(t, kc, "rack1-app1", "rel1", manifestWithNodeSelectors)
+
+	spec := runAndGetPodSpec(t, p, kk, "app1", "custom-label-worker", structs.ProcessRunOptions{
+		Release: options.String("rel1"),
+	})
+
+	// Custom labels should get affinity
+	require.NotNil(t, spec.Affinity)
+	require.NotNil(t, spec.Affinity.NodeAffinity)
+	terms := spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	require.Len(t, terms, 1)
+	require.Equal(t, "team", terms[0].MatchExpressions[0].Key)
+	require.Equal(t, []string{"ml"}, terms[0].MatchExpressions[0].Values)
+
+	// But NOT dedicated-node tolerations (only convox.io/label and convox.io/nodepool trigger those)
+	require.Empty(t, spec.Tolerations)
+}
+
+func TestProcessRun_NoNodeSelectorLabelsNoAffinityNoTolerations(t *testing.T) {
+	p, kk, kc := minimalProvider(t)
+	createAppNamespace(t, kk, "rack1", "app1")
+	createBuild(t, kc, "rack1-app1", "build1")
+	createRelease(t, kc, "rack1-app1", "rel1", manifestWithNodeSelectors)
+
+	spec := runAndGetPodSpec(t, p, kk, "app1", "web", structs.ProcessRunOptions{
+		Release: options.String("rel1"),
+	})
+
+	// Service without nodeSelectorLabels: no affinity, no tolerations
+	require.Nil(t, spec.Affinity)
+	require.Empty(t, spec.Tolerations)
+}
+
+func TestProcessRun_NodeLabelsOverridesInheritedAffinity(t *testing.T) {
+	p, kk, kc := minimalProvider(t)
+	createAppNamespace(t, kk, "rack1", "app1")
+	createBuild(t, kc, "rack1-app1", "build1")
+	createRelease(t, kc, "rack1-app1", "rel1", manifestWithNodeSelectors)
+
+	spec := runAndGetPodSpec(t, p, kk, "app1", "gpu-worker", structs.ProcessRunOptions{
+		Release:    options.String("rel1"),
+		NodeLabels: options.String("custom-pool=debug"),
+	})
+
+	// --node-labels should clear inherited affinity and use nodeSelector instead
+	require.Nil(t, spec.Affinity, "explicit --node-labels should clear inherited Affinity")
+	require.Equal(t, map[string]string{"custom-pool": "debug"}, spec.NodeSelector)
+
+	// Should have broad dedicated-node toleration (Exists operator, not Equal)
+	require.Len(t, spec.Tolerations, 1)
+	require.Equal(t, "dedicated-node", spec.Tolerations[0].Key)
+	require.Equal(t, ac.TolerationOpExists, spec.Tolerations[0].Operator)
+	require.Equal(t, ac.TaintEffectNoSchedule, spec.Tolerations[0].Effect)
+}
+
+func TestProcessRun_NodeLabelsOverridesForServiceWithoutNodeSelector(t *testing.T) {
+	p, kk, kc := minimalProvider(t)
+	createAppNamespace(t, kk, "rack1", "app1")
+	createBuild(t, kc, "rack1-app1", "build1")
+	createRelease(t, kc, "rack1-app1", "rel1", manifestWithNodeSelectors)
+
+	spec := runAndGetPodSpec(t, p, kk, "app1", "web", structs.ProcessRunOptions{
+		Release:    options.String("rel1"),
+		NodeLabels: options.String("convox.io/nodepool=other"),
+	})
+
+	// --node-labels on a service without nodeSelectorLabels should still work
+	require.Nil(t, spec.Affinity)
+	require.Equal(t, map[string]string{"convox.io/nodepool": "other"}, spec.NodeSelector)
+	require.Len(t, spec.Tolerations, 1)
+	require.Equal(t, "dedicated-node", spec.Tolerations[0].Key)
+	require.Equal(t, ac.TolerationOpExists, spec.Tolerations[0].Operator)
+}
+
+func TestProcessRun_MultipleNodeSelectorLabels(t *testing.T) {
+	p, kk, kc := minimalProvider(t)
+	createAppNamespace(t, kk, "rack1", "app1")
+	createBuild(t, kc, "rack1-app1", "build1")
+
+	manifest := `services:
+  multi:
+    build: .
+    nodeSelectorLabels:
+      convox.io/nodepool: gpu
+      team: ml
+`
+	createRelease(t, kc, "rack1-app1", "rel1", manifest)
+
+	spec := runAndGetPodSpec(t, p, kk, "app1", "multi", structs.ProcessRunOptions{
+		Release: options.String("rel1"),
+	})
+
+	// Should have affinity with both match expressions
+	require.NotNil(t, spec.Affinity)
+	terms := spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	require.Len(t, terms, 1)
+	require.Len(t, terms[0].MatchExpressions, 2)
+
+	// Sort for deterministic comparison (Go map iteration is non-deterministic)
+	exprs := terms[0].MatchExpressions
+	sort.Slice(exprs, func(i, j int) bool { return exprs[i].Key < exprs[j].Key })
+	require.Equal(t, "convox.io/nodepool", exprs[0].Key)
+	require.Equal(t, []string{"gpu"}, exprs[0].Values)
+	require.Equal(t, "team", exprs[1].Key)
+	require.Equal(t, []string{"ml"}, exprs[1].Values)
+
+	// Only convox.io/nodepool triggers a toleration, not "team"
+	require.Len(t, spec.Tolerations, 1)
+	require.Equal(t, "dedicated-node", spec.Tolerations[0].Key)
+	require.Equal(t, "gpu", spec.Tolerations[0].Value)
+}
+
+func TestProcessRun_BuildIgnoresNodeSelectorLabels(t *testing.T) {
+	p, kk, kc := minimalProvider(t)
+	createAppNamespace(t, kk, "rack1", "app1")
+	createBuild(t, kc, "rack1-app1", "build1")
+	createRelease(t, kc, "rack1-app1", "rel1", manifestWithNodeSelectors)
+
+	spec := runAndGetPodSpec(t, p, kk, "app1", "gpu-worker", structs.ProcessRunOptions{
+		Release: options.String("rel1"),
+		IsBuild: true,
+	})
+
+	// Build pods should NOT inherit nodeSelectorLabels affinity
+	// (the isBuild check in podSpecFromService skips the manifest lookup)
+	require.Nil(t, spec.Affinity)
+	require.Empty(t, spec.Tolerations)
+}

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -115,14 +115,14 @@ spec:
       {{ if .Service.NodeSelectorLabels }}
       {{ $hasTolerations := false }}
       {{ range keyValue .Service.NodeSelectorLabels }}
-        {{ if eq .Key "convox.io/label" }}
+        {{ if or (eq .Key "convox.io/label") (eq .Key "convox.io/nodepool") }}
           {{ $hasTolerations = true }}
         {{ end }}
       {{ end }}
       {{ if $hasTolerations }}
       tolerations:
         {{ range keyValue .Service.NodeSelectorLabels }}
-        {{ if eq .Key "convox.io/label" }}
+        {{ if or (eq .Key "convox.io/label") (eq .Key "convox.io/nodepool") }}
         - key: "dedicated-node"
           operator: "Equal"
           value: "{{.Value}}"

--- a/provider/k8s/template/app/timer.yml.tmpl
+++ b/provider/k8s/template/app/timer.yml.tmpl
@@ -81,14 +81,14 @@ spec:
           {{ if .Service.NodeSelectorLabels }}
           {{ $hasTolerations := false }}
           {{ range keyValue .Service.NodeSelectorLabels }}
-            {{ if eq .Key "convox.io/label" }}
+            {{ if or (eq .Key "convox.io/label") (eq .Key "convox.io/nodepool") }}
               {{ $hasTolerations = true }}
             {{ end }}
           {{ end }}
           {{ if $hasTolerations }}
           tolerations:
             {{ range keyValue .Service.NodeSelectorLabels }}
-            {{ if eq .Key "convox.io/label" }}
+            {{ if or (eq .Key "convox.io/label") (eq .Key "convox.io/nodepool") }}
             - key: "dedicated-node"
               operator: "Equal"
               value: "{{.Value}}"

--- a/sdk/methods.go
+++ b/sdk/methods.go
@@ -1267,6 +1267,12 @@ func (c *Client) SystemUpdate(opts structs.SystemUpdateOptions) error {
 	return err
 }
 
+func (c *Client) KarpenterCleanup() error {
+	ro := stdsdk.RequestOptions{Headers: stdsdk.Headers{}, Params: stdsdk.Params{}, Query: stdsdk.Query{}}
+
+	return c.Post("/system/karpenter/cleanup", ro, nil)
+}
+
 // skipcq
 func (*Client) Workers() error {
 	err := fmt.Errorf("not available via api")

--- a/terraform/api/aws/iam.tf
+++ b/terraform/api/aws/iam.tf
@@ -128,6 +128,7 @@ data "aws_iam_policy_document" "rds_provisioner" {
       "ec2:ModifySecurityGroupRules",
       "ec2:CreateTags",
       "ec2:DescribeInstanceTypes",
+      "ec2:TerminateInstances",
     ]
     resources = ["*"]
   }

--- a/terraform/cluster/aws/autoscaler.tf
+++ b/terraform/cluster/aws/autoscaler.tf
@@ -320,7 +320,6 @@ resource "kubernetes_deployment" "autoscaler" {
   depends_on = [
     aws_iam_role_policy.autoscaler_autoscale,
     null_resource.wait_eks_addons,
-    kubectl_manifest.karpenter_nodepool_workload,
   ]
 
   metadata {

--- a/terraform/cluster/aws/efs.tf
+++ b/terraform/cluster/aws/efs.tf
@@ -12,6 +12,22 @@ resource "aws_eks_addon" "aws_efs_csi_driver" {
   addon_version               = var.efs_csi_driver_version
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "OVERWRITE"
+
+  configuration_values = var.karpenter_enabled ? jsonencode({
+    controller = {
+      nodeSelector = {
+        "convox.io/system-node" = "true"
+      }
+      tolerations = [
+        {
+          key      = "convox.io/system-node"
+          operator = "Equal"
+          value    = "true"
+          effect   = "NoSchedule"
+        }
+      ]
+    }
+  }) : null
 }
 
 // setup iam permissions

--- a/terraform/cluster/aws/karpenter.tf
+++ b/terraform/cluster/aws/karpenter.tf
@@ -141,7 +141,22 @@ resource "null_resource" "wait_karpenter_ready" {
            -n kube-system --timeout=120s 2>/dev/null && \
          kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=karpenter \
            -n kube-system --timeout=120s 2>/dev/null; then
-        echo "Karpenter controller ready"
+        # Webhook registration happens shortly after pod Ready.
+        # Wait for the webhook endpoint to be populated.
+        echo "Waiting for webhook registration..."
+        WEBHOOK_READY=false
+        for i in $(seq 1 30); do
+          ENDPOINTS=$(kubectl get endpoints karpenter -n kube-system -o jsonpath='{.subsets[*].addresses[0].ip}' 2>/dev/null)
+          if [ -n "$ENDPOINTS" ]; then
+            echo "Karpenter controller and webhooks ready"
+            WEBHOOK_READY=true
+            break
+          fi
+          sleep 2
+        done
+        if [ "$WEBHOOK_READY" = "false" ]; then
+          echo "WARNING: Karpenter webhook endpoints not populated after 60s. NodePools might need a re-apply."
+        fi
       else
         echo "WARNING: Karpenter controller may not be ready. NodePools might need a re-apply."
       fi

--- a/terraform/cluster/aws/karpenter.tf
+++ b/terraform/cluster/aws/karpenter.tf
@@ -124,6 +124,28 @@ resource "helm_release" "karpenter" {
   })] : []
 }
 
+# Wait for Karpenter controller to be ready before creating NodePools.
+# The Helm release completes when the chart is installed, but the controller
+# pods and webhooks need time to start. Without this gate, kubectl_manifest
+# resources can be created before the webhooks are registered, causing them
+# to silently disappear.
+resource "null_resource" "wait_karpenter_ready" {
+  count = var.karpenter_enabled ? 1 : 0
+
+  depends_on = [helm_release.karpenter]
+
+  provisioner "local-exec" {
+    command = <<-WAIT
+      echo "Waiting for Karpenter controller to be ready..."
+      kubectl wait --for=condition=Available deployment/karpenter \
+        -n kube-system --timeout=120s 2>/dev/null || true
+      kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=karpenter \
+        -n kube-system --timeout=120s 2>/dev/null || true
+      echo "Karpenter controller ready"
+    WAIT
+  }
+}
+
 # Finalizer cleanup — strips Karpenter finalizers before destroy to prevent
 # CRD deletion deadlock. By depending on kubectl_manifest resources, this is
 # destroyed BEFORE them (Terraform reverses dependency order on destroy).

--- a/terraform/cluster/aws/karpenter.tf
+++ b/terraform/cluster/aws/karpenter.tf
@@ -137,11 +137,14 @@ resource "null_resource" "wait_karpenter_ready" {
   provisioner "local-exec" {
     command = <<-WAIT
       echo "Waiting for Karpenter controller to be ready..."
-      kubectl wait --for=condition=Available deployment/karpenter \
-        -n kube-system --timeout=120s 2>/dev/null || true
-      kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=karpenter \
-        -n kube-system --timeout=120s 2>/dev/null || true
-      echo "Karpenter controller ready"
+      if kubectl wait --for=condition=Available deployment/karpenter \
+           -n kube-system --timeout=120s 2>/dev/null && \
+         kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=karpenter \
+           -n kube-system --timeout=120s 2>/dev/null; then
+        echo "Karpenter controller ready"
+      else
+        echo "WARNING: Karpenter controller may not be ready. NodePools might need a re-apply."
+      fi
     WAIT
   }
 }

--- a/terraform/cluster/aws/karpenter_nodepool.tf
+++ b/terraform/cluster/aws/karpenter_nodepool.tf
@@ -234,7 +234,7 @@ resource "kubectl_manifest" "karpenter_nodepool_workload" {
   yaml_body = yamlencode(local.np_workload_manifest)
   wait      = true
 
-  depends_on = [helm_release.karpenter, helm_release.karpenter_crd]
+  depends_on = [null_resource.wait_karpenter_ready, helm_release.karpenter_crd]
 }
 
 ###############################################################################
@@ -247,7 +247,7 @@ resource "kubectl_manifest" "karpenter_ec2nodeclass_workload" {
   wait      = true
 
   depends_on = [
-    helm_release.karpenter,
+    null_resource.wait_karpenter_ready,
     helm_release.karpenter_crd,
     aws_ec2_tag.private_subnets_karpenter,
     aws_ec2_tag.public_subnets_karpenter,
@@ -275,7 +275,7 @@ resource "kubectl_manifest" "karpenter_nodepool_build" {
   })
 
   wait       = true
-  depends_on = [helm_release.karpenter, helm_release.karpenter_crd]
+  depends_on = [null_resource.wait_karpenter_ready, helm_release.karpenter_crd]
 }
 
 resource "kubectl_manifest" "karpenter_ec2nodeclass_build" {
@@ -296,7 +296,7 @@ resource "kubectl_manifest" "karpenter_ec2nodeclass_build" {
   wait = true
 
   depends_on = [
-    helm_release.karpenter,
+    null_resource.wait_karpenter_ready,
     helm_release.karpenter_crd,
     aws_ec2_tag.private_subnets_karpenter,
     aws_ec2_tag.public_subnets_karpenter,
@@ -329,7 +329,7 @@ resource "kubectl_manifest" "karpenter_nodepool_additional" {
   })
 
   wait       = true
-  depends_on = [helm_release.karpenter, helm_release.karpenter_crd]
+  depends_on = [null_resource.wait_karpenter_ready, helm_release.karpenter_crd]
 }
 
 resource "kubectl_manifest" "karpenter_ec2nodeclass_additional" {
@@ -350,7 +350,7 @@ resource "kubectl_manifest" "karpenter_ec2nodeclass_additional" {
   wait = true
 
   depends_on = [
-    helm_release.karpenter,
+    null_resource.wait_karpenter_ready,
     helm_release.karpenter_crd,
     aws_ec2_tag.private_subnets_karpenter,
     aws_ec2_tag.public_subnets_karpenter,

--- a/terraform/cluster/aws/karpenter_nodepool.tf
+++ b/terraform/cluster/aws/karpenter_nodepool.tf
@@ -204,17 +204,23 @@ locals {
       disk                  = tonumber(lookup(np, "disk", 0))
       volume_type           = lookup(np, "volume_type", "gp3")
       weight                = lookup(np, "weight", null) != null ? tonumber(lookup(np, "weight", null)) : null
+      dedicated             = tobool(lookup(np, "dedicated", false))
       labels = {
         for pair in compact(split(",", lookup(np, "labels", ""))) :
         trimspace(split("=", pair)[0]) => trimspace(split("=", pair)[1])
       }
-      taints = [
-        for t in compact(split(",", lookup(np, "taints", ""))) : {
+      taints = concat(
+        tobool(lookup(np, "dedicated", false)) ? [{
+          key    = "dedicated-node"
+          value  = lookup(np, "name", "custom-${idx}")
+          effect = "NoSchedule"
+        }] : [],
+        [for t in compact(split(",", lookup(np, "taints", ""))) : {
           key    = split("=", split(":", t)[0])[0]
           value  = length(split("=", split(":", t)[0])) > 1 ? split("=", split(":", t)[0])[1] : ""
           effect = element(split(":", t), length(split(":", t)) - 1)
-        }
-      ]
+        }]
+      )
     }
   }
 }

--- a/terraform/cluster/aws/lbc.tf
+++ b/terraform/cluster/aws/lbc.tf
@@ -99,6 +99,7 @@ resource "helm_release" "aws_lbc" {
     content {
       name  = "nodeSelector.convox\\.io/system-node"
       value = "true"
+      type  = "string"
     }
   }
 
@@ -123,6 +124,7 @@ resource "helm_release" "aws_lbc" {
     content {
       name  = "tolerations[0].value"
       value = "true"
+      type  = "string"
     }
   }
 

--- a/terraform/cluster/aws/lbc.tf
+++ b/terraform/cluster/aws/lbc.tf
@@ -93,4 +93,44 @@ resource "helm_release" "aws_lbc" {
     name  = "enableServiceMutatorWebhook"
     value = "false"
   }
+
+  dynamic "set" {
+    for_each = var.karpenter_enabled ? [1] : []
+    content {
+      name  = "nodeSelector.convox\\.io/system-node"
+      value = "true"
+    }
+  }
+
+  dynamic "set" {
+    for_each = var.karpenter_enabled ? [1] : []
+    content {
+      name  = "tolerations[0].key"
+      value = "convox.io/system-node"
+    }
+  }
+
+  dynamic "set" {
+    for_each = var.karpenter_enabled ? [1] : []
+    content {
+      name  = "tolerations[0].operator"
+      value = "Equal"
+    }
+  }
+
+  dynamic "set" {
+    for_each = var.karpenter_enabled ? [1] : []
+    content {
+      name  = "tolerations[0].value"
+      value = "true"
+    }
+  }
+
+  dynamic "set" {
+    for_each = var.karpenter_enabled ? [1] : []
+    content {
+      name  = "tolerations[0].effect"
+      value = "NoSchedule"
+    }
+  }
 }

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -592,13 +592,39 @@ resource "aws_eks_addon" "aws_ebs_csi_driver" {
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "OVERWRITE"
 
-  configuration_values = jsonencode({
-    sidecars = {
-      snapshotter = {
-        forceEnable = false
+  configuration_values = jsonencode(merge(
+    {
+      sidecars = {
+        snapshotter = {
+          forceEnable = false
+        }
       }
-    }
-  })
+    },
+    var.karpenter_enabled ? {
+      controller = {
+        nodeSelector = {
+          "convox.io/system-node" = "true"
+        }
+        tolerations = [
+          {
+            key      = "CriticalAddonsOnly"
+            operator = "Exists"
+          },
+          {
+            operator          = "Exists"
+            effect            = "NoExecute"
+            tolerationSeconds = 300
+          },
+          {
+            key      = "convox.io/system-node"
+            operator = "Equal"
+            value    = "true"
+            effect   = "NoSchedule"
+          },
+        ]
+      }
+    } : {}
+  ))
 }
 
 resource "null_resource" "wait_eks_addons" {

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -548,6 +548,20 @@ resource "aws_eks_addon" "coredns" {
   addon_version               = var.coredns_version
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "OVERWRITE"
+
+  configuration_values = var.karpenter_enabled ? jsonencode({
+    nodeSelector = {
+      "convox.io/system-node" = "true"
+    }
+    tolerations = [
+      {
+        key      = "convox.io/system-node"
+        operator = "Equal"
+        value    = "true"
+        effect   = "NoSchedule"
+      }
+    ]
+  }) : null
 }
 
 resource "aws_eks_addon" "kube_proxy" {

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -182,7 +182,7 @@ resource "aws_eks_node_group" "cluster" {
 
   launch_template {
     id      = aws_launch_template.cluster.id
-    version = "$Latest"
+    version = aws_launch_template.cluster.latest_version
   }
 
   # System nodes remain in all AZs regardless of Karpenter state.
@@ -262,7 +262,7 @@ resource "aws_eks_node_group" "cluster-build" {
 
   launch_template {
     id      = aws_launch_template.cluster-build.id
-    version = "$Latest"
+    version = aws_launch_template.cluster-build.latest_version
   }
 
   scaling_config {

--- a/terraform/cluster/aws/node_groups.tf
+++ b/terraform/cluster/aws/node_groups.tf
@@ -67,10 +67,20 @@ resource "random_id" "additional_node_groups" {
   }
 }
 
-module "amitype" {
-  source    = "../../helpers/aws"
-  for_each  = { for ng in local.additional_node_groups_with_defaults : ng.id => ng }
-  node_type = each.value.type
+data "aws_ec2_instance_type" "additional_node_type" {
+  for_each      = { for ng in local.additional_node_groups_with_defaults : ng.id => ng }
+  instance_type = each.value.type
+}
+
+locals {
+  additional_node_ami_type = {
+    for key, inst in data.aws_ec2_instance_type.additional_node_type : key => (
+      (substr(inst.instance_type, 0, 1) == "g" || substr(inst.instance_type, 0, 1) == "p" ||
+        substr(inst.instance_type, 0, 3) == "inf" || substr(inst.instance_type, 0, 3) == "trn")
+      ? "AL2023_x86_64_NVIDIA"
+      : contains(inst.supported_architectures, "arm64") ? "AL2023_ARM_64_STANDARD" : "AL2023_x86_64_STANDARD"
+    )
+  }
 }
 
 resource "aws_eks_node_group" "cluster_additional" {
@@ -81,7 +91,7 @@ resource "aws_eks_node_group" "cluster_additional" {
 
   for_each = { for ng in local.additional_node_groups_with_defaults : ng.id => ng }
 
-  ami_type        = random_id.additional_node_groups[each.key].keepers.ami_id != null ? "CUSTOM" : module.amitype[each.key].ami_type
+  ami_type        = random_id.additional_node_groups[each.key].keepers.ami_id != null ? "CUSTOM" : local.additional_node_ami_type[each.key]
   capacity_type   = random_id.additional_node_groups[each.key].keepers.node_capacity_type
   cluster_name    = aws_eks_cluster.cluster.name
   node_group_name = "${var.name}-additional-${each.key}-${random_id.additional_node_groups[each.key].hex}"
@@ -109,8 +119,7 @@ resource "aws_eks_node_group" "cluster_additional" {
   }
 
   lifecycle {
-    create_before_destroy = true
-    ignore_changes        = [scaling_config[0].desired_size]
+    ignore_changes = [scaling_config[0].desired_size]
   }
 
   labels = {
@@ -211,12 +220,21 @@ resource "random_id" "build_node_additional" {
   }
 }
 
-module "build_amitype" {
-  source    = "../../helpers/aws"
-  for_each  = { for ng in local.additional_build_groups_with_defaults : ng.id => ng }
-  node_type = each.value.type
+data "aws_ec2_instance_type" "build_node_type" {
+  for_each      = { for ng in local.additional_build_groups_with_defaults : ng.id => ng }
+  instance_type = each.value.type
 }
 
+locals {
+  build_node_ami_type = {
+    for key, inst in data.aws_ec2_instance_type.build_node_type : key => (
+      (substr(inst.instance_type, 0, 1) == "g" || substr(inst.instance_type, 0, 1) == "p" ||
+        substr(inst.instance_type, 0, 3) == "inf" || substr(inst.instance_type, 0, 3) == "trn")
+      ? "AL2023_x86_64_NVIDIA"
+      : contains(inst.supported_architectures, "arm64") ? "AL2023_ARM_64_STANDARD" : "AL2023_x86_64_STANDARD"
+    )
+  }
+}
 
 resource "aws_eks_node_group" "build_additional" {
   depends_on = [
@@ -226,7 +244,7 @@ resource "aws_eks_node_group" "build_additional" {
 
   for_each = { for idx, ng in local.additional_build_groups_with_defaults : ng.id => ng }
 
-  ami_type        = random_id.build_node_additional[each.key].keepers.ami_id != null ? "CUSTOM" : module.build_amitype[each.key].ami_type
+  ami_type        = random_id.build_node_additional[each.key].keepers.ami_id != null ? "CUSTOM" : local.build_node_ami_type[each.key]
   capacity_type   = random_id.build_node_additional[each.key].keepers.capacity_type != null ? random_id.build_node_additional[each.key].keepers.capacity_type : "ON_DEMAND"
   cluster_name    = aws_eks_cluster.cluster.name
   node_group_name = "${var.name}-build-additional-${each.key}-${random_id.build_node_additional[each.key].hex}"
@@ -263,9 +281,6 @@ resource "aws_eks_node_group" "build_additional" {
     create = "1h"
   }
 
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 resource "aws_launch_template" "build_additional" {

--- a/terraform/cluster/aws/node_groups.tf
+++ b/terraform/cluster/aws/node_groups.tf
@@ -102,7 +102,7 @@ resource "aws_eks_node_group" "cluster_additional" {
 
   launch_template {
     id      = aws_launch_template.cluster_additional[each.key].id
-    version = "$Latest"
+    version = aws_launch_template.cluster_additional[each.key].latest_version
   }
 
   scaling_config {
@@ -266,7 +266,7 @@ resource "aws_eks_node_group" "build_additional" {
 
   launch_template {
     id      = aws_launch_template.build_additional[each.key].id
-    version = "$Latest"
+    version = aws_launch_template.build_additional[each.key].latest_version
   }
 
   scaling_config {


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: `convox rack karpenter cleanup` Command and CLI Parameter Validation**

Two major CLI improvements shipped as direct commits in the 3.24.3 combined release.

**1. `convox rack karpenter cleanup`**

New command for cleaning up orphaned Karpenter nodes after disabling Karpenter. On AWS, the command terminates EC2 instances, cordons and drains Kubernetes nodes (respecting PodDisruptionBudgets with a 5-minute timeout), strips Karpenter finalizers, and deletes stale NodePool/NodeClaim/EC2NodeClass CRD objects. Safe to run multiple times.

**2. CLI parameter validation for `convox rack params set`**

The CLI now validates parameters before sending them to the Rack, catching common errors before they reach Terraform:

| Validation | Behavior |
|-----------|----------|
| Unknown parameters | Rejected with fuzzy "Did you mean...?" suggestion |
| Managed parameters (`image`, `release`, `k8s_version`, addon versions) | Blocked — use `convox rack update` instead |
| Install-only parameters (`high_availability`, `private`, `cidr`, `vpc_id`, `region`, etc.) | Blocked after rack creation |
| Empty values on non-clearable params | Rejected with guidance |
| Type-specific validation | `imds_http_tokens` (optional/required), `node_capacity_type` (on_demand/spot/mixed), `karpenter_auth_mode` (true/false), etc. |
| V2 racks | Auto-detected and bypassed (no behavior change) |

A new `--force` (`-f`) flag overrides the unknown-key and managed-parameter guards.

**3. Additional improvements**

- `convox rack params` now displays `additional_karpenter_nodepools_config` and `karpenter_config` as human-readable JSON instead of base64
- Karpenter controller readiness gate prevents NodePools from silently disappearing during initial enable
- Fixed spurious EKS node group rolling updates caused by `$Latest` launch template version string
- Fixed LBC Helm value types for nodeSelector and toleration when Karpenter is enabled

---

### Why is this important?

After disabling Karpenter, orphaned nodes could remain in the cluster if the controller was already removed — there was no native way to clean them up without manual `kubectl` operations. The cleanup command provides a safe, automated solution.

Parameter validation prevents a class of frustrating errors where a typo in a parameter name would pass through the CLI, get sent to Terraform, and fail during apply — often leaving the rack in an updating state for 10+ minutes before the error surfaced.

**Benefits:**

- **Safe Karpenter disable.** The cleanup command handles the entire teardown sequence — EC2 termination, node draining, finalizer removal, CRD cleanup — in one idempotent command.
- **Typo protection.** A misspelled parameter is caught immediately with a helpful suggestion, not 10 minutes later in a Terraform error.
- **Guard rails.** Install-only parameters and managed parameters are protected from accidental modification.
- **Human-readable configs.** Karpenter JSON configurations are displayed in readable form instead of base64.

---

### How to use it?

**Clean up orphaned Karpenter nodes:**

```bash
$ convox rack karpenter cleanup -r rackName
Cleaning up Karpenter nodes... OK
```

**Parameter validation in action:**

```bash
$ convox rack params set node_tyep=t3.large -r rackName
unknown parameter 'node_tyep' for aws provider
       Did you mean 'node_type'?
       Run 'sudo convox update' to get the latest parameter support, or use --force to override.
```

**Override guards when needed:**

```bash
$ convox rack params set some_param=value --force -r rackName
```

---

### Does it have a breaking change?

**No breaking changes** are introduced with these features.

- The parameter validation only affects `convox rack params set` — parameters that were valid before remain valid
- The `--force` flag provides an escape hatch for edge cases
- V2 racks are auto-detected and skip all validation
- The cleanup command is opt-in and only runs when explicitly invoked

---

### Requirements

These features require version `3.24.3` or later for the rack.

**Update the Rack:** Run `convox rack update 3.24.3 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.23.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
