### PR TITLE
replace deprecated ioutil with modern equivalents

### DIFF
--- a/pkg/api/app_test.go
+++ b/pkg/api/app_test.go
@@ -3,7 +3,7 @@ package api_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -176,12 +176,12 @@ func TestAppListError(t *testing.T) {
 func TestAppLogs(t *testing.T) {
 	testServer(t, func(c *stdsdk.Client, p *structs.MockProvider) {
 		d1 := []byte("test")
-		r1 := ioutil.NopCloser(bytes.NewReader(d1))
+		r1 := io.NopCloser(bytes.NewReader(d1))
 		opts := structs.LogsOptions{Since: options.Duration(2 * time.Minute)}
 		p.On("AppLogs", "app1", opts).Return(r1, nil)
 		r2, err := c.Websocket("/apps/app1/logs", stdsdk.RequestOptions{})
 		require.NoError(t, err)
-		d2, err := ioutil.ReadAll(r2)
+		d2, err := io.ReadAll(r2)
 		require.NoError(t, err)
 		require.Equal(t, d1, d2)
 	})
@@ -194,7 +194,7 @@ func TestAppLogsError(t *testing.T) {
 		r1, err := c.Websocket("/apps/app1/logs", stdsdk.RequestOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, r1)
-		d1, err := ioutil.ReadAll(r1)
+		d1, err := io.ReadAll(r1)
 		require.NoError(t, err)
 		require.Equal(t, []byte("ERROR: err1\n"), d1)
 	})

--- a/pkg/api/build_test.go
+++ b/pkg/api/build_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 	"time"
@@ -94,7 +93,7 @@ func TestBuildExport(t *testing.T) {
 		res, err := c.GetStream("/apps/app1/builds/build1.tgz", stdsdk.RequestOptions{})
 		require.NoError(t, err)
 		defer res.Body.Close()
-		data, err := ioutil.ReadAll(res.Body)
+		data, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
 		require.Equal(t, "data", string(data))
 	})
@@ -138,7 +137,7 @@ func TestBuildImport(t *testing.T) {
 			Body: strings.NewReader("data"),
 		}
 		p.On("BuildImport", "app1", mock.Anything).Return(&b1, nil).Run(func(args mock.Arguments) {
-			data, err := ioutil.ReadAll(args.Get(1).(io.Reader))
+			data, err := io.ReadAll(args.Get(1).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, "data", string(data))
 		})
@@ -161,12 +160,12 @@ func TestBuildImportError(t *testing.T) {
 func TestBuildLogs(t *testing.T) {
 	testServer(t, func(c *stdsdk.Client, p *structs.MockProvider) {
 		d1 := []byte("test")
-		r1 := ioutil.NopCloser(bytes.NewReader(d1))
+		r1 := io.NopCloser(bytes.NewReader(d1))
 		opts := structs.LogsOptions{Since: options.Duration(2 * time.Minute)}
 		p.On("BuildLogs", "app1", "build1", opts).Return(r1, nil)
 		r2, err := c.Websocket("/apps/app1/builds/build1/logs", stdsdk.RequestOptions{})
 		require.NoError(t, err)
-		d2, err := ioutil.ReadAll(r2)
+		d2, err := io.ReadAll(r2)
 		require.NoError(t, err)
 		require.Equal(t, d1, d2)
 	})
@@ -179,7 +178,7 @@ func TestBuildLogsError(t *testing.T) {
 		r1, err := c.Websocket("/apps/app1/builds/build1/logs", stdsdk.RequestOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, r1)
-		d1, err := ioutil.ReadAll(r1)
+		d1, err := io.ReadAll(r1)
 		require.NoError(t, err)
 		require.Equal(t, []byte("ERROR: err1\n"), d1)
 	})

--- a/pkg/api/files_test.go
+++ b/pkg/api/files_test.go
@@ -3,7 +3,6 @@ package api_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -51,7 +50,7 @@ func TestFilesDownload(t *testing.T) {
 		res, err := c.GetStream("/apps/app1/processes/pid1/files", opts)
 		require.NoError(t, err)
 		defer res.Body.Close()
-		data, err := ioutil.ReadAll(res.Body)
+		data, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
 		require.Equal(t, "data", string(data))
 	})
@@ -77,7 +76,7 @@ func TestFilesUpload(t *testing.T) {
 			Body: strings.NewReader("data"),
 		}
 		p.On("FilesUpload", "app1", "pid1", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
-			data, err := ioutil.ReadAll(args.Get(2).(io.Reader))
+			data, err := io.ReadAll(args.Get(2).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, "data", string(data))
 		})

--- a/pkg/api/object_test.go
+++ b/pkg/api/object_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -58,13 +57,13 @@ func TestObjectExistsError(t *testing.T) {
 func TestObjectFetch(t *testing.T) {
 	testServer(t, func(c *stdsdk.Client, p *structs.MockProvider) {
 		d1 := []byte("test")
-		r1 := ioutil.NopCloser(bytes.NewReader(d1))
+		r1 := io.NopCloser(bytes.NewReader(d1))
 		p.On("ObjectFetch", "app1", "path/object1.ext").Return(r1, nil)
 		res, err := c.GetStream("/apps/app1/objects/path/object1.ext", stdsdk.RequestOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, res)
 		defer res.Body.Close()
-		d2, err := ioutil.ReadAll(res.Body)
+		d2, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
 		require.Equal(t, d1, d2)
 	})
@@ -124,7 +123,7 @@ func TestObjectStore(t *testing.T) {
 			},
 		}
 		p.On("ObjectStore", "app1", "path/object1.ext", mock.Anything, opts).Return(&o1, nil).Run(func(args mock.Arguments) {
-			data, err := ioutil.ReadAll(args.Get(2).(io.Reader))
+			data, err := io.ReadAll(args.Get(2).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, "data", string(data))
 		})

--- a/pkg/api/process_test.go
+++ b/pkg/api/process_test.go
@@ -3,7 +3,6 @@ package api_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 	"time"
@@ -53,13 +52,13 @@ func TestProcessExec(t *testing.T) {
 		p.On("ProcessExec", "app1", "pid1", "command", mock.Anything, opts).Return(1, nil).Run(func(args mock.Arguments) {
 			rw := args.Get(3).(io.ReadWriter)
 			rw.Write([]byte("out"))
-			data, err := ioutil.ReadAll(rw)
+			data, err := io.ReadAll(rw)
 			require.NoError(t, err)
 			require.Equal(t, "in", string(data))
 		})
 		r, err := c.Websocket("/apps/app1/processes/pid1/exec", ro)
 		require.NoError(t, err)
-		data, err := ioutil.ReadAll(r)
+		data, err := io.ReadAll(r)
 		require.NoError(t, err)
 		require.Equal(t, "outF1E49A85-0AD7-4AEF-A618-C249C6E6568D:1\n", string(data))
 	})
@@ -88,7 +87,7 @@ func TestProcessExecError(t *testing.T) {
 		p.On("ProcessExec", "app1", "pid1", "command", mock.Anything, opts).Return(0, fmt.Errorf("err1"))
 		r, err := c.Websocket("/apps/app1/processes/pid1/exec", ro)
 		require.NoError(t, err)
-		d, err := ioutil.ReadAll(r)
+		d, err := io.ReadAll(r)
 		require.NoError(t, err)
 		require.Equal(t, []byte("F1E49A85-0AD7-4AEF-A618-C249C6E6568D:0\nERROR: err1\n"), d)
 	})
@@ -99,7 +98,7 @@ func TestProcessExecValidate(t *testing.T) {
 		p.On("AppGet", "app1").Return(nil, fmt.Errorf("no such app: app1"))
 		r, err := c.Websocket("/apps/app1/processes/pid1/exec", stdsdk.RequestOptions{})
 		require.NoError(t, err)
-		data, err := ioutil.ReadAll(r)
+		data, err := io.ReadAll(r)
 		require.NoError(t, err)
 		require.Equal(t, "ERROR: no such app: app1\n", string(data))
 	})

--- a/pkg/api/proxy_test.go
+++ b/pkg/api/proxy_test.go
@@ -3,7 +3,6 @@ package api_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -21,13 +20,13 @@ func TestProxy(t *testing.T) {
 		p.On("Proxy", "host", 5000, mock.Anything, structs.ProxyOptions{}).Return(nil).Run(func(args mock.Arguments) {
 			rw := args.Get(2).(io.ReadWriter)
 			rw.Write([]byte("out"))
-			data, err := ioutil.ReadAll(rw)
+			data, err := io.ReadAll(rw)
 			require.NoError(t, err)
 			require.Equal(t, "in", string(data))
 		})
 		r, err := c.Websocket("/proxy/host/5000", ro)
 		require.NoError(t, err)
-		data, err := ioutil.ReadAll(r)
+		data, err := io.ReadAll(r)
 		require.NoError(t, err)
 		require.Equal(t, "out", string(data))
 	})
@@ -38,7 +37,7 @@ func TestProxyError(t *testing.T) {
 		p.On("Proxy", "host", 5000, mock.Anything, structs.ProxyOptions{}).Return(fmt.Errorf("err1"))
 		r, err := c.Websocket("/proxy/host/5000", stdsdk.RequestOptions{})
 		require.NoError(t, err)
-		d, err := ioutil.ReadAll(r)
+		d, err := io.ReadAll(r)
 		require.NoError(t, err)
 		require.Equal(t, []byte("ERROR: err1\n"), d)
 	})

--- a/pkg/api/system_test.go
+++ b/pkg/api/system_test.go
@@ -3,7 +3,7 @@ package api_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -68,12 +68,12 @@ func TestSystemGetError(t *testing.T) {
 func TestSystemLogs(t *testing.T) {
 	testServer(t, func(c *stdsdk.Client, p *structs.MockProvider) {
 		d1 := []byte("test")
-		r1 := ioutil.NopCloser(bytes.NewReader(d1))
+		r1 := io.NopCloser(bytes.NewReader(d1))
 		opts := structs.LogsOptions{Since: options.Duration(2 * time.Minute)}
 		p.On("SystemLogs", opts).Return(r1, nil)
 		r2, err := c.Websocket("/system/logs", stdsdk.RequestOptions{})
 		require.NoError(t, err)
-		d2, err := ioutil.ReadAll(r2)
+		d2, err := io.ReadAll(r2)
 		require.NoError(t, err)
 		require.Equal(t, d1, d2)
 	})
@@ -86,7 +86,7 @@ func TestSystemLogsError(t *testing.T) {
 		r1, err := c.Websocket("/system/logs", stdsdk.RequestOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, r1)
-		d1, err := ioutil.ReadAll(r1)
+		d1, err := io.ReadAll(r1)
 		require.NoError(t, err)
 		require.Equal(t, []byte("ERROR: err1\n"), d1)
 	})

--- a/pkg/cli/apps.go
+++ b/pkg/cli/apps.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -213,7 +212,7 @@ func AppsImport(rack sdk.Interface, c *stdcli.Context) error {
 		if c.Reader().IsTerminal() {
 			return fmt.Errorf("pipe a file into this command or specify --file")
 		}
-		r = ioutil.NopCloser(c.Reader())
+		r = io.NopCloser(c.Reader())
 	}
 
 	defer r.Close()
@@ -364,7 +363,7 @@ func AppsUnlock(rack sdk.Interface, c *stdcli.Context) error {
 }
 
 func appExport(rack sdk.Interface, c *stdcli.Context, app string, w io.Writer) error {
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "")
 	if err != nil {
 		return err
 	}
@@ -388,7 +387,7 @@ func appExport(rack sdk.Interface, c *stdcli.Context, app string, w io.Writer) e
 		return err
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(tmp, "app.json"), data, 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(tmp, "app.json"), data, 0600); err != nil {
 		return err
 	}
 
@@ -402,7 +401,7 @@ func appExport(rack sdk.Interface, c *stdcli.Context, app string, w io.Writer) e
 			return err
 		}
 
-		if err := ioutil.WriteFile(filepath.Join(tmp, "env"), []byte(r.Env), 0600); err != nil {
+		if err := os.WriteFile(filepath.Join(tmp, "env"), []byte(r.Env), 0600); err != nil {
 			return err
 		}
 
@@ -472,7 +471,7 @@ func appExport(rack sdk.Interface, c *stdcli.Context, app string, w io.Writer) e
 }
 
 func appImport(rack sdk.Interface, c *stdcli.Context, app string, r io.Reader) error {
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "")
 	if err != nil {
 		return err
 	}
@@ -489,7 +488,7 @@ func appImport(rack sdk.Interface, c *stdcli.Context, app string, r io.Reader) e
 
 	var a structs.App
 
-	data, err := ioutil.ReadFile(filepath.Join(tmp, "app.json"))
+	data, err := os.ReadFile(filepath.Join(tmp, "app.json"))
 	if err != nil {
 		return err
 	}
@@ -533,7 +532,7 @@ func appImport(rack sdk.Interface, c *stdcli.Context, app string, r io.Reader) e
 	}
 
 	if _, err := os.Stat(env); !os.IsNotExist(err) {
-		data, err := ioutil.ReadFile(env)
+		data, err := os.ReadFile(env)
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/apps_test.go
+++ b/pkg/cli/apps_test.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -174,17 +173,17 @@ func TestAppsExport(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
 		i.On("AppGet", "app1").Return(fxApp(), nil)
 		i.On("ReleaseGet", "app1", "release1").Return(fxRelease(), nil)
-		bdata, err := ioutil.ReadFile("testdata/build.tgz")
+		bdata, err := os.ReadFile("testdata/build.tgz")
 		require.NoError(t, err)
 		i.On("BuildExport", "app1", "build1", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 			args.Get(2).(io.Writer).Write(bdata)
 		})
 		i.On("ResourceList", "app1").Return(structs.Resources{*fxResource()}, nil)
-		rdata, err := ioutil.ReadFile("testdata/resource.export")
+		rdata, err := os.ReadFile("testdata/resource.export")
 		require.NoError(t, err)
-		i.On("ResourceExport", "app1", "resource1").Return(ioutil.NopCloser(bytes.NewReader(rdata)), nil)
+		i.On("ResourceExport", "app1", "resource1").Return(io.NopCloser(bytes.NewReader(rdata)), nil)
 
-		tmp, err := ioutil.TempDir("", "")
+		tmp, err := os.MkdirTemp("", "")
 		require.NoError(t, err)
 		defer os.RemoveAll(tmp)
 
@@ -210,15 +209,15 @@ func TestAppsExport(t *testing.T) {
 		err = common.Unarchive(gz, tmp)
 		require.NoError(t, err)
 
-		data, err := ioutil.ReadFile(filepath.Join(tmp, "app.json"))
+		data, err := os.ReadFile(filepath.Join(tmp, "app.json"))
 		require.NoError(t, err)
 		require.Equal(t, "{\"generation\":\"2\",\"locked\":false,\"name\":\"app1\",\"release\":\"release1\",\"router\":\"\",\"status\":\"running\",\"parameters\":{\"ParamFoo\":\"value1\",\"ParamOther\":\"value2\"}}", string(data))
 
-		data, err = ioutil.ReadFile(filepath.Join(tmp, "env"))
+		data, err = os.ReadFile(filepath.Join(tmp, "env"))
 		require.NoError(t, err)
 		require.Equal(t, "FOO=bar\nBAZ=quux", string(data))
 
-		data, err = ioutil.ReadFile(filepath.Join(tmp, "build.tgz"))
+		data, err = os.ReadFile(filepath.Join(tmp, "build.tgz"))
 		require.NoError(t, err)
 		require.Equal(t, bdata, data)
 	})
@@ -229,17 +228,17 @@ func TestAppsImport(t *testing.T) {
 		i.On("AppCreate", "app1", structs.AppCreateOptions{Generation: options.String("2")}).Return(fxApp(), nil)
 		i.On("AppGet", "app1").Return(&structs.App{Status: "creating"}, nil).Twice()
 		i.On("AppGet", "app1").Return(fxApp(), nil).Twice()
-		bdata, err := ioutil.ReadFile("testdata/build.tgz")
+		bdata, err := os.ReadFile("testdata/build.tgz")
 		require.NoError(t, err)
 		i.On("BuildImport", "app1", mock.Anything).Return(fxBuild(), nil).Run(func(args mock.Arguments) {
-			rdata, err := ioutil.ReadAll(args.Get(1).(io.Reader))
+			rdata, err := io.ReadAll(args.Get(1).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, bdata, rdata)
 		})
 		i.On("ReleaseCreate", "app1", structs.ReleaseCreateOptions{Env: options.String("ALPHA=one\nBRAVO=two\n")}).Return(fxRelease(), nil)
 		i.On("ReleasePromote", "app1", "release1", structs.ReleasePromoteOptions{}).Return(nil)
 		i.On("ResourceImport", "app1", "resource1", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
-			rdata, err := ioutil.ReadAll(args.Get(2).(io.Reader))
+			rdata, err := io.ReadAll(args.Get(2).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, "resourcedata\n", string(rdata))
 		})
@@ -289,10 +288,10 @@ func TestAppsImportNoParams(t *testing.T) {
 		i.On("AppCreate", "app1", structs.AppCreateOptions{Generation: options.String("2")}).Return(fxApp(), nil)
 		i.On("AppGet", "app1").Return(&structs.App{Status: "creating"}, nil).Twice()
 		i.On("AppGet", "app1").Return(fxApp(), nil).Twice()
-		bdata, err := ioutil.ReadFile("testdata/build.tgz")
+		bdata, err := os.ReadFile("testdata/build.tgz")
 		require.NoError(t, err)
 		i.On("BuildImport", "app1", mock.Anything).Return(fxBuild(), nil).Run(func(args mock.Arguments) {
-			rdata, err := ioutil.ReadAll(args.Get(1).(io.Reader))
+			rdata, err := io.ReadAll(args.Get(1).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, bdata, rdata)
 		})
@@ -318,10 +317,10 @@ func TestAppsImportSameParams(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
 		i.On("AppCreate", "app1", structs.AppCreateOptions{Generation: options.String("2")}).Return(fxApp(), nil)
 		i.On("AppGet", "app1").Return(fxApp(), nil).Twice()
-		bdata, err := ioutil.ReadFile("testdata/build.tgz")
+		bdata, err := os.ReadFile("testdata/build.tgz")
 		require.NoError(t, err)
 		i.On("BuildImport", "app1", mock.Anything).Return(fxBuild(), nil).Run(func(args mock.Arguments) {
-			rdata, err := ioutil.ReadAll(args.Get(1).(io.Reader))
+			rdata, err := io.ReadAll(args.Get(1).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, bdata, rdata)
 		})
@@ -347,10 +346,10 @@ func TestAppsImportNoResources(t *testing.T) {
 		i.On("AppCreate", "app1", structs.AppCreateOptions{Generation: options.String("2")}).Return(fxApp(), nil)
 		i.On("AppGet", "app1").Return(&structs.App{Status: "creating"}, nil).Twice()
 		i.On("AppGet", "app1").Return(fxApp(), nil).Twice()
-		bdata, err := ioutil.ReadFile("testdata/build.tgz")
+		bdata, err := os.ReadFile("testdata/build.tgz")
 		require.NoError(t, err)
 		i.On("BuildImport", "app1", mock.Anything).Return(fxBuild(), nil).Run(func(args mock.Arguments) {
-			rdata, err := ioutil.ReadAll(args.Get(1).(io.Reader))
+			rdata, err := io.ReadAll(args.Get(1).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, bdata, rdata)
 		})

--- a/pkg/cli/builds.go
+++ b/pkg/cli/builds.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -230,7 +229,7 @@ func buildExternal(rack sdk.Interface, c *stdcli.Context, opts structs.BuildCrea
 
 	manifest := common.DefaultString(opts.Manifest, "convox.yml")
 
-	data, err := ioutil.ReadFile(filepath.Join(dir, manifest))
+	data, err := os.ReadFile(filepath.Join(dir, manifest))
 	if err != nil {
 		return nil, err
 	}
@@ -315,7 +314,7 @@ func finalizeBuildLogs(rack structs.Provider, c *stdcli.Context, b *structs.Buil
 	}
 	defer r.Close()
 
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}
@@ -398,7 +397,7 @@ func BuildsImport(rack sdk.Interface, c *stdcli.Context) error {
 		if c.Reader().IsTerminal() {
 			return fmt.Errorf("pipe a file into this command or specify --file")
 		}
-		r = ioutil.NopCloser(c.Reader())
+		r = io.NopCloser(c.Reader())
 	}
 
 	defer r.Close()

--- a/pkg/cli/builds_test.go
+++ b/pkg/cli/builds_test.go
@@ -3,7 +3,7 @@ package cli_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -158,12 +158,12 @@ func TestBuildsError(t *testing.T) {
 
 func TestBuildsExport(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
-		data, err := ioutil.ReadFile("testdata/build.tgz")
+		data, err := os.ReadFile("testdata/build.tgz")
 		require.NoError(t, err)
 		i.On("BuildExport", "app1", "build1", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 			args.Get(2).(io.Writer).Write(data)
 		})
-		tmpd, err := ioutil.TempDir("", "")
+		tmpd, err := os.MkdirTemp("", "")
 		require.NoError(t, err)
 		tmpf := filepath.Join(tmpd, "export.tgz")
 
@@ -172,7 +172,7 @@ func TestBuildsExport(t *testing.T) {
 		require.Equal(t, 0, res.Code)
 		res.RequireStderr(t, []string{""})
 		res.RequireStdout(t, []string{"Exporting build... OK"})
-		tdata, err := ioutil.ReadFile(tmpf)
+		tdata, err := os.ReadFile(tmpf)
 		require.NoError(t, err)
 		require.Equal(t, data, tdata)
 	})
@@ -180,7 +180,7 @@ func TestBuildsExport(t *testing.T) {
 
 func TestBuildsExportStdout(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
-		data, err := ioutil.ReadFile("testdata/build.tgz")
+		data, err := os.ReadFile("testdata/build.tgz")
 		require.NoError(t, err)
 		i.On("BuildExport", "app1", "build1", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 			args.Get(2).(io.Writer).Write(data)
@@ -208,11 +208,11 @@ func TestBuildsExportError(t *testing.T) {
 
 func TestBuildsImport(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
-		data, err := ioutil.ReadFile("testdata/build.tgz")
+		data, err := os.ReadFile("testdata/build.tgz")
 		require.NoError(t, err)
 		i.On("SystemGet").Return(fxSystem(), nil)
 		i.On("BuildImport", "app1", mock.Anything).Return(fxBuild(), nil).Run(func(args mock.Arguments) {
-			rdata, err := ioutil.ReadAll(args.Get(1).(io.Reader))
+			rdata, err := io.ReadAll(args.Get(1).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, data, rdata)
 		})
@@ -240,11 +240,11 @@ func TestBuildsImportError(t *testing.T) {
 
 func TestBuildsImportClassic(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
-		data, err := ioutil.ReadFile("testdata/build.tgz")
+		data, err := os.ReadFile("testdata/build.tgz")
 		require.NoError(t, err)
 		i.On("SystemGet").Return(fxSystemClassic(), nil)
 		i.On("BuildImportMultipart", "app1", mock.Anything).Return(fxBuild(), nil).Run(func(args mock.Arguments) {
-			rdata, err := ioutil.ReadAll(args.Get(1).(io.Reader))
+			rdata, err := io.ReadAll(args.Get(1).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, data, rdata)
 		})

--- a/pkg/cli/certs.go
+++ b/pkg/cli/certs.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -169,12 +169,12 @@ func CertsImport(rack sdk.Interface, c *stdcli.Context) error {
 		return err
 	}
 
-	pub, err := ioutil.ReadFile(c.Arg(0))
+	pub, err := os.ReadFile(c.Arg(0))
 	if err != nil {
 		return err
 	}
 
-	key, err := ioutil.ReadFile(c.Arg(1))
+	key, err := os.ReadFile(c.Arg(1))
 	if err != nil {
 		return err
 	}
@@ -182,7 +182,7 @@ func CertsImport(rack sdk.Interface, c *stdcli.Context) error {
 	var opts structs.CertificateCreateOptions
 
 	if cf := c.String("chain"); cf != "" {
-		chain, err := ioutil.ReadFile(cf)
+		chain, err := os.ReadFile(cf)
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -52,12 +51,12 @@ func testClientWait(t *testing.T, wait time.Duration, fn func(*cli.Engine, *mock
 
 	rack.TestClient = i
 
-	tmp, err := ioutil.TempDir("", "")
+	tmp, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 	e.Settings = tmp
 	defer os.RemoveAll(tmp)
 
-	err = ioutil.WriteFile(filepath.Join(tmp, "current"), []byte(`{"type":"test","name":"rack1"}`), 0600)
+	err = os.WriteFile(filepath.Join(tmp, "current"), []byte(`{"type":"test","name":"rack1"}`), 0600)
 	require.NoError(t, err)
 
 	i.On("ClientType").Return("standard").Maybe()
@@ -111,7 +110,7 @@ func testLocalRack(e *cli.Engine, name, provider, api string) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(dir, "main.tf"), []byte{}, 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte{}, 0600); err != nil {
 		return err
 	}
 
@@ -125,7 +124,7 @@ func testLocalRack(e *cli.Engine, name, provider, api string) error {
 }
 
 func testLogs(logs []string) io.ReadCloser {
-	return ioutil.NopCloser(strings.NewReader(fmt.Sprintf("%s\n", strings.Join(logs, "\n"))))
+	return io.NopCloser(strings.NewReader(fmt.Sprintf("%s\n", strings.Join(logs, "\n"))))
 }
 
 type result struct {

--- a/pkg/cli/cp_test.go
+++ b/pkg/cli/cp_test.go
@@ -3,7 +3,7 @@ package cli_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -39,10 +39,10 @@ func TestCpUploadError(t *testing.T) {
 
 func TestCpDownload(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
-		tmpd, err := ioutil.TempDir("", "")
+		tmpd, err := os.MkdirTemp("", "")
 		require.NoError(t, err)
 		tmpf := filepath.Join(tmpd, "file")
-		data, err := ioutil.ReadFile("testdata/file.tar")
+		data, err := os.ReadFile("testdata/file.tar")
 		require.NoError(t, err)
 		i.On("FilesDownload", "app1", "0123456789", "/tmp/file").Return(bytes.NewReader(data), nil)
 
@@ -51,9 +51,9 @@ func TestCpDownload(t *testing.T) {
 		require.Equal(t, 0, res.Code)
 		res.RequireStderr(t, []string{""})
 		res.RequireStdout(t, []string{""})
-		odata, err := ioutil.ReadFile("testdata/file")
+		odata, err := os.ReadFile("testdata/file")
 		require.NoError(t, err)
-		ddata, err := ioutil.ReadFile(tmpf)
+		ddata, err := os.ReadFile(tmpf)
 		require.NoError(t, err)
 		require.Equal(t, odata, ddata)
 	})
@@ -61,7 +61,7 @@ func TestCpDownload(t *testing.T) {
 
 func TestCpDownloadError(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
-		tmpd, err := ioutil.TempDir("", "")
+		tmpd, err := os.MkdirTemp("", "")
 		require.NoError(t, err)
 		tmpf := filepath.Join(tmpd, "file")
 		i.On("FilesDownload", "app1", "0123456789", "/tmp/file").Return(nil, fmt.Errorf("err1"))

--- a/pkg/cli/exec_test.go
+++ b/pkg/cli/exec_test.go
@@ -3,7 +3,6 @@ package cli_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -19,7 +18,7 @@ func TestExec(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
 		opts := structs.ProcessExecOptions{Tty: options.Bool(false)}
 		i.On("ProcessExec", "app1", "0123456789", "bash", mock.Anything, opts).Return(4, nil).Run(func(args mock.Arguments) {
-			data, err := ioutil.ReadAll(args.Get(3).(io.Reader))
+			data, err := io.ReadAll(args.Get(3).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, "in", string(data))
 			args.Get(3).(io.Writer).Write([]byte("out"))

--- a/pkg/cli/login_test.go
+++ b/pkg/cli/login_test.go
@@ -2,10 +2,10 @@ package cli_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -32,11 +32,11 @@ func TestLogin(t *testing.T) {
 		res.RequireStderr(t, []string{""})
 		res.RequireStdout(t, []string{fmt.Sprintf("Authenticating with %s... OK", tsu.Host)})
 
-		data, err := ioutil.ReadFile(filepath.Join(e.Settings, "auth"))
+		data, err := os.ReadFile(filepath.Join(e.Settings, "auth"))
 		require.NoError(t, err)
 		require.Equal(t, fmt.Sprintf("{\n  \"%s\": \"password\"\n}", tsu.Host), string(data))
 
-		data, err = ioutil.ReadFile(filepath.Join(e.Settings, "console"))
+		data, err = os.ReadFile(filepath.Join(e.Settings, "console"))
 		require.NoError(t, err)
 		require.Equal(t, tsu.Host, string(data))
 	})

--- a/pkg/cli/proxy_test.go
+++ b/pkg/cli/proxy_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"testing"
@@ -57,7 +56,7 @@ func TestProxy(t *testing.T) {
 
 		cn.Write([]byte("in"))
 
-		data, err := ioutil.ReadAll(cn)
+		data, err := io.ReadAll(cn)
 		require.NoError(t, err)
 		require.Equal(t, "out", string(data))
 
@@ -103,7 +102,7 @@ func TestProxyError(t *testing.T) {
 
 		cn.Write([]byte("in"))
 
-		data, _ := ioutil.ReadAll(cn)
+		data, _ := io.ReadAll(cn)
 		require.Len(t, data, 0)
 
 		cancel()

--- a/pkg/cli/rack_test.go
+++ b/pkg/cli/rack_test.go
@@ -2,7 +2,6 @@ package cli_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -73,10 +72,10 @@ func TestRackInstall(t *testing.T) {
 		_, err = os.Stat(tf)
 		require.NoError(t, err)
 
-		tfdata, err := ioutil.ReadFile(tf)
+		tfdata, err := os.ReadFile(tf)
 		require.NoError(t, err)
 
-		testdata, err := ioutil.ReadFile("testdata/terraform/dev1.tf")
+		testdata, err := os.ReadFile("testdata/terraform/dev1.tf")
 		require.NoError(t, err)
 
 		require.Equal(t, strings.Trim(removeSettingsLine(string(tfdata)), "\n"), removeSettingsLine(strings.Trim(string(testdata), "\n")))
@@ -127,10 +126,10 @@ func TestRackInstallArgs(t *testing.T) {
 		_, err = os.Stat(tf)
 		require.NoError(t, err)
 
-		tfdata, err := ioutil.ReadFile(tf)
+		tfdata, err := os.ReadFile(tf)
 		require.NoError(t, err)
 
-		testdata, err := ioutil.ReadFile("testdata/terraform/dev1.args.tf")
+		testdata, err := os.ReadFile("testdata/terraform/dev1.args.tf")
 		require.NoError(t, err)
 
 		require.Equal(t, strings.Trim(removeSettingsLine(string(tfdata)), "\n"), removeSettingsLine(strings.Trim(string(testdata), "\n")))
@@ -162,10 +161,10 @@ func TestRackInstallPrepare(t *testing.T) {
 		_, err = os.Stat(tf)
 		require.NoError(t, err)
 
-		tfdata, err := ioutil.ReadFile(tf)
+		tfdata, err := os.ReadFile(tf)
 		require.NoError(t, err)
 
-		testdata, err := ioutil.ReadFile("testdata/terraform/dev1.tf")
+		testdata, err := os.ReadFile("testdata/terraform/dev1.tf")
 		require.NoError(t, err)
 
 		require.Equal(t, strings.Trim(removeSettingsLine(string(tfdata)), "\n"), removeSettingsLine(strings.Trim(string(testdata), "\n")))
@@ -202,10 +201,10 @@ func TestRackInstallSwitch(t *testing.T) {
 		_, err = os.Stat(tf)
 		require.NoError(t, err)
 
-		tfdata, err := ioutil.ReadFile(tf)
+		tfdata, err := os.ReadFile(tf)
 		require.NoError(t, err)
 
-		testdata, err := ioutil.ReadFile("testdata/terraform/dev1.tf")
+		testdata, err := os.ReadFile("testdata/terraform/dev1.tf")
 		require.NoError(t, err)
 
 		require.Equal(t, strings.Trim(removeSettingsLine(string(tfdata)), "\n"), removeSettingsLine(strings.Trim(string(testdata), "\n")))
@@ -243,10 +242,10 @@ func TestRackInstallVersion(t *testing.T) {
 		_, err = os.Stat(tf)
 		require.NoError(t, err)
 
-		tfdata, err := ioutil.ReadFile(tf)
+		tfdata, err := os.ReadFile(tf)
 		require.NoError(t, err)
 
-		testdata, err := ioutil.ReadFile("testdata/terraform/dev1.version.tf")
+		testdata, err := os.ReadFile("testdata/terraform/dev1.version.tf")
 		require.NoError(t, err)
 
 		require.Equal(t, strings.Trim(removeSettingsLine(string(tfdata)), "\n"), removeSettingsLine(strings.Trim(string(testdata), "\n")))

--- a/pkg/cli/racks_test.go
+++ b/pkg/cli/racks_test.go
@@ -2,10 +2,10 @@ package cli_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -59,7 +59,7 @@ func TestRacksRemote(t *testing.T) {
 		tsu, err := url.Parse(ts.URL)
 		require.NoError(t, err)
 
-		err = ioutil.WriteFile(filepath.Join(e.Settings, "console"), []byte(tsu.Host), 0644)
+		err = os.WriteFile(filepath.Join(e.Settings, "console"), []byte(tsu.Host), 0644)
 		require.NoError(t, err)
 
 		res, err := testExecute(e, "racks", nil)
@@ -92,7 +92,7 @@ func TestRacksLocalAndRemote(t *testing.T) {
 		tsu, err := url.Parse(ts.URL)
 		require.NoError(t, err)
 
-		err = ioutil.WriteFile(filepath.Join(e.Settings, "console"), []byte(tsu.Host), 0644)
+		err = os.WriteFile(filepath.Join(e.Settings, "console"), []byte(tsu.Host), 0644)
 		require.NoError(t, err)
 
 		res, err := testExecute(e, "racks", nil)
@@ -122,7 +122,7 @@ func TestRacksError(t *testing.T) {
 		tsu, err := url.Parse(ts.URL)
 		require.NoError(t, err)
 
-		err = ioutil.WriteFile(filepath.Join(e.Settings, "host"), []byte(tsu.Host), 0644)
+		err = os.WriteFile(filepath.Join(e.Settings, "host"), []byte(tsu.Host), 0644)
 		require.NoError(t, err)
 
 		me := &mockstdcli.Executor{}

--- a/pkg/cli/resources_test.go
+++ b/pkg/cli/resources_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"testing"
@@ -110,7 +109,7 @@ func TestResourcesProxy(t *testing.T) {
 
 		cn.Write([]byte("in"))
 
-		data, err := ioutil.ReadAll(cn)
+		data, err := io.ReadAll(cn)
 		require.NoError(t, err)
 		require.Equal(t, "out", string(data))
 
@@ -390,7 +389,7 @@ func TestRackResourcesProxy(t *testing.T) {
 
 		cn.Write([]byte("in"))
 
-		data, err := ioutil.ReadAll(cn)
+		data, err := io.ReadAll(cn)
 		require.NoError(t, err)
 		require.Equal(t, "out", string(data))
 

--- a/pkg/cli/run_test.go
+++ b/pkg/cli/run_test.go
@@ -3,7 +3,6 @@ package cli_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -22,7 +21,7 @@ func TestRun(t *testing.T) {
 		i.On("ProcessGet", "app1", "pid1").Return(fxProcess(), nil)
 		opts := structs.ProcessExecOptions{Entrypoint: options.Bool(true), Tty: options.Bool(false)}
 		i.On("ProcessExec", "app1", "pid1", "bash", mock.Anything, opts).Return(4, nil).Run(func(args mock.Arguments) {
-			data, err := ioutil.ReadAll(args.Get(3).(io.Reader))
+			data, err := io.ReadAll(args.Get(3).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, "in", string(data))
 			args.Get(3).(io.Writer).Write([]byte("out"))

--- a/pkg/cli/switch_test.go
+++ b/pkg/cli/switch_test.go
@@ -1,10 +1,10 @@
 package cli_test
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -30,7 +30,7 @@ func TestSwitch(t *testing.T) {
 		tsu, err := url.Parse(ts.URL)
 		require.NoError(t, err)
 
-		err = ioutil.WriteFile(filepath.Join(e.Settings, "console"), []byte(tsu.Host), 0644)
+		err = os.WriteFile(filepath.Join(e.Settings, "console"), []byte(tsu.Host), 0644)
 		require.NoError(t, err)
 
 		res, err := testExecute(e, "switch foo", nil)
@@ -63,7 +63,7 @@ func TestSwitchUnknown(t *testing.T) {
 		tsu, err := url.Parse(ts.URL)
 		require.NoError(t, err)
 
-		err = ioutil.WriteFile(filepath.Join(e.Settings, "console"), []byte(tsu.Host), 0644)
+		err = os.WriteFile(filepath.Join(e.Settings, "console"), []byte(tsu.Host), 0644)
 		require.NoError(t, err)
 
 		res, err := testExecute(e, "switch rack1", nil)

--- a/pkg/cli/test_test.go
+++ b/pkg/cli/test_test.go
@@ -2,7 +2,6 @@ package cli_test
 
 import (
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -31,7 +30,7 @@ func TestTest(t *testing.T) {
 		i.On("ProcessGet", "app1", "pid1").Return(fxProcess(), nil)
 		opts := structs.ProcessExecOptions{Entrypoint: options.Bool(true), Tty: options.Bool(false)}
 		i.On("ProcessExec", "app1", "pid1", "make test", mock.Anything, opts).Return(0, nil).Run(func(args mock.Arguments) {
-			data, err := ioutil.ReadAll(args.Get(3).(io.Reader))
+			data, err := io.ReadAll(args.Get(3).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, "in", string(data))
 			args.Get(3).(io.Writer).Write([]byte("out"))
@@ -71,7 +70,7 @@ func TestTestFail(t *testing.T) {
 		i.On("ProcessGet", "app1", "pid1").Return(fxProcess(), nil)
 		opts := structs.ProcessExecOptions{Entrypoint: options.Bool(true), Tty: options.Bool(false)}
 		i.On("ProcessExec", "app1", "pid1", "make test", mock.Anything, opts).Return(4, nil).Run(func(args mock.Arguments) {
-			data, err := ioutil.ReadAll(args.Get(3).(io.Reader))
+			data, err := io.ReadAll(args.Get(3).(io.Reader))
 			require.NoError(t, err)
 			require.Equal(t, "in", string(data))
 			args.Get(3).(io.Writer).Write([]byte("out"))

--- a/pkg/cli/update.go
+++ b/pkg/cli/update.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"runtime"
 
@@ -94,7 +94,7 @@ func getGitHubReleaseData(url string, response interface{}) error {
 	}
 	defer res.Body.Close()
 
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		return err
 	}
@@ -105,4 +105,3 @@ func getGitHubReleaseData(url string, response interface{}) error {
 
 	return nil
 }
-

--- a/pkg/cli/version_test.go
+++ b/pkg/cli/version_test.go
@@ -2,7 +2,7 @@ package cli_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -15,7 +15,7 @@ func TestVersion(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
 		require.NoError(t, testLocalRack(e, "dev1", "local", "https://host1"))
 
-		err := ioutil.WriteFile(filepath.Join(e.Settings, "host"), []byte("host1"), 0644)
+		err := os.WriteFile(filepath.Join(e.Settings, "host"), []byte("host1"), 0644)
 		require.NoError(t, err)
 
 		i.On("SystemGet").Return(fxSystem(), nil)
@@ -35,7 +35,7 @@ func TestVersionError(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
 		require.NoError(t, testLocalRack(e, "dev1", "local", "https://host1"))
 
-		err := ioutil.WriteFile(filepath.Join(e.Settings, "host"), []byte("host1"), 0644)
+		err := os.WriteFile(filepath.Join(e.Settings, "host"), []byte("host1"), 0644)
 		require.NoError(t, err)
 
 		i.On("SystemGet").Return(nil, fmt.Errorf("err1"))

--- a/pkg/common/file.go
+++ b/pkg/common/file.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -19,7 +18,7 @@ func WriteFile(filename string, data []byte, mode os.FileMode) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(filename, data, mode); err != nil {
+	if err := os.WriteFile(filename, data, mode); err != nil {
 		return err
 	}
 

--- a/pkg/common/http.go
+++ b/pkg/common/http.go
@@ -2,7 +2,7 @@ package common
 
 import (
 	"crypto/tls"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"time"
@@ -15,7 +15,7 @@ func Get(url string) ([]byte, error) {
 	}
 	defer res.Body.Close()
 
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/common/linux.go
+++ b/pkg/common/linux.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 )
 
@@ -22,7 +22,7 @@ func LinuxRelease() (string, error) {
 func linuxReleaseAttributes() (map[string]string, error) {
 	attrs := map[string]string{}
 
-	data, err := ioutil.ReadFile("/etc/os-release")
+	data, err := os.ReadFile("/etc/os-release")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/common/tar.go
+++ b/pkg/common/tar.go
@@ -77,7 +77,7 @@ func Tarball(dir string) ([]byte, error) {
 		return nil, err
 	}
 
-	data, err := ioutil.ReadFile(filepath.Join(sym, ".dockerignore"))
+	data, err := os.ReadFile(filepath.Join(sym, ".dockerignore"))
 	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}

--- a/pkg/common/test.go
+++ b/pkg/common/test.go
@@ -2,9 +2,9 @@ package common
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 func Testdata(name string) ([]byte, error) {
-	return ioutil.ReadFile(fmt.Sprintf("testdata/%s.yml", name))
+	return os.ReadFile(fmt.Sprintf("testdata/%s.yml", name))
 }

--- a/pkg/elastic/elastic.go
+++ b/pkg/elastic/elastic.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sort"
 	"strings"
 	"time"
@@ -102,7 +101,7 @@ func (c *Client) Stream(ctx context.Context, w io.WriteCloser, index string, opt
 			}
 			defer res.Body.Close()
 
-			data, err = ioutil.ReadAll(res.Body)
+			data, err = io.ReadAll(res.Body)
 			if err != nil {
 				fmt.Fprintf(w, "error: %v\n", err)
 				return

--- a/pkg/generate/method.go
+++ b/pkg/generate/method.go
@@ -3,7 +3,7 @@ package generate
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"regexp"
 	"sort"
@@ -43,7 +43,7 @@ type Route struct {
 func Methods() ([]Method, error) {
 	ms := []Method{}
 
-	data, err := ioutil.ReadFile("pkg/structs/provider.go")
+	data, err := os.ReadFile("pkg/structs/provider.go")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/rack/direct.go
+++ b/pkg/rack/direct.go
@@ -3,7 +3,6 @@ package rack
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -87,7 +86,7 @@ func TrySaveDirectMeta(c *stdcli.Context, r Rack, client sdk.Interface) {
 	}
 
 	os.MkdirAll(metaDir, 0700)
-	ioutil.WriteFile(path, data, 0600)
+	os.WriteFile(path, data, 0600)
 }
 
 func (d Direct) Client() (sdk.Interface, error) {
@@ -211,7 +210,7 @@ func listDirect(c *stdcli.Context) ([]Direct, error) {
 		return []Direct{}, nil
 	}
 
-	subs, err := ioutil.ReadDir(dir)
+	subs, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +224,7 @@ func listDirect(c *stdcli.Context) ([]Direct, error) {
 			continue
 		}
 
-		url, err := ioutil.ReadFile(filepath.Join(dir, sub.Name()))
+		url, err := os.ReadFile(filepath.Join(dir, sub.Name()))
 		if err != nil {
 			continue
 		}
@@ -238,7 +237,7 @@ func listDirect(c *stdcli.Context) ([]Direct, error) {
 		d := LoadDirectLazy(sc, sub.Name())
 
 		if metaDir != "" {
-			if metaBytes, err := ioutil.ReadFile(filepath.Join(metaDir, sub.Name()+".json")); err == nil {
+			if metaBytes, err := os.ReadFile(filepath.Join(metaDir, sub.Name()+".json")); err == nil {
 				var meta map[string]string
 				if json.Unmarshal(metaBytes, &meta) == nil {
 					if v, ok := meta["provider"]; ok {

--- a/pkg/rack/terraform.go
+++ b/pkg/rack/terraform.go
@@ -3,7 +3,7 @@ package rack
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -198,7 +198,7 @@ func (t Terraform) Metadata() (*Metadata, error) {
 		return nil, err
 	}
 
-	state, err := ioutil.ReadFile(filepath.Join(dir, "terraform.tfstate"))
+	state, err := os.ReadFile(filepath.Join(dir, "terraform.tfstate"))
 	if err != nil {
 		return nil, err
 	}
@@ -388,7 +388,7 @@ func (t Terraform) moduleVarNames() (map[string]bool, error) {
 	}
 
 	manifestPath := filepath.Join(dir, ".terraform", "modules", "modules.json")
-	data, err := ioutil.ReadFile(manifestPath)
+	data, err := os.ReadFile(manifestPath)
 	if err != nil {
 		return nil, err
 	}
@@ -425,7 +425,7 @@ func (t Terraform) moduleVarNames() (map[string]bool, error) {
 	re := regexp.MustCompile(`(?m)^variable\s+"([^"]+)"`)
 
 	for _, f := range files {
-		content, err := ioutil.ReadFile(f)
+		content, err := os.ReadFile(f)
 		if err != nil {
 			continue
 		}
@@ -504,7 +504,7 @@ func (t Terraform) create(release string, vars map[string]string, state []byte) 
 	}
 
 	if state != nil {
-		if err := ioutil.WriteFile(filepath.Join(dir, "terraform.tfstate"), state, 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "terraform.tfstate"), state, 0644); err != nil {
 			return err
 		}
 	}
@@ -627,7 +627,7 @@ func (t Terraform) vars() (map[string]string, error) {
 	}
 
 	if _, err := os.Stat(vf); !os.IsNotExist(err) {
-		data, err := ioutil.ReadFile(vf)
+		data, err := os.ReadFile(vf)
 		if err != nil {
 			return nil, err
 		}
@@ -710,7 +710,7 @@ func (t Terraform) writeVars(vars map[string]string) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(vf, data, 0600); err != nil {
+	if err := os.WriteFile(vf, data, 0600); err != nil {
 		return err
 	}
 
@@ -727,7 +727,7 @@ func listTerraform(c *stdcli.Context) ([]Terraform, error) {
 		return []Terraform{}, nil
 	}
 
-	subs, err := ioutil.ReadDir(dir)
+	subs, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}
@@ -863,7 +863,7 @@ func getGitHubReleaseData(url string, response interface{}) error {
 	}
 	defer res.Body.Close()
 
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		return err
 	}

--- a/pkg/start/gen2_test.go
+++ b/pkg/start/gen2_test.go
@@ -3,7 +3,7 @@ package start_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -31,7 +31,7 @@ func TestStart2(t *testing.T) {
 	p.On("AppGet", "app1").Return(&structs.App{Name: "app1", Generation: "2"}, nil)
 	p.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{{Id: "release1"}}, nil)
 	p.On("ReleaseGet", "app1", "release1").Return(&structs.Release{}, nil)
-	p.On("AppLogs", "app1", structs.LogsOptions{Prefix: options.Bool(true), Since: options.Duration(1 * time.Second)}).Return(ioutil.NopCloser(strings.NewReader(logs)), nil)
+	p.On("AppLogs", "app1", structs.LogsOptions{Prefix: options.Bool(true), Since: options.Duration(1 * time.Second)}).Return(io.NopCloser(strings.NewReader(logs)), nil)
 
 	e := &exec.MockInterface{}
 	start.Exec = e
@@ -86,10 +86,10 @@ func TestStart2Options(t *testing.T) {
 	p.On("ReleaseGet", "app1", "release1").Return(&structs.Release{}, nil)
 	p.On("ObjectStore", "app1", "", mock.Anything, structs.ObjectStoreOptions{}).Return(&structs.Object{Url: "object://app1/object1.tgz"}, nil)
 	p.On("BuildCreate", "app1", "object://app1/object1.tgz", structs.BuildCreateOptions{Development: options.Bool(true), External: options.Bool(false), Manifest: options.String("convox2.yml")}).Return(&structs.Build{Id: "build1"}, nil)
-	p.On("BuildLogs", "app1", "build1", structs.LogsOptions{}).Return(ioutil.NopCloser(strings.NewReader(buildLogs)), nil)
+	p.On("BuildLogs", "app1", "build1", structs.LogsOptions{}).Return(io.NopCloser(strings.NewReader(buildLogs)), nil)
 	p.On("BuildGet", "app1", "build1").Return(&structs.Build{Id: "build1", Release: "release1", Status: "complete"}, nil)
 	p.On("ReleasePromote", "app1", "release1", structs.ReleasePromoteOptions{Development: options.Bool(true), Force: options.Bool(true), Idle: options.Bool(false), Min: options.Int(0), Timeout: options.Int(300)}).Return(nil)
-	p.On("AppLogs", "app1", structs.LogsOptions{Prefix: options.Bool(true), Since: options.Duration(1 * time.Second)}).Return(ioutil.NopCloser(strings.NewReader(appLogs)), nil).Once()
+	p.On("AppLogs", "app1", structs.LogsOptions{Prefix: options.Bool(true), Since: options.Duration(1 * time.Second)}).Return(io.NopCloser(strings.NewReader(appLogs)), nil).Once()
 	p.On("ReleasePromote", "app1", "old", structs.ReleasePromoteOptions{Development: options.Bool(false), Force: options.Bool(true)}).Return(nil)
 
 	e := &exec.MockInterface{}

--- a/provider/gcp/heartbeat.go
+++ b/provider/gcp/heartbeat.go
@@ -2,7 +2,7 @@ package gcp
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -24,7 +24,7 @@ func (p *Provider) Heartbeat() (map[string]interface{}, error) {
 	}
 	defer res.Body.Close()
 
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/k8s/file.go
+++ b/provider/k8s/file.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"io"
-	"io/ioutil"
 	"strings"
 
 	"github.com/convox/convox/pkg/structs"
@@ -31,7 +30,7 @@ func (p *Provider) FilesDelete(app, pid string, files []string) error {
 		return errors.WithStack(err)
 	}
 
-	if err := exec.Stream(remotecommand.StreamOptions{Stdout: ioutil.Discard}); err != nil {
+	if err := exec.Stream(remotecommand.StreamOptions{Stdout: io.Discard}); err != nil {
 		return errors.WithStack(err)
 	}
 

--- a/sdk/auth.go
+++ b/sdk/auth.go
@@ -2,7 +2,7 @@ package sdk
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 
 	"github.com/convox/stdsdk"
 )
@@ -18,7 +18,7 @@ func (c *Client) Auth() (string, error) {
 		Id string
 	}
 
-	data, err := ioutil.ReadAll(res.Body)
+	data, err := io.ReadAll(res.Body)
 	if err != nil {
 		return "", err
 	}

--- a/sdk/compat.go
+++ b/sdk/compat.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"strconv"
 
@@ -50,7 +49,7 @@ func (c *Client) BuildCreateUpload(app string, r io.Reader, opts structs.BuildCr
 		ro.Params["config"] = ro.Params["manifest"]
 	}
 
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +66,7 @@ func (c *Client) BuildCreateUpload(app string, r io.Reader, opts structs.BuildCr
 }
 
 func (c *Client) BuildImportMultipart(app string, r io.Reader) (*structs.Build, error) {
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Replace all deprecated `io/ioutil` calls with their modern Go standard library equivalents across 39 files (~120 occurrences). All replacements are 1:1 behavioral equivalents available since Go 1.16.

### Replacement mapping

| Deprecated | Replacement |
|-----------|-------------|
| `ioutil.ReadAll` | `io.ReadAll` |
| `ioutil.ReadFile` | `os.ReadFile` |
| `ioutil.WriteFile` | `os.WriteFile` |
| `ioutil.TempDir` | `os.MkdirTemp` |
| `ioutil.NopCloser` | `io.NopCloser` |
| `ioutil.ReadDir` | `os.ReadDir` |
| `ioutil.Discard` | `io.Discard` |

### Notes

- `pkg/common/tar.go:112` (`ioutil.ReadAll`) intentionally left — will be addressed separately as part of a decompression hardening change
- Two `ReadDir` callers (`pkg/rack/terraform.go`, `pkg/rack/direct.go`) verified safe — both only use `.IsDir()` and `.Name()` which are shared between the old `FileInfo` and new `DirEntry` return types
- Zero behavioral changes, zero API changes, zero user-facing impact