### PR TITLE
Fix PDB annotation typo, accept both spellings

### DIFF
--- a/provider/k8s/controller_deployment.go
+++ b/provider/k8s/controller_deployment.go
@@ -30,8 +30,9 @@ var labelsForDeployment = []string{
 }
 
 const (
-	AnnotationPdbDisabled     = "convox.com/pdb-disbaled"
-	AnnotationPdbMinAvailable = "convox.com/pdb-minavailable"
+	AnnotationPdbDisabled           = "convox.com/pdb-disabled"
+	AnnotationPdbDisabledDeprecated = "convox.com/pdb-disbaled" // preserved for backward compat
+	AnnotationPdbMinAvailable       = "convox.com/pdb-minavailable"
 )
 
 type DeployController struct {
@@ -150,7 +151,7 @@ func (c *DeployController) SyncPDB(d *apps.Deployment, remove bool) error {
 		return fmt.Errorf("invalid deployment selector: %s/%s", d.Namespace, d.Name)
 	}
 
-	if d.Annotations[AnnotationPdbDisabled] == "true" || d.Spec.Template.Annotations[AnnotationPdbDisabled] == "true" {
+	if isPdbDisabled(d) {
 		remove = true
 	}
 
@@ -216,6 +217,19 @@ func assertDeployment(v interface{}) (*apps.Deployment, error) {
 	}
 
 	return d, nil
+}
+
+// isPdbDisabled checks whether PDB creation should be skipped for a deployment.
+// Accepts both the corrected annotation ("pdb-disabled") and the legacy typo
+// ("pdb-disbaled") for backward compatibility. If either annotation is set to
+// "true" on either the deployment or pod template, PDB is disabled.
+func isPdbDisabled(d *apps.Deployment) bool {
+	for _, key := range []string{AnnotationPdbDisabled, AnnotationPdbDisabledDeprecated} {
+		if d.Annotations[key] == "true" || d.Spec.Template.Annotations[key] == "true" {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *Provider) CreateOrPatchPDB(ctx context.Context, meta metav1.ObjectMeta, transform func(*policyv1.PodDisruptionBudget) *policyv1.PodDisruptionBudget, opts metav1.PatchOptions) (*policyv1.PodDisruptionBudget, error) {

--- a/provider/k8s/controller_deployment_test.go
+++ b/provider/k8s/controller_deployment_test.go
@@ -1,0 +1,91 @@
+package k8s
+
+import (
+	"testing"
+
+	apps "k8s.io/api/apps/v1"
+	ac "k8s.io/api/core/v1"
+	am "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsPdbDisabled(t *testing.T) {
+	tests := []struct {
+		name           string
+		deployAnnots   map[string]string
+		templateAnnots map[string]string
+		want           bool
+	}{
+		{
+			name: "no annotations",
+			want: false,
+		},
+		{
+			name:         "new spelling on deployment",
+			deployAnnots: map[string]string{AnnotationPdbDisabled: "true"},
+			want:         true,
+		},
+		{
+			name:           "new spelling on template",
+			templateAnnots: map[string]string{AnnotationPdbDisabled: "true"},
+			want:           true,
+		},
+		{
+			name:         "old spelling on deployment",
+			deployAnnots: map[string]string{AnnotationPdbDisabledDeprecated: "true"},
+			want:         true,
+		},
+		{
+			name:           "old spelling on template",
+			templateAnnots: map[string]string{AnnotationPdbDisabledDeprecated: "true"},
+			want:           true,
+		},
+		{
+			name:           "both spellings both true",
+			deployAnnots:   map[string]string{AnnotationPdbDisabled: "true"},
+			templateAnnots: map[string]string{AnnotationPdbDisabledDeprecated: "true"},
+			want:           true,
+		},
+		{
+			name:         "value is false",
+			deployAnnots: map[string]string{AnnotationPdbDisabled: "false"},
+			want:         false,
+		},
+		{
+			name:         "value is empty string",
+			deployAnnots: map[string]string{AnnotationPdbDisabled: ""},
+			want:         false,
+		},
+		{
+			name:         "value is 1",
+			deployAnnots: map[string]string{AnnotationPdbDisabled: "1"},
+			want:         false,
+		},
+		{
+			name:         "unrelated annotations only",
+			deployAnnots: map[string]string{"foo": "bar"},
+			want:         false,
+		},
+		{
+			name:           "mixed conflict new false deploy old true template",
+			deployAnnots:   map[string]string{AnnotationPdbDisabled: "false"},
+			templateAnnots: map[string]string{AnnotationPdbDisabledDeprecated: "true"},
+			want:           true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &apps.Deployment{
+				ObjectMeta: am.ObjectMeta{Annotations: tt.deployAnnots},
+				Spec: apps.DeploymentSpec{
+					Template: ac.PodTemplateSpec{
+						ObjectMeta: am.ObjectMeta{Annotations: tt.templateAnnots},
+					},
+				},
+			}
+			if got := isPdbDisabled(d); got != tt.want {
+				t.Errorf("isPdbDisabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Fix typo in PDB disable annotation: `convox.com/pdb-disbaled` → `convox.com/pdb-disabled`
- Both spellings are accepted for full backward compatibility — no user action required
- Extract `isPdbDisabled()` helper for testability

- Closes #944

## Details

The `AnnotationPdbDisabled` constant contained a typo (`disbaled` instead of `disabled`) since the PDB feature was introduced. user who discovered this annotation by reading source had to use the misspelled version; user who guessed the correct spelling got silent failure.

This change:
1. Points `AnnotationPdbDisabled` at the corrected string `convox.com/pdb-disabled`
2. Adds `AnnotationPdbDisabledDeprecated` preserving the old `convox.com/pdb-disbaled` string
3. Extracts `isPdbDisabled()` which checks both spellings on both deployment and pod template annotations
4. Adds 11-case table-driven test covering all annotation combinations

**Precedence rule:** If either annotation is `"true"` on either location, PDB is disabled. This biases toward the user's intent — if they asked to disable PDB in any form, it's disabled.

**Downgrade note:** If a user adopts the new correct spelling `convox.com/pdb-disabled` and later downgrades to a rack version before this change, the annotation will be silently ignored and the PDB will be recreated. This is safe-side failure (more protection, not less) and is inherent to any annotation addition.