### PR TITLE
Add env mask commands for secrets

### DIFF
--- a/pkg/cli/env.go
+++ b/pkg/cli/env.go
@@ -3,10 +3,12 @@ package cli
 import (
 	"bufio"
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -17,11 +19,34 @@ import (
 	"github.com/convox/stdcli"
 )
 
+const maskedEnvKeysConfigName = "cli-env-mask"
+
+// envKeyPattern accepts any non-empty string without whitespace or '='.
+// This matches the permissiveness of Environment.Load in pkg/structs/environment.go.
+// A stricter POSIX regex would reject keys like "FOO.BAR" that `env set` accepts.
+var envKeyPattern = regexp.MustCompile(`^[^\s=]+$`)
+
+// containsControlChar rejects keys containing ASCII control chars (< 0x20 or 0x7F).
+// Control chars pass the whitespace-and-equals regex above but, when printed through
+// the CLI's display paths (`convox env mask`, `<info>%s</info>` wraps, masked `KEY=****`
+// output), would render as terminal escape sequences. A user with app-write could
+// poison the mask list with ANSI codes that another user's terminal would interpret
+// on display. Reject at write time to close this.
+func containsControlChar(s string) bool {
+	for _, r := range s {
+		if r < 0x20 || r == 0x7F {
+			return true
+		}
+	}
+	return false
+}
+
 func init() {
 	register("env", "list env vars", watch(Env), stdcli.CommandOptions{
 		Flags: []stdcli.Flag{
 			flagRack, flagApp, flagWatchInterval,
 			stdcli.StringFlag("release", "", "id of the release"),
+			stdcli.BoolFlag("reveal", "", "show unmasked env values"),
 		},
 		Validate: stdcli.Args(0),
 	}, WithCloud())
@@ -68,6 +93,23 @@ func init() {
 		Usage:    "<key> [key]...",
 		Validate: stdcli.ArgsMin(1),
 	}, WithCloud())
+
+	register("env mask", "list masked env keys", EnvMask, stdcli.CommandOptions{
+		Flags:    []stdcli.Flag{flagRack, flagApp},
+		Validate: stdcli.Args(0),
+	}, WithCloud())
+
+	register("env mask set", "mark env keys as masked", EnvMaskSet, stdcli.CommandOptions{
+		Flags:    []stdcli.Flag{flagRack, flagApp},
+		Usage:    "<key> [key]...",
+		Validate: stdcli.ArgsMin(1),
+	}, WithCloud())
+
+	register("env mask unset", "unmark masked env keys", EnvMaskUnset, stdcli.CommandOptions{
+		Flags:    []stdcli.Flag{flagRack, flagApp},
+		Usage:    "<key> [key]...",
+		Validate: stdcli.ArgsMin(1),
+	}, WithCloud())
 }
 
 func Env(rack sdk.Interface, c *stdcli.Context) error {
@@ -78,7 +120,16 @@ func Env(rack sdk.Interface, c *stdcli.Context) error {
 		return err
 	}
 
-	c.Writef("%s\n", env.String())
+	// Short-circuit: skip masking path entirely when --reveal is set OR stdout is not a TTY.
+	// Avoids an extra AppConfigGet call and keeps existing TestEnv mocks unchanged.
+	if !c.Bool("reveal") && c.Writer().IsTerminal() {
+		if masked := maskedKeysSet(rack, app(c)); masked != nil {
+			_ = c.Writef("%s\n", env.StringMasked(masked))
+			return nil
+		}
+	}
+
+	_ = c.Writef("%s\n", env.String())
 
 	return nil
 }
@@ -366,4 +417,202 @@ func getEnvHelper(rack sdk.Interface, appName, releaseId string) (structs.Enviro
 	}
 
 	return common.AppEnvironment(rack, appName)
+}
+
+func EnvMask(rack sdk.Interface, c *stdcli.Context) error {
+	keys, err := getMaskedEnvKeys(rack, app(c))
+	if err != nil {
+		return err
+	}
+
+	if len(keys) > 0 {
+		sort.Strings(keys)
+		for _, k := range keys {
+			_ = c.Writef("%s\n", k)
+		}
+	}
+
+	return nil
+}
+
+func EnvMaskSet(rack sdk.Interface, c *stdcli.Context) error {
+	for _, arg := range c.Args {
+		if strings.Contains(arg, "=") {
+			return fmt.Errorf("use `convox env set KEY=VALUE` to set env values. `convox env mask set` takes key names only")
+		}
+		if !envKeyPattern.MatchString(arg) {
+			return fmt.Errorf("invalid env key name: %q (must not contain whitespace or '=')", arg)
+		}
+		if containsControlChar(arg) {
+			return fmt.Errorf("invalid env key name: %q (must not contain control characters)", arg)
+		}
+	}
+
+	existing, _ := getMaskedEnvKeys(rack, app(c))
+
+	keySet := map[string]bool{}
+	for _, k := range existing {
+		keySet[k] = true
+	}
+	for _, k := range c.Args {
+		keySet[k] = true
+	}
+
+	if len(keySet) > 500 {
+		return fmt.Errorf("too many masked keys (max 500, got %d)", len(keySet))
+	}
+
+	keys := make([]string, 0, len(keySet))
+	for k := range keySet {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	display := make([]string, 0, len(c.Args))
+	seen := map[string]bool{}
+	for _, k := range c.Args {
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		display = append(display, fmt.Sprintf("<info>%s</info>", k))
+	}
+	sort.Strings(display)
+	c.Startf("Setting masked env keys %s", strings.Join(display, ", "))
+
+	value := strings.Join(keys, ",")
+	encoded := base64.StdEncoding.EncodeToString([]byte(value))
+
+	if err := rack.AppConfigSet(app(c), maskedEnvKeysConfigName, encoded); err != nil {
+		if isAppConfigUnsupported(err) {
+			_ = c.Writef("\nWarning: this rack version may not support env masking\n")
+			//nolint:nilerr // intentional: old rack warning is user-friendly exit-0, not an error
+			return nil
+		}
+		return err
+	}
+
+	cfg, err := rack.AppConfigGet(app(c), maskedEnvKeysConfigName)
+	if err != nil || cfg == nil || strings.TrimSpace(cfg.Value) != value {
+		_ = c.Writef("\nWarning: this rack version may not support env masking\n")
+		//nolint:nilerr // intentional: unverified write warning, exit-0 is user-friendly
+		return nil
+	}
+
+	return c.OK()
+}
+
+func EnvMaskUnset(rack sdk.Interface, c *stdcli.Context) error {
+	existing, _ := getMaskedEnvKeys(rack, app(c))
+
+	remove := map[string]bool{}
+	for _, k := range c.Args {
+		remove[k] = true
+	}
+
+	keys := []string{}
+	for _, k := range existing {
+		if !remove[k] {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+
+	display := make([]string, 0, len(c.Args))
+	seen := map[string]bool{}
+	for _, k := range c.Args {
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		display = append(display, fmt.Sprintf("<info>%s</info>", k))
+	}
+	sort.Strings(display)
+	c.Startf("Unsetting masked env keys %s", strings.Join(display, ", "))
+
+	value := strings.Join(keys, ",")
+	encoded := base64.StdEncoding.EncodeToString([]byte(value))
+
+	if err := rack.AppConfigSet(app(c), maskedEnvKeysConfigName, encoded); err != nil {
+		if isAppConfigUnsupported(err) {
+			_ = c.Writef("\nWarning: this rack version may not support env masking\n")
+			//nolint:nilerr // intentional: old rack warning is user-friendly exit-0, not an error
+			return nil
+		}
+		return err
+	}
+
+	cfg, err := rack.AppConfigGet(app(c), maskedEnvKeysConfigName)
+	if err != nil || cfg == nil || strings.TrimSpace(cfg.Value) != value {
+		_ = c.Writef("\nWarning: this rack version may not support env masking\n")
+		//nolint:nilerr // intentional: unverified write warning, exit-0 is user-friendly
+		return nil
+	}
+
+	return c.OK()
+}
+
+// getMaskedEnvKeys reads the mask list from AppConfig. Returns empty slice on any error
+// (old racks, missing config, transient failures) — never surfaces an error to the caller.
+func getMaskedEnvKeys(rack sdk.Interface, appName string) ([]string, error) {
+	cfg, err := rack.AppConfigGet(appName, maskedEnvKeysConfigName)
+	if err != nil || cfg == nil {
+		//nolint:nilerr // intentional: swallow read errors; absent mask list = no masking
+		return nil, nil
+	}
+
+	trimmed := strings.TrimSpace(cfg.Value)
+	if trimmed == "" {
+		return nil, nil
+	}
+
+	parts := strings.Split(trimmed, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+
+	return out, nil
+}
+
+// maskedKeysSet converts the mask list to a lookup map. Returns nil (not empty map)
+// when the list is empty — callers use `if masked := maskedKeysSet(...); masked != nil`
+// to branch on "masking configured" vs "no masking".
+func maskedKeysSet(rack sdk.Interface, appName string) map[string]bool {
+	keys, _ := getMaskedEnvKeys(rack, appName)
+	if len(keys) == 0 {
+		return nil
+	}
+	set := make(map[string]bool, len(keys))
+	for _, k := range keys {
+		set[k] = true
+	}
+	return set
+}
+
+// isAppConfigUnsupported detects errors from racks that don't have the AppConfig
+// endpoint (V2 racks, V3 pre-3.19.7). The SDK flattens HTTP errors to plain Go
+// errors.
+//
+// We match two specific substrings only:
+//   - "response status 404" — stdsdk's fallback string when the server returns
+//     a bare 404 with no body (route truly missing on V2 / old V3).
+//   - "app config not found" — the provider-level error (pkg/structs ErrNotFound)
+//     when the endpoint exists but the config key doesn't. Safe to treat as
+//     "unsupported" in the write path: if the rack supports AppConfig, the first
+//     write creates the key; getting this error on a SET is odd but benign.
+//
+// We DO NOT match bare "404" or bare "not found" because those substrings appear
+// in errors we must NOT swallow — notably `namespaces "my-app" not found` when the
+// user mistypes the app name. Hiding that behind a version-warning would mislead.
+func isAppConfigUnsupported(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "response status 404") ||
+		strings.Contains(msg, "app config not found")
 }

--- a/pkg/cli/env_test.go
+++ b/pkg/cli/env_test.go
@@ -226,3 +226,184 @@ func TestEnvUnsetClassic(t *testing.T) {
 		})
 	})
 }
+
+func TestEnvMask(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("AppConfigGet", "app1", "cli-env-mask").Return(&structs.AppConfig{
+			Name:  "cli-env-mask",
+			Value: "API_TOKEN,DB_URL",
+		}, nil)
+
+		res, err := testExecute(e, "env mask -a app1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		res.RequireStderr(t, []string{""})
+		res.RequireStdout(t, []string{
+			"API_TOKEN",
+			"DB_URL",
+		})
+	})
+}
+
+func TestEnvMaskEmpty(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("AppConfigGet", "app1", "cli-env-mask").Return(nil, fmt.Errorf("response status 404"))
+
+		res, err := testExecute(e, "env mask -a app1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		res.RequireStderr(t, []string{""})
+		res.RequireStdout(t, []string{""})
+	})
+}
+
+func TestEnvMaskSet(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("AppConfigGet", "app1", "cli-env-mask").Return(nil, fmt.Errorf("response status 404")).Once()
+		i.On("AppConfigSet", "app1", "cli-env-mask", "QVBJX1RPS0VO").Return(nil)
+		i.On("AppConfigGet", "app1", "cli-env-mask").Return(&structs.AppConfig{
+			Name:  "cli-env-mask",
+			Value: "API_TOKEN",
+		}, nil).Once()
+
+		res, err := testExecute(e, "env mask set API_TOKEN -a app1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		require.Contains(t, res.Stdout, "Setting masked env keys")
+		require.Contains(t, res.Stdout, "OK")
+	})
+}
+
+func TestEnvMaskSetMerge(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("AppConfigGet", "app1", "cli-env-mask").Return(&structs.AppConfig{
+			Name:  "cli-env-mask",
+			Value: "API_TOKEN",
+		}, nil).Once()
+		i.On("AppConfigSet", "app1", "cli-env-mask", "QVBJX1RPS0VOLERCX1VSTA==").Return(nil)
+		i.On("AppConfigGet", "app1", "cli-env-mask").Return(&structs.AppConfig{
+			Name:  "cli-env-mask",
+			Value: "API_TOKEN,DB_URL",
+		}, nil).Once()
+
+		res, err := testExecute(e, "env mask set DB_URL -a app1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+	})
+}
+
+func TestEnvMaskSetOldRack(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("AppConfigGet", "app1", "cli-env-mask").Return(nil, fmt.Errorf("response status 404")).Once()
+		i.On("AppConfigSet", "app1", "cli-env-mask", "QVBJX1RPS0VO").Return(fmt.Errorf("response status 404"))
+
+		res, err := testExecute(e, "env mask set API_TOKEN -a app1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		require.Contains(t, res.Stdout, "rack version may not support env masking")
+	})
+}
+
+func TestEnvMaskSetMissingApp(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("AppConfigGet", "missing-app", "cli-env-mask").Return(nil, fmt.Errorf("app missing-app not found")).Once()
+		i.On("AppConfigSet", "missing-app", "cli-env-mask", "QVBJX1RPS0VO").Return(fmt.Errorf("failed to set config: namespaces \"convox-missing-app\" not found"))
+
+		res, err := testExecute(e, "env mask set API_TOKEN -a missing-app", nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, res.Code)
+		require.Contains(t, res.Stderr, "namespaces")
+		require.NotContains(t, res.Stdout, "rack version may not support")
+	})
+}
+
+func TestEnvMaskSetInvalidFormat(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		res, err := testExecute(e, "env mask set API_TOKEN=secret -a app1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, res.Code)
+		require.Contains(t, res.Stderr, "convox env set KEY=VALUE")
+	})
+}
+
+func TestEnvMaskSetInvalidKeyName(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		res, err := testExecute(e, "env mask set 'BAD KEY' -a app1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, res.Code)
+		require.Contains(t, res.Stderr, "invalid env key name")
+	})
+}
+
+func TestEnvMaskSetRejectsControlChar(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		res, err := testExecute(e, "env mask set \"BAD\x1bKEY\" -a app1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, res.Code)
+		require.Contains(t, res.Stderr, "control characters")
+	})
+}
+
+func TestEnvMaskSetAcceptsDottedKey(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("AppConfigGet", "app1", "cli-env-mask").Return(nil, fmt.Errorf("app config not found")).Once()
+		i.On("AppConfigSet", "app1", "cli-env-mask", "Rk9PLkJBUg==").Return(nil)
+		i.On("AppConfigGet", "app1", "cli-env-mask").Return(&structs.AppConfig{
+			Name:  "cli-env-mask",
+			Value: "FOO.BAR",
+		}, nil).Once()
+
+		res, err := testExecute(e, "env mask set FOO.BAR -a app1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+	})
+}
+
+func TestEnvMaskUnset(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("AppConfigGet", "app1", "cli-env-mask").Return(&structs.AppConfig{
+			Name:  "cli-env-mask",
+			Value: "API_TOKEN,DB_URL",
+		}, nil).Once()
+		i.On("AppConfigSet", "app1", "cli-env-mask", "QVBJX1RPS0VO").Return(nil)
+		i.On("AppConfigGet", "app1", "cli-env-mask").Return(&structs.AppConfig{
+			Name:  "cli-env-mask",
+			Value: "API_TOKEN",
+		}, nil).Once()
+
+		res, err := testExecute(e, "env mask unset DB_URL -a app1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		require.Contains(t, res.Stdout, "Unsetting masked env keys")
+		require.Contains(t, res.Stdout, "OK")
+	})
+}
+
+func TestEnvMaskUnsetOldRack(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("AppConfigGet", "app1", "cli-env-mask").Return(nil, fmt.Errorf("response status 404")).Once()
+		i.On("AppConfigSet", "app1", "cli-env-mask", "").Return(fmt.Errorf("response status 404"))
+
+		res, err := testExecute(e, "env mask unset DB_URL -a app1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		require.Contains(t, res.Stdout, "rack version may not support env masking")
+	})
+}
+
+func TestEnvRevealFlag(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		opts := structs.ReleaseListOptions{Limit: options.Int(1)}
+		i.On("ReleaseList", "app1", opts).Return(structs.Releases{*fxRelease()}, nil)
+		i.On("ReleaseGet", "app1", "release1").Return(fxRelease(), nil)
+
+		res, err := testExecute(e, "env --reveal -a app1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		res.RequireStderr(t, []string{""})
+		res.RequireStdout(t, []string{
+			"BAZ=quux",
+			"FOO=bar",
+		})
+	})
+}

--- a/pkg/cli/releases.go
+++ b/pkg/cli/releases.go
@@ -26,7 +26,7 @@ func init() {
 	}, WithCloud())
 
 	register("releases info", "get information about a release", ReleasesInfo, stdcli.CommandOptions{
-		Flags:    []stdcli.Flag{flagApp, flagRack},
+		Flags:    []stdcli.Flag{flagApp, flagRack, stdcli.BoolFlag("reveal", "", "show unmasked env values")},
 		Validate: stdcli.Args(1),
 	}, WithCloud())
 
@@ -151,7 +151,19 @@ func ReleasesInfo(rack sdk.Interface, c *stdcli.Context) error {
 	i.Add("Build", r.Build)
 	i.Add("Created", r.Created.Format(time.RFC3339))
 	i.Add("Description", r.Description)
-	i.Add("Env", r.Env)
+
+	envDisplay := r.Env
+	if !c.Bool("reveal") && c.Writer().IsTerminal() {
+		if masked := maskedKeysSet(rack, app(c)); masked != nil {
+			env := structs.Environment{}
+			if err := env.Load([]byte(r.Env)); err == nil {
+				envDisplay = env.StringMasked(masked)
+			}
+			// env.Load failure: fall through with raw r.Env (no masking, but no crash)
+		}
+	}
+
+	i.Add("Env", envDisplay)
 
 	return i.Print()
 }

--- a/pkg/cli/releases_test.go
+++ b/pkg/cli/releases_test.go
@@ -222,3 +222,22 @@ func TestReleasesRollbackErrorPromote(t *testing.T) {
 		})
 	})
 }
+
+func TestReleasesInfoRevealFlag(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("ReleaseGet", "app1", "release1").Return(fxRelease(), nil)
+
+		res, err := testExecute(e, "releases info release1 --reveal -a app1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		res.RequireStderr(t, []string{""})
+		res.RequireStdout(t, []string{
+			"Id           release1",
+			"Build        build1",
+			fmt.Sprintf("Created      %s", fxRelease().Created.Format(time.RFC3339)),
+			"Description  description1",
+			"Env          FOO=bar",
+			"             BAZ=quux",
+		})
+	})
+}

--- a/pkg/structs/environment.go
+++ b/pkg/structs/environment.go
@@ -49,6 +49,28 @@ func (e Environment) String() string {
 	return strings.Join(lines, "\n")
 }
 
+// StringMasked returns the same sorted KEY=VALUE output as String(), but replaces
+// values of keys in the maskedKeys set with "****".
+//
+// WARNING: Only use in display paths (Env(), ReleasesInfo()). NEVER in write paths
+// (EnvSet, EnvEdit, EnvUnset, ReleaseCreate) — using it in a write path would
+// permanently replace real values with "****".
+func (e Environment) StringMasked(maskedKeys map[string]bool) string {
+	lines := []string{}
+
+	for k, v := range e {
+		if maskedKeys[k] {
+			lines = append(lines, fmt.Sprintf("%s=****", k))
+		} else {
+			lines = append(lines, fmt.Sprintf("%s=%s", k, v))
+		}
+	}
+
+	sort.Strings(lines)
+
+	return strings.Join(lines, "\n")
+}
+
 // SortedNames returns a slice of environment variables sorted by name.
 // func (e Environment) SortedNames() []string {
 //   names := []string{}

--- a/pkg/structs/environment_test.go
+++ b/pkg/structs/environment_test.go
@@ -1,0 +1,97 @@
+package structs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvironmentStringMasked(t *testing.T) {
+	env := Environment{
+		"FOO":       "bar",
+		"API_TOKEN": "sk-live-abc123",
+		"DB_URL":    "postgres://user:pass@host/db",
+		"PORT":      "3000",
+	}
+
+	masked := map[string]bool{
+		"API_TOKEN": true,
+		"DB_URL":    true,
+	}
+
+	result := env.StringMasked(masked)
+	require.Equal(t, "API_TOKEN=****\nDB_URL=****\nFOO=bar\nPORT=3000", result)
+}
+
+func TestEnvironmentStringMaskedEmpty(t *testing.T) {
+	env := Environment{
+		"FOO": "bar",
+		"BAZ": "quux",
+	}
+
+	result := env.StringMasked(map[string]bool{})
+	require.Equal(t, env.String(), result)
+}
+
+func TestEnvironmentStringMaskedNilMap(t *testing.T) {
+	env := Environment{
+		"FOO": "bar",
+		"BAZ": "quux",
+	}
+
+	result := env.StringMasked(nil)
+	require.Equal(t, env.String(), result)
+}
+
+func TestEnvironmentStringMaskedKeyNotInEnv(t *testing.T) {
+	env := Environment{
+		"FOO": "bar",
+	}
+
+	masked := map[string]bool{
+		"NONEXISTENT": true,
+	}
+
+	result := env.StringMasked(masked)
+	require.Equal(t, "FOO=bar", result)
+}
+
+func TestEnvironmentStringMaskedAllKeys(t *testing.T) {
+	env := Environment{
+		"SECRET1": "val1",
+		"SECRET2": "val2",
+	}
+
+	masked := map[string]bool{
+		"SECRET1": true,
+		"SECRET2": true,
+	}
+
+	result := env.StringMasked(masked)
+	require.Equal(t, "SECRET1=****\nSECRET2=****", result)
+}
+
+func TestEnvironmentStringUnchanged(t *testing.T) {
+	env := Environment{
+		"FOO": "bar",
+		"BAZ": "quux",
+	}
+
+	require.Equal(t, "BAZ=quux\nFOO=bar", env.String())
+}
+
+func TestEnvironmentStringMaskedDoesNotMutate(t *testing.T) {
+	env := Environment{
+		"API_TOKEN": "sk-live-abc123",
+		"FOO":       "bar",
+	}
+
+	masked := map[string]bool{"API_TOKEN": true}
+
+	result := env.StringMasked(masked)
+	require.Equal(t, "API_TOKEN=****\nFOO=bar", result)
+
+	require.Equal(t, "sk-live-abc123", env["API_TOKEN"])
+
+	require.Equal(t, "API_TOKEN=sk-live-abc123\nFOO=bar", env.String())
+}


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: Mask environment variable values in `convox env` and `convox releases info` output**

3.24.5 adds the ability to mark individual environment variable keys as sensitive on a per-app basis. When a key is in the mask list, its value renders as `****` in terminal output from `convox env` and `convox releases info`, while piped output and an explicit `--reveal` flag continue to show real values.

Three new subcommands manage the mask list:

| Command                               | Purpose                                           |
|---------------------------------------|---------------------------------------------------|
| `convox env mask set KEY [KEY...]`    | Mark one or more env keys as masked               |
| `convox env mask unset KEY [KEY...]`  | Remove one or more keys from the mask list        |
| `convox env mask`                     | List currently masked keys for the app            |

Two existing commands gain the new `--reveal` flag:

| Command                                    | Flag        | Behavior                                                   |
|--------------------------------------------|-------------|------------------------------------------------------------|
| `convox env --reveal`                      | `--reveal`  | Show unmasked values even in a terminal                    |
| `convox releases info <id> --reveal`       | `--reveal`  | Show unmasked `Env` field on the release record            |

The mask list is stored per-app through the rack's AppConfig endpoint (Kubernetes Secret `cfg-cli-env-mask`). No Terraform, CloudFormation, rack-parameter, CRD, API route, or Console schema changes.

| Display path              | TTY (default)       | TTY with `--reveal`  | Pipe / non-TTY       |
|---------------------------|---------------------|----------------------|----------------------|
| `convox env`              | Masked values `****`| Raw values           | Raw values (always)  |
| `convox releases info`    | Masked `Env` field  | Raw `Env` field      | Raw `Env` field      |

Pipe output is deliberately always unmasked so existing backup and restore flows (for example `convox env > backup.env` or `convox env | grep FOO`) continue to return real values without flags.

---

### Why is this important?

Convox env vars frequently contain sensitive material: DB URLs with passwords, third-party API tokens, AWS access keys, signing secrets. Before this change, those values appeared in plain text whenever anyone inspected `convox env` or `convox releases info` on a shared terminal, screen share, or captured recording. The new mask list lets app owners decide which keys should be redacted without removing the variables from the app. The sort of values most commonly masked are OAuth client secrets, database URLs that embed credentials, private SSH keys, webhook signing secrets, and any value that would trigger a security review if it appeared on a screen share.

**Benefits:**

| Benefit | Description |
|---------|-------------|
| Reduce incidental secret exposure. | Values in the mask list no longer appear in terminal scrollback, screen shares, pair programming sessions, or captured recordings. |
| Safe for existing scripts. | Piped output always shows real values, so `convox env > backup.env`, `convox env \| grep`, and similar flows are unaffected. |
| Break-glass flag available. | `convox env --reveal` and `convox releases info --reveal` let users see real values when they actually need them (for example, manual copy into another system). |
| Per-app configurable. | Each app has its own mask list, stored on the rack and shared across users. One team's mask list does not leak to another. |
| Additive and backward compatible. | No values are changed; masking only affects display. The real values in the release record and Kubernetes pod specs are untouched. |

---

### How to use it?

Mark two env keys on an app as masked:

```
$ convox env mask set API_TOKEN DB_URL -a my-app
Setting masked env keys API_TOKEN, DB_URL... OK
```

List the current mask list:

```
$ convox env mask -a my-app
API_TOKEN
DB_URL
```

Remove a key from the mask list:

```
$ convox env mask unset DB_URL -a my-app
Unsetting masked env keys DB_URL... OK
```

Inspect env output on a TTY (masked keys render as `****`):

```
$ convox env -a my-app
API_TOKEN=****
DB_URL=postgres://me@db.example.com/myapp
FOO=bar
```

Reveal values temporarily on a TTY:

```
$ convox env --reveal -a my-app
API_TOKEN=sk-live-abcdef123456
DB_URL=postgres://me:PASSWORD@db.example.com/myapp
FOO=bar
```

Backup env vars to disk (pipe output is always unmasked):

```
$ convox env -a my-app > backup.env
```

#### Key name validation

| Rule | Behavior on violation |
|------|-----------------------|
| Whitespace or `=` in key | Rejected with `invalid env key name` error. |
| ASCII control characters | Rejected to prevent terminal-escape poisoning via the mask list. |
| Key name with `=` sign | Rejected with a pointer to `convox env set KEY=VALUE` (to avoid confusion with the env-set syntax). |
| More than 500 keys in one list | Rejected with a size guard. |

### Best practices

| Practice | Why |
|----------|-----|
| Mask tokens, API keys, passwords, and DB URLs. | These are the values most commonly leaked via screen share or terminal scrollback. |
| Do not mask things that are meant to be visible (feature flags, non-sensitive config). | Masking everything defeats its purpose and makes debugging harder. |
| Use `--reveal` for one-off inspection, not in scripts. | Scripts already bypass masking via pipe detection, so `--reveal` is only needed for interactive use. |
| Run `env mask set` once per app and commit the list to your runbook. | The list persists on the rack across deploys and users, so it does not need to be re-run. |

---

### Does it have a breaking change?

**No breaking changes** are introduced with this feature.

- Zero change for users who never run `env mask set`. The mask list is empty by default and nothing is redacted.
- Piped and non-TTY output is always unmasked, preserving existing backup and automation flows.
- Older racks without AppConfig support (pre-3.19.7 or V2 racks) emit a friendly warning when `env mask set` is called, and the normal `convox env` output on those racks is unchanged.
- `convox env set` (writing values) never calls the masking path, so there is no risk of writing `****` back into a release.
- No `ReleasePromote` is triggered when setting or unsetting the mask list. Running pods keep their existing env; the change only affects what the CLI displays.

---

### Requirements

This feature requires version `3.24.5` or later for the rack.

**Update the Rack:** Run `convox rack update 3.24.5 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.23.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
