### PR TITLE
docs update 3.24.5

### DIFF
--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -138,3 +138,4 @@ The following environment variables are automatically set by Convox.
 - [convox.yml](/configuration/convox-yml) for the full configuration reference
 - [Deploying Changes](/deployment/deploying-changes) for how environment changes create new releases
 - [App Settings](/configuration/app-settings) for app-level configuration
+- [env mask](/reference/cli/env#env-mask) for masking sensitive env values in terminal output

--- a/docs/reference/cli/env.md
+++ b/docs/reference/cli/env.md
@@ -11,7 +11,7 @@ List env vars
 
 ### Usage
 ```bash
-    convox env [--release <id>]
+    convox env [--release <id>] [--reveal]
 ```
 
 ### Flags
@@ -19,6 +19,7 @@ List env vars
 | Flag | Type | Description |
 |------|------|-------------|
 | `--release` | string | Show environment from a specific release |
+| `--reveal` | bool | Show unmasked values even on a TTY. Ignored for keys not in the mask list |
 
 ### Examples
 ```bash
@@ -31,6 +32,27 @@ List env vars
     COUNT=0
     FOO=bar
 ```
+
+### Masking Sensitive Values
+
+Keys added to the per-app mask list (via `convox env mask set`) render as `****` in terminal output. Piped output always shows real values, so backup and automation flows (`convox env > backup.env`, `convox env | grep FOO`) continue to work without flags. Use `--reveal` on a TTY for one-off inspection when the real value is needed.
+
+```bash
+    $ convox env mask set API_TOKEN -a my-app
+    Setting masked env keys API_TOKEN... OK
+
+    $ convox env -a my-app
+    API_TOKEN=****
+    FOO=bar
+
+    $ convox env --reveal -a my-app
+    API_TOKEN=sk-live-abcdef123456
+    FOO=bar
+
+    $ convox env -a my-app > backup.env    # pipe output is always unmasked
+```
+
+Masking affects display only. The stored value in the release record and in Kubernetes pod specs is unchanged — no `ReleasePromote` is triggered when setting or unsetting the mask list.
 
 ## env edit
 
@@ -130,6 +152,70 @@ Unset env var(s)
     Release: RABCDEFGHI
 ```
 
+## env mask
+
+List currently masked env keys for the app.
+
+### Usage
+```bash
+    convox env mask
+```
+
+### Examples
+```bash
+    $ convox env mask -a my-app
+    API_TOKEN
+    DB_URL
+```
+
+Prints one key per line, sorted. Prints nothing when the mask list is empty.
+
+## env mask set
+
+Mark one or more environment variable keys as masked. Masked keys render as `****` in `convox env` and `convox releases info` output on a TTY.
+
+### Usage
+```bash
+    convox env mask set <key> [key]...
+```
+
+### Examples
+```bash
+    $ convox env mask set API_TOKEN DB_URL -a my-app
+    Setting masked env keys API_TOKEN, DB_URL... OK
+```
+
+### Validation
+
+| Rule | Behavior on violation |
+|------|-----------------------|
+| Keys with whitespace or `=` | Rejected with `invalid env key name` |
+| Keys with ASCII control characters | Rejected to prevent terminal-escape poisoning |
+| Arguments containing `=` | Rejected with a pointer to `convox env set KEY=VALUE` |
+| More than 500 keys in one list | Rejected with a size guard |
+
+`convox env mask set` does not validate that the keys exist as env vars on the app. Masking is applied by key name whenever an env list is rendered, so keys can be set-masked before or after they are added to the environment.
+
+### Rack Version Requirements
+
+Masking is stored per-app via the rack's `AppConfig` endpoint. Racks without `AppConfig` support (V2 racks, or V3 racks older than 3.19.7) print a warning (`Warning: this rack version may not support env masking`) and exit successfully. On those racks, `convox env` output is unchanged.
+
+## env mask unset
+
+Remove one or more keys from the mask list. Keys not currently in the list are silently ignored.
+
+### Usage
+```bash
+    convox env mask unset <key> [key]...
+```
+
+### Examples
+```bash
+    $ convox env mask unset DB_URL -a my-app
+    Unsetting masked env keys DB_URL... OK
+```
+
 ## See Also
 
 - [Environment Variables](/configuration/environment) for environment configuration
+- [releases info](/reference/cli/releases#releases-info) for the `--reveal` flag on release records

--- a/docs/reference/cli/logs.md
+++ b/docs/reference/cli/logs.md
@@ -37,6 +37,23 @@ Get logs for an app. By default, `convox logs` streams logs continuously. Use `-
 | `--service` | `-s` | Filter to a specific service |
 | `--tail` | | Number of lines to tail (service-specific logging only) |
 | `--allow-previous` | | Include logs from previous container instances |
+| `--max-log-requests` | | Maximum number of concurrent log follow streams (default `20`) |
+
+### Tailing High-Concurrency Services
+
+`convox logs --service <name>` streams logs from every pod that matches the selector. The underlying kubectl plumbing caps concurrency at 20 follow streams by default. When a service runs with more than 20 pods, the command fails with:
+
+```text
+ERROR: you are attempting to follow 50 log streams, but maximum allowed concurrency is 20, use --max-log-requests to increase the limit
+```
+
+Pass `--max-log-requests N` to raise the concurrency cap. The flag is also wired into `convox rack logs` for rack-level system log streams.
+
+```bash
+    $ convox logs --service pii-worker --since 5m --max-log-requests 50
+```
+
+Set the value to at least the pod count of the target service. Log streams are persistent HTTP connections, so very large values put sustained load on the API server — prefer filtering by `--service` and a modest concurrency over tailing the full app stream without the flag.
 
 ## See Also
 

--- a/docs/reference/cli/rack.md
+++ b/docs/reference/cli/rack.md
@@ -279,8 +279,16 @@ Display rack parameters
 
 ### Usage
 ```bash
-    convox rack params
+    convox rack params [--group <name>] [--reveal]
 ```
+
+### Flags
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--group` | `-g` | Filter output to a curated logical group. Accepts exact names and unique prefixes |
+| `--reveal` | | Show unmasked values for sensitive parameters on a TTY |
+
 ### Examples
 ```bash
     $ convox rack params
@@ -291,7 +299,75 @@ Display rack parameters
     private                true
 ```
 
-Values for `docker_hub_password`, `secret_key`, and `token` are displayed as `**********` to prevent accidental disclosure via terminal output, shell history, screen shares, or captured logs. Empty values display as empty so you can tell whether a sensitive parameter is set. The stored values are unchanged.
+### Masking Sensitive Values
+
+Values for `docker_hub_password`, `secret_key`, `token`, `access_id`, `private_eks_host`, `private_eks_user`, and `private_eks_pass` render as `**********` on a TTY to prevent accidental disclosure via terminal output, shell history, screen shares, or captured logs. Empty values display as empty so you can tell whether a sensitive parameter is set. The stored values are unchanged.
+
+Piped and non-TTY output is always unmasked, so backup and automation flows (`convox rack params > rack-state.txt`, `| grep`, `| jq`) continue to return real values. Use `--reveal` on a TTY for one-off inspection when the real value is needed.
+
+```bash
+    $ convox rack params | grep docker_hub_password    # pipe: real value
+    docker_hub_password    s3cret-t0ken
+
+    $ convox rack params                                # TTY: masked
+    docker_hub_password    **********
+
+    $ convox rack params --reveal                       # TTY override: real value
+    docker_hub_password    s3cret-t0ken
+```
+
+### Group Filter
+
+Pass `-g` / `--group` to narrow the output to one of a curated set of logical groups. Useful when a fully featured rack emits 100+ parameters and you want the handful relevant to a specific task.
+
+| Group | Covers |
+|-------|--------|
+| `build` | build node config, buildkit, additional build groups |
+| `domain` | rack domain and TLS toggle |
+| `ingress` | NGINX, idle timeout, TLS cert duration |
+| `karpenter` | Karpenter autoscaling configuration |
+| `logging` | syslog, telemetry, fluentd |
+| `network` | VPC, subnets, CIDR, routing, NLB, DNS resolver |
+| `nodes` | default node-group config, user-data, GPU, kubelet tuning |
+| `registry` | Docker Hub, ECR, image caching, storage buckets |
+| `retention` | release retention policy |
+| `scaling` | capacity counts, HA, HPA/VPA/KEDA, schedules, PDB, disruption budgets |
+| `security` | access controls, whitelist, IAM, encryption, private EKS, IMDS, TLS, credentials |
+| `storage` | CSI drivers, EBS/EFS/Azure Files, registry disk |
+| `versions` | K8s and managed component versions |
+
+Exact names and unique prefixes both resolve:
+
+```bash
+    $ convox rack params -g karpenter -r prod
+    karpenter_arch                    amd64
+    karpenter_auth_mode               true
+    karpenter_enabled                 true
+    ...
+
+    $ convox rack params -g karp -r prod              # prefix match
+    ...
+
+    $ convox rack params --group security -r prod     # long form
+    access_id                          **********
+    disable_public_access              false
+    docker_hub_password                **********
+    private_eks_host                   **********
+    ...
+```
+
+Ambiguous prefixes print a disambiguating hint and the full group list so names are discoverable without leaving the command:
+
+```bash
+    $ convox rack params -g s
+    ERROR: group 's' matches multiple groups: scaling, security, storage (use 'sca', 'sec', or 'sto')
+      available groups:
+      build        build node config, buildkit, additional build groups
+      domain       rack domain and TLS toggle
+      ...
+```
+
+Unknown groups print the same list. The filter is applied client-side on top of the rack response, so sensitive-value masking and `--reveal` compose with `--group` (`convox rack params -g security --reveal` shows unmasked credentials).
 
 ## rack params set
 

--- a/docs/reference/cli/releases.md
+++ b/docs/reference/cli/releases.md
@@ -23,12 +23,19 @@ List releases for an app
 ```
 ## releases info
 
-Get information about a release
+Get information about a release.
 
 ### Usage
 ```bash
-    convox releases info <release>
+    convox releases info <release> [--reveal]
 ```
+
+### Flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--reveal` | bool | Show unmasked values for env keys in the mask list. See [env mask](/reference/cli/env#env-mask) |
+
 ### Examples
 ```bash
     $ convox releases info RABCDEFGHI
@@ -38,6 +45,9 @@ Get information about a release
     Description
     Env
 ```
+
+The `Env` field respects the per-app mask list managed by `convox env mask`. On a TTY, values for masked keys render as `****`. Piped output and `--reveal` both show real values.
+
 ## releases create-from
 
 Create a new release using a build from one release and env from another. This is useful for combining specific builds and environments, cross-app deployments, and build-once-deploy-many workflows.

--- a/docs/reference/primitives/app/service.md
+++ b/docs/reference/primitives/app/service.md
@@ -368,6 +368,7 @@ See [Health Checks](/configuration/health-checks) for configuring readiness, liv
 | **grace**    | number | `interval` | The number of seconds to wait for a [Process](/reference/primitives/app/process) to start before starting health checks. Defaults to the value of `interval` |
 | **interval** | number | 5       | The number of seconds between health checks                                                      |
 | **path**     | string | /       | The path to request for health checks                                                            |
+| **port**     | number or map | Main service port | The port the readiness probe connects to. Accepts a scalar (`port: 8080`) or a map (`port: { port: 8080, scheme: https }`). Scheme inherits from the main service port when omitted. See [Separate Health Port](/configuration/health-checks#separate-health-port) |
 | **timeout**  | number | `interval - 1` | The number of seconds to wait for a successful response. Defaults to `interval` minus one |
 | **disable**  | bool | false       | Set to `true` to disable the health check entirely |
 
@@ -382,6 +383,7 @@ See [Health Checks](/configuration/health-checks) for configuring readiness, liv
 | **grace**    | number | 10       | The number of seconds to wait for a [Process](/reference/primitives/app/process) to start before starting liveness checks |
 | **interval** | number | 5       | The number of seconds between health checks                                                      |
 | **path**     | string |        | The path to request for health checks                                                            |
+| **port**     | number or map | Main service port | The port the liveness probe connects to. Same form as `health.port`. Unlike readiness, liveness does **not** auto-inherit the main service scheme — set `scheme` explicitly when the probe needs HTTPS. See [Separate Health Port](/configuration/health-checks#separate-health-port) |
 | **timeout**  | number | 5      | The number of seconds to wait for a successful response                                          |
 | **successThreshold**  | number | 1      | The number of consecutive successful checks required to consider the probe successful             |
 | **failureThreshold**  | number | 3      | The number of consecutive failed checks required before restarting the container                  |

--- a/docs/reference/releases/3-24.md
+++ b/docs/reference/releases/3-24.md
@@ -137,10 +137,13 @@ Convox 3.24 upgrades Kubernetes to 1.34, introduces the `convox deploy-debug` co
 
 ## 3.24.5
 
-**Released:** TBD
+**Released:** 2026-04-22
 
 **Feature Additions**
 
+- Added container-level `securityContext` on services and timers with support for `runAsNonRoot`, `runAsUser`, `runAsGroup`, `readOnlyRootFilesystem`, `allowPrivilegeEscalation`, `capabilities.add`/`drop`, and `seccompProfile` (`RuntimeDefault` or `Unconfined`). Settings apply to Deployment pods, CronJob pods (timers), `convox run`, and `convox exec` containers. Validation catches unsupported seccomp profiles, malformed capability names, and the `runAsNonRoot: true` + `runAsUser: 0` conflict at `convox deploy` time ([PR #947](https://github.com/convox/convox/pull/947)).
+- Added `convox env mask`, `convox env mask set`, and `convox env mask unset` commands to mark environment variable keys as sensitive on a per-app basis. Masked values render as `****` in `convox env` and `convox releases info` output on a TTY, while piped output and the new `--reveal` flag continue to show real values. The mask list is stored per-app on the rack and does not trigger a release promotion ([PR #1013](https://github.com/convox/convox/pull/1013)).
+- Added `health.port` and `liveness.port` manifest fields so the readiness and liveness probes can target a dedicated health endpoint instead of the main service port. Accepts either scalar (`port: 9090`) or map (`port: { port: 9090, scheme: https }`) forms. Readiness auto-inherits the main service scheme when only the port is set; liveness does not auto-inherit. The startup probe continues to target the main service port ([PR #1014](https://github.com/convox/convox/pull/1014)).
 - Added `emptyDir.sizeLimit` under `volumeOptions` to size ephemeral volumes (e.g. `/dev/shm` for ML inference sidecars). Validated at manifest parse time as a Kubernetes resource quantity.
 - Added `--gpu` and `--gpu-vendor` flags to `convox scale` for in-place GPU updates.
 - Added `convox services update <service>` command mirroring the `convox scale` update path with the same flag set (`--count`, `--cpu`, `--memory`, `--gpu`, `--gpu-vendor`).
@@ -150,6 +153,9 @@ Convox 3.24 upgrades Kubernetes to 1.34, introduces the `convox deploy-debug` co
 
 **Updates**
 
+- Added `--max-log-requests` flag to `convox logs` and `convox rack logs` so services with more than 20 pods can stream logs past the default follow-stream concurrency cap. The default remains `20` when the flag is not supplied, preserving prior behavior ([PR #958](https://github.com/convox/convox/pull/958)).
+- Added `-g` / `--group` filter to `convox rack params` that narrows output to a curated logical group (`karpenter`, `network`, `security`, `scaling`, `nodes`, `build`, `registry`, `logging`, `ingress`, `domain`, `storage`, `retention`, `versions`). Supports exact and unique-prefix matching (`-g karp` resolves to `karpenter`); ambiguous or unknown inputs print the full group list. Also extended the sensitive-param masking introduced in 3.24.4 to cover `access_id`, `private_eks_host`, `private_eks_user`, and `private_eks_pass`, closing a CLI leak path for private EKS credentials and DigitalOcean access key IDs ([PR #1015](https://github.com/convox/convox/pull/1015)).
+- Added `--reveal` flag and TTY-gated masking to `convox rack params`. Sensitive values now render as `**********` only on a TTY without `--reveal`; piped output always shows real values so existing backup and scripting flows (`convox rack params > rack.txt`, `| grep`, `| jq`) continue to work. Mirrors the pattern added to `convox env` in the same release.
 - `scale.gpu.vendor` now maps through an explicit vendor → resource-key table (`nvidia`, `nvidia.com` → `nvidia.com/gpu`; `amd`, `amd.com` → `amd.com/gpu`). Previously the template used a `.com`-suffix heuristic which emitted garbage resource keys for unknown or misspelled vendors, causing pods to stay Pending forever. Unknown or unset vendors now default to `nvidia.com/gpu`. Customers using `scale.gpu.vendor: nvidia`, `amd`, `nvidia.com`, or `amd.com` see no change. Customers using an invalid vendor string see their GPU pods begin scheduling on NVIDIA nodes instead of Pending indefinitely.
 - GPU pod scheduling on tainted GPU nodepools (e.g. `additional_karpenter_nodepools_config` with `nvidia.com/gpu=true:NoSchedule`) no longer depends on the `ExtendedResourceToleration` Kubernetes admission controller (which is not enabled by default on EKS). Convox now emits the matching `tolerations:` entry (`operator: Exists`, `effect: NoSchedule`) directly on each pod that declares `scale.gpu.count > 0`. This applies to service Deployments (via `service.yml.tmpl`), CronJob pods (via `timer.yml.tmpl`), `convox scale`/`convox services update` runtime mutations (via `ServiceUpdate`), and one-shot `convox run --gpu N` pods (via `podSpecFromRunOptions`). The emitted toleration is `effect: NoSchedule` only; clusters taint-ing GPU nodes with `effect: NoExecute` must continue to use the admission controller or custom admission webhooks.
 - `convox run --gpu N --gpu-vendor VENDOR` now honors the `--gpu-vendor` flag (previously the run path only emitted `nvidia.com/gpu`).
@@ -157,6 +163,11 @@ Convox 3.24 upgrades Kubernetes to 1.34, introduces the `convox deploy-debug` co
 **Fixes**
 
 - Agent services (`agent.enabled: true`, backed by Kubernetes DaemonSets) now report their configured `cpu` and `memory` values via the rack API's `ServiceList` response, the `convox scale` output table, and the Console Services panel. Previously the DaemonSet branch of `ServiceList` omitted the resource reads — agent services always showed `cpu: 0, memory: 0` regardless of `convox.yml` scale settings. Any dashboard or tooling that sums per-service resource requests for an app will now include the agent's real footprint.
+- Removed the spurious `sensitive = true` attribute on the `docker_hub_password` Terraform variable that was blocking `terraform apply` against legacy rack state files. The credential remains masked in `convox rack params` output via the CLI `sensitiveParams` mechanism, and rack Terraform state continues to be stored encrypted — no protection was removed, only an attribute that was breaking the legacy update path.
+
+**Behavior change: `privileged: true` now renders into Deployment and CronJob pod specs**
+
+The top-level `privileged: true` service flag was previously honored only by `convox run` on V3. Deployment and CronJob pods silently dropped it. This release brings V3 Deployment and CronJob rendering in line with V2 semantics and the V3 `convox run` path. If you have `privileged: true` in a `convox.yml` and do not actually want a privileged pod, remove the flag before upgrading — on first deploy after 3.24.5, a pod-spec diff will trigger one rolling restart on affected services ([PR #947](https://github.com/convox/convox/pull/947)).
 
 **Notes**
 
@@ -180,3 +191,8 @@ Convox 3.24 upgrades Kubernetes to 1.34, introduces the `convox deploy-debug` co
 - [azure_files_enable](/configuration/rack-parameters/azure/azure_files_enable) for Azure Files NFS volumes
 - [Volumes](/configuration/volumes) for the `azureFiles` and `awsEfs` volumeOption reference
 - [Instance](/reference/primitives/rack/instance) for `convox instances terminate` behavior on v3 racks
+- [securityContext](/reference/primitives/app/service#securitycontext) for container-level hardening on services and timers
+- [env](/reference/cli/env#env-mask) for the env mask commands and `--reveal` flag
+- [rack params](/reference/cli/rack#group-filter) for the `-g` / `--group` filter and masking behavior
+- [Separate Health Port](/configuration/health-checks#separate-health-port) for routing probes to a dedicated endpoint
+- [logs](/reference/cli/logs) for the `--max-log-requests` flag


### PR DESCRIPTION
- Docs update Rack [Release](https://github.com/convox/convox/releases/tag/3.24.5) `3.24.5`