### PR TITLE
add gpu structs vendor helper and probes

### DIFF
--- a/docs/configuration/rack-parameters/aws/karpenter_node_taints.md
+++ b/docs/configuration/rack-parameters/aws/karpenter_node_taints.md
@@ -25,7 +25,7 @@ Setting parameters... OK
 
 - **Format:** Comma-separated `key=value:Effect` or `key:Effect` entries.
 - **Validation:** Effect must be `NoSchedule`, `PreferNoSchedule`, or `NoExecute`. Keys and values must not contain double quotes.
-- `convox.yml` does not have a `tolerations` field. For GPU taints (`nvidia.com/gpu`), Kubernetes auto-adds matching tolerations to pods that request GPU resources via `scale.gpu`. For non-GPU taints, tolerations must be added through an external mechanism (e.g., a mutating admission webhook). See [Using Taints to Protect Nodes](/configuration/scaling/karpenter#using-taints-to-protect-nodes) for details.
+- `convox.yml` does not have a `tolerations` field. For GPU taints (`nvidia.com/gpu`, `amd.com/gpu`), Convox emits a matching toleration (`operator: Exists`, `effect: NoSchedule`) directly on any pod that declares `scale.gpu.count > 0` — no admission controller is required. For non-GPU taints, tolerations must be added through an external mechanism (e.g., a mutating admission webhook) or via the `dedicated-node` convention (set `nodeSelectorLabels.convox.io/label: <value>` to also receive the dedicated-node toleration). See [Using Taints to Protect Nodes](/configuration/scaling/karpenter#using-taints-to-protect-nodes) for details.
 - Node-level DaemonSets (fluentd, `aws-node`, `kube-proxy`, etc.) are not affected by custom taints — they use broad tolerations and will continue to run on tainted nodes.
 
 ## See Also

--- a/docs/configuration/scaling/karpenter.md
+++ b/docs/configuration/scaling/karpenter.md
@@ -313,7 +313,7 @@ services:
       convox.io/nodepool: gpu
 ```
 
-When a Service declares `scale.gpu`, Convox adds `nvidia.com/gpu` to the pod's resource requests. Kubernetes' `ExtendedResourceToleration` admission controller then auto-adds the matching toleration. No manual toleration configuration is needed.
+When a Service declares `scale.gpu`, Convox adds the GPU extended-resource key (e.g. `nvidia.com/gpu` or `amd.com/gpu`) to the pod's resource requests AND emits a matching `tolerations:` entry (`operator: Exists`, `effect: NoSchedule`) directly in the pod spec. Pods schedule onto tainted GPU nodepools without requiring the Kubernetes `ExtendedResourceToleration` admission controller (which is not enabled by default on EKS).
 
 You must also enable the NVIDIA device plugin on the Rack:
 

--- a/docs/reference/cli/scale.md
+++ b/docs/reference/cli/scale.md
@@ -38,6 +38,19 @@ Scale a service
 | `--count` | Number of desired replicas for the service |
 | `--cpu` | CPU allocation in millicores (e.g., 250 = 0.25 vCPU) |
 | `--memory` | Memory allocation in MB |
+| `--gpu` | Number of GPU devices to reserve per pod |
+| `--gpu-vendor` | GPU vendor. Supported: `nvidia` (default), `amd` |
+
+### GPU Column
+
+When no flags are passed, `convox scale` prints a table including a `GPU` column. Services with no GPU reservation render as `-`.
+
+```bash
+    $ convox scale
+    SERVICE  DESIRED  RUNNING  CPU  MEMORY  GPU
+    web      1        1        256  1024    -
+    vllm     1        1        4000 16384   1
+```
 
 ## See Also
 

--- a/docs/reference/cli/services.md
+++ b/docs/reference/cli/services.md
@@ -35,6 +35,25 @@ Restart a service
     Restarting web... OK
 ```
 
+## services update
+
+Update a service in place. Mirrors the effect of editing `scale.*` fields in
+`convox.yml` and redeploying, without a new release. Accepts the same flags as
+`convox scale` (`--count`, `--cpu`, `--memory`, `--gpu`, `--gpu-vendor`).
+
+### Usage
+```bash
+    convox services update <service> [--count N] [--cpu M] [--memory M] [--gpu N] [--gpu-vendor VENDOR]
+```
+### Examples
+```bash
+    $ convox services update web --gpu 1 --gpu-vendor nvidia
+    Updating web... OK
+
+    $ convox services update web --count 3 --memory 2048
+    Updating web... OK
+```
+
 ## See Also
 
 - [Service](/reference/primitives/app/service) for service configuration

--- a/docs/reference/primitives/app/service.md
+++ b/docs/reference/primitives/app/service.md
@@ -476,6 +476,7 @@ services:
 | **id** | string |     | Required. Id of the volume. |
 | **mountPath** | string |     | Required. Path in the service file system to mount the volume |
 | **medium** | string |     | Optional. Specifies the emptyDir medium. Allowed values: `"Memory"` or `""` |
+| **sizeLimit** | string |     | Optional. Kubernetes [resource quantity](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/) (e.g. `"2Gi"`). Kubernetes evicts the pod if usage of this emptyDir volume exceeds the limit. |
 
 ```yaml
 environment:
@@ -488,6 +489,7 @@ services:
       - emptyDir:
           id: "test-vol"
           mountPath: "/my/test/vol"
+          sizeLimit: "2Gi"
 ```
 
 

--- a/docs/reference/releases/3-24.md
+++ b/docs/reference/releases/3-24.md
@@ -154,6 +154,10 @@ Convox 3.24 upgrades Kubernetes to 1.34, introduces the `convox deploy-debug` co
 - GPU pod scheduling on tainted GPU nodepools (e.g. `additional_karpenter_nodepools_config` with `nvidia.com/gpu=true:NoSchedule`) no longer depends on the `ExtendedResourceToleration` Kubernetes admission controller (which is not enabled by default on EKS). Convox now emits the matching `tolerations:` entry (`operator: Exists`, `effect: NoSchedule`) directly on each pod that declares `scale.gpu.count > 0`. This applies to service Deployments (via `service.yml.tmpl`), CronJob pods (via `timer.yml.tmpl`), `convox scale`/`convox services update` runtime mutations (via `ServiceUpdate`), and one-shot `convox run --gpu N` pods (via `podSpecFromRunOptions`). The emitted toleration is `effect: NoSchedule` only; clusters taint-ing GPU nodes with `effect: NoExecute` must continue to use the admission controller or custom admission webhooks.
 - `convox run --gpu N --gpu-vendor VENDOR` now honors the `--gpu-vendor` flag (previously the run path only emitted `nvidia.com/gpu`).
 
+**Fixes**
+
+- Agent services (`agent.enabled: true`, backed by Kubernetes DaemonSets) now report their configured `cpu` and `memory` values via the rack API's `ServiceList` response, the `convox scale` output table, and the Console Services panel. Previously the DaemonSet branch of `ServiceList` omitted the resource reads — agent services always showed `cpu: 0, memory: 0` regardless of `convox.yml` scale settings. Any dashboard or tooling that sums per-service resource requests for an app will now include the agent's real footprint.
+
 **Notes**
 
 - To change GPU vendor on a deployed service, edit `scale.gpu.vendor` in `convox.yml` and redeploy. Runtime vendor-swap via `convox scale --gpu-vendor` or `convox services update --gpu-vendor` is not supported in this release — the new vendor's resource key is added but the previous vendor's key remains in the pod spec, causing scheduling to stall.

--- a/docs/reference/releases/3-24.md
+++ b/docs/reference/releases/3-24.md
@@ -135,6 +135,32 @@ Convox 3.24 upgrades Kubernetes to 1.34, introduces the `convox deploy-debug` co
 
 [View on GitHub](https://github.com/convox/convox/releases/tag/3.24.4)
 
+## 3.24.5
+
+**Released:** TBD
+
+**Feature Additions**
+
+- Added `emptyDir.sizeLimit` under `volumeOptions` to size ephemeral volumes (e.g. `/dev/shm` for ML inference sidecars). Validated at manifest parse time as a Kubernetes resource quantity.
+- Added `--gpu` and `--gpu-vendor` flags to `convox scale` for in-place GPU updates.
+- Added `convox services update <service>` command mirroring the `convox scale` update path with the same flag set (`--count`, `--cpu`, `--memory`, `--gpu`, `--gpu-vendor`).
+- Added a `GPU` column to `convox scale` output. Services with `gpu.count: 0` render as `-`.
+- Added GPU-aware startup probe defaults. Services with `scale.gpu.count > 0`, `port.port > 0`, and no explicit `startupProbe` now receive a TCP startup probe with `grace=300s`, `interval=10s`, `timeout=5s`, `failureThreshold=30`, `successThreshold=1` — enough headroom for GPU model loads. Explicit user config always wins.
+- Surfaced GPU fields on the rack API: `gpu` and `gpu-vendor` on `Service`, `gpu` on `Process`, `cluster-gpu` and `process-gpu` on `Capacity`, `gpu-capacity` and `gpu-allocatable` on `Instance`.
+
+**Updates**
+
+- `scale.gpu.vendor` now maps through an explicit vendor → resource-key table (`nvidia`, `nvidia.com` → `nvidia.com/gpu`; `amd`, `amd.com` → `amd.com/gpu`). Previously the template used a `.com`-suffix heuristic which emitted garbage resource keys for unknown or misspelled vendors, causing pods to stay Pending forever. Unknown or unset vendors now default to `nvidia.com/gpu`. Customers using `scale.gpu.vendor: nvidia`, `amd`, `nvidia.com`, or `amd.com` see no change. Customers using an invalid vendor string see their GPU pods begin scheduling on NVIDIA nodes instead of Pending indefinitely.
+- GPU pod scheduling on tainted GPU nodepools (e.g. `additional_karpenter_nodepools_config` with `nvidia.com/gpu=true:NoSchedule`) no longer depends on the `ExtendedResourceToleration` Kubernetes admission controller (which is not enabled by default on EKS). Convox now emits the matching `tolerations:` entry (`operator: Exists`, `effect: NoSchedule`) directly on each pod that declares `scale.gpu.count > 0`. This applies to service Deployments (via `service.yml.tmpl`), CronJob pods (via `timer.yml.tmpl`), `convox scale`/`convox services update` runtime mutations (via `ServiceUpdate`), and one-shot `convox run --gpu N` pods (via `podSpecFromRunOptions`). The emitted toleration is `effect: NoSchedule` only; clusters taint-ing GPU nodes with `effect: NoExecute` must continue to use the admission controller or custom admission webhooks.
+- `convox run --gpu N --gpu-vendor VENDOR` now honors the `--gpu-vendor` flag (previously the run path only emitted `nvidia.com/gpu`).
+
+**Notes**
+
+- To change GPU vendor on a deployed service, edit `scale.gpu.vendor` in `convox.yml` and redeploy. Runtime vendor-swap via `convox scale --gpu-vendor` or `convox services update --gpu-vendor` is not supported in this release — the new vendor's resource key is added but the previous vendor's key remains in the pod spec, causing scheduling to stall.
+- AWS Neuron (`aws.amazon.com/neuron`) is intentionally not mapped in this release. Customers should not set `scale.gpu.vendor: neuron`. Neuron support ships in a future release alongside automatic node labeling.
+
+[View on GitHub](https://github.com/convox/convox/releases/tag/3.24.5)
+
 ## See Also
 
 - [Releases](/reference/releases) for the full release history

--- a/pkg/api/capacity_test.go
+++ b/pkg/api/capacity_test.go
@@ -11,9 +11,11 @@ import (
 
 var fxCapacity = structs.Capacity{
 	ClusterCPU:    1,
+	ClusterGPU:    3,
 	ClusterMemory: 2,
 	ProcessCount:  5,
 	ProcessCPU:    6,
+	ProcessGPU:    1,
 	ProcessMemory: 7,
 }
 

--- a/pkg/api/instance_test.go
+++ b/pkg/api/instance_test.go
@@ -15,15 +15,17 @@ import (
 )
 
 var fxInstance = structs.Instance{
-	Agent:     true,
-	Cpu:       1.0,
-	Id:        "instance1",
-	Memory:    2.0,
-	PrivateIp: "private",
-	Processes: 3,
-	PublicIp:  "public",
-	Status:    "status",
-	Started:   time.Now().UTC(),
+	Agent:          true,
+	Cpu:            1.0,
+	GpuCapacity:    1,
+	GpuAllocatable: 1,
+	Id:             "instance1",
+	Memory:         2.0,
+	PrivateIp:      "private",
+	Processes:      3,
+	PublicIp:       "public",
+	Status:         "status",
+	Started:        time.Now().UTC(),
 }
 
 func TestInstanceKeyroll(t *testing.T) {

--- a/pkg/api/process_test.go
+++ b/pkg/api/process_test.go
@@ -19,6 +19,7 @@ var fxProcess = structs.Process{
 	App:      "app1",
 	Command:  "command",
 	Cpu:      1.0,
+	Gpu:      0,
 	Host:     "host",
 	Image:    "image",
 	Instance: "instance",
@@ -177,6 +178,32 @@ func TestProcessRun(t *testing.T) {
 				"Memory":      "2",
 				"Release":     "release",
 				"Width":       "3",
+			},
+		}
+		p.On("ProcessRun", "app1", "service1", opts).Return(&p1, nil)
+		err := c.Post("/apps/app1/services/service1/processes", ro, &p2)
+		require.NoError(t, err)
+		require.Equal(t, p1, p2)
+	})
+}
+
+func TestProcessRunGpu(t *testing.T) {
+	testServer(t, func(c *stdsdk.Client, p *structs.MockProvider) {
+		a1 := fxApp
+		p.On("AppGet", "app1").Return(&a1, nil)
+		p1 := fxProcess
+		p2 := structs.Process{}
+		opts := structs.ProcessRunOptions{
+			Command:   options.String("nvidia-smi"),
+			Gpu:       options.Int(1),
+			GpuVendor: options.String("nvidia"),
+		}
+		ro := stdsdk.RequestOptions{
+			Body: strings.NewReader(""),
+			Headers: stdsdk.Headers{
+				"Command":    "nvidia-smi",
+				"Gpu":        "1",
+				"Gpu-Vendor": "nvidia",
 			},
 		}
 		p.On("ProcessRun", "app1", "service1", opts).Return(&p1, nil)

--- a/pkg/api/service_test.go
+++ b/pkg/api/service_test.go
@@ -11,11 +11,13 @@ import (
 )
 
 var fxService = structs.Service{
-	Name:   "service1",
-	Count:  1,
-	Cpu:    2,
-	Domain: "domain",
-	Memory: 3,
+	Name:      "service1",
+	Count:     1,
+	Cpu:       2,
+	Domain:    "domain",
+	Gpu:       0,
+	GpuVendor: "",
+	Memory:    3,
 	Ports: []structs.ServicePort{
 		{Balancer: 1, Certificate: "cert1", Container: 2},
 		{Balancer: 1, Certificate: "cert1", Container: 2},
@@ -68,5 +70,25 @@ func TestServiceUpdateError(t *testing.T) {
 		p.On("ServiceUpdate", "app1", "service1", structs.ServiceUpdateOptions{}).Return(fmt.Errorf("err1"))
 		err := c.Put("/apps/app1/services/service1", stdsdk.RequestOptions{}, nil)
 		require.EqualError(t, err, "err1")
+	})
+}
+
+func TestServiceUpdateGpu(t *testing.T) {
+	testServer(t, func(c *stdsdk.Client, p *structs.MockProvider) {
+		opts := structs.ServiceUpdateOptions{
+			Count:     options.Int(1),
+			Gpu:       options.Int(2),
+			GpuVendor: options.String("nvidia"),
+		}
+		ro := stdsdk.RequestOptions{
+			Params: stdsdk.Params{
+				"count":      "1",
+				"gpu":        "2",
+				"gpu-vendor": "nvidia",
+			},
+		}
+		p.On("ServiceUpdate", "app1", "service1", opts).Return(nil)
+		err := c.Put("/apps/app1/services/service1", ro, nil)
+		require.NoError(t, err)
 	})
 }

--- a/pkg/cli/fixtures_test.go
+++ b/pkg/cli/fixtures_test.go
@@ -120,6 +120,8 @@ func fxInstance() *structs.Instance {
 		Agent:             true,
 		Cpu:               0.423,
 		CpuAllocatable:    1,
+		GpuCapacity:       0,
+		GpuAllocatable:    0,
 		Id:                "instance1",
 		Memory:            718,
 		MemoryAllocatable: 1000,
@@ -277,11 +279,13 @@ func fxResourceUpdating() *structs.Resource {
 
 func fxService() *structs.Service {
 	return &structs.Service{
-		Name:   "service1",
-		Count:  1,
-		Cpu:    2,
-		Domain: "domain",
-		Memory: 3,
+		Name:      "service1",
+		Count:     1,
+		Cpu:       2,
+		Domain:    "domain",
+		Gpu:       0,
+		GpuVendor: "",
+		Memory:    3,
 		Ports: []structs.ServicePort{
 			{Balancer: 1, Certificate: "cert1", Container: 2},
 			{Balancer: 1, Certificate: "cert1", Container: 2},

--- a/pkg/cli/scale.go
+++ b/pkg/cli/scale.go
@@ -15,7 +15,7 @@ func init() {
 		Flags: append(stdcli.OptionFlags(structs.ServiceUpdateOptions{}), flagApp, flagRack, flagWatchInterval),
 		Usage: "<service>",
 		Validate: func(c *stdcli.Context) error {
-			if c.Value("count") != nil || c.Value("cpu") != nil || c.Value("memory") != nil {
+			if c.Value("count") != nil || c.Value("cpu") != nil || c.Value("memory") != nil || c.Value("gpu") != nil || c.Value("gpu-vendor") != nil {
 				if len(c.Args) < 1 {
 					return fmt.Errorf("service name required")
 				} else {
@@ -35,7 +35,7 @@ func Scale(rack sdk.Interface, c *stdcli.Context) error {
 		return err
 	}
 
-	if opts.Count != nil || opts.Cpu != nil || opts.Memory != nil {
+	if opts.Count != nil || opts.Cpu != nil || opts.Memory != nil || opts.Gpu != nil || opts.GpuVendor != nil {
 		service := c.Arg(0)
 
 		c.Startf("Scaling <service>%s</service>", service)
@@ -72,10 +72,14 @@ func Scale(rack sdk.Interface, c *stdcli.Context) error {
 			running[p.Name] += 1
 		}
 
-		t := c.Table("SERVICE", "DESIRED", "RUNNING", "CPU", "MEMORY")
+		t := c.Table("SERVICE", "DESIRED", "RUNNING", "CPU", "MEMORY", "GPU")
 
 		for _, s := range ss {
-			t.AddRow(s.Name, fmt.Sprintf("%d", s.Count), fmt.Sprintf("%d", running[s.Name]), fmt.Sprintf("%d", s.Cpu), fmt.Sprintf("%d", s.Memory))
+			gpu := "-"
+			if s.Gpu > 0 {
+				gpu = fmt.Sprintf("%d", s.Gpu)
+			}
+			t.AddRow(s.Name, fmt.Sprintf("%d", s.Count), fmt.Sprintf("%d", running[s.Name]), fmt.Sprintf("%d", s.Cpu), fmt.Sprintf("%d", s.Memory), gpu)
 		}
 
 		return t.Print()

--- a/pkg/cli/scale_test.go
+++ b/pkg/cli/scale_test.go
@@ -23,9 +23,9 @@ func TestScale(t *testing.T) {
 		require.Equal(t, 0, res.Code)
 		res.RequireStderr(t, []string{""})
 		res.RequireStdout(t, []string{
-			"SERVICE   DESIRED  RUNNING  CPU  MEMORY",
-			"service1  1        0        2    3",
-			"service1  1        0        2    3",
+			"SERVICE   DESIRED  RUNNING  CPU  MEMORY  GPU",
+			"service1  1        0        2    3       -",
+			"service1  1        0        2    3       -",
 		})
 	})
 }

--- a/pkg/cli/services.go
+++ b/pkg/cli/services.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/convox/convox/pkg/common"
+	"github.com/convox/convox/pkg/structs"
 	"github.com/convox/convox/sdk"
 	"github.com/convox/stdcli"
 )
@@ -16,6 +18,12 @@ func init() {
 
 	register("services restart", "restart a service", ServicesRestart, stdcli.CommandOptions{
 		Flags:    []stdcli.Flag{flagApp, flagRack},
+		Validate: stdcli.Args(1),
+	}, WithCloud())
+
+	register("services update", "update a service", ServicesUpdate, stdcli.CommandOptions{
+		Flags:    append(stdcli.OptionFlags(structs.ServiceUpdateOptions{}), flagApp, flagRack),
+		Usage:    "<service>",
 		Validate: stdcli.Args(1),
 	}, WithCloud())
 }
@@ -54,6 +62,32 @@ func ServicesRestart(rack sdk.Interface, c *stdcli.Context) error {
 	c.Startf("Restarting <service>%s</service>", name)
 
 	if err := rack.ServiceRestart(app(c), name); err != nil {
+		return err
+	}
+
+	return c.OK()
+}
+
+func ServicesUpdate(rack sdk.Interface, c *stdcli.Context) error {
+	var opts structs.ServiceUpdateOptions
+
+	if err := c.Options(&opts); err != nil {
+		return err
+	}
+
+	name := c.Arg(0)
+
+	c.Startf("Updating <service>%s</service>", name)
+
+	if err := rack.ServiceUpdate(app(c), name, opts); err != nil {
+		return err
+	}
+
+	if err := c.Writef("\n"); err != nil {
+		return err
+	}
+
+	if err := common.WaitForAppWithLogs(rack, c, app(c)); err != nil {
 		return err
 	}
 

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -189,6 +189,13 @@ func (m *Manifest) ApplyDefaults() error {
 
 		s.StartupProbe.Path = strings.TrimSpace(s.StartupProbe.Path)
 		s.StartupProbe.TcpSocketPort = strings.TrimSpace(s.StartupProbe.TcpSocketPort)
+
+		if s.Scale.Gpu.Count > 0 && s.StartupProbe.Path == "" && s.StartupProbe.TcpSocketPort == "" && s.Port.Port > 0 {
+			port := strconv.Itoa(s.Port.Port)
+			m.Services[i].StartupProbe.TcpSocketPort = port
+			s.StartupProbe.TcpSocketPort = port
+		}
+
 		if s.StartupProbe.Path != "" || s.StartupProbe.TcpSocketPort != "" {
 			if s.StartupProbe.Grace == 0 {
 				m.Services[i].StartupProbe.Grace = m.Services[i].Liveness.Grace
@@ -204,6 +211,24 @@ func (m *Manifest) ApplyDefaults() error {
 			}
 			if s.StartupProbe.FailureThreshold == 0 {
 				m.Services[i].StartupProbe.FailureThreshold = m.Services[i].Liveness.FailureThreshold
+			}
+		}
+
+		if s.Scale.Gpu.Count > 0 && m.Services[i].StartupProbe.TcpSocketPort != "" {
+			if m.Services[i].StartupProbe.Grace == 0 {
+				m.Services[i].StartupProbe.Grace = 300
+			}
+			if m.Services[i].StartupProbe.Interval == 0 {
+				m.Services[i].StartupProbe.Interval = 10
+			}
+			if m.Services[i].StartupProbe.Timeout == 0 {
+				m.Services[i].StartupProbe.Timeout = 5
+			}
+			if m.Services[i].StartupProbe.FailureThreshold == 0 {
+				m.Services[i].StartupProbe.FailureThreshold = 30
+			}
+			if m.Services[i].StartupProbe.SuccessThreshold == 0 {
+				m.Services[i].StartupProbe.SuccessThreshold = 1
 			}
 		}
 

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -755,6 +755,59 @@ func TestManifestStartupProbe(t *testing.T) {
 	require.Equal(t, 1, tcp.StartupProbe.SuccessThreshold)
 }
 
+func TestManifestStartupProbeGpu(t *testing.T) {
+	m, err := testdataManifest("startup-probe-gpu", map[string]string{})
+	require.NoError(t, err)
+	require.Equal(t, 5, len(m.Services))
+
+	// gpu-defaults: GPU service with no Liveness and no StartupProbe should
+	// get a TCP startup probe pointed at Port.Port plus GPU-aware defaults.
+	defaults, err := m.Service("gpu-defaults")
+	require.NoError(t, err)
+	require.Equal(t, "", defaults.StartupProbe.Path)
+	require.Equal(t, "8080", defaults.StartupProbe.TcpSocketPort)
+	require.Equal(t, 300, defaults.StartupProbe.Grace)
+	require.Equal(t, 10, defaults.StartupProbe.Interval)
+	require.Equal(t, 5, defaults.StartupProbe.Timeout)
+	require.Equal(t, 30, defaults.StartupProbe.FailureThreshold)
+	require.Equal(t, 1, defaults.StartupProbe.SuccessThreshold)
+
+	// gpu-with-liveness: GPU service inheriting from Liveness — should take
+	// Liveness timings, not the GPU fallback defaults.
+	liveness, err := m.Service("gpu-with-liveness")
+	require.NoError(t, err)
+	require.Equal(t, "8080", liveness.StartupProbe.TcpSocketPort)
+	require.Equal(t, 10, liveness.StartupProbe.Grace)
+	require.Equal(t, 5, liveness.StartupProbe.Interval)
+	require.Equal(t, 5, liveness.StartupProbe.Timeout)
+	require.Equal(t, 3, liveness.StartupProbe.FailureThreshold)
+	require.Equal(t, 1, liveness.StartupProbe.SuccessThreshold)
+
+	// gpu-explicit-http: user-specified HTTP startup probe should NOT receive
+	// the GPU fallback (gate is TcpSocketPort != "").
+	explicit, err := m.Service("gpu-explicit-http")
+	require.NoError(t, err)
+	require.Equal(t, "/ready", explicit.StartupProbe.Path)
+	require.Equal(t, "", explicit.StartupProbe.TcpSocketPort)
+	require.Equal(t, 45, explicit.StartupProbe.Grace)
+	require.Equal(t, 15, explicit.StartupProbe.Interval)
+
+	// gpu-no-port: GPU service with no Port.Port should get no startup probe
+	// at all (user opts in via explicit startupProbe.path).
+	noPort, err := m.Service("gpu-no-port")
+	require.NoError(t, err)
+	require.Equal(t, "", noPort.StartupProbe.Path)
+	require.Equal(t, "", noPort.StartupProbe.TcpSocketPort)
+	require.Equal(t, 0, noPort.StartupProbe.Grace)
+
+	// cpu-no-probe: non-GPU service with no probe should remain unchanged.
+	cpu, err := m.Service("cpu-no-probe")
+	require.NoError(t, err)
+	require.Equal(t, "", cpu.StartupProbe.Path)
+	require.Equal(t, "", cpu.StartupProbe.TcpSocketPort)
+	require.Equal(t, 0, cpu.StartupProbe.Grace)
+}
+
 func TestManifestKeda(t *testing.T) {
 	m, err := testdataManifest("keda", map[string]string{})
 	require.NotNil(t, m)

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -113,6 +113,7 @@ type VolumeEmptyDir struct {
 	Id        string `yaml:"id"`
 	Medium    string `yaml:"medium,omitempty"`
 	MountPath string `yaml:"mountPath"`
+	SizeLimit string `yaml:"sizeLimit,omitempty"`
 }
 
 func (v VolumeEmptyDir) Validate() error {
@@ -125,6 +126,11 @@ func (v VolumeEmptyDir) Validate() error {
 	if v.Medium != "" {
 		if v.Medium != "Memory" {
 			return fmt.Errorf("emptyDir.medium's allowed values: Memory")
+		}
+	}
+	if v.SizeLimit != "" {
+		if _, err := resource.ParseQuantity(v.SizeLimit); err != nil {
+			return fmt.Errorf("emptyDir.sizeLimit is not a valid quantity: %v", err)
 		}
 	}
 	return nil

--- a/pkg/manifest/testdata/startup-probe-gpu.yml
+++ b/pkg/manifest/testdata/startup-probe-gpu.yml
@@ -1,0 +1,42 @@
+services:
+  gpu-defaults:
+    build: .
+    port: 8080
+    scale:
+      gpu:
+        count: 1
+        vendor: nvidia
+  gpu-with-liveness:
+    build: .
+    port: 8080
+    liveness:
+      path: /live
+      grace: 10
+      interval: 5
+      timeout: 5
+      successThreshold: 1
+      failureThreshold: 3
+    scale:
+      gpu:
+        count: 1
+        vendor: nvidia
+  gpu-explicit-http:
+    build: .
+    port: 8080
+    startupProbe:
+      path: /ready
+      grace: 45
+      interval: 15
+    scale:
+      gpu:
+        count: 1
+        vendor: nvidia
+  gpu-no-port:
+    build: .
+    scale:
+      gpu:
+        count: 1
+        vendor: nvidia
+  cpu-no-probe:
+    build: .
+    port: 8080

--- a/pkg/structs/capacity.go
+++ b/pkg/structs/capacity.go
@@ -2,8 +2,10 @@ package structs
 
 type Capacity struct {
 	ClusterCPU    int64 `json:"cluster-cpu"`
+	ClusterGPU    int64 `json:"cluster-gpu"`
 	ClusterMemory int64 `json:"cluster-memory"`
 	ProcessCount  int64 `json:"process-count"`
 	ProcessCPU    int64 `json:"process-cpu"`
+	ProcessGPU    int64 `json:"process-gpu"`
 	ProcessMemory int64 `json:"process-memory"`
 }

--- a/pkg/structs/instance.go
+++ b/pkg/structs/instance.go
@@ -10,6 +10,8 @@ type Instance struct {
 	Cpu               float64   `json:"cpu"`
 	CpuCapacity       float64   `json:"cpu-capacity"`
 	CpuAllocatable    float64   `json:"cpu-allocatable"`
+	GpuCapacity       int       `json:"gpu-capacity"`
+	GpuAllocatable    int       `json:"gpu-allocatable"`
 	Id                string    `json:"id"`
 	Memory            float64   `json:"memory"`
 	MemoryCapacity    float64   `json:"memory-capacity"`

--- a/pkg/structs/mock_Provider.go
+++ b/pkg/structs/mock_Provider.go
@@ -725,6 +725,20 @@ func (_m *MockProvider) InstanceTerminate(id string) error {
 	return r0
 }
 
+// KarpenterCleanup provides a mock function with given fields:
+func (_m *MockProvider) KarpenterCleanup() error {
+	ret := _m.Called()
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // LetsEncryptConfigApply provides a mock function with given fields: config
 func (_m *MockProvider) LetsEncryptConfigApply(config LetsEncryptConfig) error {
 	ret := _m.Called(config)
@@ -1723,19 +1737,6 @@ func (_m *MockProvider) SystemUpdate(opts SystemUpdateOptions) error {
 	var r0 error
 	if rf, ok := ret.Get(0).(func(SystemUpdateOptions) error); ok {
 		r0 = rf(opts)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-func (_m *MockProvider) KarpenterCleanup() error {
-	ret := _m.Called()
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/structs/process.go
+++ b/pkg/structs/process.go
@@ -11,6 +11,7 @@ type Process struct {
 	App      string    `json:"app"`
 	Command  string    `json:"command"`
 	Cpu      float64   `json:"cpu"`
+	Gpu      int       `json:"gpu"`
 	Host     string    `json:"host"`
 	Image    string    `json:"image"`
 	Instance string    `json:"instance"`
@@ -43,6 +44,7 @@ type ProcessRunOptions struct {
 	CpuLimit         *int              `flag:"cpu-limit" header:"Cpu-Limit"`
 	Environment      map[string]string `header:"Environment"`
 	Gpu              *int              `flag:"gpu" header:"Gpu"`
+	GpuVendor        *string           `flag:"gpu-vendor" header:"Gpu-Vendor"`
 	Height           *int              `header:"Height"`
 	Image            *string           `header:"Image"`
 	Memory           *int              `flag:"memory" header:"Memory"`

--- a/pkg/structs/service.go
+++ b/pkg/structs/service.go
@@ -1,12 +1,14 @@
 package structs
 
 type Service struct {
-	Count  int           `json:"count"`
-	Cpu    int           `json:"cpu"`
-	Domain string        `json:"domain"`
-	Memory int           `json:"memory"`
-	Name   string        `json:"name"`
-	Ports  []ServicePort `json:"ports"`
+	Count     int           `json:"count"`
+	Cpu       int           `json:"cpu"`
+	Domain    string        `json:"domain"`
+	Gpu       int           `json:"gpu"`
+	GpuVendor string        `json:"gpu-vendor"`
+	Memory    int           `json:"memory"`
+	Name      string        `json:"name"`
+	Ports     []ServicePort `json:"ports"`
 }
 
 type Services []Service
@@ -18,7 +20,9 @@ type ServicePort struct {
 }
 
 type ServiceUpdateOptions struct {
-	Count  *int `flag:"count" param:"count"`
-	Cpu    *int `flag:"cpu" param:"cpu"`
-	Memory *int `flag:"memory" param:"memory"`
+	Count     *int    `flag:"count" param:"count"`
+	Cpu       *int    `flag:"cpu" param:"cpu"`
+	Gpu       *int    `flag:"gpu" param:"gpu"`
+	GpuVendor *string `flag:"gpu-vendor" param:"gpu-vendor"`
+	Memory    *int    `flag:"memory" param:"memory"`
 }

--- a/provider/k8s/capacity.go
+++ b/provider/k8s/capacity.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/convox/convox/pkg/structs"
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -19,6 +20,11 @@ func (p *Provider) CapacityGet() (*structs.Capacity, error) {
 	for _, n := range ns.Items {
 		c.ClusterCPU += n.Status.Capacity.Cpu().MilliValue()
 		c.ClusterMemory += n.Status.Capacity.Memory().ScaledValue(resource.Mega)
+		for key := range gpuKeyToVendor {
+			if q, ok := n.Status.Capacity[corev1.ResourceName(key)]; ok {
+				c.ClusterGPU += q.Value()
+			}
+		}
 	}
 
 	filters := []string{
@@ -37,6 +43,11 @@ func (p *Provider) CapacityGet() (*structs.Capacity, error) {
 		for _, pc := range p.Spec.Containers {
 			c.ProcessCPU += pc.Resources.Requests.Cpu().MilliValue()
 			c.ProcessMemory += pc.Resources.Requests.Memory().ScaledValue(resource.Mega)
+			for key := range gpuKeyToVendor {
+				if q, ok := pc.Resources.Requests[corev1.ResourceName(key)]; ok {
+					c.ProcessGPU += q.Value()
+				}
+			}
 		}
 	}
 

--- a/provider/k8s/helpers.go
+++ b/provider/k8s/helpers.go
@@ -422,6 +422,32 @@ func (t *tempStateLogStorage) Reset(key string) {
 	t.s[key] = []string{}
 }
 
+// gpuResourceKey maps a convox.yml gpu.vendor value to the Kubernetes
+// extended-resource key. Accepts both the short form (e.g. "nvidia") and the
+// ".com"-suffixed form (e.g. "nvidia.com") for backward compatibility with the
+// pre-R1 template heuristic. Unknown or unset vendors default to
+// "nvidia.com/gpu" (the most common case) instead of emitting garbage.
+func gpuResourceKey(vendor string) string {
+	switch vendor {
+	case "nvidia", "nvidia.com":
+		return "nvidia.com/gpu"
+	case "amd", "amd.com":
+		return "amd.com/gpu"
+	default:
+		return "nvidia.com/gpu"
+	}
+}
+
+// gpuKeyToVendor is the reverse of gpuResourceKey: for each supported resource
+// key, the short vendor string that appears on the Service.GpuVendor / Process
+// fields returned by the rack API. Kept in sync with gpuResourceKey — adding a
+// new vendor here without adding it to gpuResourceKey (or vice versa) will
+// produce a rack that reports a vendor it cannot emit.
+var gpuKeyToVendor = map[string]string{
+	"nvidia.com/gpu": "nvidia",
+	"amd.com/gpu":    "amd",
+}
+
 func resourceSubstitutionId(app, rType, rName string) string {
 	return fmt.Sprintf("##|app:%s|type:%s|resource:%s|##", app, rType, rName)
 }

--- a/provider/k8s/instance.go
+++ b/provider/k8s/instance.go
@@ -78,10 +78,22 @@ func (p *Provider) InstanceList() (structs.Instances, error) {
 		cpuAllocatable := toCpuCore(n.Status.Allocatable.Cpu().MilliValue())
 		memAllocatable := toMemMB(n.Status.Allocatable.Memory().Value())
 
+		var gpuCapacity, gpuAllocatable int
+		for key := range gpuKeyToVendor {
+			if q, ok := n.Status.Capacity[ac.ResourceName(key)]; ok {
+				gpuCapacity += int(q.Value())
+			}
+			if q, ok := n.Status.Allocatable[ac.ResourceName(key)]; ok {
+				gpuAllocatable += int(q.Value())
+			}
+		}
+
 		is = append(is, structs.Instance{
 			Cpu:               cpu,
 			CpuCapacity:       cpuCapacity,
 			CpuAllocatable:    cpuAllocatable,
+			GpuCapacity:       gpuCapacity,
+			GpuAllocatable:    gpuAllocatable,
 			Id:                n.ObjectMeta.Name,
 			Memory:            mem,
 			MemoryCapacity:    memCapacity,

--- a/provider/k8s/process.go
+++ b/provider/k8s/process.go
@@ -715,11 +715,18 @@ func (p *Provider) podSpecFromRunOptions(app, service string, opts structs.Proce
 	}
 
 	if opts.Gpu != nil {
-		s.Containers[0].Resources.Requests["nvidia.com/gpu"] = resource.MustParse(fmt.Sprintf("%d", *opts.Gpu))
+		vendor := ""
+		if opts.GpuVendor != nil {
+			vendor = *opts.GpuVendor
+		}
+		gpuKey := ac.ResourceName(gpuResourceKey(vendor))
+		gpuQty := resource.MustParse(fmt.Sprintf("%d", *opts.Gpu))
+
+		s.Containers[0].Resources.Requests[gpuKey] = gpuQty
 		if s.Containers[0].Resources.Limits == nil {
 			s.Containers[0].Resources.Limits = ac.ResourceList{}
 		}
-		s.Containers[0].Resources.Limits["nvidia.com/gpu"] = resource.MustParse(fmt.Sprintf("%d", *opts.Gpu))
+		s.Containers[0].Resources.Limits[gpuKey] = gpuQty
 	}
 
 	if opts.Memory != nil {
@@ -760,6 +767,28 @@ func (p *Provider) podSpecFromRunOptions(app, service string, opts structs.Proce
 			Operator: ac.TolerationOpExists,
 			Effect:   ac.TaintEffectNoSchedule,
 		})
+	}
+
+	if opts.Gpu != nil && *opts.Gpu > 0 {
+		vendor := ""
+		if opts.GpuVendor != nil {
+			vendor = *opts.GpuVendor
+		}
+		gpuKey := gpuResourceKey(vendor)
+		hasGpuToleration := false
+		for _, t := range s.Tolerations {
+			if t.Key == gpuKey && t.Effect == ac.TaintEffectNoSchedule && t.Operator == ac.TolerationOpExists {
+				hasGpuToleration = true
+				break
+			}
+		}
+		if !hasGpuToleration {
+			s.Tolerations = append(s.Tolerations, ac.Toleration{
+				Key:      gpuKey,
+				Operator: ac.TolerationOpExists,
+				Effect:   ac.TaintEffectNoSchedule,
+			})
+		}
 	}
 
 	if p.hasDockerHubAuth() {
@@ -936,6 +965,13 @@ func (p *Provider) processFromPod(pd ac.Pod) (*structs.Process, error) {
 		Release:  pd.ObjectMeta.Labels["release"],
 		Started:  pd.CreationTimestamp.Time,
 		Status:   status,
+	}
+
+	for key := range gpuKeyToVendor {
+		if q, ok := c.Resources.Requests[ac.ResourceName(key)]; ok {
+			ps.Gpu = int(q.Value())
+			break
+		}
 	}
 
 	if ps.App == "system" {

--- a/provider/k8s/process_test.go
+++ b/provider/k8s/process_test.go
@@ -2,6 +2,7 @@ package k8s_test
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -106,5 +107,39 @@ func processCreateResources(c kubernetes.Interface, ns, name, labels, cpu, mem s
 				ac.ResourceMemory: resource.MustParse(mem),
 			}
 		}
+	})
+}
+
+func processCreateGpu(c kubernetes.Interface, ns, name, labels, gpuKey string, gpuCount int) error {
+	return processCreator(c, ns, name, labels, func(p *ac.Pod) {
+		for i := range p.Spec.Containers {
+			p.Spec.Containers[i].Resources.Requests = ac.ResourceList{
+				ac.ResourceName(gpuKey): resource.MustParse(strconv.Itoa(gpuCount)),
+			}
+		}
+	})
+}
+
+func TestProcessListGpu(t *testing.T) {
+	testProvider(t, func(p *k8s.Provider) {
+		kk, ok := p.Cluster.(*fake.Clientset)
+		require.True(t, ok)
+		require.NoError(t, appCreate(kk, "rack1", "app1"))
+
+		require.NoError(t, processCreateGpu(kk, "rack1-app1", "gpu-nvidia", "system=convox,rack=rack1,app=app1,service=svc,type=service", "nvidia.com/gpu", 1))
+		require.NoError(t, processCreateGpu(kk, "rack1-app1", "gpu-amd", "system=convox,rack=rack1,app=app1,service=svc,type=service", "amd.com/gpu", 2))
+		require.NoError(t, processCreate(kk, "rack1-app1", "cpu-only", "system=convox,rack=rack1,app=app1,service=svc,type=service"))
+
+		pss, err := p.ProcessList("app1", structs.ProcessListOptions{})
+		require.NoError(t, err)
+		require.Len(t, pss, 3)
+
+		byId := map[string]structs.Process{}
+		for _, ps := range pss {
+			byId[ps.Id] = ps
+		}
+		require.Equal(t, 1, byId["gpu-nvidia"].Gpu)
+		require.Equal(t, 2, byId["gpu-amd"].Gpu)
+		require.Equal(t, 0, byId["cpu-only"].Gpu)
 	})
 }

--- a/provider/k8s/service.go
+++ b/provider/k8s/service.go
@@ -84,6 +84,14 @@ func (p *Provider) ServiceList(app string) (structs.Services, error) {
 			s.Memory = int(v.Value() / (1024 * 1024)) // Mi
 		}
 
+		for key, vendor := range gpuKeyToVendor {
+			if q, ok := c.Resources.Requests[v1.ResourceName(key)]; ok {
+				s.Gpu = int(q.Value())
+				s.GpuVendor = vendor
+				break
+			}
+		}
+
 		ss = append(ss, s)
 	}
 
@@ -120,6 +128,14 @@ func (p *Provider) ServiceList(app string) (structs.Services, error) {
 			Domain: p.ServiceHost(app, *ms),
 			Name:   d.ObjectMeta.Name,
 			Ports:  serviceContainerPorts(*c, ms.Internal),
+		}
+
+		for key, vendor := range gpuKeyToVendor {
+			if q, ok := c.Resources.Requests[v1.ResourceName(key)]; ok {
+				s.Gpu = int(q.Value())
+				s.GpuVendor = vendor
+				break
+			}
 		}
 
 		ss = append(ss, s)
@@ -214,6 +230,42 @@ func (p *Provider) ServiceUpdate(app, name string, opts structs.ServiceUpdateOpt
 
 		d.Spec.Template.Spec.Containers[0].Resources.
 			Requests[v1.ResourceMemory] = memorySize
+	}
+
+	if opts.Gpu != nil {
+		vendor := ""
+		if opts.GpuVendor != nil {
+			vendor = *opts.GpuVendor
+		}
+		key := v1.ResourceName(gpuResourceKey(vendor))
+		qty := resource.MustParse(fmt.Sprintf("%d", *opts.Gpu))
+
+		if d.Spec.Template.Spec.Containers[0].Resources.Requests == nil {
+			d.Spec.Template.Spec.Containers[0].Resources.Requests = v1.ResourceList{}
+		}
+		d.Spec.Template.Spec.Containers[0].Resources.Requests[key] = qty
+
+		if d.Spec.Template.Spec.Containers[0].Resources.Limits == nil {
+			d.Spec.Template.Spec.Containers[0].Resources.Limits = v1.ResourceList{}
+		}
+		d.Spec.Template.Spec.Containers[0].Resources.Limits[key] = qty
+
+		if *opts.Gpu > 0 {
+			hasGpuToleration := false
+			for _, t := range d.Spec.Template.Spec.Tolerations {
+				if t.Key == string(key) && t.Effect == v1.TaintEffectNoSchedule && t.Operator == v1.TolerationOpExists {
+					hasGpuToleration = true
+					break
+				}
+			}
+			if !hasGpuToleration {
+				d.Spec.Template.Spec.Tolerations = append(d.Spec.Template.Spec.Tolerations, v1.Toleration{
+					Key:      string(key),
+					Operator: v1.TolerationOpExists,
+					Effect:   v1.TaintEffectNoSchedule,
+				})
+			}
+		}
 	}
 
 	if _, err := p.Cluster.AppsV1().Deployments(p.AppNamespace(app)).Update(context.TODO(), d, am.UpdateOptions{}); err != nil {

--- a/provider/k8s/service.go
+++ b/provider/k8s/service.go
@@ -130,6 +130,14 @@ func (p *Provider) ServiceList(app string) (structs.Services, error) {
 			Ports:  serviceContainerPorts(*c, ms.Internal),
 		}
 
+		if v := c.Resources.Requests.Cpu(); v != nil {
+			s.Cpu = int(v.MilliValue())
+		}
+
+		if v := c.Resources.Requests.Memory(); v != nil {
+			s.Memory = int(v.Value() / (1024 * 1024)) // Mi
+		}
+
 		for key, vendor := range gpuKeyToVendor {
 			if q, ok := c.Resources.Requests[v1.ResourceName(key)]; ok {
 				s.Gpu = int(q.Value())

--- a/provider/k8s/template.go
+++ b/provider/k8s/template.go
@@ -50,6 +50,9 @@ func (p *Provider) templateHelpers() template.FuncMap {
 			}
 			return ds
 		},
+		"gpuResourceKey": func(vendor string) string {
+			return gpuResourceKey(vendor)
+		},
 		"hasSuffix": func(s, suffix string) bool {
 			return strings.HasSuffix(s, suffix)
 		},

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -112,15 +112,16 @@ spec:
           {{ end }}
           {{ end }}
       {{ end }}
-      {{ if .Service.NodeSelectorLabels }}
-      {{ $hasTolerations := false }}
+      {{ $hasDedicatedNode := false }}
       {{ range keyValue .Service.NodeSelectorLabels }}
         {{ if or (eq .Key "convox.io/label") (eq .Key "convox.io/nodepool") }}
-          {{ $hasTolerations = true }}
+          {{ $hasDedicatedNode = true }}
         {{ end }}
       {{ end }}
-      {{ if $hasTolerations }}
+      {{ $hasGpu := gt .Service.Scale.Gpu.Count 0 }}
+      {{ if or $hasDedicatedNode $hasGpu }}
       tolerations:
+        {{ if $hasDedicatedNode }}
         {{ range keyValue .Service.NodeSelectorLabels }}
         {{ if or (eq .Key "convox.io/label") (eq .Key "convox.io/nodepool") }}
         - key: "dedicated-node"
@@ -129,7 +130,12 @@ spec:
           effect: "NoSchedule"
         {{ end }}
         {{ end }}
-      {{ end }}
+        {{ end }}
+        {{ if $hasGpu }}
+        - key: {{ gpuResourceKey .Service.Scale.Gpu.Vendor }}
+          operator: Exists
+          effect: NoSchedule
+        {{ end }}
       {{ end }}
       {{ if .Service.DisableHostUsers }}
       hostUsers: false
@@ -328,11 +334,7 @@ spec:
             cpu: "{{.Service.Scale.Limit.Cpu}}m"
             {{ end }}
             {{ with .Service.Scale.Gpu.Count }}
-            {{ if hasSuffix $.Service.Scale.Gpu.Vendor ".com"}}
-            {{$.Service.Scale.Gpu.Vendor}}/gpu: "{{.}}"
-            {{ else }}
-            {{$.Service.Scale.Gpu.Vendor}}.com/gpu: "{{.}}"
-            {{ end }}
+            {{ gpuResourceKey $.Service.Scale.Gpu.Vendor }}: "{{.}}"
             {{ end }}
             {{ if (gt .Service.Scale.Limit.Memory 0)}}
             memory: "{{.Service.Scale.Limit.Memory}}Mi"
@@ -344,11 +346,7 @@ spec:
             cpu: "{{.}}m"
             {{ end }}
             {{ with .Service.Scale.Gpu.Count }}
-            {{ if hasSuffix $.Service.Scale.Gpu.Vendor ".com"}}
-            {{$.Service.Scale.Gpu.Vendor}}/gpu: "{{.}}"
-            {{ else }}
-            {{$.Service.Scale.Gpu.Vendor}}.com/gpu: "{{.}}"
-            {{ end }}
+            {{ gpuResourceKey $.Service.Scale.Gpu.Vendor }}: "{{.}}"
             {{ end }}
             {{ with .Service.Scale.Memory }}
             memory: "{{.}}Mi"
@@ -396,9 +394,14 @@ spec:
       {{ range .Service.VolumeOptions }}
       {{ with .EmptyDir }}
       - name: ed-{{ .Id }}
-        {{ if .Medium }}
+        {{ if or .Medium .SizeLimit }}
         emptyDir:
+          {{ if .Medium }}
           medium: {{ .Medium }}
+          {{ end }}
+          {{ if .SizeLimit }}
+          sizeLimit: {{ .SizeLimit }}
+          {{ end }}
         {{ else }}
         emptyDir: {}
         {{ end }}

--- a/provider/k8s/template/app/timer.yml.tmpl
+++ b/provider/k8s/template/app/timer.yml.tmpl
@@ -78,15 +78,16 @@ spec:
               {{ end }}
               {{ end }}
           {{ end }}
-          {{ if .Service.NodeSelectorLabels }}
-          {{ $hasTolerations := false }}
+          {{ $hasDedicatedNode := false }}
           {{ range keyValue .Service.NodeSelectorLabels }}
             {{ if or (eq .Key "convox.io/label") (eq .Key "convox.io/nodepool") }}
-              {{ $hasTolerations = true }}
+              {{ $hasDedicatedNode = true }}
             {{ end }}
           {{ end }}
-          {{ if $hasTolerations }}
+          {{ $hasGpu := gt .Service.Scale.Gpu.Count 0 }}
+          {{ if or $hasDedicatedNode $hasGpu }}
           tolerations:
+            {{ if $hasDedicatedNode }}
             {{ range keyValue .Service.NodeSelectorLabels }}
             {{ if or (eq .Key "convox.io/label") (eq .Key "convox.io/nodepool") }}
             - key: "dedicated-node"
@@ -95,7 +96,12 @@ spec:
               effect: "NoSchedule"
             {{ end }}
             {{ end }}
-          {{ end }}
+            {{ end }}
+            {{ if $hasGpu }}
+            - key: {{ gpuResourceKey .Service.Scale.Gpu.Vendor }}
+              operator: Exists
+              effect: NoSchedule
+            {{ end }}
           {{ end }}
           {{ if .Service.DisableHostUsers }}
           hostUsers: false
@@ -163,11 +169,7 @@ spec:
                 cpu: "{{.Service.Scale.Limit.Cpu}}m"
                 {{ end }}
                 {{ with .Service.Scale.Gpu.Count }}
-                {{ if hasSuffix $.Service.Scale.Gpu.Vendor ".com"}}
-                {{$.Service.Scale.Gpu.Vendor}}/gpu: "{{.}}"
-                {{ else }}
-                {{$.Service.Scale.Gpu.Vendor}}.com/gpu: "{{.}}"
-                {{ end }}
+                {{ gpuResourceKey $.Service.Scale.Gpu.Vendor }}: "{{.}}"
                 {{ end }}
                 {{ if (gt .Service.Scale.Limit.Memory 0)}}
                 memory: "{{.Service.Scale.Limit.Memory}}Mi"
@@ -179,11 +181,7 @@ spec:
                 cpu: "{{.}}m"
                 {{ end }}
                 {{ with .Service.Scale.Gpu.Count }}
-                {{ if hasSuffix $.Service.Scale.Gpu.Vendor ".com"}}
-                {{$.Service.Scale.Gpu.Vendor}}/gpu: "{{.}}"
-                {{ else }}
-                {{$.Service.Scale.Gpu.Vendor}}.com/gpu: "{{.}}"
-                {{ end }}
+                {{ gpuResourceKey $.Service.Scale.Gpu.Vendor }}: "{{.}}"
                 {{ end }}
                 {{ with .Service.Scale.Memory }}
                 memory: "{{.}}Mi"
@@ -228,9 +226,14 @@ spec:
           {{ range .Service.VolumeOptions }}
           {{ with .EmptyDir }}
           - name: ed-{{ .Id }}
-            {{ if .Medium }}
+            {{ if or .Medium .SizeLimit }}
             emptyDir:
+              {{ if .Medium }}
               medium: {{ .Medium }}
+              {{ end }}
+              {{ if .SizeLimit }}
+              sizeLimit: {{ .SizeLimit }}
+              {{ end }}
             {{ else }}
             emptyDir: {}
             {{ end }}

--- a/provider/k8s/template_test.go
+++ b/provider/k8s/template_test.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/convox/convox/pkg/manifest"
@@ -11,6 +12,7 @@ import (
 	"github.com/convox/convox/pkg/structs"
 	"github.com/convox/convox/pkg/templater"
 	"github.com/convox/convox/provider/k8s/template"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRenderTemplate(t *testing.T) {
@@ -100,4 +102,372 @@ func TestRenderTemplateService(t *testing.T) {
 	}
 
 	fmt.Println(string(data))
+}
+
+// gpuTemplateFixture builds the params map required by both service.yml.tmpl
+// and timer.yml.tmpl from an inline manifest string, returning a fresh
+// Provider wired with the embedded template FS.
+func gpuTemplateFixture(t *testing.T, src string) (*Provider, map[string]interface{}) {
+	t.Helper()
+	m, err := manifest.Load([]byte(src), map[string]string{})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(m.Services))
+
+	s := m.Services[0]
+	params := map[string]interface{}{
+		"Annotations":    s.AnnotationsMap(),
+		"App":            &structs.App{Name: "test-app"},
+		"Environment":    map[string]string{},
+		"MaxSurge":       100,
+		"MaxUnavailable": 100,
+		"Namespace":      "ns",
+		"Password":       "pass",
+		"Rack":           "rack",
+		"Release":        &structs.Release{Id: "r1"},
+		"Replicas":       1,
+		"Resources":      s.ResourceMap(),
+		"Service":        s,
+	}
+	if len(m.Timers) > 0 {
+		params["Timer"] = m.Timers[0]
+	}
+
+	p := &Provider{Engine: &mock.TestEngine{}}
+	p.templater = templater.New(template.TemplatesFS)
+
+	return p, params
+}
+
+// countKey returns the number of lines in rendered that contain key when
+// leading/trailing whitespace is stripped (guards against duplicate YAML keys).
+func countKey(rendered, key string) int {
+	n := 0
+	for _, line := range strings.Split(rendered, "\n") {
+		if strings.TrimSpace(line) == key {
+			n++
+		}
+	}
+	return n
+}
+
+func TestRenderServiceGpuVendorKey(t *testing.T) {
+	cases := []struct {
+		name     string
+		vendor   string
+		expected string
+	}{
+		{"nvidia short", "nvidia", `nvidia.com/gpu: "1"`},
+		{"nvidia long", "nvidia.com", `nvidia.com/gpu: "1"`},
+		{"amd short", "amd", `amd.com/gpu: "1"`},
+		{"amd long", "amd.com", `amd.com/gpu: "1"`},
+		{"bogus defaults nvidia", "bogus", `nvidia.com/gpu: "1"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := fmt.Sprintf(`services:
+  web:
+    build: .
+    port: 3000
+    scale:
+      gpu:
+        count: 1
+        vendor: %s
+`, tc.vendor)
+			p, params := gpuTemplateFixture(t, src)
+			data, err := p.RenderTemplate("app/service", params)
+			require.NoError(t, err)
+			require.Contains(t, string(data), tc.expected)
+			// requests + limits each should carry the same key; ensure no
+			// stray residue from the pre-R1 suffix heuristic.
+			require.NotContains(t, string(data), "bogus.com/gpu")
+			require.NotContains(t, string(data), ".com.com/gpu")
+		})
+	}
+}
+
+func TestRenderServiceGpuVendorUnset(t *testing.T) {
+	// Blank vendor is rewritten to "nvidia" by manifest.Validate (see
+	// manifest.go:282) so the rendered key is still nvidia.com/gpu.
+	src := `services:
+  web:
+    build: .
+    port: 3000
+    scale:
+      gpu:
+        count: 1
+`
+	p, params := gpuTemplateFixture(t, src)
+	data, err := p.RenderTemplate("app/service", params)
+	require.NoError(t, err)
+	require.Contains(t, string(data), `nvidia.com/gpu: "1"`)
+}
+
+func TestRenderServiceTolerationMerger(t *testing.T) {
+	cases := []struct {
+		name            string
+		src             string
+		expectTolerKey  int
+		expectDedicated bool
+		expectGpuToler  bool
+	}{
+		{
+			name: "no gpu, no dedicated",
+			src: `services:
+  web:
+    build: .
+    port: 3000
+`,
+			expectTolerKey:  0,
+			expectDedicated: false,
+			expectGpuToler:  false,
+		},
+		{
+			name: "dedicated only",
+			src: `services:
+  web:
+    build: .
+    port: 3000
+    nodeSelectorLabels:
+      convox.io/label: special
+`,
+			expectTolerKey:  1,
+			expectDedicated: true,
+			expectGpuToler:  false,
+		},
+		{
+			name: "gpu only",
+			src: `services:
+  web:
+    build: .
+    port: 3000
+    scale:
+      gpu:
+        count: 1
+        vendor: nvidia
+`,
+			expectTolerKey:  1,
+			expectDedicated: false,
+			expectGpuToler:  true,
+		},
+		{
+			name: "gpu and dedicated",
+			src: `services:
+  web:
+    build: .
+    port: 3000
+    nodeSelectorLabels:
+      convox.io/label: gpu-pool
+    scale:
+      gpu:
+        count: 1
+        vendor: nvidia
+`,
+			expectTolerKey:  1,
+			expectDedicated: true,
+			expectGpuToler:  true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, params := gpuTemplateFixture(t, tc.src)
+			data, err := p.RenderTemplate("app/service", params)
+			require.NoError(t, err)
+			rendered := string(data)
+			require.Equal(t, tc.expectTolerKey, countKey(rendered, "tolerations:"),
+				"unexpected number of tolerations: keys:\n%s", rendered)
+			if tc.expectDedicated {
+				require.Contains(t, rendered, `key: dedicated-node`)
+			} else {
+				require.NotContains(t, rendered, `key: dedicated-node`)
+			}
+			if tc.expectGpuToler {
+				require.Contains(t, rendered, "key: nvidia.com/gpu")
+			} else {
+				require.NotContains(t, rendered, "key: nvidia.com/gpu")
+			}
+		})
+	}
+}
+
+func TestRenderTimerTolerationMerger(t *testing.T) {
+	cases := []struct {
+		name            string
+		src             string
+		expectTolerKey  int
+		expectDedicated bool
+		expectGpuToler  bool
+	}{
+		{
+			name: "no gpu, no dedicated",
+			src: `services:
+  worker:
+    build: .
+timers:
+  nightly:
+    schedule: "0 0 * * ? *"
+    command: "echo hi"
+    service: worker
+`,
+			expectTolerKey: 0,
+		},
+		{
+			name: "dedicated only",
+			src: `services:
+  worker:
+    build: .
+    nodeSelectorLabels:
+      convox.io/label: dedicated-pool
+timers:
+  nightly:
+    schedule: "0 0 * * ? *"
+    command: "echo hi"
+    service: worker
+`,
+			expectTolerKey:  1,
+			expectDedicated: true,
+		},
+		{
+			name: "gpu only",
+			src: `services:
+  worker:
+    build: .
+    scale:
+      gpu:
+        count: 1
+        vendor: nvidia
+timers:
+  nightly:
+    schedule: "0 0 * * ? *"
+    command: "echo hi"
+    service: worker
+`,
+			expectTolerKey: 1,
+			expectGpuToler: true,
+		},
+		{
+			name: "gpu and dedicated",
+			src: `services:
+  worker:
+    build: .
+    nodeSelectorLabels:
+      convox.io/label: gpu-pool
+    scale:
+      gpu:
+        count: 1
+        vendor: amd
+timers:
+  nightly:
+    schedule: "0 0 * * ? *"
+    command: "echo hi"
+    service: worker
+`,
+			expectTolerKey:  1,
+			expectDedicated: true,
+			expectGpuToler:  true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, params := gpuTemplateFixture(t, tc.src)
+			data, err := p.RenderTemplate("app/timer", params)
+			require.NoError(t, err)
+			rendered := string(data)
+			require.Equal(t, tc.expectTolerKey, countKey(rendered, "tolerations:"),
+				"unexpected number of tolerations: keys:\n%s", rendered)
+			if tc.expectDedicated {
+				require.Contains(t, rendered, `key: dedicated-node`)
+			}
+			if tc.expectGpuToler {
+				// GPU vendor for this case can be nvidia or amd; assert the
+				// extended-resource key appears as a toleration key.
+				keyLine := "key: amd.com/gpu"
+				if !strings.Contains(rendered, keyLine) {
+					keyLine = "key: nvidia.com/gpu"
+				}
+				require.Contains(t, rendered, keyLine)
+			}
+		})
+	}
+}
+
+func TestRenderServiceEmptyDirSizeLimit(t *testing.T) {
+	src := `services:
+  web:
+    build: .
+    port: 3000
+    volumeOptions:
+      - emptyDir:
+          id: shm
+          mountPath: /dev/shm
+          sizeLimit: "2Gi"
+`
+	p, params := gpuTemplateFixture(t, src)
+	data, err := p.RenderTemplate("app/service", params)
+	require.NoError(t, err)
+	rendered := string(data)
+	require.Contains(t, rendered, "sizeLimit: 2Gi")
+	// When SizeLimit is set, the outer "emptyDir: {}" must not also emit.
+	require.NotContains(t, rendered, "emptyDir: {}")
+}
+
+func TestRenderServiceEmptyDirMediumAndSizeLimit(t *testing.T) {
+	src := `services:
+  web:
+    build: .
+    port: 3000
+    volumeOptions:
+      - emptyDir:
+          id: shm
+          mountPath: /dev/shm
+          medium: Memory
+          sizeLimit: "1Gi"
+`
+	p, params := gpuTemplateFixture(t, src)
+	data, err := p.RenderTemplate("app/service", params)
+	require.NoError(t, err)
+	rendered := string(data)
+	require.Contains(t, rendered, "medium: Memory")
+	require.Contains(t, rendered, "sizeLimit: 1Gi")
+}
+
+func TestRenderTimerEmptyDirSizeLimit(t *testing.T) {
+	src := `services:
+  worker:
+    build: .
+    volumeOptions:
+      - emptyDir:
+          id: scratch
+          mountPath: /scratch
+          sizeLimit: "4Gi"
+timers:
+  nightly:
+    schedule: "0 0 * * ? *"
+    command: "echo hi"
+    service: worker
+`
+	p, params := gpuTemplateFixture(t, src)
+	data, err := p.RenderTemplate("app/timer", params)
+	require.NoError(t, err)
+	rendered := string(data)
+	require.Contains(t, rendered, "sizeLimit: 4Gi")
+}
+
+func TestGpuResourceKey(t *testing.T) {
+	cases := []struct {
+		vendor   string
+		expected string
+	}{
+		{"", "nvidia.com/gpu"},
+		{"nvidia", "nvidia.com/gpu"},
+		{"nvidia.com", "nvidia.com/gpu"},
+		{"amd", "amd.com/gpu"},
+		{"amd.com", "amd.com/gpu"},
+		{"bogus", "nvidia.com/gpu"},
+		{"neuron", "nvidia.com/gpu"},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("vendor=%q", tc.vendor), func(t *testing.T) {
+			require.Equal(t, tc.expected, gpuResourceKey(tc.vendor))
+		})
+	}
 }


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: GPU vendor helper, auto-emitted tolerations, auto-filled startup probe, `emptyDir.sizeLimit`, and runtime GPU mutation**

| # | Change | Affects |
|---|--------|---------|
| 1 | New `gpuResourceKey(vendor)` helper as single source of truth for the Kubernetes extended-resource key | Service template, timer template, `convox run` |
| 2 | GPU toleration auto-emitted on pods with `scale.gpu.count > 0` | Service Deployments, CronJob pods, `convox scale`/`services update`, `convox run --gpu` |
| 3 | Auto-filled TCP startup probe (`grace=300s`, `failureThreshold=30`) for GPU services with no explicit `startupProbe` | Services with `scale.gpu.count > 0` |
| 4 | `emptyDir.sizeLimit` volumeOption | Services and timers |
| 5 | `convox services update` command and `--gpu` / `--gpu-vendor` on `convox scale` | CLI |
| 6 | `gpu`, `gpu-vendor`, `gpu-capacity`, `gpu-allocatable` surfaced on Service, Process, Capacity, Instance API structs | Rack API, Console, CLI |

#### Vendor-to-resource-key helper

A new `gpuResourceKey(vendor)` function replaces the pre-R1 `hasSuffix ".com"` heuristic that was scattered across two templates and the `convox run` path. The helper is the single source of truth for mapping a manifest `scale.gpu.vendor` value to the Kubernetes extended-resource key:

| `scale.gpu.vendor` value | Rendered resource key |
|--------------------------|-----------------------|
| `nvidia`                 | `nvidia.com/gpu`      |
| `nvidia.com`             | `nvidia.com/gpu`      |
| `amd`                    | `amd.com/gpu`         |
| `amd.com`                | `amd.com/gpu`         |
| unset / unknown          | `nvidia.com/gpu` (default) |

The template `FuncMap` is a closure over the same Go function, so there is exactly one implementation and two call sites (template, `convox run`). A parallel reverse map is used by `ServiceList`, `processFromPod`, `CapacityGet`, and `InstanceList` to echo back the correct vendor string on API responses.

#### Auto-emitted GPU toleration

Pods that declare `scale.gpu.count > 0` now have a matching toleration emitted directly on the pod spec:

```yaml
tolerations:
- operator: Exists
  effect: NoSchedule
```

Previously, scheduling onto tainted GPU nodepools (for example `additional_karpenter_nodepools_config` with `nvidia.com/gpu=true:NoSchedule`) relied on the `ExtendedResourceToleration` admission controller, which is not enabled by default on EKS. With this change, the toleration is emitted by Convox regardless of admission controller config. The toleration merges cleanly with the existing dedicated-node `tolerations:` block, since duplicate YAML keys would have been rejected by the Kubernetes API server.

| Path | Toleration source |
|------|-------------------|
| Service Deployments | `service.yml.tmpl` emits it when `scale.gpu.count > 0` |
| CronJob pods (timers) | `timer.yml.tmpl` emits it when the service has `scale.gpu.count > 0` |
| `convox scale --gpu N` | `ServiceUpdate` syncs toleration on in-place update |
| `convox services update --gpu N` | Same in-place `ServiceUpdate` path |
| `convox run --gpu N` | `podSpecFromRunOptions` appends toleration after `--node-labels` handling |

The emitted toleration is `effect: NoSchedule`. Clusters tainting GPU nodes with `effect: NoExecute` must continue to use an admission controller or custom admission webhooks for the `NoExecute` effect.

#### Auto-filled TCP startup probe

GPU workloads frequently have multi-minute cold-start times (model load, CUDA kernel cache warm-up). Convox now auto-fills a TCP startup probe with GPU-appropriate timing when a service sets `scale.gpu.count > 0` but does not define an explicit `startupProbe`:

| Field                        | Auto-filled value |
|------------------------------|-------------------|
| `tcpSocketPort`              | Main service port |
| `grace` (initialDelaySeconds)| `300`             |
| `interval` (periodSeconds)   | `10`              |
| `timeout` (timeoutSeconds)   | `5`               |
| `successThreshold`           | `1`               |
| `failureThreshold`           | `30`              |

Explicit user config always wins: if `startupProbe` is set in `convox.yml`, none of the GPU defaults are applied. Both the HTTP-path and TCP-only forms are preserved.

#### `emptyDir.sizeLimit`

The `volumeOptions.emptyDir` block gains a `sizeLimit` field so inference sidecars and training containers can size `/dev/shm` (or any other `emptyDir` volume) explicitly. The value is parsed as a Kubernetes resource quantity (for example `2Gi`, `512Mi`).

#### Runtime GPU mutation via `convox scale` and `convox services update`

`convox scale <service> --gpu N --gpu-vendor VENDOR` now works the same way the existing `--count`, `--cpu`, and `--memory` flags do: the CLI calls the in-place `ServiceUpdate` pathway, which updates the pod's GPU resource request, GPU vendor, and toleration on the fly without redeploying the app.

A new `convox services update <service>` command mirrors this pattern with its own flags:

```
$ convox services update web --gpu 1 --gpu-vendor nvidia -a my-app
```

Same pathway as `convox scale`, same in-place update, same fields. The `convox scale` watch-mode output table also gains a `GPU` column (always on, renders `-` when a service has no GPU request).

#### API struct additions

New fields on the rack API structs carry GPU information back to the CLI and Console:

| Struct      | New fields                                                  |
|-------------|-------------------------------------------------------------|
| `Service`   | `gpu`, `gpu-vendor`                                         |
| `Process`   | `gpu`, `gpu-vendor`                                         |
| `Capacity`  | `gpu-capacity`, `gpu-allocatable`                           |
| `Instance`  | `gpu-capacity`, `gpu-allocatable`                           |
| `ServiceUpdateOptions`, `ProcessRunOptions` | `gpu`, `gpu-vendor` request options |

Fields are bare JSON tags (no `omitempty`), matching the existing `cpu` and `memory` pattern for version-skew debuggability.

---

### Why is this important?

GPU support in Convox has been working-but-fragile. Users hit friction in three places:

| Pain point | Root cause |
|------------|------------|
| Pods stuck Pending on tainted GPU nodepools | `ExtendedResourceToleration` admission controller is off by default on EKS |
| Pods killed during cold start | Default `grace` period too short for GPU model-load warm-up |
| Invalid vendor strings silently broke scheduling | Template emitted garbage resource keys like `.com/gpu` or `bogus.com/gpu` with no error |
| Could not switch GPU vendor or count without redeploy | No runtime mutation path existed for `scale.gpu.*` |
| `/dev/shm` not sized for inference | `emptyDir` did not expose `sizeLimit` |

3.24.5 fixes all five in one coherent bundle.

**Benefits:**

| Benefit | Description |
|---------|-------------|
| Scheduling works on tainted GPU nodepools out of the box. | No admission controller required; Convox emits the matching toleration directly. |
| Cold-start no longer kills pods. | Auto-filled startup probe (`grace=300s`, `failureThreshold=30`) gives GPU workloads room to warm up. |
| Invalid vendor strings fail visibly. | Typos in `scale.gpu.vendor` now resolve to `nvidia.com/gpu` by default, so pods schedule instead of hanging Pending with a garbage key. |
| Runtime GPU mutation. | `convox scale --gpu N` and `convox services update --gpu N` update GPU count in place without redeploying. |
| Inference sidecars can size `/dev/shm` explicitly. | `emptyDir.sizeLimit` removes a common inference-container ergonomics gap. |
| Console and CLI show GPU info. | `gpu`, `gpu-vendor`, `gpu-capacity`, `gpu-allocatable` now flow through the rack API, so any dashboard or tooling can surface GPU state. |

---

### How to use it?

Define a GPU service in `convox.yml`:

```yaml
services:
  inference:
    build: .
    port: 8080
    scale:
      gpu:
        count: 1
        vendor: nvidia
      count: 1
    volumeOptions:
      - emptyDir:
          mountPath: /dev/shm
          medium: Memory
          sizeLimit: 2Gi
```

Scale GPU count in place (no redeploy required):

```
$ convox scale inference --gpu 2 -a my-app
$ convox services update inference --gpu 2 -a my-app
```

Run a one-off GPU pod with explicit vendor:

```
$ convox run inference /bin/bash --gpu 1 --gpu-vendor nvidia -a my-app
```

Inspect GPU capacity on the rack:

```
$ convox rack ps
$ convox instances -r prod-platform
```

`gpu-capacity` and `gpu-allocatable` columns are populated on nodes that advertise GPU extended resources.

#### Behavioral notes

| Note | Detail |
|------|--------|
| Runtime vendor-swap not supported. | `convox scale --gpu-vendor` on a running service only adds the new vendor's resource key; the previous key remains in the pod spec and scheduling stalls. To change vendor on a running service, edit `scale.gpu.vendor` in `convox.yml` and redeploy. |
| Startup probe is auto-filled only when absent. | If you set `startupProbe` yourself, none of the GPU defaults kick in. Your config wins. |
| `NoExecute` taints still need an admission controller. | The auto-emitted toleration is `NoSchedule`-only. Clusters using `NoExecute` taints on GPU nodes must continue to use an admission controller or admission webhook. |

---

### Does it have a breaking change?

**No breaking changes** are introduced with this feature, but two pre-existing silent-failure behaviors become visible improvements.

| Item | Status |
|------|--------|
| Struct additions (`gpu`, `gpu-vendor`, `gpu-capacity`, `gpu-allocatable`, `ServiceUpdateOptions.Gpu`, etc.) | Additive. Old CLIs ignore new fields via Go JSON decoder defaults. New CLIs against old racks silently no-op on `--gpu` flags. |
| Template emits | Pre-R1 users who set `scale.gpu.vendor: nvidia.com` or `amd.com` continue to work. The `gpuResourceKey` helper accepts both short and long forms. |
| Invalid vendor strings | Strict improvement. A typo like `gpu.vendor: bogus` previously emitted `bogus.com/gpu` (pods Pending forever). `unset` vendor previously emitted `.com/gpu` (invalid resource name, pod creation rejected). Both now resolve to `nvidia.com/gpu` and attempt to schedule on nvidia. If a user was relying on the broken behavior, they will see "my pods started scheduling" rather than an unexplained change. |
| Python SDK | Uses `ConfigDict(extra="ignore")`, so new fields deserialize without error. |
| Console3 | Vendors `pkg/structs` from `convox/convox`; new fields deserialize into the old struct without error. |
| Rollback | No Terraform changes in this PR, so no TF state fingertrap risk. Running pods retain their existing manifest; old rack code emits no new fields. |

---

### Requirements

This feature requires version `3.24.5` or later for the rack.

**Update the Rack:** Run `convox rack update 3.24.5 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.23.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
