### PR TITLE
fix(azure): add cert-manager annotation for API ingress TLS

### DIFF
--- a/terraform/api/azure/main.tf
+++ b/terraform/api/azure/main.tf
@@ -59,6 +59,10 @@ module "k8s" {
   replicas                  = var.high_availability ? 2 : 1
   resolver                  = var.resolver
 
+  annotations = {
+    "cert-manager.io/cluster-issuer" = "letsencrypt"
+  }
+
   labels = {
     "aadpodidbinding" : "api"
   }


### PR DESCRIPTION
## Problem

The Azure provider was missing the `cert-manager.io/cluster-issuer` annotation on the API ingress, unlike AWS, GCP, and DO providers. Without this annotation, cert-manager does not provision the `api-certificate` TLS secret, causing nginx to serve its default `ingress.local` certificate.

This breaks features like `convox build --external` which requires Docker to authenticate against the API endpoint over TLS:

```
Authenticating api.<domain>.convox.cloud/myapp: Error response from daemon:
Get "https://api.<domain>.convox.cloud/v2/": tls: failed to verify certificate:
x509: certificate is valid for ingress.local, not api.<domain>.convox.cloud
```

## Fix

Add the `cert-manager.io/cluster-issuer = "letsencrypt"` annotation to the Azure `module "k8s"` block in `terraform/api/azure/main.tf`, consistent with all other providers:

| Provider | Has annotation? |
|----------|----------------|
| AWS | ✅ `terraform/api/aws/main.tf` |
| GCP | ✅ `terraform/api/gcp/main.tf` |
| DO | ✅ `terraform/api/do/main.tf` |
| Azure | ❌ → ✅ (this PR) |

## Workaround (for existing racks)

Existing Azure racks can be fixed without a rack update by manually annotating the API ingress:

```bash
kubectl annotate ingress api-ing-v1 -n <rack-namespace> cert-manager.io/cluster-issuer=letsencrypt
```

cert-manager will then automatically provision the `api-certificate` secret via Let's Encrypt within ~30 seconds.