### PR TITLE
add rack params masking and group filter

### DIFF
--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -150,6 +150,295 @@ var managedParams = map[string]bool{
 	"eks_api_server_public_access_cidrs": true,
 }
 
+// paramGroups categorizes rack params into curated logical groups for the
+// `convox rack params -g <group>` filter. A param may belong to multiple
+// groups. Params not listed here are shown in the default view but not
+// surfaced by any group filter.
+var paramGroups = map[string]map[string]bool{
+	"karpenter": {
+		"additional_karpenter_nodepools_config": true,
+		"karpenter_arch":                        true,
+		"karpenter_auth_mode":                   true,
+		"karpenter_build_capacity_types":        true,
+		"karpenter_build_consolidate_after":     true,
+		"karpenter_build_cpu_limit":             true,
+		"karpenter_build_instance_families":     true,
+		"karpenter_build_instance_sizes":        true,
+		"karpenter_build_memory_limit_gb":       true,
+		"karpenter_build_node_labels":           true,
+		"karpenter_capacity_types":              true,
+		"karpenter_config":                      true,
+		"karpenter_consolidate_after":           true,
+		"karpenter_consolidation_enabled":       true,
+		"karpenter_cpu_limit":                   true,
+		"karpenter_disruption_budget_nodes":     true,
+		"karpenter_enabled":                     true,
+		"karpenter_instance_families":           true,
+		"karpenter_instance_sizes":              true,
+		"karpenter_memory_limit_gb":             true,
+		"karpenter_node_disk":                   true,
+		"karpenter_node_expiry":                 true,
+		"karpenter_node_labels":                 true,
+		"karpenter_node_taints":                 true,
+		"karpenter_node_volume_type":            true,
+	},
+	"network": {
+		"availability_zones":      true,
+		"cidr":                    true,
+		"deploy_extra_nlb":        true,
+		"disable_convox_resolver": true,
+		"internal_router":         true,
+		"internet_gateway_id":     true,
+		"nlb_security_group":      true,
+		"private_eks_host":        true,
+		"private_subnets_ids":     true,
+		"proxy_protocol":          true,
+		"public_subnets_ids":      true,
+		"vpc_id":                  true,
+	},
+	"security": {
+		"access_id":                          true,
+		"disable_public_access":              true,
+		"docker_hub_password":                true,
+		"ebs_volume_encryption_enabled":      true,
+		"ecr_scan_on_push_enable":            true,
+		"eks_api_server_public_access_cidrs": true,
+		"enable_private_access":              true,
+		"imds_http_hop_limit":                true,
+		"imds_http_tokens":                   true,
+		"imds_tags_enable":                   true,
+		"nlb_security_group":                 true,
+		"pod_identity_agent_enable":          true,
+		"private_eks_host":                   true,
+		"private_eks_pass":                   true,
+		"private_eks_user":                   true,
+		"secret_key":                         true,
+		"ssl_ciphers":                        true,
+		"ssl_protocols":                      true,
+		"token":                              true,
+		"whitelist":                          true,
+	},
+	"scaling": {
+		"high_availability":                    true,
+		"karpenter_disruption_budget_nodes":    true,
+		"keda_enable":                          true,
+		"max_on_demand_count":                  true,
+		"min_on_demand_count":                  true,
+		"node_max_unavailable_percentage":      true,
+		"pdb_default_min_available_percentage": true,
+		"schedule_rack_scale_down":             true,
+		"schedule_rack_scale_up":               true,
+		"vpa_enable":                           true,
+	},
+	"nodes": {
+		"additional_node_groups_config":       true,
+		"gpu_tag_enable":                      true,
+		"key_pair_name":                       true,
+		"kubelet_registry_burst":              true,
+		"kubelet_registry_pull_qps":           true,
+		"node_capacity_type":                  true,
+		"node_disk":                           true,
+		"node_max_unavailable_percentage":     true,
+		"node_type":                           true,
+		"nvidia_device_plugin_enable":         true,
+		"nvidia_device_time_slicing_replicas": true,
+		"os":                                  true,
+		"preemptible":                         true,
+		"user_data":                           true,
+		"user_data_url":                       true,
+	},
+	"build": {
+		"additional_build_groups_config":    true,
+		"build_disable_convox_resolver":     true,
+		"build_node_enabled":                true,
+		"build_node_min_count":              true,
+		"build_node_type":                   true,
+		"buildkit_enabled":                  true,
+		"buildkit_host_path_cache_enable":   true,
+		"karpenter_build_capacity_types":    true,
+		"karpenter_build_consolidate_after": true,
+		"karpenter_build_cpu_limit":         true,
+		"karpenter_build_instance_families": true,
+		"karpenter_build_instance_sizes":    true,
+		"karpenter_build_memory_limit_gb":   true,
+		"karpenter_build_node_labels":       true,
+	},
+	// docker_hub_password is dual-listed in "security" (above) because it is
+	// a masked credential; docker_hub_username stays registry-only as a
+	// public identifier (matches existing non-masked convention).
+	"registry": {
+		"custom_provided_bucket":       true,
+		"disable_image_manifest_cache": true,
+		"docker_hub_password":          true,
+		"docker_hub_username":          true,
+		"ecr_docker_hub_cache":         true,
+		"ecr_scan_on_push_enable":      true,
+	},
+	"logging": {
+		"access_log_retention_in_days": true,
+		"fluentd_disable":              true,
+		"fluentd_memory":               true,
+		"syslog":                       true,
+		"telemetry":                    true,
+	},
+	"ingress": {
+		"cert_duration":           true,
+		"idle_timeout":            true,
+		"nginx_additional_config": true,
+		"nginx_image":             true,
+		"ssl_ciphers":             true,
+		"ssl_protocols":           true,
+	},
+	"domain": {
+		"convox_domain_tls_cert_disable": true,
+		"convox_rack_domain":             true,
+		"domain":                         true,
+	},
+	"storage": {
+		"aws_ebs_csi_driver_version":    true,
+		"azure_files_enable":            true,
+		"ebs_volume_encryption_enabled": true,
+		"efs_csi_driver_enable":         true,
+		"efs_csi_driver_version":        true,
+		"registry_disk":                 true,
+	},
+	"retention": {
+		"releases_to_retain_after_active":           true,
+		"releases_to_retain_task_run_interval_hour": true,
+	},
+	"versions": {
+		"aws_ebs_csi_driver_version": true,
+		"coredns_version":            true,
+		"efs_csi_driver_version":     true,
+		"k8s_version":                true,
+		"kube_proxy_version":         true,
+		"nginx_image":                true,
+		"pod_identity_agent_version": true,
+		"vpc_cni_version":            true,
+	},
+}
+
+// groupDescriptions provides the one-line label shown next to each group
+// name in error output (e.g., unknown-group and ambiguous-prefix errors).
+// Keep in sync with paramGroups keys.
+var groupDescriptions = map[string]string{
+	"karpenter": "Karpenter autoscaling configuration",
+	"network":   "VPC, subnets, CIDR, routing, NLB, DNS resolver",
+	"security":  "access controls, whitelist, IAM, encryption, private EKS, IMDS, TLS, credentials",
+	"scaling":   "capacity counts, HA, HPA/VPA/KEDA, schedules, PDB, disruption budgets",
+	"nodes":     "default node-group config, user-data, GPU, kubelet tuning",
+	"build":     "build node config, buildkit, additional build groups",
+	"registry":  "Docker Hub, ECR, image caching, storage buckets",
+	"logging":   "syslog, telemetry, fluentd",
+	"ingress":   "NGINX, idle timeout, TLS cert duration",
+	"domain":    "rack domain and TLS toggle",
+	"storage":   "CSI drivers, EBS/EFS/Azure Files, registry disk",
+	"retention": "release retention policy",
+	"versions":  "K8s and managed component versions",
+}
+
+// resolveGroup resolves a possibly-partial group name to an exact group key.
+// Priority: exact match > unique prefix match. Case-insensitive. Whitespace
+// is trimmed. Returns an error listing candidates or all groups on
+// ambiguous / unknown input.
+func resolveGroup(input string) (string, error) {
+	input = strings.ToLower(strings.TrimSpace(input))
+	if input == "" {
+		return "", fmt.Errorf("group name required\n  %s", formatGroupList())
+	}
+
+	if _, ok := paramGroups[input]; ok {
+		return input, nil
+	}
+
+	var matches []string
+	for g := range paramGroups {
+		if strings.HasPrefix(g, input) {
+			matches = append(matches, g)
+		}
+	}
+	sort.Strings(matches)
+
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("group '%s' not found\n  %s", input, formatGroupList())
+	case 1:
+		return matches[0], nil
+	default:
+		return "", fmt.Errorf("group '%s' matches multiple groups: %s %s\n  %s",
+			input, strings.Join(matches, ", "), formatAmbiguousHint(matches), formatGroupList())
+	}
+}
+
+// formatGroupList returns a sorted, padded two-column listing of all
+// available groups for inclusion in error output.
+func formatGroupList() string {
+	names := make([]string, 0, len(groupDescriptions))
+	maxLen := 0
+	for g := range groupDescriptions {
+		names = append(names, g)
+		if len(g) > maxLen {
+			maxLen = len(g)
+		}
+	}
+	sort.Strings(names)
+
+	var b strings.Builder
+	b.WriteString("available groups:\n")
+	for _, g := range names {
+		b.WriteString(fmt.Sprintf("  %-*s    %s\n", maxLen, g, groupDescriptions[g]))
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// formatAmbiguousHint returns a parenthesized hint showing a short-but-
+// readable disambiguating prefix for each ambiguous candidate, e.g.,
+// "(use 'net' or 'nod')" for candidates ["network", "nodes"].
+func formatAmbiguousHint(candidates []string) string {
+	if len(candidates) == 0 {
+		return ""
+	}
+	hints := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		hints = append(hints, "'"+disambiguatingPrefix(c)+"'")
+	}
+	switch len(hints) {
+	case 1:
+		return "(use " + hints[0] + ")"
+	case 2:
+		return "(use " + hints[0] + " or " + hints[1] + ")"
+	default:
+		return "(use " + strings.Join(hints[:len(hints)-1], ", ") + ", or " + hints[len(hints)-1] + ")"
+	}
+}
+
+// disambiguatingPrefix returns a short-but-readable prefix of `group` that
+// resolves uniquely against all paramGroups keys. Uses a 3-character
+// minimum for human readability — a technically-unique 1- or 2-char
+// prefix like "no" for "nodes" reads like negation and is avoided.
+func disambiguatingPrefix(group string) string {
+	const minLen = 3
+	if len(group) <= minLen {
+		return group
+	}
+	for n := minLen; n <= len(group); n++ {
+		prefix := group[:n]
+		hits := 0
+		for g := range paramGroups {
+			if strings.HasPrefix(g, prefix) {
+				hits++
+				if hits > 1 {
+					break
+				}
+			}
+		}
+		if hits == 1 {
+			return prefix
+		}
+	}
+	return group
+}
+
 func init() {
 	register("rack", "get information about the rack", watch(Rack), stdcli.CommandOptions{
 		Flags:    []stdcli.Flag{flagRack, flagWatchInterval},
@@ -202,7 +491,10 @@ func init() {
 	})
 
 	registerWithoutProvider("rack params", "display rack parameters", RackParams, stdcli.CommandOptions{
-		Flags:    []stdcli.Flag{flagRack},
+		Flags: []stdcli.Flag{
+			flagRack,
+			stdcli.StringFlag("group", "g", "filter to a param group (invalid name lists all)"),
+		},
 		Validate: stdcli.Args(0),
 	})
 
@@ -1486,6 +1778,19 @@ func RackMv(_ sdk.Interface, c *stdcli.Context) error {
 }
 
 func RackParams(_ sdk.Interface, c *stdcli.Context) error {
+	var (
+		groupFilter   map[string]bool
+		resolvedGroup string
+	)
+	if groupInput := c.String("group"); groupInput != "" {
+		resolved, rerr := resolveGroup(groupInput)
+		if rerr != nil {
+			return rerr
+		}
+		resolvedGroup = resolved
+		groupFilter = paramGroups[resolved]
+	}
+
 	r, err := rack.Current(c)
 	if err != nil {
 		return err
@@ -1518,19 +1823,36 @@ func RackParams(_ sdk.Interface, c *stdcli.Context) error {
 		"docker_hub_password": true,
 		"secret_key":          true,
 		"token":               true,
+		"access_id":           true,
+		"private_eks_host":    true,
+		"private_eks_user":    true,
+		"private_eks_pass":    true,
 	}
 
 	i := c.Info()
+	rowsAdded := 0
 
 	for _, k := range keys {
+		if groupFilter != nil && !groupFilter[k] {
+			continue
+		}
 		v := params[k]
 		if sensitiveParams[k] && v != "" {
 			v = "**********"
 		}
 		i.Add(k, v)
+		rowsAdded++
 	}
 
-	return i.Print()
+	if err := i.Print(); err != nil {
+		return err
+	}
+
+	if groupFilter != nil && rowsAdded == 0 {
+		fmt.Fprintf(os.Stderr, "NOTICE: no params in group '%s' for this rack\n", resolvedGroup)
+	}
+
+	return nil
 }
 
 func RackParamsSet(_ sdk.Interface, c *stdcli.Context) error {

--- a/pkg/cli/rack_group_test.go
+++ b/pkg/cli/rack_group_test.go
@@ -1,0 +1,232 @@
+package cli
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestResolveGroupExactMatch(t *testing.T) {
+	got, err := resolveGroup("karpenter")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "karpenter" {
+		t.Errorf("expected 'karpenter', got %q", got)
+	}
+}
+
+func TestResolveGroupPrefixUnique(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"karp", "karpenter"},
+		{"k", "karpenter"},
+		{"net", "network"},
+		{"nod", "nodes"},
+		{"sec", "security"},
+		{"sca", "scaling"},
+		{"sto", "storage"},
+		{"reg", "registry"},
+		{"ret", "retention"},
+		{"b", "build"},
+		{"l", "logging"},
+		{"i", "ingress"},
+		{"d", "domain"},
+		{"v", "versions"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			got, err := resolveGroup(tc.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("resolveGroup(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveGroupCaseInsensitive(t *testing.T) {
+	got, err := resolveGroup("KARPENTER")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "karpenter" {
+		t.Errorf("expected 'karpenter', got %q", got)
+	}
+}
+
+func TestResolveGroupTrimsWhitespace(t *testing.T) {
+	got, err := resolveGroup("  karp  ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "karpenter" {
+		t.Errorf("expected 'karpenter', got %q", got)
+	}
+}
+
+func TestResolveGroupAmbiguousPrefix(t *testing.T) {
+	cases := []struct {
+		input       string
+		wantMatches []string
+		wantHint    string
+	}{
+		{"n", []string{"network", "nodes"}, "(use 'net' or 'nod')"},
+		{"s", []string{"scaling", "security", "storage"}, "(use 'sca', 'sec', or 'sto')"},
+		{"r", []string{"registry", "retention"}, "(use 'reg' or 'ret')"},
+		{"re", []string{"registry", "retention"}, "(use 'reg' or 'ret')"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			_, err := resolveGroup(tc.input)
+			if err == nil {
+				t.Fatalf("expected error for ambiguous input %q, got nil", tc.input)
+			}
+			msg := err.Error()
+			if !strings.Contains(msg, "matches multiple groups") {
+				t.Errorf("error should mention 'matches multiple groups', got: %s", msg)
+			}
+			for _, m := range tc.wantMatches {
+				if !strings.Contains(msg, m) {
+					t.Errorf("error should name candidate %q, got: %s", m, msg)
+				}
+			}
+			if !strings.Contains(msg, tc.wantHint) {
+				t.Errorf("error should contain disambiguation hint %q, got: %s", tc.wantHint, msg)
+			}
+		})
+	}
+}
+
+func TestResolveGroupNotFound(t *testing.T) {
+	_, err := resolveGroup("nope")
+	if err == nil {
+		t.Fatal("expected error for unknown group, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention 'not found', got: %s", err.Error())
+	}
+	if !strings.Contains(err.Error(), "available groups") {
+		t.Errorf("error should list available groups, got: %s", err.Error())
+	}
+}
+
+func TestResolveGroupEmptyInput(t *testing.T) {
+	for _, input := range []string{"", "   ", "\t\n"} {
+		t.Run("input="+input, func(t *testing.T) {
+			_, err := resolveGroup(input)
+			if err == nil {
+				t.Fatal("expected error for empty input, got nil")
+			}
+			if !strings.Contains(err.Error(), "group name required") {
+				t.Errorf("error should mention 'group name required', got: %s", err.Error())
+			}
+		})
+	}
+}
+
+func TestResolveGroupCaseInsensitiveAmbiguous(t *testing.T) {
+	_, err := resolveGroup("N")
+	if err == nil {
+		t.Fatal("expected error for ambiguous uppercase input, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "matches multiple groups") {
+		t.Errorf("error should mention 'matches multiple groups', got: %s", msg)
+	}
+	if !strings.Contains(msg, "network") || !strings.Contains(msg, "nodes") {
+		t.Errorf("error should name candidates network and nodes, got: %s", msg)
+	}
+}
+
+func TestFormatGroupList(t *testing.T) {
+	out := formatGroupList()
+	if !strings.HasPrefix(out, "available groups:\n") {
+		t.Errorf("output should start with 'available groups:' header, got: %s", out)
+	}
+
+	// Compute expected padding width = longest group name length.
+	maxLen := 0
+	for g := range groupDescriptions {
+		if len(g) > maxLen {
+			maxLen = len(g)
+		}
+	}
+
+	// Every group in groupDescriptions must appear as a properly padded row.
+	for g, desc := range groupDescriptions {
+		expectedRow := "  " + g + strings.Repeat(" ", maxLen-len(g)) + "    " + desc
+		if !strings.Contains(out, expectedRow) {
+			t.Errorf("missing or mispadded row for group %q; expected to contain %q; full output:\n%s", g, expectedRow, out)
+		}
+	}
+
+	// Rows must appear in alphabetical order of group name.
+	var names []string
+	for g := range groupDescriptions {
+		names = append(names, g)
+	}
+	sort.Strings(names)
+	lastIdx := -1
+	for _, g := range names {
+		idx := strings.Index(out, "  "+g+" ")
+		if idx <= lastIdx {
+			t.Errorf("group %q not in alphabetical position (idx=%d, prev=%d)", g, idx, lastIdx)
+		}
+		lastIdx = idx
+	}
+}
+
+func TestFormatAmbiguousHint(t *testing.T) {
+	cases := []struct {
+		name       string
+		candidates []string
+		want       string
+	}{
+		{"empty", []string{}, ""},
+		{"one", []string{"karpenter"}, "(use 'kar')"},
+		{"two", []string{"network", "nodes"}, "(use 'net' or 'nod')"},
+		{"three", []string{"scaling", "security", "storage"}, "(use 'sca', 'sec', or 'sto')"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatAmbiguousHint(tc.candidates)
+			if got != tc.want {
+				t.Errorf("formatAmbiguousHint(%v) = %q, want %q", tc.candidates, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDisambiguatingPrefix(t *testing.T) {
+	cases := []struct {
+		group string
+		want  string
+	}{
+		{"karpenter", "kar"},
+		{"build", "bui"},
+		{"logging", "log"},
+		{"ingress", "ing"},
+		{"domain", "dom"},
+		{"versions", "ver"},
+		{"network", "net"},
+		{"nodes", "nod"},
+		{"security", "sec"},
+		{"scaling", "sca"},
+		{"storage", "sto"},
+		{"registry", "reg"},
+		{"retention", "ret"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.group, func(t *testing.T) {
+			got := disambiguatingPrefix(tc.group)
+			if got != tc.want {
+				t.Errorf("disambiguatingPrefix(%q) = %q, want %q", tc.group, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What is the feature/update/fix?

**Update: Extend `convox rack params` masking to credential-triple params and add `-g` / `--group` filter**

3.24.5 makes two improvements to `convox rack params`:

**1. Extended sensitive-params masking.** The masking mechanism introduced in 3.24.4 (which covered `docker_hub_password`, `secret_key`, and `token`) now also masks four additional credential values that the Console already treated as sensitive:

| Parameter          | Notes                                              |
|--------------------|----------------------------------------------------|
| `access_id`        | DigitalOcean access key ID                         |
| `private_eks_host` | Private EKS endpoint hostname                      |
| `private_eks_user` | Private EKS endpoint username                      |
| `private_eks_pass` | Private EKS endpoint password                      |

These four values were previously emitted in plain text by the CLI. They now render as `**********` in TTY output where they were leaking before. Values on racks that do not set these params are shown as empty (unchanged).

**2. New `-g` / `--group` filter.** `convox rack params` now supports a group flag that filters output to one of 13 curated logical groups. Names match by exact string or by unique prefix (for example, `-g karp` resolves to `karpenter`).

| Group       | What it covers                                                                      |
|-------------|-------------------------------------------------------------------------------------|
| `karpenter` | Karpenter autoscaling configuration                                                 |
| `network`   | VPC, subnets, CIDR, routing, NLB, DNS resolver                                      |
| `security`  | Access controls, whitelist, IAM, encryption, private EKS, IMDS, TLS, credentials    |
| `scaling`   | Capacity counts, HA, HPA/VPA/KEDA, schedules, PDB, disruption budgets               |
| `nodes`     | Default node-group config, user-data, GPU, kubelet tuning                           |
| `build`     | Build node config, BuildKit, additional build groups                                |
| `registry`  | Docker Hub, ECR, image caching, storage buckets                                     |
| `logging`   | syslog, telemetry, fluentd                                                          |
| `ingress`   | NGINX, idle timeout, TLS cert duration                                              |
| `domain`    | Rack domain and TLS toggle                                                          |
| `storage`   | CSI drivers, EBS, EFS, Azure Files, registry disk                                   |
| `retention` | Release retention policy                                                            |
| `versions`  | Kubernetes and managed component versions                                           |

Ambiguous prefixes produce a helpful error that lists the candidate groups and a disambiguating prefix for each:

```
$ convox rack params -g s
ERROR: group 's' matches multiple groups: scaling, security, storage (use 'sca', 'sec', or 'sto')
  available groups:
  build        build node config, buildkit, additional build groups
  domain       rack domain and TLS toggle
  ...
```

Unknown groups produce the same list so users can discover valid names without leaving the command.

---

### Why is this important?

`convox rack params` is the primary way to inspect rack configuration. It emits 100+ parameters by default on a fully featured AWS rack, which makes it painful to find the handful relevant to a given task. The group filter collapses that to the 5 to 25 params that actually matter for the context (for example, "is Karpenter on and what are its limits?" or "what's my current TLS and ingress config?").

The extended masking closes a matching gap where the CLI and Console disagreed on which params were sensitive. The Console's `ParameterHideList` already redacted `private_eks_host`, `private_eks_user`, `private_eks_pass`, and DO `access_id`; the CLI was not. Anyone running `convox rack params` on a rack using private EKS was leaking the EKS API endpoint and credentials in plaintext terminal output until this release.

**Benefits:**

| Benefit | Description |
|---------|-------------|
| Credential parity with Console. | The CLI now masks the same values Console has always hidden, closing a terminal-output leak path for private EKS and DO credentials. |
| Find relevant params faster. | The `-g` flag cuts the output to a focused subset (for example 25 Karpenter params instead of 100+ total), eliminating scroll-and-grep. |
| Prefix matching is forgiving. | `-g karp`, `-g sec`, `-g sto` all resolve unambiguously; users do not need to remember exact names. |
| Discoverable without docs. | Invalid or ambiguous input returns the full group list with descriptions, so the command teaches itself. |
| Backward compatible. | `convox rack params` without the flag produces byte-identical output to prior releases, except the four new sensitive keys now render as `**********` when set. |

---

### How to use it?

Show only the Karpenter params (exact match):

```
$ convox rack params -g karpenter -r prod-platform
karpenter_arch                    amd64
karpenter_auth_mode               true
karpenter_build_capacity_types    on-demand
karpenter_enabled                 true
...
```

Prefix match resolves to the same group:

```
$ convox rack params -g karp -r prod-platform
```

Long form works too:

```
$ convox rack params --group security -r prod-platform
access_id                          **********
disable_public_access              false
docker_hub_password                **********
private_eks_host                   **********
private_eks_user                   **********
private_eks_pass                   **********
secret_key                         **********
token                              **********
whitelist                          0.0.0.0/0
```

Ambiguous prefix produces a helpful error:

```
$ convox rack params -g s -r prod-platform
ERROR: group 's' matches multiple groups: scaling, security, storage (use 'sca', 'sec', or 'sto')
  available groups:
  ...
```

#### When to use each group

| Use case | Group |
|----------|-------|
| Troubleshooting autoscaling behavior, nodepool churn, or consolidation | `karpenter`, `scaling`, `nodes` |
| Reviewing what is exposed on the public network | `network`, `security`, `ingress`, `domain` |
| Diagnosing image-pull failures or registry rate limits | `registry`, `build` |
| Preparing for a K8s or component version bump | `versions` |
| Auditing which credentials the rack holds | `security` |
| Confirming storage CSI driver versions and encryption posture | `storage`, `security` |

---

### Does it have a breaking change?

**No breaking changes** are introduced with this update.

- `convox rack params` with no flag shows the same set of params in the same order and format as prior releases. The only visible change is that four additional keys (`access_id`, `private_eks_host`, `private_eks_user`, `private_eks_pass`) now render as `**********` where they previously showed plaintext. Output on racks where these four keys are empty is byte-identical to pre-change output.
- The new `-g` / `--group` flag is opt-in. Users who never pass it see no change.
- No API, rack-parameter, Terraform, or CloudFormation changes. This is a CLI-only update.
- The group filter is applied client-side on top of the existing rack-params response, so old rack versions continue to work with the new flag (the flag simply filters whatever the rack returns).

---

### Requirements

This update requires version `3.24.5` or later for the rack.

**Update the Rack:** Run `convox rack update 3.24.5 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.23.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
