### PR TITLE
feat: ECR pull-through cache support for Docker Hub images

### DIFF
--- a/docs/configuration/rack-parameters/aws/README.md
+++ b/docs/configuration/rack-parameters/aws/README.md
@@ -28,8 +28,8 @@ The following parameters are available for configuring your Convox rack on Amazo
 | [docker_hub_username](/configuration/rack-parameters/aws/docker_hub_username) | Configures Docker Hub username for authenticated image pulls (avoids rate limits). |
 | [docker_hub_password](/configuration/rack-parameters/aws/docker_hub_password) | Sets Docker Hub access token for authenticated image pulls. Use with docker_hub_username. |
 | [ebs_volume_encryption_enabled](/configuration/rack-parameters/aws/ebs_volume_encryption_enabled) | Enables encryption for EBS volumes used by primary node disks. |
-| [ecr_scan_on_push_enable](/configuration/rack-parameters/aws/ecr_scan_on_push_enable) | Enables automatic vulnerability scanning for images pushed to ECR. |
 | [ecr_docker_hub_cache](/configuration/rack-parameters/aws/ecr_docker_hub_cache) | Enables ECR pull-through cache for Docker Hub images to avoid rate limits. |
+| [ecr_scan_on_push_enable](/configuration/rack-parameters/aws/ecr_scan_on_push_enable) | Enables automatic vulnerability scanning for images pushed to ECR. |
 | [efs_csi_driver_enable](/configuration/rack-parameters/aws/efs_csi_driver_enable)   | Enables the EFS CSI driver to use AWS EFS volumes.                       |
 | [fluentd_disable](/configuration/rack-parameters/aws/fluentd_disable)               | Disables Fluentd installation in the rack.                               |
 | [fluentd_memory](/configuration/rack-parameters/aws/fluentd_memory)                 | Configures memory allocation for the Fluentd log collector DaemonSet.    |

--- a/docs/configuration/rack-parameters/aws/README.md
+++ b/docs/configuration/rack-parameters/aws/README.md
@@ -29,6 +29,7 @@ The following parameters are available for configuring your Convox rack on Amazo
 | [docker_hub_password](/configuration/rack-parameters/aws/docker_hub_password) | Sets Docker Hub access token for authenticated image pulls. Use with docker_hub_username. |
 | [ebs_volume_encryption_enabled](/configuration/rack-parameters/aws/ebs_volume_encryption_enabled) | Enables encryption for EBS volumes used by primary node disks. |
 | [ecr_scan_on_push_enable](/configuration/rack-parameters/aws/ecr_scan_on_push_enable) | Enables automatic vulnerability scanning for images pushed to ECR. |
+| [ecr_docker_hub_cache](/configuration/rack-parameters/aws/ecr_docker_hub_cache) | Enables ECR pull-through cache for Docker Hub images to avoid rate limits. |
 | [efs_csi_driver_enable](/configuration/rack-parameters/aws/efs_csi_driver_enable)   | Enables the EFS CSI driver to use AWS EFS volumes.                       |
 | [fluentd_disable](/configuration/rack-parameters/aws/fluentd_disable)               | Disables Fluentd installation in the rack.                               |
 | [fluentd_memory](/configuration/rack-parameters/aws/fluentd_memory)                 | Configures memory allocation for the Fluentd log collector DaemonSet.    |

--- a/docs/configuration/rack-parameters/aws/ecr_docker_hub_cache.md
+++ b/docs/configuration/rack-parameters/aws/ecr_docker_hub_cache.md
@@ -43,3 +43,4 @@ The cache also works without Docker Hub credentials (anonymous upstream pulls), 
 - Cached images follow your ECR lifecycle policies and region configuration.
 - This feature complements `docker_hub_username` and `docker_hub_password` — those parameters authenticate direct pulls for build pods and service images, while `ecr_docker_hub_cache` specifically caches the images used by Convox-managed resource pods.
 - Standard ECR storage costs apply for cached images.
+- The ECR pull-through cache rule uses the prefix `docker-hub`, which is an account+region level resource in AWS. Only one rack per AWS account per region should enable this parameter. If multiple racks in the same account and region enable it, the second rack's update will fail because the cache rule already exists.

--- a/docs/configuration/rack-parameters/aws/ecr_docker_hub_cache.md
+++ b/docs/configuration/rack-parameters/aws/ecr_docker_hub_cache.md
@@ -34,13 +34,13 @@ The cache also works without Docker Hub credentials (anonymous upstream pulls), 
 
 ## Additional Information
 - When enabled, Convox creates:
-  - An ECR pull-through cache rule with prefix `docker-hub` pointing to `registry-1.docker.io`
+  - An ECR pull-through cache rule with prefix `docker-hub-<rack-name>` pointing to `registry-1.docker.io`
   - An AWS Secrets Manager secret with Docker Hub credentials (if `docker_hub_username` and `docker_hub_password` are set)
   - An IAM policy granting cluster nodes permission to create ECR repositories and import upstream images
-- Resource images are automatically rewritten to use the ECR cache URL. For example, `redis:4.0.10` becomes `<account_id>.dkr.ecr.<region>.amazonaws.com/docker-hub/library/redis:4.0.10`.
+- Resource images are automatically rewritten to use the ECR cache URL. For example, `redis:4.0.10` becomes `<account_id>.dkr.ecr.<region>.amazonaws.com/docker-hub-<rack-name>/library/redis:4.0.10`.
 - Docker Hub "library" images (redis, postgres, mysql, mariadb, memcached) get a `library/` prefix in the ECR path per Docker Hub convention. Non-library images (e.g., `postgis/postgis`) use their full path.
 - ECR repositories are created automatically on first pull — no manual setup is needed.
 - Cached images follow your ECR lifecycle policies and region configuration.
 - This feature complements `docker_hub_username` and `docker_hub_password` — those parameters authenticate direct pulls for build pods and service images, while `ecr_docker_hub_cache` specifically caches the images used by Convox-managed resource pods.
 - Standard ECR storage costs apply for cached images.
-- The ECR pull-through cache rule uses the prefix `docker-hub`, which is an account+region level resource in AWS. Only one rack per AWS account per region should enable this parameter. If multiple racks in the same account and region enable it, the second rack's update will fail because the cache rule already exists.
+- Each rack gets its own ECR pull-through cache rule with a rack-specific prefix (`docker-hub-<rack-name>`), so multiple racks in the same AWS account can each enable this feature independently.

--- a/docs/configuration/rack-parameters/aws/ecr_docker_hub_cache.md
+++ b/docs/configuration/rack-parameters/aws/ecr_docker_hub_cache.md
@@ -1,0 +1,45 @@
+---
+title: "ecr_docker_hub_cache"
+slug: ecr_docker_hub_cache
+url: /configuration/rack-parameters/aws/ecr_docker_hub_cache
+---
+
+# ecr_docker_hub_cache
+
+## Description
+The `ecr_docker_hub_cache` parameter enables an ECR pull-through cache for Docker Hub images. When enabled, resource pods (Redis, Postgres, MySQL, MariaDB, Memcached, PostGIS) pull Docker Hub images through your account's ECR registry, which transparently caches them. This eliminates Docker Hub rate limit (429 Too Many Requests) errors on clusters with node churn, where fresh nodes frequently need to pull images.
+
+## Default Value
+The default value for `ecr_docker_hub_cache` is `false`.
+
+## Use Cases
+- **Eliminate Docker Hub Rate Limits**: Avoid 429 errors caused by anonymous or authenticated pull rate limits, especially on clusters where nodes are frequently replaced (e.g., Spot instances, Karpenter-managed nodes).
+- **Faster Image Pulls**: After the first pull, images are served from ECR in the same region, significantly reducing pull times.
+- **Reduced External Dependencies**: Once cached, images are available even if Docker Hub experiences outages.
+
+## Setting Parameters
+To enable the ECR pull-through cache:
+```bash
+$ convox rack params set ecr_docker_hub_cache=true -r rackName
+Setting parameters... OK
+```
+
+For best results, also set Docker Hub credentials so upstream cache misses use authenticated pulls with higher rate limits:
+```bash
+$ convox rack params set ecr_docker_hub_cache=true docker_hub_username=myuser docker_hub_password=dckr_pat_xxxxx -r rackName
+Setting parameters... OK
+```
+
+The cache also works without Docker Hub credentials (anonymous upstream pulls), but cache miss pulls are subject to Docker Hub's anonymous rate limits.
+
+## Additional Information
+- When enabled, Convox creates:
+  - An ECR pull-through cache rule with prefix `docker-hub` pointing to `registry-1.docker.io`
+  - An AWS Secrets Manager secret with Docker Hub credentials (if `docker_hub_username` and `docker_hub_password` are set)
+  - An IAM policy granting cluster nodes permission to create ECR repositories and import upstream images
+- Resource images are automatically rewritten to use the ECR cache URL. For example, `redis:4.0.10` becomes `<account_id>.dkr.ecr.<region>.amazonaws.com/docker-hub/library/redis:4.0.10`.
+- Docker Hub "library" images (redis, postgres, mysql, mariadb, memcached) get a `library/` prefix in the ECR path per Docker Hub convention. Non-library images (e.g., `postgis/postgis`) use their full path.
+- ECR repositories are created automatically on first pull — no manual setup is needed.
+- Cached images follow your ECR lifecycle policies and region configuration.
+- This feature complements `docker_hub_username` and `docker_hub_password` — those parameters authenticate direct pulls for build pods and service images, while `ecr_docker_hub_cache` specifically caches the images used by Convox-managed resource pods.
+- Standard ECR storage costs apply for cached images.

--- a/provider/k8s/ecr_cache_test.go
+++ b/provider/k8s/ecr_cache_test.go
@@ -1,0 +1,90 @@
+package k8s
+
+import (
+	"testing"
+)
+
+func TestEcrCachedResourceImage(t *testing.T) {
+	prefix := "123456789012.dkr.ecr.us-east-1.amazonaws.com/docker-hub"
+
+	tests := []struct {
+		name         string
+		resourceType string
+		options      map[string]string
+		want         string
+	}{
+		{
+			name:         "redis default version",
+			resourceType: "redis",
+			options:      map[string]string{},
+			want:         prefix + "/library/redis:4.0.10",
+		},
+		{
+			name:         "redis custom version",
+			resourceType: "redis",
+			options:      map[string]string{"version": "7.0"},
+			want:         prefix + "/library/redis:7.0",
+		},
+		{
+			name:         "postgres default version",
+			resourceType: "postgres",
+			options:      map[string]string{},
+			want:         prefix + "/library/postgres:10.5",
+		},
+		{
+			name:         "mysql default version",
+			resourceType: "mysql",
+			options:      map[string]string{},
+			want:         prefix + "/library/mysql:5.7.23",
+		},
+		{
+			name:         "mariadb default version",
+			resourceType: "mariadb",
+			options:      map[string]string{},
+			want:         prefix + "/library/mariadb:10.6.0",
+		},
+		{
+			name:         "memcached default version",
+			resourceType: "memcached",
+			options:      map[string]string{},
+			want:         prefix + "/library/memcached:1.4.34",
+		},
+		{
+			name:         "postgis non-library image",
+			resourceType: "postgis",
+			options:      map[string]string{},
+			want:         prefix + "/postgis/postgis:10-3.2",
+		},
+		{
+			name:         "postgis custom version",
+			resourceType: "postgis",
+			options:      map[string]string{"version": "15-3.3"},
+			want:         prefix + "/postgis/postgis:15-3.3",
+		},
+		{
+			name:         "unknown resource type",
+			resourceType: "unknown",
+			options:      map[string]string{},
+			want:         "",
+		},
+		{
+			name:         "trailing slash on prefix",
+			resourceType: "redis",
+			options:      map[string]string{},
+			want:         prefix + "/library/redis:4.0.10",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := prefix
+			if tt.name == "trailing slash on prefix" {
+				p = prefix + "/"
+			}
+			got := ecrCachedResourceImage(p, tt.resourceType, tt.options)
+			if got != tt.want {
+				t.Errorf("ecrCachedResourceImage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/provider/k8s/k8s.go
+++ b/provider/k8s/k8s.go
@@ -60,6 +60,7 @@ type Provider struct {
 	DiscoveryClient                     discovery.DiscoveryInterface
 	DockerUsername                      string
 	DockerPassword                      string
+	EcrDockerHubCachePrefix             string
 	Domain                              string
 	DomainInternal                      string
 	DynamicClient                       dynamic.Interface
@@ -198,6 +199,7 @@ func FromEnv() (*Provider, error) {
 		VpcID:                            os.Getenv("VPC_ID"),
 		DockerUsername:                   os.Getenv("DOCKER_HUB_USERNAME"),
 		DockerPassword:                   os.Getenv("DOCKER_HUB_PASSWORD"),
+		EcrDockerHubCachePrefix:          os.Getenv("ECR_DOCKER_HUB_CACHE_PREFIX"),
 		IsKedaEnabled:                    os.Getenv("KEDA_ENABLED") == "true",
 		IsVpaEnabled:                     os.Getenv("VPA_ENABLED") == "true",
 	}

--- a/provider/k8s/release.go
+++ b/provider/k8s/release.go
@@ -580,6 +580,12 @@ func (p *Provider) releaseTemplateResource(a *structs.App, e structs.Environment
 		"Image":      r.Image,
 	}
 
+	if r.Image == "" && p.EcrDockerHubCachePrefix != "" {
+		if img := ecrCachedResourceImage(p.EcrDockerHubCachePrefix, r.Type, r.Options); img != "" {
+			params["Image"] = img
+		}
+	}
+
 	data, err := p.RenderTemplate(fmt.Sprintf("resource/%s", r.Type), params)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -1079,4 +1085,40 @@ func (p *Provider) applyAnnotationsToHPA(app string, service string, annotations
 		return errors.WithStack(err)
 	}
 	return nil
+}
+
+// resourceDefaultImages maps resource types to their default Docker Hub image references.
+// Library images use just the name (e.g. "redis"), non-library images include the org (e.g. "postgis/postgis").
+var resourceDefaultImages = map[string]struct {
+	image          string
+	defaultVersion string
+	isLibrary      bool
+}{
+	"redis":     {image: "redis", defaultVersion: "4.0.10", isLibrary: true},
+	"postgres":  {image: "postgres", defaultVersion: "10.5", isLibrary: true},
+	"mysql":     {image: "mysql", defaultVersion: "5.7.23", isLibrary: true},
+	"mariadb":   {image: "mariadb", defaultVersion: "10.6.0", isLibrary: true},
+	"memcached": {image: "memcached", defaultVersion: "1.4.34", isLibrary: true},
+	"postgis":   {image: "postgis/postgis", defaultVersion: "10-3.2", isLibrary: false},
+}
+
+// ecrCachedResourceImage returns the ECR pull-through cache URL for a resource's Docker Hub image.
+// Returns empty string if the resource type is not recognized.
+func ecrCachedResourceImage(prefix, resourceType string, options map[string]string) string {
+	info, ok := resourceDefaultImages[resourceType]
+	if !ok {
+		return ""
+	}
+
+	version := info.defaultVersion
+	if v, ok := options["version"]; ok && v != "" {
+		version = v
+	}
+
+	imagePath := info.image
+	if info.isLibrary {
+		imagePath = "library/" + imagePath
+	}
+
+	return fmt.Sprintf("%s/%s:%s", strings.TrimRight(prefix, "/"), imagePath, version)
 }

--- a/terraform/api/aws/main.tf
+++ b/terraform/api/aws/main.tf
@@ -22,6 +22,7 @@ module "k8s" {
   docker_hub_authentication      = var.docker_hub_authentication
   docker_hub_username            = var.docker_hub_username
   docker_hub_password            = var.docker_hub_password
+  ecr_docker_hub_cache_prefix    = var.ecr_docker_hub_cache_prefix
   domain                         = var.domain
   domain_internal                = var.domain_internal
   disable_image_manifest_cache   = var.disable_image_manifest_cache

--- a/terraform/api/aws/variables.tf
+++ b/terraform/api/aws/variables.tf
@@ -50,6 +50,11 @@ variable "docker_hub_password" {
   default = ""
 }
 
+variable "ecr_docker_hub_cache_prefix" {
+  type    = string
+  default = ""
+}
+
 variable "domain" {
   type = string
 }

--- a/terraform/api/k8s/main.tf
+++ b/terraform/api/k8s/main.tf
@@ -192,6 +192,11 @@ resource "kubernetes_deployment" "api" {
           }
 
           env {
+            name  = "ECR_DOCKER_HUB_CACHE_PREFIX"
+            value = var.ecr_docker_hub_cache_prefix
+          }
+
+          env {
             name  = "DOMAIN"
             value = var.domain
           }

--- a/terraform/api/k8s/variables.tf
+++ b/terraform/api/k8s/variables.tf
@@ -42,6 +42,11 @@ variable "docker_hub_password" {
   default = ""
 }
 
+variable "ecr_docker_hub_cache_prefix" {
+  type    = string
+  default = ""
+}
+
 variable "domain" {
   type = string
 }

--- a/terraform/cluster/aws/ecr_pull_through.tf
+++ b/terraform/cluster/aws/ecr_pull_through.tf
@@ -1,0 +1,59 @@
+data "aws_caller_identity" "current" {}
+
+resource "aws_secretsmanager_secret" "docker_hub_pull_through" {
+  count = var.ecr_docker_hub_cache && var.docker_hub_username != "" && var.docker_hub_password != "" ? 1 : 0
+
+  name        = "${var.name}-docker-hub-pull-through"
+  description = "Docker Hub credentials for ECR pull-through cache"
+}
+
+resource "aws_secretsmanager_secret_version" "docker_hub_pull_through" {
+  count = var.ecr_docker_hub_cache && var.docker_hub_username != "" && var.docker_hub_password != "" ? 1 : 0
+
+  secret_id = aws_secretsmanager_secret.docker_hub_pull_through[0].id
+  secret_string = jsonencode({
+    username    = var.docker_hub_username
+    accessToken = var.docker_hub_password
+  })
+}
+
+resource "aws_ecr_pull_through_cache_rule" "docker_hub" {
+  count = var.ecr_docker_hub_cache ? 1 : 0
+
+  ecr_repository_prefix = "docker-hub"
+  upstream_registry_url = "registry-1.docker.io"
+  credential_arn        = var.docker_hub_username != "" && var.docker_hub_password != "" ? aws_secretsmanager_secret.docker_hub_pull_through[0].arn : null
+}
+
+resource "aws_iam_policy" "ecr_pull_through" {
+  count = var.ecr_docker_hub_cache ? 1 : 0
+
+  name = "${var.name}-ecr-pull-through"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchImportUpstreamImage",
+          "ecr:CreateRepository",
+        ]
+        Resource = "arn:${data.aws_partition.current.partition}:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:repository/docker-hub/*"
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "nodes_ecr_pull_through" {
+  count = var.ecr_docker_hub_cache ? 1 : 0
+
+  role       = aws_iam_role.nodes.name
+  policy_arn = aws_iam_policy.ecr_pull_through[0].arn
+}
+
+resource "aws_iam_role_policy_attachment" "karpenter_nodes_ecr_pull_through" {
+  count = var.ecr_docker_hub_cache && var.karpenter_enabled ? 1 : 0
+
+  role       = aws_iam_role.karpenter_nodes[0].name
+  policy_arn = aws_iam_policy.ecr_pull_through[0].arn
+}

--- a/terraform/cluster/aws/ecr_pull_through.tf
+++ b/terraform/cluster/aws/ecr_pull_through.tf
@@ -3,8 +3,9 @@ data "aws_caller_identity" "current" {}
 resource "aws_secretsmanager_secret" "docker_hub_pull_through" {
   count = var.ecr_docker_hub_cache && var.docker_hub_username != "" && var.docker_hub_password != "" ? 1 : 0
 
-  name        = "${var.name}-docker-hub-pull-through"
-  description = "Docker Hub credentials for ECR pull-through cache"
+  name                    = "${var.name}-docker-hub-pull-through"
+  description             = "Docker Hub credentials for ECR pull-through cache"
+  recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "docker_hub_pull_through" {

--- a/terraform/cluster/aws/ecr_pull_through.tf
+++ b/terraform/cluster/aws/ecr_pull_through.tf
@@ -21,7 +21,7 @@ resource "aws_secretsmanager_secret_version" "docker_hub_pull_through" {
 resource "aws_ecr_pull_through_cache_rule" "docker_hub" {
   count = var.ecr_docker_hub_cache ? 1 : 0
 
-  ecr_repository_prefix = "docker-hub"
+  ecr_repository_prefix = "docker-hub-${var.name}"
   upstream_registry_url = "registry-1.docker.io"
   credential_arn        = var.docker_hub_username != "" && var.docker_hub_password != "" ? aws_secretsmanager_secret.docker_hub_pull_through[0].arn : null
 }
@@ -39,7 +39,7 @@ resource "aws_iam_policy" "ecr_pull_through" {
           "ecr:BatchImportUpstreamImage",
           "ecr:CreateRepository",
         ]
-        Resource = "arn:${data.aws_partition.current.partition}:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:repository/docker-hub/*"
+        Resource = "arn:${data.aws_partition.current.partition}:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:repository/docker-hub-${var.name}/*"
       },
     ]
   })

--- a/terraform/cluster/aws/outputs.tf
+++ b/terraform/cluster/aws/outputs.tf
@@ -66,5 +66,5 @@ output "karpenter_interruption_queue_name" {
 }
 
 output "ecr_docker_hub_cache_prefix" {
-  value = var.ecr_docker_hub_cache ? "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/docker-hub" : ""
+  value = var.ecr_docker_hub_cache ? "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/docker-hub-${var.name}" : ""
 }

--- a/terraform/cluster/aws/outputs.tf
+++ b/terraform/cluster/aws/outputs.tf
@@ -64,3 +64,7 @@ output "karpenter_node_role_name" {
 output "karpenter_interruption_queue_name" {
   value = var.karpenter_enabled ? aws_sqs_queue.karpenter_interruption[0].name : ""
 }
+
+output "ecr_docker_hub_cache_prefix" {
+  value = var.ecr_docker_hub_cache ? "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/docker-hub" : ""
+}

--- a/terraform/cluster/aws/variables.tf
+++ b/terraform/cluster/aws/variables.tf
@@ -390,3 +390,19 @@ variable "vpa_enable" {
   type    = bool
   default = false
 }
+
+variable "ecr_docker_hub_cache" {
+  type    = bool
+  default = false
+}
+
+variable "docker_hub_username" {
+  type    = string
+  default = ""
+}
+
+variable "docker_hub_password" {
+  type    = string
+  default = ""
+  sensitive = true
+}

--- a/terraform/rack/aws/main.tf
+++ b/terraform/rack/aws/main.tf
@@ -37,6 +37,7 @@ module "api" {
   domain_internal                           = module.router.endpoint_internal
   disable_image_manifest_cache              = var.disable_image_manifest_cache
   ecr_scan_on_push_enable                   = var.ecr_scan_on_push_enable
+  ecr_docker_hub_cache_prefix               = var.ecr_docker_hub_cache_prefix
   efs_csi_driver_enable                     = var.efs_csi_driver_enable
   efs_file_system_id                        = var.efs_file_system_id
   high_availability                         = var.high_availability

--- a/terraform/rack/aws/variables.tf
+++ b/terraform/rack/aws/variables.tf
@@ -68,6 +68,11 @@ variable "ecr_scan_on_push_enable" {
   default = false
 }
 
+variable "ecr_docker_hub_cache_prefix" {
+  type    = string
+  default = ""
+}
+
 variable "efs_csi_driver_enable" {
   type    = bool
   default = false

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -157,6 +157,9 @@ module "cluster" {
   vpc_cni_version                     = var.vpc_cni_version
   vpc_id                              = var.vpc_id
   vpa_enable                          = var.vpa_enable
+  ecr_docker_hub_cache                = var.ecr_docker_hub_cache
+  docker_hub_username                 = var.docker_hub_username
+  docker_hub_password                 = var.docker_hub_password
 }
 
 resource "null_resource" "wait_for_cluster" {
@@ -245,6 +248,7 @@ module "rack" {
   telemetry_default_map                     = local.telemetry_default_map
   whitelist                                 = split(",", var.whitelist)
   ecr_scan_on_push_enable                   = var.ecr_scan_on_push_enable
+  ecr_docker_hub_cache_prefix               = module.cluster.ecr_docker_hub_cache_prefix
   vpc_id                                    = module.cluster.vpc
   vpa_enable                                = var.vpa_enable
 }

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -91,6 +91,11 @@ variable "docker_hub_password" {
   default = ""
 }
 
+variable "ecr_docker_hub_cache" {
+  type    = bool
+  default = false
+}
+
 variable "fluentd_disable" {
   type    = bool
   default = false


### PR DESCRIPTION
## Summary

Adds a new `ecr_docker_hub_cache` rack parameter that creates an ECR pull-through cache for Docker Hub images. When enabled, resource pods (Redis, Postgres, MySQL, MariaDB, Memcached, PostGIS) pull Docker Hub images via ECR, eliminating 429 rate limit errors.

## Problem

On EKS clusters with node churn, fresh nodes must pull Docker Hub images (e.g. `redis:4.0.10`, `postgres:10.5`). Docker Hub's rate limits cause `ImagePullBackOff` failures that cascade into application downtime.

## Solution

### Terraform
- **New `ecr_pull_through.tf`**: Creates ECR pull-through cache rule (rack-scoped prefix `docker-hub-<rack-name>` → `registry-1.docker.io`), optional Secrets Manager secret for Docker Hub credentials with immediate deletion on disable (`recovery_window_in_days = 0`), and IAM policy granting nodes `ecr:CreateRepository` + `ecr:BatchImportUpstreamImage` scoped to the rack's cache prefix only
- **Variable threading**: `ecr_docker_hub_cache` bool flows through `system → cluster` to create infra; `ecr_docker_hub_cache_prefix` output flows through `cluster → rack → api → k8s` as env var on the API pod

### Go
- **Provider struct**: New `EcrDockerHubCachePrefix` field read from `ECR_DOCKER_HUB_CACHE_PREFIX` env var
- **Image rewriting**: In `releaseTemplateResource()`, when ECR cache is enabled and no custom image override is set, rewrites resource images to ECR pull-through URLs (e.g. `redis:4.0.10` → `<account>.dkr.ecr.<region>.amazonaws.com/docker-hub-<rack>/library/redis:4.0.10`)
- Library images get `library/` prefix per Docker Hub convention; non-library images (e.g. `postgis/postgis`) use their full path

### Console
- Added `ecr_docker_hub_cache` to `boolParams` validation map in console3 for proper type validation on console-managed racks

### Usage
```bash
# Enable with Docker Hub credentials for authenticated upstream pulls
convox rack params set ecr_docker_hub_cache=true docker_hub_username=myuser docker_hub_password=mytoken

# Also works without credentials (anonymous pulls, subject to rate limits on cache misses)
convox rack params set ecr_docker_hub_cache=true
```

## Testing
- Unit tests for image rewriting logic covering all 6 resource types, custom versions, unknown types, trailing slash edge case
- Full Go build passes
- Console build passes

## Related
- Complements #998 which adds `imagePullSecrets` to resource/service pods
