### PR TITLE
add public access block

### DIFF
--- a/terraform/api/aws/s3.tf
+++ b/terraform/api/aws/s3.tf
@@ -29,6 +29,14 @@ resource "aws_s3_bucket_acl" "storage" {
   acl    = "private"
 }
 
+resource "aws_s3_bucket_public_access_block" "storage" {
+  bucket = aws_s3_bucket.storage.bucket
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
 
 data "aws_s3_bucket" "custom_bucket" {
   count  = var.custom_provided_bucket != "" ? 1 : 0


### PR DESCRIPTION
## Summary

- Add `aws_s3_bucket_public_access_block` to the Convox-managed storage bucket (`terraform/api/aws/s3.tf`), resolving checkov CKV2_AWS_6
- All four public access block settings enabled: `block_public_acls`, `block_public_policy`, `ignore_public_acls`, `restrict_public_buckets`
- No new Terraform variables — purely additive resource with no state fingertrap risk

## Context

The storage bucket (build artifacts, release data) was already private by ACL and encrypted with KMS, but lacked the explicit public access block that prevents accidental public exposure via bucket policy changes. This is a defense-in-depth hardening identified during the CI linting rollout (#991).

## Impact

- **Normal operations**: Unaffected. All authenticated S3 operations (PutObject, GetObject, DeleteObject, ListObjects) continue to work via IAM.
- **Upgrade (N-1 → N)**: Terraform adds a `public_access_block` configuration to the existing bucket. All existing build logs, releases, and artifacts remain intact.
- **Downgrade (N → N-1)**: Terraform destroys the block, reverting to pre-upgrade posture. Security regression but not a functional break.
- **Console**: No changes needed. Resource addition, not a variable.
- **Custom bucket users**: Unaffected. Block applies only to the Convox-managed bucket.