### PR TITLE
fix port/ports dedup in manifest loading

### DIFF
--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -215,6 +215,23 @@ func (m *Manifest) ApplyDefaults() error {
 			m.Services[i].Port.Scheme = "http"
 		}
 
+		// deduplicate ports: remove entries from Ports that match Port.Port
+		// with the same effective protocol. Port (main) takes priority because
+		// it controls health checks, probes, and ingress routing.
+		if s.Port.Port > 0 && len(s.Ports) > 0 {
+			filtered := make([]ServicePortProtocol, 0, len(s.Ports))
+			for _, p := range s.Ports {
+				proto := strings.ToLower(p.Protocol)
+				if proto == "" {
+					proto = "tcp"
+				}
+				if p.Port != s.Port.Port || proto != "tcp" {
+					filtered = append(filtered, p)
+				}
+			}
+			m.Services[i].Ports = filtered
+		}
+
 		sp := fmt.Sprintf("services.%s.scale", s.Name)
 
 		// if no scale attributes set

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -764,3 +764,143 @@ func TestManifestKeda(t *testing.T) {
 	require.Equal(t, true, m.Services[0].Scale.IsKedaEnabled())
 	require.Equal(t, 1, len(m.Services[0].Scale.Keda.Triggers))
 }
+
+func TestLoadPortDeduplication(t *testing.T) {
+	// port and ports with same value — ports entry removed
+	data := []byte(`services:
+  web:
+    port: 4001
+    ports:
+      - 4001
+`)
+	m, err := manifest.Load(data, map[string]string{})
+	require.NoError(t, err)
+	require.Equal(t, 4001, m.Services[0].Port.Port)
+	require.Len(t, m.Services[0].Ports, 0)
+}
+
+func TestLoadPortDeduplicationDifferentPorts(t *testing.T) {
+	// port and ports with different values — no dedup
+	data := []byte(`services:
+  web:
+    port: 4001
+    ports:
+      - 8080
+`)
+	m, err := manifest.Load(data, map[string]string{})
+	require.NoError(t, err)
+	require.Equal(t, 4001, m.Services[0].Port.Port)
+	require.Len(t, m.Services[0].Ports, 1)
+	require.Equal(t, 8080, m.Services[0].Ports[0].Port)
+	require.Equal(t, "tcp", m.Services[0].Ports[0].Protocol)
+}
+
+func TestLoadPortDeduplicationDifferentProtocol(t *testing.T) {
+	// port: 4001 (TCP) + ports: [4001/udp] — NOT a duplicate
+	// K8s uses (port, protocol) as composite merge key
+	data := []byte(`services:
+  web:
+    port: 4001
+    ports:
+      - 4001/udp
+`)
+	m, err := manifest.Load(data, map[string]string{})
+	require.NoError(t, err)
+	require.Equal(t, 4001, m.Services[0].Port.Port)
+	require.Len(t, m.Services[0].Ports, 1)
+	require.Equal(t, 4001, m.Services[0].Ports[0].Port)
+	require.Equal(t, "udp", m.Services[0].Ports[0].Protocol)
+}
+
+func TestLoadPortDeduplicationPartial(t *testing.T) {
+	// port overlaps one of several ports entries — only duplicate removed
+	data := []byte(`services:
+  web:
+    port: 4001
+    ports:
+      - 4001
+      - 8080
+`)
+	m, err := manifest.Load(data, map[string]string{})
+	require.NoError(t, err)
+	require.Equal(t, 4001, m.Services[0].Port.Port)
+	require.Len(t, m.Services[0].Ports, 1)
+	require.Equal(t, 8080, m.Services[0].Ports[0].Port)
+	require.Equal(t, "tcp", m.Services[0].Ports[0].Protocol)
+}
+
+func TestLoadPortDeduplicationMultiService(t *testing.T) {
+	// only the service with overlapping ports gets deduped
+	data := []byte(`services:
+  api:
+    port: 3000
+    ports:
+      - 3000
+      - 8080
+  worker:
+    ports:
+      - 9090
+`)
+	m, err := manifest.Load(data, map[string]string{})
+	require.NoError(t, err)
+	api, err := m.Service("api")
+	require.NoError(t, err)
+	require.Equal(t, 3000, api.Port.Port)
+	require.Len(t, api.Ports, 1)
+	require.Equal(t, 8080, api.Ports[0].Port)
+	worker, err := m.Service("worker")
+	require.NoError(t, err)
+	require.Equal(t, 0, worker.Port.Port)
+	require.Len(t, worker.Ports, 1)
+	require.Equal(t, 9090, worker.Ports[0].Port)
+}
+
+func TestLoadPortDeduplicationWithScheme(t *testing.T) {
+	// port with https scheme + same port in ports — still deduped
+	data := []byte(`services:
+  web:
+    port: https:4001
+    ports:
+      - 4001
+`)
+	m, err := manifest.Load(data, map[string]string{})
+	require.NoError(t, err)
+	require.Equal(t, 4001, m.Services[0].Port.Port)
+	require.Equal(t, "https", m.Services[0].Port.Scheme)
+	require.Len(t, m.Services[0].Ports, 0)
+}
+
+func TestLoadPortNoDeduplicationPortOnly(t *testing.T) {
+	// port only — no change
+	data := []byte(`services:
+  web:
+    port: 4001
+`)
+	m, err := manifest.Load(data, map[string]string{})
+	require.NoError(t, err)
+	require.Equal(t, 4001, m.Services[0].Port.Port)
+	require.Len(t, m.Services[0].Ports, 0)
+}
+
+func TestLoadPortNoDeduplicationPortsOnly(t *testing.T) {
+	// ports only — no change
+	data := []byte(`services:
+  web:
+    ports:
+      - 4001
+`)
+	m, err := manifest.Load(data, map[string]string{})
+	require.NoError(t, err)
+	require.Equal(t, 0, m.Services[0].Port.Port)
+	require.Len(t, m.Services[0].Ports, 1)
+}
+
+func TestLoadPortDeduplicationEmptyProtocol(t *testing.T) {
+	// Quoted string port without protocol suffix parses Protocol=""
+	// The dedup normalizes empty protocol to "tcp" before comparison
+	data := []byte("services:\n  web:\n    port: 4001\n    ports:\n      - \"4001\"\n")
+	m, err := manifest.Load(data, map[string]string{})
+	require.NoError(t, err)
+	require.Equal(t, 4001, m.Services[0].Port.Port)
+	require.Len(t, m.Services[0].Ports, 0)
+}


### PR DESCRIPTION
## Fix: Deduplicate port/ports in manifest loading

- Closes #960

### Problem

Deploys fail when `port` and `ports` in `convox.yml` specify the same port number. The K8s Service template renders two entries with different names (`main` vs `port-N`) at the same port number. When `kubectl apply` computes a strategic merge patch, having two entries at the same merge key causes undefined behavior — the patch can delete the only Service port, and Kubernetes rejects the result with `spec.ports: Required value`.

### Fix

Deduplicate ports during manifest loading in `ApplyDefaults()`. When `port` (the main service port) and an entry in `ports` share the same port number and protocol (TCP), the duplicate is removed from `ports`. The `port` field takes priority because it controls health checks, probes, and ingress routing.

The dedup is protocol-aware: `port: 4001` (TCP) and `ports: [4001/udp]` are NOT considered duplicates because Kubernetes uses `(port, protocol)` as the composite merge key.

### What changes

- `pkg/manifest/manifest.go` — 10 lines added to `ApplyDefaults()` for port deduplication
- `pkg/manifest/manifest_test.go` — 9 test cases covering: exact match, different ports, different protocols, partial overlap, multi-service, scheme variants, port-only, ports-only, and empty-protocol edge case

### What doesn't change

- Zero template changes — dedup at load time fixes all rendering sites (Service spec.ports AND Deployment container ports)
- No Terraform changes
- No console changes
- No rack parameter changes
- Existing deploys with non-overlapping ports are completely unaffected
