### PR TITLE
feat: implement InstanceTerminate for k8s provider

### DIFF
--- a/provider/aws/instance.go
+++ b/provider/aws/instance.go
@@ -2,11 +2,16 @@ package aws
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/convox/convox/pkg/options"
 	"github.com/convox/convox/pkg/structs"
+	"github.com/pkg/errors"
+	ae "k8s.io/apimachinery/pkg/api/errors"
+	am "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func (p *Provider) InstanceKeyroll() (*structs.KeyPair, error) {
@@ -23,6 +28,47 @@ func (p *Provider) InstanceKeyroll() (*structs.KeyPair, error) {
 		Name:       &key,
 		PrivateKey: res.KeyMaterial,
 	}, nil
+}
+
+func (p *Provider) InstanceTerminate(id string) error {
+	ctx := p.Provider.Context()
+
+	node, err := p.Cluster.CoreV1().Nodes().Get(ctx, id, am.GetOptions{})
+	if err != nil {
+		if ae.IsNotFound(err) {
+			return errors.WithStack(structs.ErrNotFound("instance not found: %s", id))
+		}
+		return errors.WithStack(err)
+	}
+
+	instanceID := parseInstanceID(node.Spec.ProviderID)
+
+	if err := p.Provider.InstanceTerminate(id); err != nil {
+		return err
+	}
+
+	if instanceID != "" {
+		_, err := p.Ec2.TerminateInstances(&ec2.TerminateInstancesInput{
+			InstanceIds: []*string{aws.String(instanceID)},
+		})
+		if err != nil {
+			return errors.WithStack(fmt.Errorf("failed to terminate EC2 instance %s: %s", instanceID, err))
+		}
+	}
+
+	return nil
+}
+
+func parseInstanceID(providerID string) string {
+	if !strings.HasPrefix(providerID, "aws://") {
+		return ""
+	}
+	parts := strings.Split(strings.TrimPrefix(providerID, "aws://"), "/")
+	instanceID := parts[len(parts)-1]
+	if !strings.HasPrefix(instanceID, "i-") {
+		return ""
+	}
+	return instanceID
 }
 
 func (p *Provider) GPUIntanceList(instanceTypes []string) ([]string, error) {

--- a/provider/aws/instance_internal_test.go
+++ b/provider/aws/instance_internal_test.go
@@ -1,0 +1,53 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseInstanceID(t *testing.T) {
+	tests := []struct {
+		name       string
+		providerID string
+		expected   string
+	}{
+		{
+			name:       "valid AWS provider ID",
+			providerID: "aws:///us-east-1a/i-0123456789abcdef0",
+			expected:   "i-0123456789abcdef0",
+		},
+		{
+			name:       "empty string",
+			providerID: "",
+			expected:   "",
+		},
+		{
+			name:       "non-AWS provider ID",
+			providerID: "gce://my-project/us-central1-a/my-node",
+			expected:   "",
+		},
+		{
+			name:       "AWS prefix but no instance ID",
+			providerID: "aws:///us-east-1a/vol-abc123",
+			expected:   "",
+		},
+		{
+			name:       "AWS prefix with trailing slash",
+			providerID: "aws:///us-east-1a/",
+			expected:   "",
+		},
+		{
+			name:       "Azure provider ID",
+			providerID: "azure:///subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm",
+			expected:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseInstanceID(tt.providerID)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/provider/k8s/instance.go
+++ b/provider/k8s/instance.go
@@ -5,12 +5,16 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/convox/convox/pkg/structs"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 	ac "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	ae "k8s.io/apimachinery/pkg/api/errors"
 	am "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	metricsv1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 )
 
@@ -185,5 +189,132 @@ func (p *Provider) InstanceShell(id string, rw io.ReadWriter, opts structs.Insta
 }
 
 func (p *Provider) InstanceTerminate(id string) error {
-	return errors.WithStack(structs.ErrNotImplemented("unimplemented"))
+	ctx := context.TODO()
+
+	node, err := p.Cluster.CoreV1().Nodes().Get(ctx, id, am.GetOptions{})
+	if err != nil {
+		if ae.IsNotFound(err) {
+			return errors.WithStack(structs.ErrNotFound("instance not found: %s", id))
+		}
+		return errors.WithStack(err)
+	}
+
+	// cordon the node (mark unschedulable)
+	if !node.Spec.Unschedulable {
+		patch := []byte(`{"spec":{"unschedulable":true}}`)
+		if _, err := p.Cluster.CoreV1().Nodes().Patch(ctx, id, types.StrategicMergePatchType, patch, am.PatchOptions{}); err != nil {
+			return errors.WithStack(fmt.Errorf("failed to cordon node %s: %w", id, err))
+		}
+	}
+
+	nodeReady := isNodeReady(node)
+
+	// evict or force-delete pods on the node
+	if err := p.drainNode(ctx, id, nodeReady); err != nil {
+		return errors.WithStack(fmt.Errorf("failed to drain node %s: %w", id, err))
+	}
+
+	// delete the node object
+	if err := p.Cluster.CoreV1().Nodes().Delete(ctx, id, am.DeleteOptions{}); err != nil {
+		if !ae.IsNotFound(err) {
+			return errors.WithStack(fmt.Errorf("failed to delete node %s: %w", id, err))
+		}
+	}
+
+	return nil
+}
+
+func isNodeReady(node *ac.Node) bool {
+	for _, c := range node.Status.Conditions {
+		if c.Type == ac.NodeReady {
+			return c.Status == ac.ConditionTrue
+		}
+	}
+	return false
+}
+
+func (p *Provider) drainNode(ctx context.Context, nodeName string, nodeReady bool) error {
+	pods, err := p.Cluster.CoreV1().Pods("").List(ctx, am.ListOptions{
+		FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
+	})
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+
+		// skip mirror pods (managed by kubelet directly)
+		if _, isMirror := pod.Annotations[ac.MirrorPodAnnotationKey]; isMirror {
+			continue
+		}
+
+		// skip DaemonSet-managed pods — they're expected on every node
+		if isDaemonSetPod(pod) {
+			continue
+		}
+
+		if nodeReady {
+			if err := p.evictPod(ctx, pod); err != nil {
+				return err
+			}
+		} else {
+			// on NotReady nodes the kubelet can't process evictions, force-delete
+			if err := p.forceDeletePod(ctx, pod); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func isDaemonSetPod(pod *ac.Pod) bool {
+	for _, ref := range pod.OwnerReferences {
+		if ref.Kind == "DaemonSet" {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *Provider) evictPod(ctx context.Context, pod *ac.Pod) error {
+	eviction := &policyv1.Eviction{
+		ObjectMeta: am.ObjectMeta{
+			Name:      pod.Name,
+			Namespace: pod.Namespace,
+		},
+	}
+
+	err := p.Cluster.CoreV1().Pods(pod.Namespace).EvictV1(ctx, eviction)
+	if err != nil {
+		if ae.IsNotFound(err) {
+			return nil
+		}
+		// if eviction fails (e.g. PDB blocks it), fall back to force-delete
+		return p.forceDeletePod(ctx, pod)
+	}
+
+	// wait up to 30 seconds for the pod to be removed
+	for i := 0; i < 30; i++ {
+		_, err := p.Cluster.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, am.GetOptions{})
+		if ae.IsNotFound(err) {
+			return nil
+		}
+		time.Sleep(1 * time.Second)
+	}
+
+	// pod still exists after timeout, force-delete it
+	return p.forceDeletePod(ctx, pod)
+}
+
+func (p *Provider) forceDeletePod(ctx context.Context, pod *ac.Pod) error {
+	grace := int64(0)
+	err := p.Cluster.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, am.DeleteOptions{
+		GracePeriodSeconds: &grace,
+	})
+	if err != nil && !ae.IsNotFound(err) {
+		return errors.WithStack(fmt.Errorf("failed to force-delete pod %s/%s: %w", pod.Namespace, pod.Name, err))
+	}
+	return nil
 }

--- a/provider/k8s/instance.go
+++ b/provider/k8s/instance.go
@@ -188,6 +188,11 @@ func (p *Provider) InstanceShell(id string, rw io.ReadWriter, opts structs.Insta
 	return code, nil
 }
 
+const (
+	drainTimeout          = 5 * time.Minute
+	evictionRetryInterval = 5 * time.Second
+)
+
 func (p *Provider) InstanceTerminate(id string) error {
 	ctx := context.TODO()
 
@@ -203,21 +208,19 @@ func (p *Provider) InstanceTerminate(id string) error {
 	if !node.Spec.Unschedulable {
 		patch := []byte(`{"spec":{"unschedulable":true}}`)
 		if _, err := p.Cluster.CoreV1().Nodes().Patch(ctx, id, types.StrategicMergePatchType, patch, am.PatchOptions{}); err != nil {
-			return errors.WithStack(fmt.Errorf("failed to cordon node %s: %w", id, err))
+			return errors.WithStack(fmt.Errorf("failed to cordon node %s: %s", id, err))
 		}
 	}
 
 	nodeReady := isNodeReady(node)
 
-	// evict or force-delete pods on the node
 	if err := p.drainNode(ctx, id, nodeReady); err != nil {
-		return errors.WithStack(fmt.Errorf("failed to drain node %s: %w", id, err))
+		return errors.WithStack(fmt.Errorf("failed to drain node %s: %s", id, err))
 	}
 
-	// delete the node object
 	if err := p.Cluster.CoreV1().Nodes().Delete(ctx, id, am.DeleteOptions{}); err != nil {
 		if !ae.IsNotFound(err) {
-			return errors.WithStack(fmt.Errorf("failed to delete node %s: %w", id, err))
+			return errors.WithStack(fmt.Errorf("failed to delete node %s: %s", id, err))
 		}
 	}
 
@@ -241,6 +244,8 @@ func (p *Provider) drainNode(ctx context.Context, nodeName string, nodeReady boo
 		return errors.WithStack(err)
 	}
 
+	deadline := time.Now().Add(drainTimeout)
+
 	for i := range pods.Items {
 		pod := &pods.Items[i]
 
@@ -249,17 +254,17 @@ func (p *Provider) drainNode(ctx context.Context, nodeName string, nodeReady boo
 			continue
 		}
 
-		// skip DaemonSet-managed pods — they're expected on every node
+		// skip DaemonSet-managed pods
 		if isDaemonSetPod(pod) {
 			continue
 		}
 
 		if nodeReady {
-			if err := p.evictPod(ctx, pod); err != nil {
+			if err := p.evictPod(ctx, pod, deadline); err != nil {
 				return err
 			}
 		} else {
-			// on NotReady nodes the kubelet can't process evictions, force-delete
+			// on NotReady nodes the kubelet can't process evictions
 			if err := p.forceDeletePod(ctx, pod); err != nil {
 				return err
 			}
@@ -278,7 +283,7 @@ func isDaemonSetPod(pod *ac.Pod) bool {
 	return false
 }
 
-func (p *Provider) evictPod(ctx context.Context, pod *ac.Pod) error {
+func (p *Provider) evictPod(ctx context.Context, pod *ac.Pod, deadline time.Time) error {
 	eviction := &policyv1.Eviction{
 		ObjectMeta: am.ObjectMeta{
 			Name:      pod.Name,
@@ -286,26 +291,28 @@ func (p *Provider) evictPod(ctx context.Context, pod *ac.Pod) error {
 		},
 	}
 
-	err := p.Cluster.CoreV1().Pods(pod.Namespace).EvictV1(ctx, eviction)
-	if err != nil {
+	for {
+		err := p.Cluster.CoreV1().Pods(pod.Namespace).EvictV1(ctx, eviction)
+		if err == nil {
+			return nil
+		}
+
 		if ae.IsNotFound(err) {
 			return nil
 		}
-		// if eviction fails (e.g. PDB blocks it), fall back to force-delete
+
+		// PDB is blocking eviction — retry until deadline
+		if ae.IsTooManyRequests(err) {
+			if time.Now().After(deadline) {
+				return p.forceDeletePod(ctx, pod)
+			}
+			time.Sleep(evictionRetryInterval)
+			continue
+		}
+
+		// other errors — force delete
 		return p.forceDeletePod(ctx, pod)
 	}
-
-	// wait up to 30 seconds for the pod to be removed
-	for i := 0; i < 30; i++ {
-		_, err := p.Cluster.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, am.GetOptions{})
-		if ae.IsNotFound(err) {
-			return nil
-		}
-		time.Sleep(1 * time.Second)
-	}
-
-	// pod still exists after timeout, force-delete it
-	return p.forceDeletePod(ctx, pod)
 }
 
 func (p *Provider) forceDeletePod(ctx context.Context, pod *ac.Pod) error {
@@ -314,7 +321,7 @@ func (p *Provider) forceDeletePod(ctx context.Context, pod *ac.Pod) error {
 		GracePeriodSeconds: &grace,
 	})
 	if err != nil && !ae.IsNotFound(err) {
-		return errors.WithStack(fmt.Errorf("failed to force-delete pod %s/%s: %w", pod.Namespace, pod.Name, err))
+		return errors.WithStack(fmt.Errorf("failed to force-delete pod %s/%s: %s", pod.Namespace, pod.Name, err))
 	}
 	return nil
 }

--- a/provider/k8s/instance_test.go
+++ b/provider/k8s/instance_test.go
@@ -182,6 +182,18 @@ func TestInstanceTerminateReadyNode(t *testing.T) {
 	// DaemonSet pod should still exist (was skipped)
 	_, err = c.CoreV1().Pods("kube-system").Get(context.TODO(), "ds-pod", am.GetOptions{})
 	require.NoError(t, err)
+
+	// verify eviction was called for app-pod in default namespace
+	// (fake client records actions but doesn't actually delete pods on eviction)
+	evictionCalled := false
+	for _, action := range c.Actions() {
+		if action.GetVerb() == "create" && action.GetResource().Resource == "pods" &&
+			action.GetSubresource() == "eviction" && action.GetNamespace() == "default" {
+			evictionCalled = true
+			break
+		}
+	}
+	require.True(t, evictionCalled, "eviction should have been called for app-pod in default namespace")
 }
 
 func TestInstanceTerminateNotReadyNode(t *testing.T) {

--- a/provider/k8s/instance_test.go
+++ b/provider/k8s/instance_test.go
@@ -23,6 +23,27 @@ import (
 	metricfake "k8s.io/metrics/pkg/client/clientset/versioned/fake"
 )
 
+func newTestProvider() (*k8s.Provider, *fake.Clientset) {
+	c := fake.NewSimpleClientset()
+	cc := cvfake.NewSimpleClientset()
+	mc := metricfake.NewSimpleClientset()
+	a := &atom.MockInterface{}
+
+	p := &k8s.Provider{
+		Atom:          a,
+		Cluster:       c,
+		Convox:        cc,
+		Domain:        "domain1",
+		Engine:        &mock.TestEngine{},
+		MetricsClient: mc,
+		Name:          "rack1",
+		Namespace:     "ns1",
+		Provider:      "test",
+	}
+
+	return p, c
+}
+
 func nodeCreator(c kubernetes.Interface, name string, fn func(n *ac.Node)) error {
 	n := &ac.Node{
 		ObjectMeta: am.ObjectMeta{
@@ -106,4 +127,152 @@ func TestInstanceShellError(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Equal(t, 0, code)
+}
+
+func TestInstanceTerminateNotFound(t *testing.T) {
+	p, _ := newTestProvider()
+
+	err := p.InstanceTerminate("nonexistent-node")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "instance not found")
+}
+
+func TestInstanceTerminateReadyNode(t *testing.T) {
+	p, c := newTestProvider()
+
+	// create a Ready node
+	_, err := c.CoreV1().Nodes().Create(context.TODO(), &ac.Node{
+		ObjectMeta: am.ObjectMeta{Name: "node-ready"},
+		Status: ac.NodeStatus{
+			Conditions: []ac.NodeCondition{
+				{Type: ac.NodeReady, Status: ac.ConditionTrue},
+			},
+		},
+	}, am.CreateOptions{})
+	require.NoError(t, err)
+
+	// create a regular pod on the node
+	_, err = c.CoreV1().Pods("default").Create(context.TODO(), &ac.Pod{
+		ObjectMeta: am.ObjectMeta{Name: "app-pod", Namespace: "default"},
+		Spec:       ac.PodSpec{NodeName: "node-ready"},
+	}, am.CreateOptions{})
+	require.NoError(t, err)
+
+	// create a DaemonSet pod on the node — should be skipped
+	_, err = c.CoreV1().Pods("kube-system").Create(context.TODO(), &ac.Pod{
+		ObjectMeta: am.ObjectMeta{
+			Name:      "ds-pod",
+			Namespace: "kube-system",
+			OwnerReferences: []am.OwnerReference{
+				{Kind: "DaemonSet", Name: "fluentd", APIVersion: "apps/v1"},
+			},
+		},
+		Spec: ac.PodSpec{NodeName: "node-ready"},
+	}, am.CreateOptions{})
+	require.NoError(t, err)
+
+	err = p.InstanceTerminate("node-ready")
+	require.NoError(t, err)
+
+	// node should be deleted
+	_, err = c.CoreV1().Nodes().Get(context.TODO(), "node-ready", am.GetOptions{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+
+	// DaemonSet pod should still exist (was skipped)
+	_, err = c.CoreV1().Pods("kube-system").Get(context.TODO(), "ds-pod", am.GetOptions{})
+	require.NoError(t, err)
+}
+
+func TestInstanceTerminateNotReadyNode(t *testing.T) {
+	p, c := newTestProvider()
+
+	// create a NotReady node
+	_, err := c.CoreV1().Nodes().Create(context.TODO(), &ac.Node{
+		ObjectMeta: am.ObjectMeta{Name: "node-notready"},
+		Status: ac.NodeStatus{
+			Conditions: []ac.NodeCondition{
+				{Type: ac.NodeReady, Status: ac.ConditionFalse},
+			},
+		},
+	}, am.CreateOptions{})
+	require.NoError(t, err)
+
+	// create stuck pods on the NotReady node
+	for _, name := range []string{"stuck-pod-1", "stuck-pod-2"} {
+		_, err = c.CoreV1().Pods("app-ns").Create(context.TODO(), &ac.Pod{
+			ObjectMeta: am.ObjectMeta{Name: name, Namespace: "app-ns"},
+			Spec:       ac.PodSpec{NodeName: "node-notready"},
+		}, am.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	err = p.InstanceTerminate("node-notready")
+	require.NoError(t, err)
+
+	// node should be deleted
+	_, err = c.CoreV1().Nodes().Get(context.TODO(), "node-notready", am.GetOptions{})
+	require.Error(t, err)
+
+	// pods should be force-deleted
+	pods, err := c.CoreV1().Pods("app-ns").List(context.TODO(), am.ListOptions{})
+	require.NoError(t, err)
+	require.Empty(t, pods.Items)
+}
+
+func TestInstanceTerminateAlreadyCordoned(t *testing.T) {
+	p, c := newTestProvider()
+
+	// create an already-cordoned node
+	_, err := c.CoreV1().Nodes().Create(context.TODO(), &ac.Node{
+		ObjectMeta: am.ObjectMeta{Name: "node-cordoned"},
+		Spec:       ac.NodeSpec{Unschedulable: true},
+		Status: ac.NodeStatus{
+			Conditions: []ac.NodeCondition{
+				{Type: ac.NodeReady, Status: ac.ConditionTrue},
+			},
+		},
+	}, am.CreateOptions{})
+	require.NoError(t, err)
+
+	err = p.InstanceTerminate("node-cordoned")
+	require.NoError(t, err)
+
+	// node should be deleted
+	_, err = c.CoreV1().Nodes().Get(context.TODO(), "node-cordoned", am.GetOptions{})
+	require.Error(t, err)
+}
+
+func TestInstanceTerminateMirrorPodSkipped(t *testing.T) {
+	p, c := newTestProvider()
+
+	_, err := c.CoreV1().Nodes().Create(context.TODO(), &ac.Node{
+		ObjectMeta: am.ObjectMeta{Name: "node-mirror"},
+		Status: ac.NodeStatus{
+			Conditions: []ac.NodeCondition{
+				{Type: ac.NodeReady, Status: ac.ConditionTrue},
+			},
+		},
+	}, am.CreateOptions{})
+	require.NoError(t, err)
+
+	// create a mirror pod (managed by kubelet)
+	_, err = c.CoreV1().Pods("kube-system").Create(context.TODO(), &ac.Pod{
+		ObjectMeta: am.ObjectMeta{
+			Name:      "kube-apiserver-node-mirror",
+			Namespace: "kube-system",
+			Annotations: map[string]string{
+				ac.MirrorPodAnnotationKey: "mirror-hash",
+			},
+		},
+		Spec: ac.PodSpec{NodeName: "node-mirror"},
+	}, am.CreateOptions{})
+	require.NoError(t, err)
+
+	err = p.InstanceTerminate("node-mirror")
+	require.NoError(t, err)
+
+	// mirror pod should still exist (was skipped)
+	_, err = c.CoreV1().Pods("kube-system").Get(context.TODO(), "kube-apiserver-node-mirror", am.GetOptions{})
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary

Implements the previously unimplemented `InstanceTerminate` method for the k8s provider, enabling `convox instances terminate <id>` to work on Kubernetes-based racks. Adds an AWS provider override that also terminates the underlying EC2 instance.

## Motivation

When EKS cluster upgrades leave behind `NotReady` nodes (e.g. nodes running an older kubelet version that failed to drain), operators currently have no way to clean them up via Convox -- `convox instances terminate` returns `"ERROR: unimplemented"`. This forces manual `kubectl` intervention (cordon -> force-delete stuck pods -> delete node), which is error-prone and undocumented.

These stuck `NotReady` nodes can also cause rack updates to fail, compounding the problem.

## Implementation

### k8s Provider (all providers inherit this)

The `InstanceTerminate` method in `provider/k8s/instance.go`:

1. **Validates** the node exists (returns `NotFound` if missing)
2. **Cordons** the node (marks `Unschedulable` to prevent new pod scheduling)
3. **Drains** pods intelligently:
   - Skips **DaemonSet-managed** pods (expected on every node, cleaned up automatically)
   - Skips **mirror pods** (managed by kubelet directly)
   - Uses the **Eviction API** (`policy/v1`) for graceful removal on Ready nodes
   - **Force-deletes** pods on NotReady nodes (where kubelet cannot process evictions)
   - Retries on **PDB-blocked** evictions (`429 TooManyRequests`) with 5s backoff up to a 5-minute drain deadline, then falls back to force-delete
4. **Deletes** the node object from Kubernetes

### AWS Provider Override

The AWS provider overrides `InstanceTerminate` to additionally terminate the underlying EC2 instance:

1. Extracts the EC2 instance ID from the node's `Spec.ProviderID`
2. Delegates to the k8s base for cordon, drain, and node object deletion
3. Terminates the EC2 instance via `ec2:TerminateInstances`

This ensures the EC2 instance is cleaned up rather than left running and billable.

## Tests

### k8s Provider Tests (`provider/k8s/instance_test.go`)

5 new tests + test helper:
- `TestInstanceTerminateNotFound` -- returns proper NotFound error
- `TestInstanceTerminateReadyNode` -- evicts app pods (verified via action recording), skips DaemonSet pods, deletes node
- `TestInstanceTerminateNotReadyNode` -- force-deletes stuck pods on unresponsive nodes
- `TestInstanceTerminateAlreadyCordoned` -- handles pre-cordoned nodes correctly
- `TestInstanceTerminateMirrorPodSkipped` -- skips kubelet mirror pods

### AWS Provider Tests (`provider/aws/instance_internal_test.go`)

Table-driven tests for `parseInstanceID` covering:
- Valid AWS provider ID format
- Empty string, non-AWS providers (GCE, Azure)
- Malformed AWS provider IDs (missing instance ID, trailing slash)

All existing tests continue to pass across k8s provider, AWS provider, API, and CLI packages.

## Notes

- GCP, Azure, DO, Metal, and Local providers inherit the k8s base implementation. The node is removed from Kubernetes but the cloud VM is not terminated (cloud-specific overrides can be added in future PRs following the AWS pattern).
- The drain logic aligns with the patterns established in the `karpenter-cleanup-command` branch (PDB-aware eviction retry, 5-minute drain timeout, force-delete fallback).
- No changes to Provider interface, API routes, SDK, CLI, or Console -- all wiring already existed.
