### PR TITLE
Aws regional sts endpoints

### DIFF
--- a/pkg/rack/terraform.go
+++ b/pkg/rack/terraform.go
@@ -796,6 +796,8 @@ func terraform(c *stdcli.Context, dir string, args ...string) error {
 	signal.Ignore(os.Interrupt)
 	defer signal.Reset(os.Interrupt)
 
+	os.Setenv("AWS_STS_REGIONAL_ENDPOINTS", "regional")
+
 	if err := c.Terminal("terraform", args...); err != nil {
 		return err
 	}

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/cloudformation/cloudformationiface"
@@ -90,7 +91,9 @@ func (p *Provider) WithContext(ctx context.Context) structs.Provider {
 }
 
 func (p *Provider) initializeAwsServices() error {
-	s, err := session.NewSession()
+	s, err := session.NewSession(aws.NewConfig().
+		WithSTSRegionalEndpoint(endpoints.RegionalSTSEndpoint),
+	)
 	if err != nil {
 		return err
 	}

--- a/provider/aws/helpers.go
+++ b/provider/aws/helpers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/convox/convox/pkg/common"
@@ -44,7 +45,8 @@ func (p *Provider) ecrAuth(host, access, secret string) (string, string, error) 
 	m := ecrHostMatcher.FindStringSubmatch(host)
 
 	c := &aws.Config{
-		Region: aws.String(m[2]),
+		Region:              aws.String(m[2]),
+		STSRegionalEndpoint: endpoints.RegionalSTSEndpoint,
 	}
 
 	if access != "" {

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -1,5 +1,6 @@
 provider "aws" {
-  region = var.region
+  region     = var.region
+  sts_region = var.region
 }
 
 provider "kubernetes" {


### PR DESCRIPTION
## Summary

Fixes rack install/update failures in AWS opt-in regions (eu-south-2, ap-south-2, me-central-1, etc.) by forcing regional STS endpoints.

- Add `sts_region = var.region` to Terraform AWS provider block
- Set `AWS_STS_REGIONAL_ENDPOINTS=regional` in CLI process env before spawning terraform (covers `aws eks get-token` exec blocks)
- Configure `STSRegionalEndpoint` on rack API server AWS sessions (needed for IRSA credential resolution)
- Configure `STSRegionalEndpoint` on ECR auth helper session (IRSA fallback path for cross-account/cross-region ECR)

- Closes #910

## Background

Opt-in regions require regional STS endpoints (`sts.<region>.amazonaws.com`). The global endpoint returns `InvalidClientTokenId` for credentials scoped to these regions. Regional endpoints work for ALL regions including established ones, so this is safe for existing racks.

No new Terraform variables or rack parameters. `sts_region` is a provider config attribute (not stored in state), so existing racks see no `terraform plan` diff.

## Changes

### `terraform/system/aws/main.tf`
Add `sts_region = var.region` to the AWS provider block. This tells the provider to resolve STS to the regional endpoint for its `GetCallerIdentity` credential validation during init. Only `provider "aws"` block in the repo — child modules inherit via `providers = { aws = aws }`.

### `pkg/rack/terraform.go`
Add `os.Setenv("AWS_STS_REGIONAL_ENDPOINTS", "regional")` in the `terraform()` function before spawning the terraform subprocess. Covers the `aws eks get-token` exec blocks in cluster/system modules (4 exec blocks total, none use `env` attribute overrides). The `terraformEnv()` function's return value is discarded by callers, so the env var must be set on the process directly.

### `provider/aws/aws.go`
Add `WithSTSRegionalEndpoint(endpoints.RegionalSTSEndpoint)` to the rack API server's `initializeAwsServices()` session creation. The rack API runs inside EKS using IRSA — credential resolution calls `sts:AssumeRoleWithWebIdentity`, which needs the regional STS endpoint in opt-in regions.

### `provider/aws/helpers.go`
Add `STSRegionalEndpoint: endpoints.RegionalSTSEndpoint` to the `ecrAuth()` session config. When called without explicit credentials (e.g., from `RepositoryAuth` for the rack's own ECR), the session falls back to IRSA, which needs regional STS. Without this, app deployments in opt-in regions would fail at ECR auth time.