### PR TITLE
fix: add Docker Hub imagePullSecrets to resource and service deployments

### DIFF
--- a/provider/k8s/process.go
+++ b/provider/k8s/process.go
@@ -724,27 +724,7 @@ func (p *Provider) podSpecFromRunOptions(app, service string, opts structs.Proce
 	}
 
 	if p.DockerUsername != "" && p.DockerPassword != "" {
-		_, err = p.CreateOrPatchSecret(p.ctx, am.ObjectMeta{
-			Name:      "docker-hub-authentication",
-			Namespace: p.AppNamespace(app),
-		}, func(s *ac.Secret) *ac.Secret {
-			s.Data = map[string][]byte{
-				".dockerconfigjson": []byte(fmt.Sprintf(
-					`{
-				"auths": {
-				  "https://index.docker.io/v2/": {
-					"auth": "%s" 
-				  }
-				}
-			  }`, base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", p.DockerUsername, p.DockerPassword))))),
-			}
-			s.Type = "kubernetes.io/dockerconfigjson"
-			return s
-		}, am.PatchOptions{
-			FieldManager: "convox",
-		},
-		)
-		if err != nil {
+		if err := p.ensureDockerHubSecret(p.AppNamespace(app)); err != nil {
 			return nil, errors.WithStack(err)
 		}
 
@@ -808,6 +788,33 @@ func (p *Provider) podSpecFromRunOptions(app, service string, opts structs.Proce
 	s.RestartPolicy = "Never"
 
 	return s, nil
+}
+
+func (p *Provider) ensureDockerHubSecret(namespace string) error {
+	_, err := p.CreateOrPatchSecret(p.ctx, am.ObjectMeta{
+		Name:      "docker-hub-authentication",
+		Namespace: namespace,
+	}, func(s *ac.Secret) *ac.Secret {
+		s.Data = map[string][]byte{
+			".dockerconfigjson": []byte(fmt.Sprintf(
+				`{
+				"auths": {
+				  "https://index.docker.io/v1/": {
+					"auth": "%s"
+				  }
+				}
+			  }`, base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", p.DockerUsername, p.DockerPassword))))),
+		}
+		s.Type = "kubernetes.io/dockerconfigjson"
+		return s
+	}, am.PatchOptions{
+		FieldManager: "convox",
+	})
+	return errors.WithStack(err)
+}
+
+func (p *Provider) hasDockerHubAuth() bool {
+	return p.DockerUsername != "" && p.DockerPassword != ""
 }
 
 func (p *Provider) podVolume(app, from string) ac.Volume {

--- a/provider/k8s/process.go
+++ b/provider/k8s/process.go
@@ -723,7 +723,7 @@ func (p *Provider) podSpecFromRunOptions(app, service string, opts structs.Proce
 		})
 	}
 
-	if p.DockerUsername != "" && p.DockerPassword != "" {
+	if p.hasDockerHubAuth() {
 		if err := p.ensureDockerHubSecret(p.AppNamespace(app)); err != nil {
 			return nil, errors.WithStack(err)
 		}

--- a/provider/k8s/release.go
+++ b/provider/k8s/release.go
@@ -144,6 +144,13 @@ func (p *Provider) ReleasePromote(app, id string, opts structs.ReleasePromoteOpt
 			return errors.WithStack(err)
 		}
 
+		// docker hub auth secret (once per promote, before resource/service/timer loops)
+		if p.hasDockerHubAuth() {
+			if err := p.ensureDockerHubSecret(p.AppNamespace(app)); err != nil {
+				return errors.WithStack(err)
+			}
+		}
+
 		// balancers
 		for _, b := range m.Balancers {
 			data, err := p.releaseTemplateBalancer(a, r, b, m.Labels)
@@ -581,12 +588,6 @@ func (p *Provider) releaseTemplateResource(a *structs.App, e structs.Environment
 		"DockerHubAuth":  p.hasDockerHubAuth(),
 	}
 
-	if p.hasDockerHubAuth() {
-		if err := p.ensureDockerHubSecret(p.AppNamespace(a.Name)); err != nil {
-			return nil, errors.WithStack(err)
-		}
-	}
-
 	data, err := p.RenderTemplate(fmt.Sprintf("resource/%s", r.Type), params)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -698,12 +699,6 @@ func (p *Provider) releaseTemplateServices(a *structs.App, e structs.Environment
 			"DockerHubAuth":  p.hasDockerHubAuth(),
 		}
 
-		if p.hasDockerHubAuth() {
-			if err := p.ensureDockerHubSecret(p.AppNamespace(a.Name)); err != nil {
-				return nil, errors.WithStack(err)
-			}
-		}
-
 		if ip, err := p.Engine.ResolverHost(); err == nil {
 			params["Resolver"] = ip
 		}
@@ -787,14 +782,15 @@ func (p *Provider) releaseTemplateTimer(a *structs.App, e structs.Environment, r
 	}
 
 	params := map[string]interface{}{
-		"Annotations": t.AnnotationsMap(),
-		"App":         a,
-		"Namespace":   p.AppNamespace(a.Name),
-		"Rack":        p.Name,
-		"Release":     r,
-		"Resources":   s.ResourceMap(),
-		"Service":     s,
-		"Timer":       t,
+		"Annotations":   t.AnnotationsMap(),
+		"App":           a,
+		"Namespace":     p.AppNamespace(a.Name),
+		"Rack":          p.Name,
+		"Release":       r,
+		"Resources":     s.ResourceMap(),
+		"Service":       s,
+		"Timer":         t,
+		"DockerHubAuth": p.hasDockerHubAuth(),
 	}
 
 	if ip, err := p.Engine.ResolverHost(); err == nil {

--- a/provider/k8s/release.go
+++ b/provider/k8s/release.go
@@ -571,13 +571,20 @@ func (p *Provider) releaseTemplateResource(a *structs.App, e structs.Environment
 	}
 
 	params := map[string]interface{}{
-		"App":        a.Name,
-		"Namespace":  p.AppNamespace(a.Name),
-		"Name":       r.Name,
-		"Parameters": r.Options,
-		"Password":   fmt.Sprintf("%x", sha256.Sum256([]byte(p.Name)))[0:30],
-		"Rack":       p.Name,
-		"Image":      r.Image,
+		"App":            a.Name,
+		"Namespace":      p.AppNamespace(a.Name),
+		"Name":           r.Name,
+		"Parameters":     r.Options,
+		"Password":       fmt.Sprintf("%x", sha256.Sum256([]byte(p.Name)))[0:30],
+		"Rack":           p.Name,
+		"Image":          r.Image,
+		"DockerHubAuth":  p.hasDockerHubAuth(),
+	}
+
+	if p.hasDockerHubAuth() {
+		if err := p.ensureDockerHubSecret(p.AppNamespace(a.Name)); err != nil {
+			return nil, errors.WithStack(err)
+		}
 	}
 
 	data, err := p.RenderTemplate(fmt.Sprintf("resource/%s", r.Type), params)
@@ -688,6 +695,13 @@ func (p *Provider) releaseTemplateServices(a *structs.App, e structs.Environment
 			"Resources":      s.ResourceMap(),
 			"Service":        s,
 			"KedaIsEnabled":  s.Scale.IsKedaEnabled(),
+			"DockerHubAuth":  p.hasDockerHubAuth(),
+		}
+
+		if p.hasDockerHubAuth() {
+			if err := p.ensureDockerHubSecret(p.AppNamespace(a.Name)); err != nil {
+				return nil, errors.WithStack(err)
+			}
 		}
 
 		if ip, err := p.Engine.ResolverHost(); err == nil {

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -155,6 +155,10 @@ spec:
         {{ end }}
         {{ end }}
       {{ end }}
+      {{ if .DockerHubAuth }}
+      imagePullSecrets:
+      - name: docker-hub-authentication
+      {{ end }}
       serviceAccountName: {{.Service.Name}}
       shareProcessNamespace: {{.Service.Init}}
       terminationGracePeriodSeconds: {{$.Service.Termination.Grace}}

--- a/provider/k8s/template/app/timer.yml.tmpl
+++ b/provider/k8s/template/app/timer.yml.tmpl
@@ -121,6 +121,10 @@ spec:
             {{ end }}
             {{ end }}
           {{ end }}
+          {{ if .DockerHubAuth }}
+          imagePullSecrets:
+          - name: docker-hub-authentication
+          {{ end }}
           restartPolicy: Never
           shareProcessNamespace: {{.Service.Init}}
           serviceAccountName: timer-{{.Timer.Name}}

--- a/provider/k8s/template/resource/mariadb.yml.tmpl
+++ b/provider/k8s/template/resource/mariadb.yml.tmpl
@@ -67,6 +67,10 @@ spec:
         type: resource
         resource: {{.Name}}
     spec:
+      {{ if .DockerHubAuth }}
+      imagePullSecrets:
+      - name: docker-hub-authentication
+      {{ end }}
       containers:
       - name: mariadb
         image: {{ if not .Image }}mariadb:{{ coalesce (index .Parameters "version") "10.6.0" }}{{ else }}{{ .Image }}{{ end }}

--- a/provider/k8s/template/resource/memcached.yml.tmpl
+++ b/provider/k8s/template/resource/memcached.yml.tmpl
@@ -48,6 +48,10 @@ spec:
         type: resource
         resource: {{.Name}}
     spec:
+      {{ if .DockerHubAuth }}
+      imagePullSecrets:
+      - name: docker-hub-authentication
+      {{ end }}
       containers:
       - name: memcached
         image: {{ if not .Image }}memcached:{{ coalesce (index .Parameters "version") "1.4.34" }}{{ else }}{{ .Image }}{{ end }}

--- a/provider/k8s/template/resource/mysql.yml.tmpl
+++ b/provider/k8s/template/resource/mysql.yml.tmpl
@@ -67,6 +67,10 @@ spec:
         type: resource
         resource: {{.Name}}
     spec:
+      {{ if .DockerHubAuth }}
+      imagePullSecrets:
+      - name: docker-hub-authentication
+      {{ end }}
       containers:
       - name: mysql
         image: {{ if not .Image }}mysql:{{ coalesce (index .Parameters "version") "5.7.23" }}{{ else }}{{ .Image }}{{ end }}

--- a/provider/k8s/template/resource/postgis.yml.tmpl
+++ b/provider/k8s/template/resource/postgis.yml.tmpl
@@ -68,6 +68,10 @@ spec:
         type: resource
         resource: {{.Name}}
     spec:
+      {{ if .DockerHubAuth }}
+      imagePullSecrets:
+      - name: docker-hub-authentication
+      {{ end }}
       containers:
       - name: postgis
         image: {{ if not .Image }}postgis/postgis:{{ coalesce (index .Parameters "version") "10-3.2" }}{{ else }}{{ .Image }}{{ end }}

--- a/provider/k8s/template/resource/postgres.yml.tmpl
+++ b/provider/k8s/template/resource/postgres.yml.tmpl
@@ -68,6 +68,10 @@ spec:
         type: resource
         resource: {{.Name}}
     spec:
+      {{ if .DockerHubAuth }}
+      imagePullSecrets:
+      - name: docker-hub-authentication
+      {{ end }}
       containers:
       - name: postgres
         image: {{ if not .Image }}postgres:{{ coalesce (index .Parameters "version") "10.5" }}{{ else }}{{ .Image }}{{ end }}

--- a/provider/k8s/template/resource/redis.yml.tmpl
+++ b/provider/k8s/template/resource/redis.yml.tmpl
@@ -48,6 +48,10 @@ spec:
         type: resource
         resource: {{.Name}}
     spec:
+      {{ if .DockerHubAuth }}
+      imagePullSecrets:
+      - name: docker-hub-authentication
+      {{ end }}
       containers:
       - name: redis
         image: {{ if not .Image }}redis:{{ coalesce (index .Parameters "version") "4.0.10" }}{{ else }}{{ .Image }}{{ end }}

--- a/terraform/rack/k8s/main.tf
+++ b/terraform/rack/k8s/main.tf
@@ -41,7 +41,7 @@ resource "kubernetes_secret" "docker_hub_authentication" {
     ".dockerconfigjson" = <<DOCKER
 {
   "auths": {
-    "https://index.docker.io/v2/": {
+    "https://index.docker.io/v1/": {
       "auth": "${base64encode("${var.docker_hub_username}:${var.docker_hub_password}")}"
     }
   }


### PR DESCRIPTION
## Problem

When `docker_hub_username` and `docker_hub_password` rack params are configured, the `docker-hub-authentication` Kubernetes secret is only referenced as `imagePullSecrets` on **build/run pods** (created via `ProcessRun`). Resource deployments (Redis, Postgres, MySQL, etc.), service deployments, and timer CronJobs have no `imagePullSecrets`, causing Docker Hub rate limit (HTTP 429) failures when kubelet tries to pull images on nodes without cached images.

This is especially problematic on clusters with node churn (autoscaling, spot instances) where fresh nodes frequently need to pull images.

## Fix

### Go code (`process.go`, `release.go`)
- Extract `ensureDockerHubSecret(namespace)` helper method for creating/patching the `docker-hub-authentication` secret — previously this logic was inline in `podSpecFromRunOptions()`
- Add `hasDockerHubAuth()` helper for clean conditional checks
- During release promote, create the `docker-hub-authentication` secret once in the app namespace before resource/service/timer template rendering
- Pass `DockerHubAuth: true` to resource, service, and timer templates
- Fix Docker Hub auth registry key from `https://index.docker.io/v2/` to `https://index.docker.io/v1/` (the canonical Docker Hub registry URL expected by containerd/kubelet)

### Templates (all 7 resource templates + service template + timer template)
- Add conditional `imagePullSecrets` block to: `redis`, `postgres`, `mysql`, `mariadb`, `memcached`, `postgis`, `service`, and `timer` templates
- Only rendered when Docker Hub credentials are configured (no impact when not set)

### Terraform
- Fix system namespace secret URL from `/v2/` to `/v1/` to match Go code

## Testing

- `go build ./provider/k8s/...` — compiles cleanly
- Existing tests pass (pre-existing failures are unrelated to this change)
- Manually verified on a live rack that the docker-hub-authentication secret resolves ImagePullBackOff for resource pods
