### PR TITLE
Add dedicated flag to additional Karpenter pools

### DIFF
--- a/docs/configuration/scaling/karpenter.md
+++ b/docs/configuration/scaling/karpenter.md
@@ -239,6 +239,7 @@ Use this for dedicated GPU pools, tenant isolation, specialized instance require
 | `weight` | integer | _(unset)_ | no | Scheduling weight (0-100). Higher = preferred. |
 | `labels` | string | _(none)_ | no | Comma-separated `key=value`. `convox.io/nodepool` is reserved. |
 | `taints` | string | _(none)_ | no | Comma-separated `key=value:Effect`. Valid effects: `NoSchedule`, `PreferNoSchedule`, `NoExecute`. Prevents pods without matching tolerations from scheduling on these nodes. See [Using Taints to Protect Nodes](#using-taints-to-protect-nodes) below. |
+| `dedicated` | bool | `false` | no | When `true`, adds a `dedicated-node={name}:NoSchedule` taint automatically. Services with `nodeSelectorLabels: { convox.io/nodepool: {name} }` get the matching toleration injected. Simpler alternative to manual `taints` for pool isolation. |
 
 Every custom pool automatically gets a `convox.io/nodepool={name}` label. Target Services to a custom pool using `nodeSelectorLabels` in `convox.yml`:
 
@@ -250,7 +251,29 @@ services:
       convox.io/nodepool: gpu
 ```
 
-**Example: GPU pool and high-memory pool**
+**Example: Dedicated GPU pool (simple path)**
+
+```bash
+$ convox rack params set additional_karpenter_nodepools_config='[{"name":"gpu","instance_families":"g5,g6","dedicated":true}]' -r rackName
+Setting parameters... OK
+```
+
+```yaml
+# convox.yml
+services:
+  gpu-worker:
+    build: .
+    scale:
+      gpu:
+        count: 1
+        vendor: nvidia
+    nodeSelectorLabels:
+      convox.io/nodepool: gpu
+```
+
+With `dedicated: true`, only services targeting this pool (via `nodeSelectorLabels`) can schedule on it. No manual taint configuration needed. `convox run gpu-worker` also inherits the placement automatically.
+
+**Example: GPU pool and high-memory pool (advanced)**
 
 ```bash
 $ convox rack params set additional_karpenter_nodepools_config='[{"name":"gpu","instance_families":"g5,g6","capacity_types":"on-demand","cpu_limit":64,"memory_limit_gb":256,"taints":"nvidia.com/gpu=true:NoSchedule","disk":200},{"name":"high-mem","instance_families":"r5,r6i","instance_sizes":"xlarge,2xlarge,4xlarge","capacity_types":"on-demand,spot","cpu_limit":200,"memory_limit_gb":1600,"labels":"pool=high-mem"}]' -r rackName
@@ -288,9 +311,13 @@ $ convox rack params set nvidia_device_plugin_enable=true -r rackName
 Setting parameters... OK
 ```
 
-#### Non-GPU taints
+#### Dedicated pools
 
-For non-GPU custom taints (e.g., tenant isolation), Convox does not currently auto-inject tolerations. Pods targeting pools with non-GPU taints will need tolerations added through an external mechanism such as a Kubernetes mutating admission webhook. For most non-GPU use cases, using `labels` + `nodeSelectorLabels` without taints is the recommended approach — Karpenter only provisions nodes for pods that need them, so unwanted pods won't cause unnecessary GPU-class nodes to spin up.
+The simplest way to isolate a pool is `dedicated: true`. This auto-applies a `dedicated-node={name}:NoSchedule` taint and Convox auto-injects the matching toleration for any Service with `nodeSelectorLabels: { convox.io/nodepool: {name} }`. No external webhooks or manual taint configuration needed.
+
+#### Non-GPU custom taints
+
+For custom taints beyond `dedicated` (e.g., tenant isolation with specific taint keys), Convox does not auto-inject tolerations. Pods targeting pools with custom non-GPU taints will need tolerations added through an external mechanism such as a Kubernetes mutating admission webhook. For most non-GPU use cases, using `dedicated: true` or `labels` + `nodeSelectorLabels` without taints is the recommended approach — Karpenter only provisions nodes for pods that need them, so unwanted pods won't cause unnecessary scaling.
 
 #### DaemonSets on tainted nodes
 

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -199,6 +199,7 @@ type KarpenterNodePoolConfigParam struct {
 	VolumeType            *string `json:"volume_type,omitempty"`
 	Labels                *string `json:"labels,omitempty"`
 	Taints                *string `json:"taints,omitempty"`
+	Dedicated             *bool   `json:"dedicated,omitempty"`
 	Weight                *int    `json:"weight,omitempty"`
 }
 

--- a/pkg/cli/rack_karpenter_test.go
+++ b/pkg/cli/rack_karpenter_test.go
@@ -412,6 +412,7 @@ func TestValidateAndMutateParams_KarpenterConfigProtectedFields(t *testing.T) {
 func TestKarpenterNodePoolConfigParam_Validate(t *testing.T) {
 	strPtr := func(s string) *string { return &s }
 	intPtr := func(i int) *int { return &i }
+	boolPtr := func(b bool) *bool { return &b }
 
 	tests := []struct {
 		name    string
@@ -422,6 +423,26 @@ func TestKarpenterNodePoolConfigParam_Validate(t *testing.T) {
 		{
 			"minimal valid",
 			KarpenterNodePoolConfigParam{Name: "test"},
+			false, "",
+		},
+		{
+			"dedicated true valid",
+			KarpenterNodePoolConfigParam{Name: "gpu", Dedicated: boolPtr(true)},
+			false, "",
+		},
+		{
+			"dedicated false valid",
+			KarpenterNodePoolConfigParam{Name: "gpu", Dedicated: boolPtr(false)},
+			false, "",
+		},
+		{
+			"dedicated nil valid",
+			KarpenterNodePoolConfigParam{Name: "gpu"},
+			false, "",
+		},
+		{
+			"dedicated true with taints valid",
+			KarpenterNodePoolConfigParam{Name: "gpu", Dedicated: boolPtr(true), Taints: strPtr("nvidia.com/gpu=true:NoSchedule")},
 			false, "",
 		},
 		{
@@ -1621,6 +1642,123 @@ func TestCheckRackNameRegex(t *testing.T) {
 				if !strings.Contains(err.Error(), tt.errMsg) {
 					t.Errorf("name=%q: error %q does not contain %q", tt.input, err.Error(), tt.errMsg)
 				}
+			}
+		})
+	}
+}
+
+func TestKarpenterNodePoolConfigParam_DedicatedJSONRoundtrip(t *testing.T) {
+	boolPtr := func(b bool) *bool { return &b }
+
+	tests := []struct {
+		name       string
+		input      string
+		wantDedicated *bool
+		wantJSON   string
+	}{
+		{
+			"dedicated true roundtrips",
+			`[{"name":"gpu","dedicated":true}]`,
+			boolPtr(true),
+			`true`,
+		},
+		{
+			"dedicated false roundtrips",
+			`[{"name":"gpu","dedicated":false}]`,
+			boolPtr(false),
+			`false`,
+		},
+		{
+			"dedicated absent stays nil",
+			`[{"name":"gpu"}]`,
+			nil,
+			"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var npCfgs KarpenterNodePools
+			if err := json.Unmarshal([]byte(tt.input), &npCfgs); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if len(npCfgs) != 1 {
+				t.Fatalf("expected 1 pool, got %d", len(npCfgs))
+			}
+
+			got := npCfgs[0].Dedicated
+			if tt.wantDedicated == nil {
+				if got != nil {
+					t.Errorf("expected nil Dedicated, got %v", *got)
+				}
+			} else {
+				if got == nil {
+					t.Fatalf("expected Dedicated=%v, got nil", *tt.wantDedicated)
+				}
+				if *got != *tt.wantDedicated {
+					t.Errorf("expected Dedicated=%v, got %v", *tt.wantDedicated, *got)
+				}
+			}
+
+			data, err := json.Marshal(npCfgs)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+
+			if tt.wantDedicated == nil {
+				if strings.Contains(string(data), `"dedicated"`) {
+					t.Errorf("nil dedicated should be omitted from JSON, got: %s", data)
+				}
+			} else {
+				if !strings.Contains(string(data), `"dedicated":`+tt.wantJSON) {
+					t.Errorf("expected JSON to contain dedicated:%s, got: %s", tt.wantJSON, data)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateAndMutateParams_KarpenterDedicatedNodepools(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  map[string]string
+		wantErr bool
+	}{
+		{
+			"dedicated true passes validation",
+			map[string]string{
+				"additional_karpenter_nodepools_config": `[{"name":"gpu","dedicated":true}]`,
+			},
+			false,
+		},
+		{
+			"dedicated false passes validation",
+			map[string]string{
+				"additional_karpenter_nodepools_config": `[{"name":"gpu","dedicated":false}]`,
+			},
+			false,
+		},
+		{
+			"dedicated absent passes validation",
+			map[string]string{
+				"additional_karpenter_nodepools_config": `[{"name":"gpu"}]`,
+			},
+			false,
+		},
+		{
+			"dedicated true with taints passes validation",
+			map[string]string{
+				"additional_karpenter_nodepools_config": `[{"name":"gpu","dedicated":true,"taints":"nvidia.com/gpu=true:NoSchedule"}]`,
+			},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAndMutateParams(tt.params, "aws", map[string]string{})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("got err=%v, wantErr=%v", err, tt.wantErr)
 			}
 		})
 	}

--- a/provider/k8s/process.go
+++ b/provider/k8s/process.go
@@ -509,6 +509,7 @@ func (p *Provider) podSpecFromService(app, service, release string, isBuild bool
 	})
 
 	serviceAccountName := ""
+	var nodeSelectorLabels map[string]string
 	if !isBuild && release != "" {
 		m, r, err := common.ReleaseManifest(p, app, release)
 		if err != nil {
@@ -577,6 +578,8 @@ func (p *Provider) podSpecFromService(app, service, release string, isBuild bool
 					MountPath: to,
 				})
 			}
+
+			nodeSelectorLabels = s.NodeSelectorLabels
 		}
 
 		for k, v := range env {
@@ -589,6 +592,40 @@ func (p *Provider) podSpecFromService(app, service, release string, isBuild bool
 		Containers:            []ac.Container{c},
 		ShareProcessNamespace: options.Bool(true),
 		Volumes:               vs,
+	}
+
+	if len(nodeSelectorLabels) > 0 {
+		matchExpressions := []ac.NodeSelectorRequirement{}
+		for k, v := range nodeSelectorLabels {
+			matchExpressions = append(matchExpressions, ac.NodeSelectorRequirement{
+				Key:      k,
+				Operator: ac.NodeSelectorOpIn,
+				Values:   []string{v},
+			})
+		}
+		ps.Affinity = &ac.Affinity{
+			NodeAffinity: &ac.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &ac.NodeSelector{
+					NodeSelectorTerms: []ac.NodeSelectorTerm{
+						{MatchExpressions: matchExpressions},
+					},
+				},
+			},
+		}
+
+		for k, v := range nodeSelectorLabels {
+			if k == "convox.io/label" || k == "convox.io/nodepool" {
+				if ps.Tolerations == nil {
+					ps.Tolerations = []ac.Toleration{}
+				}
+				ps.Tolerations = append(ps.Tolerations, ac.Toleration{
+					Key:      "dedicated-node",
+					Operator: ac.TolerationOpEqual,
+					Value:    v,
+					Effect:   ac.TaintEffectNoSchedule,
+				})
+			}
+		}
 	}
 
 	if !isBuild {
@@ -702,6 +739,8 @@ func (p *Provider) podSpecFromRunOptions(app, service string, opts structs.Proce
 	}
 
 	if opts.NodeLabels != nil {
+		s.Affinity = nil
+		s.Tolerations = nil
 		labelStrList := strings.Split(*opts.NodeLabels, ",")
 		for _, lb := range labelStrList {
 			parts := strings.SplitN(lb, "=", 2)

--- a/provider/k8s/process_nodeselector_test.go
+++ b/provider/k8s/process_nodeselector_test.go
@@ -1,0 +1,303 @@
+package k8s
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/convox/convox/pkg/atom"
+	"github.com/convox/convox/pkg/mock"
+	"github.com/convox/convox/pkg/options"
+	"github.com/convox/convox/pkg/structs"
+	ca "github.com/convox/convox/provider/k8s/pkg/apis/convox/v1"
+	cvfake "github.com/convox/convox/provider/k8s/pkg/client/clientset/versioned/fake"
+	"github.com/convox/logger"
+	"github.com/stretchr/testify/require"
+	ac "k8s.io/api/core/v1"
+	am "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	metricfake "k8s.io/metrics/pkg/client/clientset/versioned/fake"
+)
+
+// minimalProvider creates a Provider with fake clients and no informers.
+// Informer-based lookups fall back to direct API calls against the fakes.
+func minimalProvider(t *testing.T) (*Provider, *fake.Clientset, *cvfake.Clientset) {
+	t.Helper()
+	kk := fake.NewSimpleClientset()
+	kc := cvfake.NewSimpleClientset()
+	mc := metricfake.NewSimpleClientset()
+	aa := &atom.MockInterface{}
+	aa.On("Status", "rack1-app1", "app").Return("Running", "rel1", nil)
+
+	p := &Provider{
+		Atom:          aa,
+		Cluster:       kk,
+		Convox:        kc,
+		Engine:        &mock.TestEngine{},
+		MetricsClient: mc,
+		Name:          "rack1",
+		Namespace:     "ns1",
+		Provider:      "test",
+		logger:        logger.New("ns=k8s-test"),
+	}
+
+	return p, kk, kc
+}
+
+func createAppNamespace(t *testing.T, kk *fake.Clientset, rack, app string) {
+	t.Helper()
+	_, err := kk.CoreV1().Namespaces().Create(context.TODO(), &ac.Namespace{
+		ObjectMeta: am.ObjectMeta{
+			Name:        rack + "-" + app,
+			Annotations: map[string]string{"convox.com/lock": "false"},
+			Labels: map[string]string{
+				"app":    app,
+				"name":   app,
+				"rack":   rack,
+				"system": "convox",
+				"type":   "app",
+			},
+		},
+	}, am.CreateOptions{})
+	require.NoError(t, err)
+}
+
+func createBuild(t *testing.T, kc *cvfake.Clientset, ns, id string) {
+	t.Helper()
+	_, err := kc.ConvoxV1().Builds(ns).Create(&ca.Build{
+		ObjectMeta: am.ObjectMeta{
+			Name:   id,
+			Labels: map[string]string{"app": "app1"},
+		},
+		Spec: ca.BuildSpec{
+			Description: "test build",
+			Started:     "20200101.000000.000000000",
+			Ended:       "20200101.000000.000000000",
+			Manifest:    "services:\n  web:\n    build: .\n",
+		},
+	})
+	require.NoError(t, err)
+}
+
+func createRelease(t *testing.T, kc *cvfake.Clientset, ns, id, manifest string) {
+	t.Helper()
+	_, err := kc.ConvoxV1().Releases(ns).Create(&ca.Release{
+		ObjectMeta: am.ObjectMeta{Name: id},
+		Spec: ca.ReleaseSpec{
+			Build:    "build1",
+			Created:  "20200101.000000.000000000",
+			Manifest: manifest,
+		},
+	})
+	require.NoError(t, err)
+}
+
+// runAndGetPodSpec calls ProcessRun then retrieves the pod from the fake clientset.
+func runAndGetPodSpec(t *testing.T, p *Provider, kk *fake.Clientset, app, service string, opts structs.ProcessRunOptions) *ac.PodSpec {
+	t.Helper()
+	ps, err := p.ProcessRun(app, service, opts)
+	require.NoError(t, err)
+	require.NotNil(t, ps)
+
+	pod, err := kk.CoreV1().Pods(p.AppNamespace(app)).Get(context.TODO(), ps.Id, am.GetOptions{})
+	require.NoError(t, err)
+	return &pod.Spec
+}
+
+const manifestWithNodeSelectors = `services:
+  web:
+    build: .
+    port: 5000
+  gpu-worker:
+    build: .
+    nodeSelectorLabels:
+      convox.io/nodepool: gpu
+  labeled-worker:
+    build: .
+    nodeSelectorLabels:
+      convox.io/label: special
+  custom-label-worker:
+    build: .
+    nodeSelectorLabels:
+      team: ml
+`
+
+func TestProcessRun_InheritsNodeSelectorLabelsAffinity(t *testing.T) {
+	p, kk, kc := minimalProvider(t)
+	createAppNamespace(t, kk, "rack1", "app1")
+	createBuild(t, kc, "rack1-app1", "build1")
+	createRelease(t, kc, "rack1-app1", "rel1", manifestWithNodeSelectors)
+
+	spec := runAndGetPodSpec(t, p, kk, "app1", "gpu-worker", structs.ProcessRunOptions{
+		Release: options.String("rel1"),
+	})
+
+	// Should have required node affinity for convox.io/nodepool=gpu
+	require.NotNil(t, spec.Affinity, "expected Affinity to be set")
+	require.NotNil(t, spec.Affinity.NodeAffinity)
+	req := spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	require.NotNil(t, req)
+	require.Len(t, req.NodeSelectorTerms, 1)
+	require.Len(t, req.NodeSelectorTerms[0].MatchExpressions, 1)
+	require.Equal(t, "convox.io/nodepool", req.NodeSelectorTerms[0].MatchExpressions[0].Key)
+	require.Equal(t, ac.NodeSelectorOpIn, req.NodeSelectorTerms[0].MatchExpressions[0].Operator)
+	require.Equal(t, []string{"gpu"}, req.NodeSelectorTerms[0].MatchExpressions[0].Values)
+
+	// Should have dedicated-node toleration (Equal operator, exact value)
+	require.Len(t, spec.Tolerations, 1)
+	require.Equal(t, "dedicated-node", spec.Tolerations[0].Key)
+	require.Equal(t, ac.TolerationOpEqual, spec.Tolerations[0].Operator)
+	require.Equal(t, "gpu", spec.Tolerations[0].Value)
+	require.Equal(t, ac.TaintEffectNoSchedule, spec.Tolerations[0].Effect)
+}
+
+func TestProcessRun_InheritsConvoxLabelToleration(t *testing.T) {
+	p, kk, kc := minimalProvider(t)
+	createAppNamespace(t, kk, "rack1", "app1")
+	createBuild(t, kc, "rack1-app1", "build1")
+	createRelease(t, kc, "rack1-app1", "rel1", manifestWithNodeSelectors)
+
+	spec := runAndGetPodSpec(t, p, kk, "app1", "labeled-worker", structs.ProcessRunOptions{
+		Release: options.String("rel1"),
+	})
+
+	// convox.io/label should also trigger the dedicated-node toleration
+	require.NotNil(t, spec.Affinity)
+	require.Len(t, spec.Tolerations, 1)
+	require.Equal(t, "dedicated-node", spec.Tolerations[0].Key)
+	require.Equal(t, ac.TolerationOpEqual, spec.Tolerations[0].Operator)
+	require.Equal(t, "special", spec.Tolerations[0].Value)
+}
+
+func TestProcessRun_CustomLabelGetsAffinityButNoToleration(t *testing.T) {
+	p, kk, kc := minimalProvider(t)
+	createAppNamespace(t, kk, "rack1", "app1")
+	createBuild(t, kc, "rack1-app1", "build1")
+	createRelease(t, kc, "rack1-app1", "rel1", manifestWithNodeSelectors)
+
+	spec := runAndGetPodSpec(t, p, kk, "app1", "custom-label-worker", structs.ProcessRunOptions{
+		Release: options.String("rel1"),
+	})
+
+	// Custom labels should get affinity
+	require.NotNil(t, spec.Affinity)
+	require.NotNil(t, spec.Affinity.NodeAffinity)
+	terms := spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	require.Len(t, terms, 1)
+	require.Equal(t, "team", terms[0].MatchExpressions[0].Key)
+	require.Equal(t, []string{"ml"}, terms[0].MatchExpressions[0].Values)
+
+	// But NOT dedicated-node tolerations (only convox.io/label and convox.io/nodepool trigger those)
+	require.Empty(t, spec.Tolerations)
+}
+
+func TestProcessRun_NoNodeSelectorLabelsNoAffinityNoTolerations(t *testing.T) {
+	p, kk, kc := minimalProvider(t)
+	createAppNamespace(t, kk, "rack1", "app1")
+	createBuild(t, kc, "rack1-app1", "build1")
+	createRelease(t, kc, "rack1-app1", "rel1", manifestWithNodeSelectors)
+
+	spec := runAndGetPodSpec(t, p, kk, "app1", "web", structs.ProcessRunOptions{
+		Release: options.String("rel1"),
+	})
+
+	// Service without nodeSelectorLabels: no affinity, no tolerations
+	require.Nil(t, spec.Affinity)
+	require.Empty(t, spec.Tolerations)
+}
+
+func TestProcessRun_NodeLabelsOverridesInheritedAffinity(t *testing.T) {
+	p, kk, kc := minimalProvider(t)
+	createAppNamespace(t, kk, "rack1", "app1")
+	createBuild(t, kc, "rack1-app1", "build1")
+	createRelease(t, kc, "rack1-app1", "rel1", manifestWithNodeSelectors)
+
+	spec := runAndGetPodSpec(t, p, kk, "app1", "gpu-worker", structs.ProcessRunOptions{
+		Release:    options.String("rel1"),
+		NodeLabels: options.String("custom-pool=debug"),
+	})
+
+	// --node-labels should clear inherited affinity and use nodeSelector instead
+	require.Nil(t, spec.Affinity, "explicit --node-labels should clear inherited Affinity")
+	require.Equal(t, map[string]string{"custom-pool": "debug"}, spec.NodeSelector)
+
+	// Should have broad dedicated-node toleration (Exists operator, not Equal)
+	require.Len(t, spec.Tolerations, 1)
+	require.Equal(t, "dedicated-node", spec.Tolerations[0].Key)
+	require.Equal(t, ac.TolerationOpExists, spec.Tolerations[0].Operator)
+	require.Equal(t, ac.TaintEffectNoSchedule, spec.Tolerations[0].Effect)
+}
+
+func TestProcessRun_NodeLabelsOverridesForServiceWithoutNodeSelector(t *testing.T) {
+	p, kk, kc := minimalProvider(t)
+	createAppNamespace(t, kk, "rack1", "app1")
+	createBuild(t, kc, "rack1-app1", "build1")
+	createRelease(t, kc, "rack1-app1", "rel1", manifestWithNodeSelectors)
+
+	spec := runAndGetPodSpec(t, p, kk, "app1", "web", structs.ProcessRunOptions{
+		Release:    options.String("rel1"),
+		NodeLabels: options.String("convox.io/nodepool=other"),
+	})
+
+	// --node-labels on a service without nodeSelectorLabels should still work
+	require.Nil(t, spec.Affinity)
+	require.Equal(t, map[string]string{"convox.io/nodepool": "other"}, spec.NodeSelector)
+	require.Len(t, spec.Tolerations, 1)
+	require.Equal(t, "dedicated-node", spec.Tolerations[0].Key)
+	require.Equal(t, ac.TolerationOpExists, spec.Tolerations[0].Operator)
+}
+
+func TestProcessRun_MultipleNodeSelectorLabels(t *testing.T) {
+	p, kk, kc := minimalProvider(t)
+	createAppNamespace(t, kk, "rack1", "app1")
+	createBuild(t, kc, "rack1-app1", "build1")
+
+	manifest := `services:
+  multi:
+    build: .
+    nodeSelectorLabels:
+      convox.io/nodepool: gpu
+      team: ml
+`
+	createRelease(t, kc, "rack1-app1", "rel1", manifest)
+
+	spec := runAndGetPodSpec(t, p, kk, "app1", "multi", structs.ProcessRunOptions{
+		Release: options.String("rel1"),
+	})
+
+	// Should have affinity with both match expressions
+	require.NotNil(t, spec.Affinity)
+	terms := spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	require.Len(t, terms, 1)
+	require.Len(t, terms[0].MatchExpressions, 2)
+
+	// Sort for deterministic comparison (Go map iteration is non-deterministic)
+	exprs := terms[0].MatchExpressions
+	sort.Slice(exprs, func(i, j int) bool { return exprs[i].Key < exprs[j].Key })
+	require.Equal(t, "convox.io/nodepool", exprs[0].Key)
+	require.Equal(t, []string{"gpu"}, exprs[0].Values)
+	require.Equal(t, "team", exprs[1].Key)
+	require.Equal(t, []string{"ml"}, exprs[1].Values)
+
+	// Only convox.io/nodepool triggers a toleration, not "team"
+	require.Len(t, spec.Tolerations, 1)
+	require.Equal(t, "dedicated-node", spec.Tolerations[0].Key)
+	require.Equal(t, "gpu", spec.Tolerations[0].Value)
+}
+
+func TestProcessRun_BuildIgnoresNodeSelectorLabels(t *testing.T) {
+	p, kk, kc := minimalProvider(t)
+	createAppNamespace(t, kk, "rack1", "app1")
+	createBuild(t, kc, "rack1-app1", "build1")
+	createRelease(t, kc, "rack1-app1", "rel1", manifestWithNodeSelectors)
+
+	spec := runAndGetPodSpec(t, p, kk, "app1", "gpu-worker", structs.ProcessRunOptions{
+		Release: options.String("rel1"),
+		IsBuild: true,
+	})
+
+	// Build pods should NOT inherit nodeSelectorLabels affinity
+	// (the isBuild check in podSpecFromService skips the manifest lookup)
+	require.Nil(t, spec.Affinity)
+	require.Empty(t, spec.Tolerations)
+}

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -115,14 +115,14 @@ spec:
       {{ if .Service.NodeSelectorLabels }}
       {{ $hasTolerations := false }}
       {{ range keyValue .Service.NodeSelectorLabels }}
-        {{ if eq .Key "convox.io/label" }}
+        {{ if or (eq .Key "convox.io/label") (eq .Key "convox.io/nodepool") }}
           {{ $hasTolerations = true }}
         {{ end }}
       {{ end }}
       {{ if $hasTolerations }}
       tolerations:
         {{ range keyValue .Service.NodeSelectorLabels }}
-        {{ if eq .Key "convox.io/label" }}
+        {{ if or (eq .Key "convox.io/label") (eq .Key "convox.io/nodepool") }}
         - key: "dedicated-node"
           operator: "Equal"
           value: "{{.Value}}"

--- a/provider/k8s/template/app/timer.yml.tmpl
+++ b/provider/k8s/template/app/timer.yml.tmpl
@@ -81,14 +81,14 @@ spec:
           {{ if .Service.NodeSelectorLabels }}
           {{ $hasTolerations := false }}
           {{ range keyValue .Service.NodeSelectorLabels }}
-            {{ if eq .Key "convox.io/label" }}
+            {{ if or (eq .Key "convox.io/label") (eq .Key "convox.io/nodepool") }}
               {{ $hasTolerations = true }}
             {{ end }}
           {{ end }}
           {{ if $hasTolerations }}
           tolerations:
             {{ range keyValue .Service.NodeSelectorLabels }}
-            {{ if eq .Key "convox.io/label" }}
+            {{ if or (eq .Key "convox.io/label") (eq .Key "convox.io/nodepool") }}
             - key: "dedicated-node"
               operator: "Equal"
               value: "{{.Value}}"

--- a/terraform/cluster/aws/karpenter_nodepool.tf
+++ b/terraform/cluster/aws/karpenter_nodepool.tf
@@ -204,17 +204,23 @@ locals {
       disk                  = tonumber(lookup(np, "disk", 0))
       volume_type           = lookup(np, "volume_type", "gp3")
       weight                = lookup(np, "weight", null) != null ? tonumber(lookup(np, "weight", null)) : null
+      dedicated             = tobool(lookup(np, "dedicated", false))
       labels = {
         for pair in compact(split(",", lookup(np, "labels", ""))) :
         trimspace(split("=", pair)[0]) => trimspace(split("=", pair)[1])
       }
-      taints = [
-        for t in compact(split(",", lookup(np, "taints", ""))) : {
+      taints = concat(
+        tobool(lookup(np, "dedicated", false)) ? [{
+          key    = "dedicated-node"
+          value  = lookup(np, "name", "custom-${idx}")
+          effect = "NoSchedule"
+        }] : [],
+        [for t in compact(split(",", lookup(np, "taints", ""))) : {
           key    = split("=", split(":", t)[0])[0]
           value  = length(split("=", split(":", t)[0])) > 1 ? split("=", split(":", t)[0])[1] : ""
           effect = element(split(":", t), length(split(":", t)) - 1)
-        }
-      ]
+        }]
+      )
     }
   }
 }


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: Dedicated Karpenter Pool Isolation and Automatic Node Placement for `convox run`**

Two related features that simplify workload placement on custom Karpenter node pools.

**1. `dedicated` field for pool isolation**

A new `dedicated` boolean field on `additional_karpenter_nodepools_config` entries. When `true`, a `dedicated-node={name}:NoSchedule` taint is automatically applied to the pool's nodes, and Convox auto-injects the matching toleration for any Service or Timer targeting the pool via `nodeSelectorLabels`. This eliminates the need for manual taint configuration or external admission webhooks for pool isolation.

| Field | Type | Default | Description |
|-------|------|---------|-------------|
| `dedicated` | bool | `false` | When `true`, adds a `dedicated-node={name}:NoSchedule` taint and auto-injects matching tolerations for Services targeting the pool |

**2. Automatic node placement for `convox run`**

`convox run` now auto-inherits `nodeSelectorLabels` from the service's `convox.yml` manifest. One-off processes target the same nodes as their deployed Service without requiring `--node-labels`. Use `--node-labels` to override or `--node-labels=""` to clear inherited placement. Build pods are excluded from inheritance.

**Toleration auto-injection extended to `convox.io/nodepool`**

Previously, only `convox.io/label` triggered `dedicated-node` toleration injection. Now `convox.io/nodepool` also triggers it — affecting deployed Services, Timer workloads, and `convox run` processes.

---

### Why is this important?

Before this change, isolating a custom Karpenter pool required manually configuring taints and setting up an external Kubernetes mutating admission webhook to inject tolerations — Convox had no native toleration support for non-GPU taints. This was a significant barrier for users wanting simple pool isolation (e.g., dedicated GPU pools, tenant isolation).

**Benefits:**

- **One-field pool isolation.** Set `dedicated: true` on a pool and Convox handles both the taint and toleration. No webhooks, no manual taint configuration.
- **`convox run` lands on the right nodes.** Running `convox run gpu-worker bash` now targets the same GPU pool as the deployed service, without needing `--node-labels`.
- **Debugging flexibility.** Use `--node-labels ""` to temporarily run a service on general nodes for debugging, or `--node-labels "custom=value"` to target a different pool.
- **Timers included.** Cron-scheduled Timer workloads targeting pools via `nodeSelectorLabels` also get the correct tolerations.

---

### How to use it?

**Dedicated pool setup:**

```bash
$ convox rack params set additional_karpenter_nodepools_config='[{"name":"gpu","instance_families":"g5,g6","dedicated":true}]' -r rackName
Setting parameters... OK
```

**Target services to the pool in `convox.yml`:**

```yaml
services:
  gpu-worker:
    build: .
    scale:
      gpu:
        count: 1
        vendor: nvidia
    nodeSelectorLabels:
      convox.io/nodepool: gpu
```

**Run one-off processes (automatic placement):**

```bash
$ convox run gpu-worker bash
```

**Override placement for debugging:**

```bash
$ convox run gpu-worker bash --node-labels ""
```

#### New Pool Configuration Field

| Field | Type | Default | Description |
|-------|------|---------|-------------|
| `dedicated` | bool | `false` | Auto-generates `dedicated-node={name}:NoSchedule` taint on pool nodes and injects matching toleration for targeting Services |

---

### Does it have a breaking change?

**No breaking changes** are introduced with this feature.

- `dedicated` defaults to `false` — existing pool configurations are unchanged
- The `*bool` type with `omitempty` means older CLI versions ignore the unknown JSON field
- Terraform `lookup` with default means older rack versions ignore the unknown key
- `convox run` automatic placement only activates for services that have `nodeSelectorLabels` configured — services without it see no behavior change
- `--node-labels` flag still works as before and overrides inherited placement

---

### Requirements

This feature requires version `3.24.3` or later for the rack.

**Update the Rack:** Run `convox rack update 3.24.3 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.23.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
