### PR TITLE
feat: add azureFiles volumeOption for Azure Files CSI NFS support

### DIFF
--- a/assets/provider/azure/params.yaml
+++ b/assets/provider/azure/params.yaml
@@ -120,6 +120,12 @@ Groups:
         type: boolean
         description: Enables the NVIDIA GPU device plugin for GPU-accelerated workloads.
           Requires GPU-enabled VM sizes.
+      - name: azure_files_enable
+        default: "false"
+        type: boolean
+        description: Enable Azure Files NFS volumes for shared persistent storage
+          across service replicas. Creates a Premium FileStorage account and NFS
+          StorageClass.
       - name: nvidia_device_time_slicing_replicas
         default: "0"
         type: integer

--- a/docs/configuration/rack-parameters/azure/README.md
+++ b/docs/configuration/rack-parameters/azure/README.md
@@ -15,6 +15,7 @@ The following parameters are available for configuring your Convox rack on Micro
 |:-------------------------------------|:-------------------------------------------------------------------------|
 | [additional_build_groups_config](/configuration/rack-parameters/azure/additional_build_groups_config) | Configures additional dedicated build node pools for the cluster. |
 | [additional_node_groups_config](/configuration/rack-parameters/azure/additional_node_groups_config) | Configures additional customized node pools for the cluster. |
+| [azure_files_enable](/configuration/rack-parameters/azure/azure_files_enable) | Enable Azure Files NFS volumes for shared persistent storage. |
 | [cert_duration](/configuration/rack-parameters/azure/cert_duration) | Certificate renewal period. |
 | [docker_hub_password](/configuration/rack-parameters/azure/docker_hub_password) | Docker Hub access token for authenticated image pulls. |
 | [docker_hub_username](/configuration/rack-parameters/azure/docker_hub_username) | Docker Hub username for authenticated image pulls. |

--- a/docs/configuration/rack-parameters/azure/azure_files_enable.md
+++ b/docs/configuration/rack-parameters/azure/azure_files_enable.md
@@ -1,0 +1,51 @@
+---
+title: "azure_files_enable"
+slug: azure_files_enable
+url: /configuration/rack-parameters/azure/azure_files_enable
+---
+
+# azure_files_enable
+
+## Description
+The `azure_files_enable` parameter enables Azure Files NFS volumes for shared persistent storage across service replicas. This creates a Premium FileStorage account and an NFS StorageClass in your AKS cluster.
+
+## Default Value
+The default value for `azure_files_enable` is `false`.
+
+## Use Cases
+- **Shared Service Volumes**: Enable multiple service replicas to access the same file system simultaneously, supporting access modes like ReadWriteOnce (RWO), ReadOnlyMany (ROM), and ReadWriteMany (RWM).
+- **Persistent Storage**: Use Azure Files for applications requiring shared access to files across distributed instances and restarts.
+- **ML Model Storage**: Store large model weights on a shared NFS volume accessible by all replicas without downloading on each startup.
+
+## Setting Parameters
+To enable Azure Files volumes, use the following command:
+```bash
+$ convox rack params set azure_files_enable=true -r rackName
+Setting parameters... OK
+```
+This command enables the Azure Files NFS volume feature for your rack.
+
+## Additional Information
+Azure Files provides a scalable file storage solution using the NFS protocol. It uses a Premium FileStorage account for the performance required by NFS shares, with a minimum share size of 100GiB.
+
+AKS includes the Azure Files CSI driver (`file.csi.azure.com`) by default — no additional driver installation is needed.
+
+### Example Configuration
+To configure your services to use Azure Files for persistent storage, set up your `convox.yml` as follows:
+```yaml
+services:
+  web:
+    build: .
+    port: 3000
+    volumeOptions:
+      - azureFiles:
+          id: "shared-data"
+          accessMode: ReadWriteMany
+          mountPath: "/mnt/data/"
+      - azureFiles:
+          id: "models"
+          accessMode: ReadOnlyMany
+          mountPath: "/mnt/models/"
+          shareSize: "200Gi"
+```
+Enabling Azure Files provides shared, persistent NFS storage for your applications running on Azure AKS.

--- a/docs/configuration/volumes.md
+++ b/docs/configuration/volumes.md
@@ -8,6 +8,63 @@ url: /configuration/volumes
 
 Convox supports multiple types of volumes to manage both persistent and temporary data for your applications. These volumes provide flexibility for different use cases, from high-speed temporary data storage to persistent, scalable file storage across multiple services.
 
+## Azure Files Volumes
+
+> Azure only. Requires the [azure_files_enable](/configuration/rack-parameters/azure/azure_files_enable) rack parameter.
+
+Azure Files provides a scalable, persistent NFS storage solution that allows multiple Convox services to access the same file system simultaneously. Azure Files volumes use a Premium FileStorage account with the NFS protocol for high-performance shared storage.
+
+### Supported Access Modes
+
+- **ReadWriteOnce (RWO)**: Single-service write operations. Each service has dedicated write access to its own files.
+- **ReadOnlyMany (ROM)**: Multiple-service read operations. Suitable for distributing read-only content like model weights or configuration files across services.
+- **ReadWriteMany (RWM)**: Multi-service read/write operations. Useful for shared file access among multiple services.
+
+### Enabling Azure Files Volumes
+
+To use Azure Files volumes, you must enable Azure Files on your rack. Run the following command to enable it:
+
+```bash
+convox rack params set azure_files_enable=true -r rackName
+```
+
+### Configuring Azure Files Volumes in convox.yml
+
+After enabling the feature, define your Azure Files volumes in the `convox.yml` file:
+
+```yaml
+environment:
+  - PORT=3000
+services:
+  web:
+    build: .
+    port: 3000
+    volumeOptions:
+      - azureFiles:
+          id: "shared-data"
+          accessMode: ReadWriteMany
+          mountPath: "/mnt/data/"
+      - azureFiles:
+          id: "models"
+          accessMode: ReadOnlyMany
+          mountPath: "/mnt/models/"
+          shareSize: "200Gi"
+```
+
+- **azureFiles.id**: A unique identifier for the volume.
+- **azureFiles.accessMode**: Specifies ReadWriteMany, ReadOnlyMany, or ReadWriteOnce.
+- **azureFiles.mountPath**: Defines the mount point for the volume inside the service.
+- **azureFiles.shareSize**: (Optional) The size of the NFS share. Defaults to 100Gi. Azure Premium Files has a minimum share size of 100GiB.
+
+### Best Practices and Use Cases for Azure Files Volumes
+
+Azure Files volumes are ideal for:
+
+- **Shared Storage**: Ensures data is accessible to multiple service replicas.
+- **Persistent Storage Across Restarts**: Maintains data persistence even after service restarts or scaling events.
+- **ML Model Storage**: Store large model weights on a shared NFS volume accessible by all replicas without downloading on each startup.
+- **Content Management Systems**: Allows multiple editors to access and modify shared content.
+
 ## AWS EFS Volumes
 
 > AWS only. Requires the [efs_csi_driver_enable](/configuration/rack-parameters/aws/efs_csi_driver_enable) rack parameter.

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -105,7 +105,8 @@ var gcpKnownParams = map[string]bool{
 
 var azureKnownParams = map[string]bool{
 	"additional_build_groups_config": true, "additional_node_groups_config": true,
-	"cert_duration": true, "docker_hub_password": true, "docker_hub_username": true,
+	"azure_files_enable": true, "cert_duration": true,
+	"docker_hub_password": true, "docker_hub_username": true,
 	"fluentd_memory": true, "high_availability": true, "idle_timeout": true,
 	"image": true, "k8s_version": true, "max_on_demand_count": true,
 	"min_on_demand_count": true, "name": true, "nginx_additional_config": true,

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -788,6 +788,15 @@ func TestVolumeAzureFilesValidate(t *testing.T) {
 			wantErr: "azureFiles.id is required",
 		},
 		{
+			name: "invalid id format",
+			vol: manifest.VolumeAzureFiles{
+				Id:         "My Volume/data",
+				AccessMode: "ReadWriteMany",
+				MountPath:  "/mnt/data",
+			},
+			wantErr: "azureFiles.id must match ^[a-z][a-z0-9-]*$",
+		},
+		{
 			name: "missing mountPath",
 			vol: manifest.VolumeAzureFiles{
 				Id:         "models",
@@ -812,6 +821,26 @@ func TestVolumeAzureFilesValidate(t *testing.T) {
 				MountPath:  "/mnt/data",
 				ShareSize:  "200Gi",
 			},
+		},
+		{
+			name: "invalid shareSize format",
+			vol: manifest.VolumeAzureFiles{
+				Id:         "models",
+				AccessMode: "ReadWriteMany",
+				MountPath:  "/mnt/data",
+				ShareSize:  "banana",
+			},
+			wantErr: "azureFiles.shareSize is invalid: banana",
+		},
+		{
+			name: "shareSize below minimum",
+			vol: manifest.VolumeAzureFiles{
+				Id:         "models",
+				AccessMode: "ReadWriteMany",
+				MountPath:  "/mnt/data",
+				ShareSize:  "1Gi",
+			},
+			wantErr: "azureFiles.shareSize must be at least 100Gi (Azure Premium NFS minimum)",
 		},
 	}
 

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -764,3 +764,76 @@ func TestManifestKeda(t *testing.T) {
 	require.Equal(t, true, m.Services[0].Scale.IsKedaEnabled())
 	require.Equal(t, 1, len(m.Services[0].Scale.Keda.Triggers))
 }
+
+func TestVolumeAzureFilesValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		vol     manifest.VolumeAzureFiles
+		wantErr string
+	}{
+		{
+			name: "valid",
+			vol: manifest.VolumeAzureFiles{
+				Id:         "models",
+				AccessMode: "ReadWriteMany",
+				MountPath:  "/mnt/data",
+			},
+		},
+		{
+			name: "missing id",
+			vol: manifest.VolumeAzureFiles{
+				AccessMode: "ReadWriteMany",
+				MountPath:  "/mnt/data",
+			},
+			wantErr: "azureFiles.id is required",
+		},
+		{
+			name: "missing mountPath",
+			vol: manifest.VolumeAzureFiles{
+				Id:         "models",
+				AccessMode: "ReadWriteMany",
+			},
+			wantErr: "azureFiles.mountPath is required",
+		},
+		{
+			name: "invalid accessMode",
+			vol: manifest.VolumeAzureFiles{
+				Id:         "models",
+				AccessMode: "Invalid",
+				MountPath:  "/mnt/data",
+			},
+			wantErr: "azureFiles.accessMode must be one of these values: ReadOnlyMany, ReadWriteMany, ReadWriteOnce",
+		},
+		{
+			name: "valid with shareSize",
+			vol: manifest.VolumeAzureFiles{
+				Id:         "models",
+				AccessMode: "ReadWriteMany",
+				MountPath:  "/mnt/data",
+				ShareSize:  "200Gi",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.vol.Validate()
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestVolumeOptionAzureFilesValidate(t *testing.T) {
+	vo := manifest.VolumeOption{
+		AzureFiles: &manifest.VolumeAzureFiles{
+			Id:         "shared",
+			AccessMode: "ReadWriteMany",
+			MountPath:  "/data",
+		},
+	}
+	require.NoError(t, vo.Validate())
+}

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -180,6 +180,9 @@ func (v VolumeAzureFiles) Validate() error {
 	if v.Id == "" {
 		return fmt.Errorf("azureFiles.id is required")
 	}
+	if !NameValidator.MatchString(v.Id) {
+		return fmt.Errorf("azureFiles.id must match %s", NameValidator.String())
+	}
 	if v.MountPath == "" {
 		return fmt.Errorf("azureFiles.mountPath is required")
 	}
@@ -193,6 +196,18 @@ func (v VolumeAzureFiles) Validate() error {
 	if !containsInStringSlice(allowedModes, v.AccessMode) {
 		return fmt.Errorf("azureFiles.accessMode must be one of these values: %s", strings.Join(allowedModes, ", "))
 	}
+
+	if v.ShareSize != "" {
+		qty, err := resource.ParseQuantity(v.ShareSize)
+		if err != nil {
+			return fmt.Errorf("azureFiles.shareSize is invalid: %s", v.ShareSize)
+		}
+		minQty := resource.MustParse("100Gi")
+		if qty.Cmp(minQty) < 0 {
+			return fmt.Errorf("azureFiles.shareSize must be at least 100Gi (Azure Premium NFS minimum)")
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -91,8 +91,9 @@ type InitContainer struct {
 }
 
 type VolumeOption struct {
-	EmptyDir *VolumeEmptyDir `yaml:"emptyDir,omitempty"`
-	AwsEfs   *VolumeAwsEfs   `yaml:"awsEfs,omitempty"`
+	EmptyDir   *VolumeEmptyDir   `yaml:"emptyDir,omitempty"`
+	AwsEfs     *VolumeAwsEfs     `yaml:"awsEfs,omitempty"`
+	AzureFiles *VolumeAzureFiles `yaml:"azureFiles,omitempty"`
 }
 
 func (v VolumeOption) Validate() error {
@@ -101,6 +102,9 @@ func (v VolumeOption) Validate() error {
 	}
 	if v.AwsEfs != nil {
 		return v.AwsEfs.Validate()
+	}
+	if v.AzureFiles != nil {
+		return v.AzureFiles.Validate()
 	}
 	return nil
 }
@@ -162,6 +166,34 @@ func (v *VolumeAwsEfs) ProcessTemplate(efsFsId, app, service string) {
 
 	v.VolumeHandle = strings.ReplaceAll(v.VolumeHandle, "[APP]", app)
 	v.VolumeHandle = strings.ReplaceAll(v.VolumeHandle, "[SERVICE]", service)
+}
+
+type VolumeAzureFiles struct {
+	Id string `yaml:"id"`
+
+	AccessMode string `yaml:"accessMode,omitempty"`
+	MountPath  string `yaml:"mountPath"`
+	ShareSize  string `yaml:"shareSize,omitempty"`
+}
+
+func (v VolumeAzureFiles) Validate() error {
+	if v.Id == "" {
+		return fmt.Errorf("azureFiles.id is required")
+	}
+	if v.MountPath == "" {
+		return fmt.Errorf("azureFiles.mountPath is required")
+	}
+
+	allowedModes := []string{
+		PVCAccessModeReadOnlyMany,
+		PVCAccessModeReadWriteMany,
+		PVCAccessModeReadWriteOnce,
+	}
+
+	if !containsInStringSlice(allowedModes, v.AccessMode) {
+		return fmt.Errorf("azureFiles.accessMode must be one of these values: %s", strings.Join(allowedModes, ", "))
+	}
+	return nil
 }
 
 type Services []Service

--- a/provider/k8s/k8s.go
+++ b/provider/k8s/k8s.go
@@ -64,6 +64,7 @@ type Provider struct {
 	DomainInternal                      string
 	DynamicClient                       dynamic.Interface
 	EfsFileSystemId                     string
+	AzureFilesEnabled                   string
 	Engine                              Engine
 	Image                               string
 	JwtMngr                             *jwt.JwtManager
@@ -179,6 +180,7 @@ func FromEnv() (*Provider, error) {
 		DomainInternal:                   os.Getenv("DOMAIN_INTERNAL"),
 		DynamicClient:                    dc,
 		EfsFileSystemId:                  os.Getenv("EFS_FILE_SYSTEM_ID"),
+		AzureFilesEnabled:                os.Getenv("AZURE_FILES_ENABLED"),
 		Image:                            os.Getenv("IMAGE"),
 		MetricScraper:                    ms,
 		MetricsClient:                    mc,

--- a/provider/k8s/release.go
+++ b/provider/k8s/release.go
@@ -841,7 +841,7 @@ func (p *Provider) releaseTemplateAzureFiles(a *structs.App, s manifest.Service)
 	for i := range s.VolumeOptions {
 		if s.VolumeOptions[i].AzureFiles != nil {
 			hasAzureFiles = true
-			if p.AzureFilesEnabled == "" || p.AzureFilesEnabled == "false" {
+			if p.AzureFilesEnabled != "true" {
 				return nil, structs.ErrBadRequest("azure files is not enabled but azureFiles volume is specified")
 			}
 		}

--- a/provider/k8s/release.go
+++ b/provider/k8s/release.go
@@ -651,6 +651,15 @@ func (p *Provider) releaseTemplateServices(a *structs.App, e structs.Environment
 			items = append(items, vdata)
 		}
 
+		// azure files
+		afdata, err := p.releaseTemplateAzureFiles(a, ss[i])
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		if afdata != nil {
+			items = append(items, afdata)
+		}
+
 		s := ss[i]
 		min := s.Deployment.Minimum
 		max := s.Deployment.Maximum
@@ -820,6 +829,39 @@ func (p *Provider) releaseTemplateEfs(a *structs.App, s manifest.Service) ([]byt
 	}
 
 	data, err := p.RenderTemplate("app/efs", params)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return data, nil
+}
+
+func (p *Provider) releaseTemplateAzureFiles(a *structs.App, s manifest.Service) ([]byte, error) {
+	hasAzureFiles := false
+	for i := range s.VolumeOptions {
+		if s.VolumeOptions[i].AzureFiles != nil {
+			hasAzureFiles = true
+			if p.AzureFilesEnabled == "" || p.AzureFilesEnabled == "false" {
+				return nil, structs.ErrBadRequest("azure files is not enabled but azureFiles volume is specified")
+			}
+		}
+		if err := s.VolumeOptions[i].Validate(); err != nil {
+			return nil, err
+		}
+	}
+
+	if !hasAzureFiles {
+		return nil, nil
+	}
+
+	params := map[string]interface{}{
+		"App":       a,
+		"Namespace": p.AppNamespace(a.Name),
+		"Rack":      p.Name,
+		"Service":   s,
+	}
+
+	data, err := p.RenderTemplate("app/azurefiles", params)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/provider/k8s/template/app/azurefiles.yml.tmpl
+++ b/provider/k8s/template/app/azurefiles.yml.tmpl
@@ -1,0 +1,22 @@
+{{ range .Service.VolumeOptions }}
+{{ with .AzureFiles }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: azurefiles-{{$.Service.Name}}-{{.Id}}
+  namespace: {{$.Namespace}}
+  labels:
+    system: convox
+    {{ range keyValue $.Service.Labels }}
+    {{.Key}}: "{{.Value}}"
+    {{ end }}
+spec:
+  accessModes:
+    - {{.AccessMode}}
+  storageClassName: azurefile-csi-nfs
+  resources:
+    requests:
+      storage: {{ if .ShareSize }}{{.ShareSize}}{{ else }}100Gi{{ end }}
+{{ end }}
+{{ end }}

--- a/provider/k8s/template/app/azurefiles.yml.tmpl
+++ b/provider/k8s/template/app/azurefiles.yml.tmpl
@@ -15,6 +15,7 @@ spec:
   accessModes:
     - {{.AccessMode}}
   storageClassName: azurefile-csi-nfs
+  volumeMode: Filesystem
   resources:
     requests:
       storage: {{ if .ShareSize }}{{.ShareSize}}{{ else }}100Gi{{ end }}

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -191,6 +191,10 @@ spec:
         - name: efs-{{ .Id }}
           mountPath: {{ .MountPath }}
         {{ end }}
+        {{ with .AzureFiles }}
+        - name: azurefiles-{{ .Id }}
+          mountPath: {{ .MountPath }}
+        {{ end }}
         {{ end }}
         {{ range .Service.InitContainer.ConfigMounts }}
         - name: cfg-{{ .Id }}
@@ -366,6 +370,10 @@ spec:
         - name: efs-{{ .Id }}
           mountPath: {{ .MountPath }}
         {{ end }}
+        {{ with .AzureFiles }}
+        - name: azurefiles-{{ .Id }}
+          mountPath: {{ .MountPath }}
+        {{ end }}
         {{ end }}
       volumes:
       - name: ca
@@ -395,6 +403,11 @@ spec:
       - name: efs-{{ .Id }}
         persistentVolumeClaim:
           claimName: efs-{{$.Service.Name}}-{{.Id}}
+      {{ end }}
+      {{ with .AzureFiles }}
+      - name: azurefiles-{{ .Id }}
+        persistentVolumeClaim:
+          claimName: azurefiles-{{$.Service.Name}}-{{.Id}}
       {{ end }}
       {{ end }}
       {{ range $.Service.ConfigMounts }}

--- a/terraform/api/azure/main.tf
+++ b/terraform/api/azure/main.tf
@@ -66,7 +66,7 @@ module "k8s" {
   env = {
     AZURE_CLIENT_ID                      = azuread_service_principal.api.client_id
     AZURE_CLIENT_SECRET                  = azuread_service_principal_password.api.value
-    AZURE_FILES_ENABLED                  = tostring(var.azure_files_enabled)
+    AZURE_FILES_ENABLED                  = tostring(var.azure_files_enable)
     AZURE_SUBSCRIPTION_ID                = data.azurerm_subscription.current.subscription_id
     AZURE_TENANT_ID                      = data.azurerm_client_config.current.tenant_id
     CERT_MANAGER                         = "true"

--- a/terraform/api/azure/main.tf
+++ b/terraform/api/azure/main.tf
@@ -66,6 +66,7 @@ module "k8s" {
   env = {
     AZURE_CLIENT_ID                      = azuread_service_principal.api.client_id
     AZURE_CLIENT_SECRET                  = azuread_service_principal_password.api.value
+    AZURE_FILES_ENABLED                  = tostring(var.azure_files_enabled)
     AZURE_SUBSCRIPTION_ID                = data.azurerm_subscription.current.subscription_id
     AZURE_TENANT_ID                      = data.azurerm_client_config.current.tenant_id
     CERT_MANAGER                         = "true"

--- a/terraform/api/azure/variables.tf
+++ b/terraform/api/azure/variables.tf
@@ -2,7 +2,7 @@ variable "cluster" {
   type = string
 }
 
-variable "azure_files_enabled" {
+variable "azure_files_enable" {
   default = false
   type    = bool
 }

--- a/terraform/api/azure/variables.tf
+++ b/terraform/api/azure/variables.tf
@@ -2,6 +2,11 @@ variable "cluster" {
   type = string
 }
 
+variable "azure_files_enabled" {
+  default = false
+  type    = bool
+}
+
 variable "fluentd_memory" {
   type    = string
   default = "200Mi"

--- a/terraform/cluster/azure/azurefiles.tf
+++ b/terraform/cluster/azure/azurefiles.tf
@@ -1,0 +1,51 @@
+// Azure Files NFS storage class and storage account
+// Gated by azure_files_enable variable
+// AKS includes the azurefile-csi driver by default, so no CSI driver installation is needed
+
+resource "azurerm_storage_account" "azurefiles" {
+  count = var.azure_files_enable ? 1 : 0
+
+  name                     = "af${substr(replace(var.name, "/[^a-z0-9]/", ""), 0, 16)}${random_string.azurefiles_suffix[0].result}"
+  resource_group_name      = var.resource_group_name
+  location                 = var.resource_group_location
+  account_tier             = "Premium"
+  account_kind             = "FileStorage"
+  account_replication_type = "LRS"
+
+  tags = {
+    system = "convox"
+    rack   = var.name
+  }
+}
+
+resource "random_string" "azurefiles_suffix" {
+  count = var.azure_files_enable ? 1 : 0
+
+  length  = 6
+  special = false
+  upper   = false
+}
+
+resource "kubernetes_storage_class_v1" "azurefile_csi_nfs" {
+  count = var.azure_files_enable ? 1 : 0
+
+  metadata {
+    name = "azurefile-csi-nfs"
+  }
+
+  storage_provisioner    = "file.csi.azure.com"
+  reclaim_policy         = "Delete"
+  volume_binding_mode    = "Immediate"
+  allow_volume_expansion = true
+
+  parameters = {
+    protocol         = "nfs"
+    skuName          = "Premium_LRS"
+    resourceGroup    = var.resource_group_name
+    storageAccount   = azurerm_storage_account.azurefiles[0].name
+  }
+
+  mount_options = [
+    "nconnect=4",
+  ]
+}

--- a/terraform/cluster/azure/outputs.tf
+++ b/terraform/cluster/azure/outputs.tf
@@ -22,6 +22,6 @@ output "workspace" {
   value = azurerm_log_analytics_workspace.rack.workspace_id
 }
 
-output "azure_files_enabled" {
+output "azure_files_enable" {
   value = var.azure_files_enable
 }

--- a/terraform/cluster/azure/outputs.tf
+++ b/terraform/cluster/azure/outputs.tf
@@ -21,3 +21,7 @@ output "id" {
 output "workspace" {
   value = azurerm_log_analytics_workspace.rack.workspace_id
 }
+
+output "azure_files_enabled" {
+  value = var.azure_files_enable
+}

--- a/terraform/cluster/azure/variables.tf
+++ b/terraform/cluster/azure/variables.tf
@@ -66,3 +66,8 @@ variable "terraform_update_timeout" {
 variable "resource_group_location" {
   type = string
 }
+
+variable "azure_files_enable" {
+  default = false
+  type    = bool
+}

--- a/terraform/rack/azure/main.tf
+++ b/terraform/rack/azure/main.tf
@@ -24,6 +24,7 @@ module "api" {
   }
 
   cluster                              = var.cluster
+  azure_files_enabled                  = var.azure_files_enabled
   docker_hub_authentication            = module.k8s.docker_hub_authentication
   fluentd_memory                       = var.fluentd_memory
   domain                               = module.router.endpoint

--- a/terraform/rack/azure/main.tf
+++ b/terraform/rack/azure/main.tf
@@ -24,7 +24,7 @@ module "api" {
   }
 
   cluster                              = var.cluster
-  azure_files_enabled                  = var.azure_files_enabled
+  azure_files_enable                   = var.azure_files_enable
   docker_hub_authentication            = module.k8s.docker_hub_authentication
   fluentd_memory                       = var.fluentd_memory
   domain                               = module.router.endpoint

--- a/terraform/rack/azure/variables.tf
+++ b/terraform/rack/azure/variables.tf
@@ -2,7 +2,7 @@ variable "cluster" {
   type = string
 }
 
-variable "azure_files_enabled" {
+variable "azure_files_enable" {
   default = false
   type    = bool
 }

--- a/terraform/rack/azure/variables.tf
+++ b/terraform/rack/azure/variables.tf
@@ -2,6 +2,11 @@ variable "cluster" {
   type = string
 }
 
+variable "azure_files_enabled" {
+  default = false
+  type    = bool
+}
+
 variable "fluentd_memory" {
   type    = string
   default = "200Mi"

--- a/terraform/system/azure/main.tf
+++ b/terraform/system/azure/main.tf
@@ -46,6 +46,7 @@ module "cluster" {
 
   additional_node_groups              = local.additional_node_groups
   additional_build_groups             = local.additional_build_groups
+  azure_files_enable                  = var.azure_files_enable
   k8s_version                         = var.k8s_version
   max_on_demand_count                 = var.max_on_demand_count
   min_on_demand_count                 = var.min_on_demand_count
@@ -70,6 +71,7 @@ module "rack" {
   }
 
   cluster                              = module.cluster.id
+  azure_files_enabled                  = module.cluster.azure_files_enabled
   docker_hub_username                  = var.docker_hub_username
   docker_hub_password                  = var.docker_hub_password
   high_availability                    = var.high_availability

--- a/terraform/system/azure/main.tf
+++ b/terraform/system/azure/main.tf
@@ -71,7 +71,7 @@ module "rack" {
   }
 
   cluster                              = module.cluster.id
-  azure_files_enabled                  = module.cluster.azure_files_enabled
+  azure_files_enable                   = module.cluster.azure_files_enable
   docker_hub_username                  = var.docker_hub_username
   docker_hub_password                  = var.docker_hub_password
   high_availability                    = var.high_availability

--- a/terraform/system/azure/telemetry.tf
+++ b/terraform/system/azure/telemetry.tf
@@ -5,6 +5,7 @@ locals {
   telemetry_map = {
     additional_build_groups_config = var.additional_build_groups_config
     additional_node_groups_config = var.additional_node_groups_config
+    azure_files_enable = var.azure_files_enable
     cert_duration = var.cert_duration
     docker_hub_password = var.docker_hub_password
     docker_hub_username = var.docker_hub_username
@@ -38,6 +39,7 @@ locals {
   telemetry_default_map = {
     additional_build_groups_config = ""
     additional_node_groups_config = ""
+    azure_files_enable = "false"
     cert_duration = "2160h"
     docker_hub_password = ""
     docker_hub_username = ""

--- a/terraform/system/azure/variables.tf
+++ b/terraform/system/azure/variables.tf
@@ -139,6 +139,11 @@ variable "fluentd_memory" {
   default = "200Mi"
 }
 
+variable "azure_files_enable" {
+  default = false
+  type    = bool
+}
+
 variable "whitelist" {
   default = "0.0.0.0/0"
 }


### PR DESCRIPTION
## Summary

Add native Azure Files volume support as a new `volumeOption` type, following the existing `awsEfs` pattern. This enables shared persistent NFS storage for services running on Azure/AKS.

## Usage

```yaml
services:
  web:
    volumeOptions:
      - azureFiles:
          id: shared-data
          accessMode: ReadWriteMany
          mountPath: /mnt/data
          shareSize: 200Gi  # optional, defaults to 100Gi
```

Requires enabling on the rack:

```
convox rack params set azure_files_enable=true
```

## Changes

### Go (manifest + provider)

- **`pkg/manifest/service.go`** — Added `VolumeAzureFiles` struct with `Id`, `AccessMode`, `MountPath`, `ShareSize` fields; `Validate()` method with ID format validation (`NameValidator`), accessMode enum check, and shareSize validation (format + 100Gi minimum enforcement); wired into `VolumeOption` struct dispatch
- **`pkg/cli/rack.go`** — Added `azure_files_enable` to `azureKnownParams` whitelist so the CLI recognizes the parameter
- **`provider/k8s/k8s.go`** — Added `AzureFilesEnabled` field to Provider, initialized from `AZURE_FILES_ENABLED` env var
- **`provider/k8s/release.go`** — Added `releaseTemplateAzureFiles()` with deny-by-default enablement check (`!= "true"`) and validation, called from `releaseTemplateServices()`

### Kubernetes Templates

- **`provider/k8s/template/app/azurefiles.yml.tmpl`** (new) — PVC template using `azurefile-csi-nfs` StorageClass with dynamic provisioning, `volumeMode: Filesystem`
- **`provider/k8s/template/app/service.yml.tmpl`** — Added `azureFiles` volume mount blocks in init container, main container, and volumes section

### Terraform (infrastructure + variable threading)

- **`terraform/cluster/azure/azurefiles.tf`** (new) — Premium FileStorage account + NFS StorageClass (`file.csi.azure.com` provisioner), all resources gated by `azure_files_enable` count
- Variable threading: `system` → `cluster` → `rack` → `API` across `variables.tf`, `outputs.tf`, and `main.tf` in all four modules — using consistent `azure_files_enable` naming throughout
- **`terraform/system/azure/telemetry.tf`** — Added `azure_files_enable` to both `telemetry_map` and `telemetry_default_map`
- **`assets/provider/azure/params.yaml`** — Added `azure_files_enable` rack parameter (default: false)

### Console3

- **`api/controller/cli.go`** — Added `azure_files_enable` to `boolParams` validation whitelist in `validateRackParams()`

### Tests

- **`pkg/manifest/manifest_test.go`** — 9 test cases: valid config, missing id, invalid id format, missing mountPath, invalid accessMode, valid shareSize, invalid shareSize format, shareSize below 100Gi minimum, VolumeOption integration

## Design Decisions

- **Dynamic PVC provisioning** (StorageClass + PVC only) rather than static PV + PVC — Azure Files CSI handles NFS share creation automatically, unlike EFS which needs explicit volume handles
- **NFS protocol** over SMB for EFS-like semantics and Linux compatibility
- **Premium FileStorage** account kind required for NFS shares (Azure requirement)
- **`nconnect=4`** mount option for improved throughput
- **AKS includes `file.csi.azure.com`** by default — no CSI driver addon installation needed
- **Deny-by-default enable check** — `AzureFilesEnabled != "true"` rejects any non-explicit-true value
- **ShareSize validation** — `resource.ParseQuantity` for format, 100Gi minimum to match Azure Premium NFS requirements
- **Volume ID format validation** — uses existing `NameValidator` (`^[a-z][a-z0-9-]*$`) to prevent invalid K8s resource names at manifest time rather than deploy time

## Parameter Guard Layers (belt-and-suspenders)

| Layer | File | Guard |
|-------|------|-------|
| CLI | `pkg/cli/rack.go` | `azureKnownParams` — rejects unknown params with suggestion |
| Console3 | `api/controller/cli.go` | `boolParams` — validates "true"/"false" server-side |
| Terraform | `system/azure/variables.tf` | `type = bool` — rejects non-boolean at apply time |

## Files Changed (18)

| File | Change |
|------|--------|
| `pkg/manifest/service.go` | VolumeAzureFiles struct + validation (ID format, shareSize) |
| `pkg/manifest/manifest_test.go` | 9 unit tests |
| `pkg/cli/rack.go` | azureKnownParams whitelist |
| `provider/k8s/k8s.go` | AzureFilesEnabled field |
| `provider/k8s/release.go` | releaseTemplateAzureFiles() |
| `provider/k8s/template/app/azurefiles.yml.tmpl` | PVC template (new) |
| `provider/k8s/template/app/service.yml.tmpl` | Volume mounts |
| `terraform/cluster/azure/azurefiles.tf` | Storage + StorageClass (new) |
| `terraform/cluster/azure/variables.tf` | azure_files_enable var |
| `terraform/cluster/azure/outputs.tf` | azure_files_enable output |
| `terraform/system/azure/main.tf` | Threading |
| `terraform/system/azure/variables.tf` | azure_files_enable var |
| `terraform/system/azure/telemetry.tf` | Telemetry entries |
| `terraform/rack/azure/main.tf` | Threading |
| `terraform/rack/azure/variables.tf` | azure_files_enable var |
| `terraform/api/azure/main.tf` | AZURE_FILES_ENABLED env |
| `terraform/api/azure/variables.tf` | azure_files_enable var |
| `assets/provider/azure/params.yaml` | Rack parameter |
