### PR TITLE
docs: add external builds documentation

### DIFF
--- a/docs/deployment/deploying-changes.md
+++ b/docs/deployment/deploying-changes.md
@@ -64,12 +64,40 @@ against the new [Release](/reference/primitives/app/release) before it is pushed
     OK
 ```
 
+## External Builds
+
+By default, `convox build` and `convox deploy` package your entire source directory into a tarball and upload it to the rack for in-cluster building. For applications with large source directories (e.g., machine learning model weights, large binary assets), this upload can be slow or hit load balancer timeout limits.
+
+The `--external` flag changes this flow by building the Docker image **locally** and pushing it directly to the rack's container registry:
+
+```bash
+    convox build --external -a myapp
+    convox deploy --external -a myapp
+```
+
+With external builds:
+
+1. The CLI creates a build record on the rack (a small API call)
+2. The rack returns container registry credentials
+3. Docker builds the image locally using your source directory
+4. The CLI pushes the built image directly to the rack's container registry (ECR on AWS, ACR on Azure)
+5. A release is created on the rack
+
+The source tarball never passes through the rack's load balancer, eliminating upload size and timeout constraints. This approach also benefits from local Docker layer caching for faster rebuilds.
+
+**Requirements:**
+
+- Docker must be installed and running on the build machine
+- The build machine must have network access to the rack's container registry
+
+External builds work on all cloud providers (AWS, Azure, GCP) and are well-suited for CI/CD pipelines. See the [build](/reference/cli/build#external-builds) CLI reference for more details.
+
 ## Troubleshooting Failed Deployments
 
 If a deployment fails or hangs, use `convox deploy-debug` to diagnose the issue:
 
 ```bash
-    $ convox deploy-debug -a myapp
+    convox deploy-debug -a myapp
 ```
 
 This command inspects your app's pods and provides actionable hints for common failure states like crash loops, image pull errors, OOM kills, and health check failures. See the [deploy-debug](/reference/cli/deploy-debug) reference for details.

--- a/docs/reference/cli/build.md
+++ b/docs/reference/cli/build.md
@@ -44,6 +44,50 @@ Create a build
     Release: RABCDEFGHI
 ```
 
+### External Builds
+
+> External builds are available since Convox **3.0.50**.
+
+The `--external` flag runs the Docker build **locally** on your machine (or CI runner) instead of uploading the source to the rack for in-cluster building. This is useful when:
+
+- Your source directory is large (e.g., ML model weights, large assets)
+- Source uploads are timing out through the load balancer
+- You want to leverage local Docker layer caching for faster builds
+- You are building from a CI pipeline that already has the source checked out
+
+#### How It Works
+
+A standard build packages the entire source directory into a tarball, uploads it through the rack's load balancer, and builds the image in-cluster. With `--external`, the flow changes:
+
+1. The CLI creates a build record on the rack (a small API call)
+2. The rack returns container registry credentials (ECR on AWS, ACR on Azure)
+3. Docker builds the image **locally** using your source directory
+4. The CLI pushes the built image **directly** to the rack's container registry
+5. A release is created on the rack referencing the pushed image
+
+The source tarball never passes through the load balancer, so there are no upload size or timeout constraints.
+
+#### Requirements
+
+- Docker must be running on the machine executing the build
+- The machine must have network access to the rack's container registry
+
+#### Example
+
+```bash
+    $ convox build --external -a myapp
+    Building: .
+    Sending build context to Docker daemon  2.51GB
+    Step 1/10 : FROM python:3.11-slim AS base
+     ---> a1b2c3d4e5f6
+    ...
+    Running: docker push 1234567890.dkr.ecr.us-east-1.amazonaws.com/test-regis-1mjiluel3aiv3:web.BABCDEFGHI
+    Build:   BABCDEFGHI
+    Release: RABCDEFGHI
+```
+
+> **Note:** `convox deploy --external` works the same way but also promotes the release after building.
+
 ### Pass build time env vars
 
 You can pass env vars that will only exist at build time.

--- a/docs/reference/cli/deploy.md
+++ b/docs/reference/cli/deploy.md
@@ -77,6 +77,14 @@ You can pass env vars that will only exist at build time.
     OK
 ```
 
+### External Builds
+
+The `--external` flag builds the Docker image locally instead of uploading source to the rack. This is the same as `convox build --external` but also promotes the resulting release. See the [build --external](/reference/cli/build#external-builds) documentation for details.
+
+```bash
+    convox deploy --external -a myapp
+```
+
 ## See Also
 
 - [Deploying Changes](/deployment/deploying-changes) for deployment workflow


### PR DESCRIPTION
## Summary

Documents the `--external` flag for `convox build` and `convox deploy`, which has been available since **v3.0.50** but was never documented beyond the CLI flag listing.

## Changes

### `docs/reference/cli/build.md`
- Added comprehensive "External Builds" section explaining:
  - When to use it (large source directories, timeout issues, CI pipelines)
  - How it works (5-step flow comparison with standard builds)
  - Requirements (Docker, registry access)
  - Example output
  - Version availability note (3.0.50+)

### `docs/reference/cli/deploy.md`
- Added "External Builds" cross-reference section noting `deploy --external` works the same as `build --external` but also promotes

### `docs/deployment/deploying-changes.md`
- Added "External Builds" as a third deployment method alongside "One Step" and "Two Steps"
- Covers the use case, requirements, and links to the CLI reference for details

## Context

The `--external` flag builds Docker images **locally** and pushes directly to the rack's container registry (ECR/ACR), bypassing the load balancer source upload entirely. This is particularly useful for:
- Applications with large source directories (e.g., ML model weights)
- Azure racks where the default LB idle timeout is 4 minutes
- CI/CD pipelines that already have the source checked out