### PR TITLE
add rack build import image endpoint

### DIFF
--- a/pkg/api/build_test.go
+++ b/pkg/api/build_test.go
@@ -157,6 +157,58 @@ func TestBuildImportError(t *testing.T) {
 	})
 }
 
+func TestBuildImportImage(t *testing.T) {
+	testServer(t, func(c *stdsdk.Client, p *structs.MockProvider) {
+		opts := structs.BuildImportImageOptions{}
+		p.On("BuildImportImage", "app1", "build1", "vllm/vllm-openai:v0.6.3", opts).Return(nil)
+		ro := stdsdk.RequestOptions{
+			Params: stdsdk.Params{"image": "vllm/vllm-openai:v0.6.3"},
+		}
+		err := c.Post("/apps/app1/builds/build1/image", ro, nil)
+		require.NoError(t, err)
+	})
+}
+
+func TestBuildImportImageWithCreds(t *testing.T) {
+	testServer(t, func(c *stdsdk.Client, p *structs.MockProvider) {
+		opts := structs.BuildImportImageOptions{
+			SrcCredsUser: options.String("$oauthtoken"),
+			SrcCredsPass: options.String("nvapi-key"),
+		}
+		p.On("BuildImportImage", "app1", "build1", "nvcr.io/nim/x:1.0", opts).Return(nil)
+		ro := stdsdk.RequestOptions{
+			Params: stdsdk.Params{
+				"image":          "nvcr.io/nim/x:1.0",
+				"src_creds_user": "$oauthtoken",
+				"src_creds_pass": "nvapi-key",
+			},
+		}
+		err := c.Post("/apps/app1/builds/build1/image", ro, nil)
+		require.NoError(t, err)
+	})
+}
+
+func TestBuildImportImageMissingImage(t *testing.T) {
+	testServer(t, func(c *stdsdk.Client, _ *structs.MockProvider) {
+		ro := stdsdk.RequestOptions{Params: stdsdk.Params{}}
+		err := c.Post("/apps/app1/builds/build1/image", ro, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "image param required")
+	})
+}
+
+func TestBuildImportImageProviderError(t *testing.T) {
+	testServer(t, func(c *stdsdk.Client, p *structs.MockProvider) {
+		opts := structs.BuildImportImageOptions{}
+		p.On("BuildImportImage", "app1", "build1", "vllm/vllm-openai:v0.6.3", opts).Return(fmt.Errorf("downstream rack fail"))
+		ro := stdsdk.RequestOptions{
+			Params: stdsdk.Params{"image": "vllm/vllm-openai:v0.6.3"},
+		}
+		err := c.Post("/apps/app1/builds/build1/image", ro, nil)
+		require.EqualError(t, err, "downstream rack fail")
+	})
+}
+
 func TestBuildLogs(t *testing.T) {
 	testServer(t, func(c *stdsdk.Client, p *structs.MockProvider) {
 		d1 := []byte("test")

--- a/pkg/api/controllers.go
+++ b/pkg/api/controllers.go
@@ -341,6 +341,32 @@ func (s *Server) BuildImport(c *stdapi.Context) error {
 	return c.RenderJSON(v)
 }
 
+func (s *Server) BuildImportImage(c *stdapi.Context) error {
+	if err := s.hook("BuildImportImageValidate", c); err != nil {
+		return err
+	}
+
+	app := c.Var("app")
+	id := c.Var("id")
+	image := c.Value("image")
+
+	if image == "" {
+		return structs.ErrUnprocessable("image param required")
+	}
+
+	var opts structs.BuildImportImageOptions
+	if err := stdapi.UnmarshalOptions(c.Request(), &opts); err != nil {
+		return err
+	}
+
+	if err := s.provider(c).WithContext(contextFrom(c)).BuildImportImage(app, id, image, opts); err != nil {
+		return err
+	}
+
+	c.Response().WriteHeader(http.StatusAccepted)
+	return nil
+}
+
 func (s *Server) BuildList(c *stdapi.Context) error {
 	if err := s.hook("BuildListValidate", c); err != nil {
 		return err

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -19,6 +19,7 @@ func (s *Server) setupRoutes(r stdapi.Router) {
 	r.Route("GET", "/apps/{app}/builds/{id}.tgz", s.BuildExport)
 	r.Route("GET", "/apps/{app}/builds/{id}", s.BuildGet)
 	r.Route("POST", "/apps/{app}/builds/import", s.BuildImport)
+	r.Route("POST", "/apps/{app}/builds/{id}/image", s.BuildImportImage)
 	r.Route("GET", "/apps/{app}/builds", s.BuildList)
 	r.Route("SOCKET", "/apps/{app}/builds/{id}/logs", s.BuildLogs)
 	r.Route("PUT", "/apps/{app}/builds/{id}", s.BuildUpdate)

--- a/pkg/cli/builds.go
+++ b/pkg/cli/builds.go
@@ -50,6 +50,18 @@ func init() {
 		Validate: stdcli.Args(0),
 	}, WithCloud())
 
+	register("builds import-image", "import a prebuilt container image into a new build", BuildsImportImage, stdcli.CommandOptions{
+		Flags: []stdcli.Flag{
+			flagRack,
+			flagApp,
+			stdcli.StringFlag("manifest", "m", "path to convox.yml manifest"),
+			stdcli.StringFlag("src-creds-user", "", "source registry username"),
+			stdcli.StringFlag("src-creds-pass", "", "source registry password"),
+		},
+		Usage:    "<source-image>",
+		Validate: stdcli.Args(1),
+	}, WithCloud())
+
 	register("builds info", "get information about a build", BuildsInfo, stdcli.CommandOptions{
 		Flags:    []stdcli.Flag{flagRack, flagApp},
 		Usage:    "<build>",
@@ -437,6 +449,109 @@ func BuildsImport(rack sdk.Interface, c *stdcli.Context) error {
 	}
 
 	return nil
+}
+
+func BuildsImportImage(rack sdk.Interface, c *stdcli.Context) error {
+	source := c.Arg(0)
+
+	manifestPath := coalesce(c.String("manifest"), "convox.yml")
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return fmt.Errorf("read manifest %s: %w", manifestPath, err)
+	}
+
+	c.Startf("Creating build")
+	b, err := rack.BuildCreate(app(c), "", structs.BuildCreateOptions{
+		External: options.Bool(true),
+	})
+	if err != nil {
+		return err
+	}
+
+	if _, err := rack.BuildUpdate(app(c), b.Id, structs.BuildUpdateOptions{
+		Manifest: options.String(string(data)),
+	}); err != nil {
+		return err
+	}
+	if err := c.OK(b.Id); err != nil {
+		return err
+	}
+
+	var opts structs.BuildImportImageOptions
+	if u := c.String("src-creds-user"); u != "" {
+		opts.SrcCredsUser = options.String(u)
+	}
+	if p := c.String("src-creds-pass"); p != "" {
+		opts.SrcCredsPass = options.String(p)
+	}
+
+	c.Startf("Relaying image %s", source)
+	if err := rack.BuildImportImage(app(c), b.Id, source, opts); err != nil {
+		return err
+	}
+	if err := c.OK(); err != nil {
+		return err
+	}
+
+	c.Startf("Waiting for import to complete")
+	// 2 hours covers a multi-service manifest where the rack's 30-min
+	// per-service skopeo timeout can legitimately stack (e.g. 3 services
+	// ⇒ 90 min worst case). Single-service wizard flows complete in minutes.
+	deadline := time.After(2 * time.Hour)
+	tick := time.NewTicker(2 * time.Second)
+	defer tick.Stop()
+
+	var consecutiveFails int
+	for {
+		select {
+		case <-deadline:
+			return fmt.Errorf("import %s timed out after 2 hours; check: convox builds info %s", b.Id, b.Id)
+		case <-tick.C:
+			cur, err := rack.BuildGet(app(c), b.Id)
+			if err != nil {
+				consecutiveFails++
+				if consecutiveFails > 5 {
+					return fmt.Errorf("build %s still running on rack; check: convox builds info %s (last poll error: %w)", b.Id, b.Id, err)
+				}
+				continue
+			}
+			consecutiveFails = 0
+			switch cur.Status {
+			case "created", "running":
+				continue
+			case "complete":
+				if err := c.OK(); err != nil {
+					return err
+				}
+				c.Startf("Creating release")
+				r, err := rack.ReleaseCreate(app(c), structs.ReleaseCreateOptions{
+					Build: options.String(cur.Id),
+				})
+				if err != nil {
+					return err
+				}
+				if _, err := rack.BuildUpdate(app(c), cur.Id, structs.BuildUpdateOptions{
+					Release: options.String(r.Id),
+				}); err != nil {
+					return err
+				}
+				if err := c.OK(r.Id); err != nil {
+					return err
+				}
+				if err := c.Writef("Build:   <build>%s</build>\n", cur.Id); err != nil {
+					return err
+				}
+				return c.Writef("Release: <release>%s</release>\n", r.Id)
+			case "failed":
+				if cur.Reason != "" {
+					return fmt.Errorf("import failed: %s", cur.Reason)
+				}
+				return fmt.Errorf("import failed")
+			default:
+				return fmt.Errorf("unexpected build status: %s", cur.Status)
+			}
+		}
+	}
 }
 
 func BuildsInfo(rack sdk.Interface, c *stdcli.Context) error {

--- a/pkg/cli/builds_test.go
+++ b/pkg/cli/builds_test.go
@@ -238,6 +238,79 @@ func TestBuildsImportError(t *testing.T) {
 	})
 }
 
+func TestBuildsImportImage(t *testing.T) {
+	testClientWait(t, 10*time.Millisecond, func(e *cli.Engine, i *mocksdk.Interface) {
+		manifestData, err := os.ReadFile("testdata/import-manifest/convox.yml")
+		require.NoError(t, err)
+
+		bExternal := &structs.Build{Id: "build1", App: "app1", Status: "created"}
+		bRunning := &structs.Build{Id: "build1", App: "app1", Status: "running"}
+		bComplete := &structs.Build{Id: "build1", App: "app1", Status: "complete"}
+
+		i.On("BuildCreate", "app1", "", structs.BuildCreateOptions{External: options.Bool(true)}).Return(bExternal, nil)
+		i.On("BuildUpdate", "app1", "build1", structs.BuildUpdateOptions{Manifest: options.String(string(manifestData))}).Return(bExternal, nil).Once()
+		i.On("BuildImportImage", "app1", "build1", "vllm/vllm-openai:v0.6.3", structs.BuildImportImageOptions{}).Return(nil)
+		i.On("BuildGet", "app1", "build1").Return(bRunning, nil).Once()
+		i.On("BuildGet", "app1", "build1").Return(bComplete, nil)
+		i.On("ReleaseCreate", "app1", structs.ReleaseCreateOptions{Build: options.String("build1")}).Return(&structs.Release{Id: "release1"}, nil)
+		i.On("BuildUpdate", "app1", "build1", structs.BuildUpdateOptions{Release: options.String("release1")}).Return(bComplete, nil).Once()
+
+		res, err := testExecute(e, "builds import-image vllm/vllm-openai:v0.6.3 -a app1 -m testdata/import-manifest/convox.yml", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		res.RequireStdout(t, []string{
+			"Creating build... OK, build1",
+			"Relaying image vllm/vllm-openai:v0.6.3... OK",
+			"Waiting for import to complete... OK",
+			"Creating release... OK, release1",
+			"Build:   build1",
+			"Release: release1",
+		})
+	})
+}
+
+func TestBuildsImportImageFailure(t *testing.T) {
+	testClientWait(t, 10*time.Millisecond, func(e *cli.Engine, i *mocksdk.Interface) {
+		bExternal := &structs.Build{Id: "build1", App: "app1", Status: "created"}
+		bFailed := &structs.Build{Id: "build1", App: "app1", Status: "failed", Reason: "manifest unknown"}
+
+		i.On("BuildCreate", "app1", "", structs.BuildCreateOptions{External: options.Bool(true)}).Return(bExternal, nil)
+		i.On("BuildUpdate", "app1", "build1", mock.Anything).Return(bExternal, nil).Once()
+		i.On("BuildImportImage", "app1", "build1", "bad/image:1", structs.BuildImportImageOptions{}).Return(nil)
+		i.On("BuildGet", "app1", "build1").Return(bFailed, nil)
+
+		res, err := testExecute(e, "builds import-image bad/image:1 -a app1 -m testdata/import-manifest/convox.yml", nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, res.Code)
+		res.RequireStderr(t, []string{"ERROR: import failed: manifest unknown"})
+	})
+}
+
+func TestBuildsImportImageWithCreds(t *testing.T) {
+	testClientWait(t, 10*time.Millisecond, func(e *cli.Engine, i *mocksdk.Interface) {
+		bExternal := &structs.Build{Id: "build1", App: "app1", Status: "created"}
+		bComplete := &structs.Build{Id: "build1", App: "app1", Status: "complete"}
+
+		opts := structs.BuildImportImageOptions{
+			SrcCredsUser: options.String("$oauthtoken"),
+			SrcCredsPass: options.String("nvapi-key"),
+		}
+
+		i.On("BuildCreate", "app1", "", structs.BuildCreateOptions{External: options.Bool(true)}).Return(bExternal, nil)
+		i.On("BuildUpdate", "app1", "build1", mock.Anything).Return(bExternal, nil).Once()
+		i.On("BuildImportImage", "app1", "build1", "nvcr.io/nim/x:1.0", opts).Return(nil)
+		i.On("BuildGet", "app1", "build1").Return(bComplete, nil)
+		i.On("ReleaseCreate", "app1", mock.Anything).Return(&structs.Release{Id: "release1"}, nil)
+		i.On("BuildUpdate", "app1", "build1", mock.MatchedBy(func(o structs.BuildUpdateOptions) bool {
+			return o.Release != nil && *o.Release == "release1"
+		})).Return(bComplete, nil).Once()
+
+		res, err := testExecute(e, "builds import-image nvcr.io/nim/x:1.0 -a app1 -m testdata/import-manifest/convox.yml --src-creds-user $oauthtoken --src-creds-pass nvapi-key", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+	})
+}
+
 func TestBuildsImportClassic(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
 		data, err := os.ReadFile("testdata/build.tgz")

--- a/pkg/cli/testdata/import-manifest/convox.yml
+++ b/pkg/cli/testdata/import-manifest/convox.yml
@@ -1,0 +1,4 @@
+services:
+  web:
+    image: placeholder
+    port: 5000

--- a/pkg/mock/sdk/interface.go
+++ b/pkg/mock/sdk/interface.go
@@ -428,6 +428,20 @@ func (_m *Interface) BuildImport(app string, r io.Reader) (*structs.Build, error
 	return r0, r1
 }
 
+// BuildImportImage provides a mock function with given fields: app, id, image, opts
+func (_m *Interface) BuildImportImage(app string, id string, image string, opts structs.BuildImportImageOptions) error {
+	ret := _m.Called(app, id, image, opts)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string, string, structs.BuildImportImageOptions) error); ok {
+		r0 = rf(app, id, image, opts)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // BuildImportMultipart provides a mock function with given fields: _a0, _a1
 func (_m *Interface) BuildImportMultipart(_a0 string, _a1 io.Reader) (*structs.Build, error) {
 	ret := _m.Called(_a0, _a1)
@@ -695,6 +709,20 @@ func (_m *Interface) CertificateRenew(id string) error {
 		r0 = rf(id)
 	} else {
 		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// ClientType provides a mock function with given fields:
+func (_m *Interface) ClientType() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
 	}
 
 	return r0
@@ -1039,6 +1067,29 @@ func (_m *Interface) LetsEncryptConfigGet() (*structs.LetsEncryptConfig, error) 
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*structs.LetsEncryptConfig)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MachineList provides a mock function with given fields:
+func (_m *Interface) MachineList() (structs.Machines, error) {
+	ret := _m.Called()
+
+	var r0 structs.Machines
+	if rf, ok := ret.Get(0).(func() structs.Machines); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(structs.Machines)
 		}
 	}
 
@@ -2450,37 +2501,4 @@ func (_m *Interface) WorkflowList(rackOrgSlug string) (structs.WorkflowListResp,
 	}
 
 	return r0, r1
-}
-
-func (_m *Interface) MachineList() (structs.Machines, error) {
-	ret := _m.Called()
-
-	var r0 structs.Machines
-	if rf, ok := ret.Get(0).(func() structs.Machines); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(structs.Machines)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-func (_m *Interface) ClientType() string {
-	ret := _m.Called()
-
-	var r0 string
-	if rf, ok := ret.Get(0).(func() string); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	return r0
 }

--- a/pkg/structs/build.go
+++ b/pkg/structs/build.go
@@ -38,6 +38,11 @@ type BuildCreateOptions struct {
 	GitSha *string `param:"git-sha"`
 }
 
+type BuildImportImageOptions struct {
+	SrcCredsUser *string `flag:"src-creds-user" param:"src_creds_user" json:"src_creds_user,omitempty"`
+	SrcCredsPass *string `flag:"src-creds-pass" param:"src_creds_pass" json:"src_creds_pass,omitempty"`
+}
+
 type BuildListOptions struct {
 	Limit *int `flag:"limit,l" query:"limit"`
 }

--- a/pkg/structs/error.go
+++ b/pkg/structs/error.go
@@ -44,3 +44,7 @@ func ErrConflict(format string, args ...interface{}) *HttpError {
 func ErrNotImplemented(format string, args ...interface{}) *HttpError {
 	return newHttpError(http.StatusNotImplemented, format, args...)
 }
+
+func ErrUnprocessable(format string, args ...interface{}) *HttpError {
+	return newHttpError(http.StatusUnprocessableEntity, format, args...)
+}

--- a/pkg/structs/mock_Provider.go
+++ b/pkg/structs/mock_Provider.go
@@ -362,6 +362,20 @@ func (_m *MockProvider) BuildImport(app string, r io.Reader) (*Build, error) {
 	return r0, r1
 }
 
+// BuildImportImage provides a mock function with given fields: app, id, image, opts
+func (_m *MockProvider) BuildImportImage(app string, id string, image string, opts BuildImportImageOptions) error {
+	ret := _m.Called(app, id, image, opts)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string, string, BuildImportImageOptions) error); ok {
+		r0 = rf(app, id, image, opts)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // BuildList provides a mock function with given fields: app, opts
 func (_m *MockProvider) BuildList(app string, opts BuildListOptions) (Builds, error) {
 	ret := _m.Called(app, opts)

--- a/pkg/structs/provider.go
+++ b/pkg/structs/provider.go
@@ -30,6 +30,7 @@ type Provider interface {
 	BuildExport(app, id string, w io.Writer) error
 	BuildGet(app, id string) (*Build, error)
 	BuildImport(app string, r io.Reader) (*Build, error)
+	BuildImportImage(app, id, image string, opts BuildImportImageOptions) error
 	BuildLogs(app, id string, opts LogsOptions) (io.ReadCloser, error)
 	BuildList(app string, opts BuildListOptions) (Builds, error)
 	BuildUpdate(app, id string, opts BuildUpdateOptions) (*Build, error)

--- a/pkg/structs/routes.go
+++ b/pkg/structs/routes.go
@@ -19,6 +19,7 @@ func init() {
 	routes["BuildExport"] = "GET /apps/{app}/builds/{id}.tgz"
 	routes["BuildGet"] = "GET /apps/{app}/builds/{id}"
 	routes["BuildImport"] = "POST /apps/{app}/builds/import"
+	routes["BuildImportImage"] = "POST /apps/{app}/builds/{id}/image"
 	routes["BuildLogs"] = "SOCKET /apps/{app}/builds/{id}/logs"
 	routes["BuildList"] = "GET /apps/{app}/builds"
 	routes["BuildUpdate"] = "PUT /apps/{app}/builds/{id}"

--- a/provider/k8s/build.go
+++ b/provider/k8s/build.go
@@ -3,6 +3,8 @@ package k8s
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -10,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime/debug"
 	"sort"
 	"strconv"
@@ -22,6 +25,7 @@ import (
 	"github.com/convox/convox/pkg/structs"
 	ca "github.com/convox/convox/provider/k8s/pkg/apis/convox/v1"
 	"github.com/pkg/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	am "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -304,6 +308,289 @@ func (p *Provider) BuildGet(app, id string) (*structs.Build, error) {
 	}
 
 	return b, nil
+}
+
+// skopeoExec wraps the external `skopeo` binary so tests can substitute a fake
+// without shelling out. Production code runs the binary baked into the rack API
+// image (Dockerfile installs it under apt). The ctx deadline bounds long copies
+// so a hung registry cannot pin the goroutine indefinitely.
+var skopeoExec = func(ctx context.Context, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, "skopeo", args...).CombinedOutput()
+}
+
+// skopeoCopyTimeout caps a single `skopeo copy` invocation. Multi-GB inference
+// images over a constrained rack uplink can legitimately need 10+ minutes; 30
+// minutes is the upper bound we'll wait before failing the build.
+const skopeoCopyTimeout = 30 * time.Minute
+
+// validImageRef is a permissive docker-reference allowlist. The character set
+// covers registry hosts (`.`, `:`), image paths (`/`), tags (`:`), and
+// digests (`@`). The leading anchor blocks values starting with `-` which
+// skopeo could parse as a flag. isDangerousImageRef below rejects sequences
+// that still look valid per the allowlist but would confuse skopeo or the
+// registry URL parser.
+var validImageRef = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:/@+-]*$`)
+
+// isDangerousImageRef catches sequences that pass validImageRef but could
+// either smuggle a flag into skopeo (`@-`, `:-`, `/-`), produce a malformed
+// docker reference (double separators, trailing separators) that skopeo
+// would spend minutes failing to resolve, or open a path-traversal-shaped
+// registry URL (`//`).
+func isDangerousImageRef(image string) bool {
+	bad := []string{"//", "@-", ":-", "/-", "::", "@@", ":@", "/@"}
+	for _, b := range bad {
+		if strings.Contains(image, b) {
+			return true
+		}
+	}
+	if strings.HasSuffix(image, ":") || strings.HasSuffix(image, "@") || strings.HasSuffix(image, "/") {
+		return true
+	}
+	return false
+}
+
+// credScrub matches docker-style inline credentials in URLs (user:pass@host),
+// anchored on the `://` scheme prefix so benign `service:port@host` strings
+// that appear in K8s event messages aren't redacted. bearerScrub catches
+// Authorization: Bearer tokens echoed by skopeo during auth challenges.
+// registryAuthScrub catches the X-Registry-Auth header form used by some
+// registry middleware. All run before storing error text in Build.Reason
+// (visible via `kubectl get build -o yaml`).
+var credScrub = regexp.MustCompile(`(://)[A-Za-z0-9._+-]*:[^\s@/]+@`)
+var bearerScrub = regexp.MustCompile(`([Bb]earer\s+)[A-Za-z0-9._~+/=-]{10,}`)
+var registryAuthScrub = regexp.MustCompile(`([Xx]-[Rr]egistry-[Aa]uth:\s*)[A-Za-z0-9._~+/=-]+`)
+
+func scrubCredentials(s string) string {
+	s = credScrub.ReplaceAllString(s, "${1}[REDACTED]@")
+	s = bearerScrub.ReplaceAllString(s, "${1}[REDACTED]")
+	s = registryAuthScrub.ReplaceAllString(s, "${1}[REDACTED]")
+	if len(s) > 500 {
+		s = s[:500]
+	}
+	return s
+}
+
+// parseRegistryHost extracts the registry host from a docker image reference.
+// Defaults to docker.io when the first path component has no dot/colon (i.e.
+// `user/image` or `image`), matching Docker's canonical interpretation.
+func parseRegistryHost(image string) string {
+	if i := strings.Index(image, "/"); i != -1 {
+		first := image[:i]
+		if strings.ContainsAny(first, ".:") || first == "localhost" {
+			return first
+		}
+	}
+	return "docker.io"
+}
+
+// writeImportAuthFile writes a docker-style auth.json containing BOTH source
+// and destination registry credentials to a 0600-mode temp file and returns
+// its path. Using a unified `--authfile` instead of `--src-creds` / `--dest-creds`
+// on argv keeps all secrets out of /proc/<pid>/cmdline where they could be read
+// by any sidecar or co-located process. Skopeo resolves per-registry entries
+// by host at copy time so one authfile correctly authenticates both directions.
+// Source entries are optional (public pulls need no auth); destination entries
+// are required whenever the destination host writer needs credentials.
+// Callers must os.Remove(path) when done.
+func writeImportAuthFile(srcImage, srcUser, srcPass, destHost, destUser, destPass string) (string, error) {
+	auths := map[string]map[string]string{}
+	if srcUser != "" && srcPass != "" {
+		srcHost := parseRegistryHost(srcImage)
+		auths[srcHost] = map[string]string{"auth": base64.StdEncoding.EncodeToString([]byte(srcUser + ":" + srcPass))}
+	}
+	if destUser != "" && destHost != "" {
+		// destHost returned by Engine.RepositoryHost may include a repository
+		// path (e.g. `acct.dkr.ecr.region.amazonaws.com/rack/app`); strip to
+		// the bare host so skopeo's auth lookup matches.
+		bareDest := destHost
+		if i := strings.Index(bareDest, "/"); i != -1 {
+			bareDest = bareDest[:i]
+		}
+		auths[bareDest] = map[string]string{"auth": base64.StdEncoding.EncodeToString([]byte(destUser + ":" + destPass))}
+	}
+	data, err := json.Marshal(map[string]map[string]map[string]string{"auths": auths})
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	f, err := os.CreateTemp("", "convox-import-auth-*.json")
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	path := f.Name()
+	if err := os.Chmod(path, 0600); err != nil {
+		_ = f.Close()
+		_ = os.Remove(path)
+		return "", errors.WithStack(err)
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		_ = os.Remove(path)
+		return "", errors.WithStack(err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(path)
+		return "", errors.WithStack(err)
+	}
+	return path, nil
+}
+
+// finalizeImportImageBuild records the terminal state of an import-image build.
+// Runs in the goroutine's happy path and (via defer/recover) on panic. Falls
+// back to the in-memory Build captured before the goroutine started if a fresh
+// BuildGet fails, so the record is never left at "running" forever.
+func (p *Provider) finalizeImportImageBuild(app string, captured *structs.Build, runErr error) *structs.Build {
+	fresh, getErr := p.BuildGet(app, captured.Id)
+	if getErr != nil {
+		fmt.Printf("err: BuildImportImage refresh %s: %+v\n", captured.Id, getErr)
+		fresh = captured
+	}
+	fresh.Ended = time.Now().UTC()
+	if runErr != nil {
+		fresh.Status = "failed"
+		fresh.Reason = scrubCredentials(runErr.Error())
+	} else {
+		fresh.Status = "complete"
+		fresh.Reason = ""
+	}
+	if _, err := p.buildUpdate(fresh); err != nil {
+		fmt.Printf("err: BuildImportImage final update %s: %+v\n", captured.Id, err)
+	}
+	return fresh
+}
+
+func (p *Provider) BuildImportImage(app, id, image string, opts structs.BuildImportImageOptions) error {
+	if image == "" {
+		return errors.WithStack(structs.ErrUnprocessable("image ref required"))
+	}
+	if !validImageRef.MatchString(image) || isDangerousImageRef(image) {
+		return errors.WithStack(structs.ErrUnprocessable("invalid image ref: must start with a letter or digit, contain only A-Z a-z 0-9 . _ : / @ + -, and not include // @- :- or /-"))
+	}
+
+	b, err := p.BuildGet(app, id)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	// Reject re-invocation on a build already in flight. The informer may be a
+	// few hundred ms behind reality; the buildUpdate below closes any remaining
+	// TOCTOU window via K8s optimistic concurrency on ResourceVersion.
+	if b.Status == "running" {
+		return errors.WithStack(structs.ErrConflict("build %s is already importing; wait for completion before retrying", id))
+	}
+
+	if strings.TrimSpace(b.Manifest) == "" {
+		return errors.WithStack(structs.ErrUnprocessable("build %s has no manifest; populate via BuildUpdate before BuildImportImage", id))
+	}
+
+	m, err := manifest.Load([]byte(b.Manifest), map[string]string{})
+	if err != nil {
+		return errors.WithStack(structs.ErrUnprocessable("manifest parse failed: %s", err.Error()))
+	}
+	if len(m.Services) == 0 {
+		return errors.WithStack(structs.ErrUnprocessable("manifest has no services to relay"))
+	}
+
+	b.Status = "running"
+	b.Started = time.Now().UTC()
+	b.Reason = ""
+	if _, err := p.buildUpdate(b); err != nil {
+		// K8s returns a Conflict (HTTP 409) when the informer-cached
+		// ResourceVersion is stale — a concurrent writer (including a racing
+		// BuildImportImage caller) beat us to the update. Surface as a clean
+		// 409 so clients see the same status they'd get from the running guard.
+		if k8serrors.IsConflict(err) {
+			return errors.WithStack(structs.ErrConflict("build %s is currently being modified; wait and retry", id))
+		}
+		return errors.WithStack(err)
+	}
+
+	// Capture the opts values into locals so the goroutine doesn't hold pointers
+	// into the caller's request-scoped memory once the HTTP handler returns.
+	var srcUser, srcPass string
+	if opts.SrcCredsUser != nil {
+		srcUser = *opts.SrcCredsUser
+	}
+	if opts.SrcCredsPass != nil {
+		srcPass = *opts.SrcCredsPass
+	}
+
+	// Emit :start synchronously before launching the goroutine so subscribers
+	// cannot observe :done before :start when the webhook dispatcher fans out
+	// on its own goroutines.
+	_ = p.EventSend("build:import-image:start", structs.EventSendOptions{
+		Data: map[string]string{"app": app, "build": b.Id, "image": image},
+	})
+
+	// Copy the build by value for the goroutine. Tags is a map — we nil it
+	// defensively rather than deep-copy because buildMarshal does not persist
+	// it and we do not want the goroutine aliasing the caller's map.
+	captured := *b
+	captured.Tags = nil
+	go func() {
+		var runErr error
+		defer func() {
+			if r := recover(); r != nil {
+				fmt.Printf("panic in BuildImportImage for build %s: %v\nstack: %s\n", captured.Id, r, debug.Stack())
+				runErr = fmt.Errorf("panic during image import: %v", r)
+			}
+			final := p.finalizeImportImageBuild(app, &captured, runErr)
+			_ = p.EventSend("build:import-image:done", structs.EventSendOptions{
+				Data: map[string]string{"app": app, "build": captured.Id, "status": final.Status},
+			})
+		}()
+
+		runErr = p.buildImportImageRun(app, &captured, m, image, srcUser, srcPass)
+	}()
+
+	return nil
+}
+
+func (p *Provider) buildImportImageRun(app string, b *structs.Build, m *manifest.Manifest, imageRef, srcUser, srcPass string) error {
+	repo, _, err := p.Engine.RepositoryHost(app)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	destUser, destPass, err := p.Engine.RepositoryAuth(app)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	// Unified authfile covers both source (optional) and destination creds so
+	// neither touches /proc/<pid>/cmdline. `--authfile` works for both lookups.
+	authPath, err := writeImportAuthFile(imageRef, srcUser, srcPass, repo, destUser, destPass)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer func() { _ = os.Remove(authPath) }()
+
+	for i := range m.Services {
+		svc := &m.Services[i]
+		src := imageRef
+		if svc.Image != "" {
+			src = svc.Image
+		}
+		if !validImageRef.MatchString(src) || isDangerousImageRef(src) {
+			return fmt.Errorf("invalid image ref for service %s", svc.Name)
+		}
+		dst := fmt.Sprintf("%s:%s.%s", repo, svc.Name, b.Id)
+
+		args := []string{
+			"copy",
+			"--authfile", authPath,
+			"--",
+			fmt.Sprintf("docker://%s", src),
+			fmt.Sprintf("docker://%s", dst),
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), skopeoCopyTimeout)
+		out, runErr := skopeoExec(ctx, args...)
+		cancel()
+		if runErr != nil {
+			return fmt.Errorf("image relay failed for service %s: %s (output: %s)", svc.Name, runErr, strings.TrimSpace(string(out)))
+		}
+	}
+
+	return nil
 }
 
 func (p *Provider) BuildImport(app string, r io.Reader) (*structs.Build, error) {
@@ -735,6 +1022,7 @@ func (p *Provider) buildMarshal(b *structs.Build) *ca.Build {
 			Logs:        b.Logs,
 			Manifest:    b.Manifest,
 			Process:     b.Process,
+			Reason:      b.Reason,
 			Release:     b.Release,
 			Started:     b.Started.UTC().Format(common.SortableTime),
 			Status:      b.Status,
@@ -764,6 +1052,7 @@ func (p *Provider) buildUnmarshal(kb *ca.Build) (*structs.Build, error) {
 		Logs:        kb.Spec.Logs,
 		Manifest:    kb.Spec.Manifest,
 		Process:     kb.Spec.Process,
+		Reason:      kb.Spec.Reason,
 		Release:     kb.Spec.Release,
 		Started:     started,
 		Status:      kb.Spec.Status,

--- a/provider/k8s/build_test.go
+++ b/provider/k8s/build_test.go
@@ -1,6 +1,7 @@
 package k8s_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -316,4 +317,461 @@ func buildFixture(name string) (*ca.BuildSpec, error) {
 	}
 
 	return s, nil
+}
+
+func waitForBuildStatus(t *testing.T, p *k8s.Provider, app, id string, want string) *structs.Build {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		b, err := p.BuildGet(app, id)
+		if err == nil && b.Status == want {
+			return b
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	b, err := p.BuildGet(app, id)
+	require.NoError(t, err)
+	t.Fatalf("build %s never reached status %q (last status: %q, reason: %q)", id, want, b.Status, b.Reason)
+	return nil
+}
+
+// readAuthfile reads the file path stored after the `--authfile` flag in a
+// captured skopeo args slice and returns its contents. Returns "" if the flag
+// isn't present.
+func readAuthfileFromArgs(t *testing.T, args []string) string {
+	t.Helper()
+	for i, a := range args {
+		if a == "--authfile" && i+1 < len(args) {
+			data, err := os.ReadFile(args[i+1])
+			require.NoError(t, err)
+			return string(data)
+		}
+	}
+	return ""
+}
+
+// assertArgsShape checks the canonical skopeo args order: copy [...flags] -- docker://<src> docker://<dst>.
+// Returns the (src, dst) positional pair.
+func assertArgsShape(t *testing.T, args []string) (string, string) {
+	t.Helper()
+	require.NotEmpty(t, args)
+	require.Equal(t, "copy", args[0])
+	require.GreaterOrEqual(t, len(args), 4, "args must have at least: copy -- src dst")
+	// positional args are the last two; the token right before them is `--`
+	require.Equal(t, "--", args[len(args)-3])
+	src := args[len(args)-2]
+	dst := args[len(args)-1]
+	require.Truef(t, strings.HasPrefix(src, "docker://"), "src missing docker:// prefix: %q", src)
+	require.Truef(t, strings.HasPrefix(dst, "docker://"), "dst missing docker:// prefix: %q", dst)
+	return src, dst
+}
+
+func TestBuildImportImage(t *testing.T) {
+	origSkopeo := *k8s.SkopeoExecForTest
+	defer func() { *k8s.SkopeoExecForTest = origSkopeo }()
+
+	t.Run("Success", func(t *testing.T) {
+		testProvider(t, func(p *k8s.Provider) {
+			kk, ok := p.Cluster.(*fake.Clientset)
+			require.True(t, ok)
+			require.NoError(t, appCreate(kk, "rack1", "app1"))
+			require.NoError(t, buildCreate(p.Convox, "rack1-app1", "build1", "basic"))
+
+			var capturedArgs []string
+			var authContents string
+			var ctxNonNil bool
+			*k8s.SkopeoExecForTest = func(ctx context.Context, args ...string) ([]byte, error) {
+				capturedArgs = append([]string(nil), args...)
+				authContents = readAuthfileFromArgs(t, args)
+				ctxNonNil = ctx != nil
+				return []byte("ok"), nil
+			}
+
+			err := p.BuildImportImage("app1", "build1", "vllm/vllm-openai:v0.6.3", structs.BuildImportImageOptions{})
+			require.NoError(t, err)
+
+			b := waitForBuildStatus(t, p, "app1", "build1", "complete")
+			assert.Equal(t, "", b.Reason)
+			assert.True(t, ctxNonNil, "skopeoExec must be called with non-nil ctx")
+
+			src, dst := assertArgsShape(t, capturedArgs)
+			assert.Equal(t, "docker://vllm/vllm-openai:v0.6.3", src)
+			assert.Equal(t, "docker://repo1:web.BUILD1", dst)
+			assert.Contains(t, capturedArgs, "--authfile", "unified authfile flag expected")
+			assert.NotContains(t, capturedArgs, "--dest-creds", "dest creds must NOT be on argv")
+			assert.NotContains(t, capturedArgs, "--src-creds", "src creds must NOT be on argv")
+			assert.NotContains(t, capturedArgs, "--src-authfile", "legacy split-authfile flag must not be emitted")
+			for _, a := range capturedArgs {
+				assert.NotContains(t, a, "un1:pw1", "dest cred colon-pair must not appear on argv")
+			}
+			// authfile must carry the dest creds (base64 of "un1:pw1") under the rack registry host.
+			require.NotEmpty(t, authContents, "authfile must exist during skopeo invocation")
+			assert.Contains(t, authContents, "repo1", "authfile must scope to destination host")
+			assert.Contains(t, authContents, "dW4xOnB3MQ==", "authfile must carry base64(un1:pw1) for dest")
+		})
+	})
+
+	t.Run("SrcAndDestCredsInAuthfile", func(t *testing.T) {
+		testProvider(t, func(p *k8s.Provider) {
+			kk, ok := p.Cluster.(*fake.Clientset)
+			require.True(t, ok)
+			require.NoError(t, appCreate(kk, "rack1", "app1"))
+			require.NoError(t, buildCreate(p.Convox, "rack1-app1", "build2", "basic"))
+
+			var capturedArgs []string
+			var authContentsAtRuntime string
+			*k8s.SkopeoExecForTest = func(ctx context.Context, args ...string) ([]byte, error) {
+				capturedArgs = append([]string(nil), args...)
+				authContentsAtRuntime = readAuthfileFromArgs(t, args)
+				return nil, nil
+			}
+
+			user := "$oauthtoken"
+			pass := "nvapi-secret"
+			err := p.BuildImportImage("app1", "build2", "nvcr.io/nim/meta/llama3-8b:1.0.0", structs.BuildImportImageOptions{
+				SrcCredsUser: &user,
+				SrcCredsPass: &pass,
+			})
+			require.NoError(t, err)
+
+			waitForBuildStatus(t, p, "app1", "build2", "complete")
+			assert.Contains(t, capturedArgs, "--authfile")
+			assert.NotContains(t, capturedArgs, "--src-creds", "src creds must NOT be on argv")
+			assert.NotContains(t, capturedArgs, "--dest-creds", "dest creds must NOT be on argv")
+			for _, a := range capturedArgs {
+				assert.NotContains(t, a, "nvapi-secret", "src cred must not appear anywhere on argv")
+				assert.NotContains(t, a, "$oauthtoken:nvapi-secret", "src colon-pair must not be on argv")
+				assert.NotContains(t, a, "un1:pw1", "dest cred colon-pair must not be on argv")
+			}
+			// Authfile contains BOTH source and destination host entries.
+			assert.Contains(t, authContentsAtRuntime, "nvcr.io", "authfile must include source registry host")
+			assert.Contains(t, authContentsAtRuntime, "repo1", "authfile must include destination registry host")
+			assert.Contains(t, authContentsAtRuntime, "JG9hdXRodG9rZW46bnZhcGktc2VjcmV0", "base64 of '$oauthtoken:nvapi-secret'")
+			assert.Contains(t, authContentsAtRuntime, "dW4xOnB3MQ==", "base64 of 'un1:pw1' (dest)")
+		})
+	})
+
+	t.Run("EmptyStringSrcCredsSkipped", func(t *testing.T) {
+		testProvider(t, func(p *k8s.Provider) {
+			kk, ok := p.Cluster.(*fake.Clientset)
+			require.True(t, ok)
+			require.NoError(t, appCreate(kk, "rack1", "app1"))
+			require.NoError(t, buildCreate(p.Convox, "rack1-app1", "buildec", "basic"))
+
+			var capturedArgs []string
+			var authContents string
+			*k8s.SkopeoExecForTest = func(ctx context.Context, args ...string) ([]byte, error) {
+				capturedArgs = append([]string(nil), args...)
+				authContents = readAuthfileFromArgs(t, args)
+				return nil, nil
+			}
+
+			empty := ""
+			err := p.BuildImportImage("app1", "buildec", "vllm/vllm-openai:v0.6.3", structs.BuildImportImageOptions{
+				SrcCredsUser: &empty,
+				SrcCredsPass: &empty,
+			})
+			require.NoError(t, err)
+
+			waitForBuildStatus(t, p, "app1", "buildec", "complete")
+			// Dest creds still present (required); source entry must NOT be written.
+			assert.Contains(t, capturedArgs, "--authfile")
+			assert.NotContains(t, authContents, "docker.io", "empty src creds must not produce a Docker Hub entry")
+			assert.Contains(t, authContents, "repo1", "dest entry must still be present")
+		})
+	})
+
+	t.Run("SkopeoFailureScrubbed", func(t *testing.T) {
+		testProvider(t, func(p *k8s.Provider) {
+			kk, ok := p.Cluster.(*fake.Clientset)
+			require.True(t, ok)
+			require.NoError(t, appCreate(kk, "rack1", "app1"))
+			require.NoError(t, buildCreate(p.Convox, "rack1-app1", "build3", "basic"))
+
+			// stderr includes a Bearer token and an inline cred URL; both must be scrubbed.
+			*k8s.SkopeoExecForTest = func(ctx context.Context, args ...string) ([]byte, error) {
+				return []byte("auth failed: Bearer abcdef1234567890TOKEN at https://user:sup3rs3cret@host/x"), fmt.Errorf("exit status 1")
+			}
+
+			err := p.BuildImportImage("app1", "build3", "nvcr.io/private/gated:1.0", structs.BuildImportImageOptions{})
+			require.NoError(t, err)
+
+			b := waitForBuildStatus(t, p, "app1", "build3", "failed")
+			assert.Contains(t, b.Reason, "image relay failed for service web")
+			assert.NotContains(t, b.Reason, "sup3rs3cret", "inline password must be scrubbed")
+			assert.NotContains(t, b.Reason, "abcdef1234567890TOKEN", "bearer token must be scrubbed")
+			assert.LessOrEqual(t, len(b.Reason), 500, "Reason must be truncated")
+		})
+	})
+
+	t.Run("ScrubEmptyUsernameToken", func(t *testing.T) {
+		testProvider(t, func(p *k8s.Provider) {
+			kk, ok := p.Cluster.(*fake.Clientset)
+			require.True(t, ok)
+			require.NoError(t, appCreate(kk, "rack1", "app1"))
+			require.NoError(t, buildCreate(p.Convox, "rack1-app1", "buildeu", "basic"))
+
+			// URL with empty username and a bare bearer-style token after the colon.
+			*k8s.SkopeoExecForTest = func(ctx context.Context, args ...string) ([]byte, error) {
+				return []byte("auth: fetch https://:eyJhbGciOiJIUzI1NiJ9-veryLongToken@registry.example.com/v2/"), fmt.Errorf("exit status 1")
+			}
+
+			err := p.BuildImportImage("app1", "buildeu", "registry.example.com/gated:1.0", structs.BuildImportImageOptions{})
+			require.NoError(t, err)
+
+			b := waitForBuildStatus(t, p, "app1", "buildeu", "failed")
+			assert.NotContains(t, b.Reason, "eyJhbGciOiJIUzI1NiJ9-veryLongToken", "empty-username token must still be scrubbed")
+			assert.Contains(t, b.Reason, "[REDACTED]@", "redaction marker must be present")
+		})
+	})
+
+	t.Run("ScrubPreservesBenignColons", func(t *testing.T) {
+		testProvider(t, func(p *k8s.Provider) {
+			kk, ok := p.Cluster.(*fake.Clientset)
+			require.True(t, ok)
+			require.NoError(t, appCreate(kk, "rack1", "app1"))
+			require.NoError(t, buildCreate(p.Convox, "rack1-app1", "buildsb", "basic"))
+
+			// error text with benign `host:port` and no `://` prefix — must NOT be scrubbed.
+			*k8s.SkopeoExecForTest = func(ctx context.Context, args ...string) ([]byte, error) {
+				return []byte("dial tcp registry.internal:5000@pod-abc: connection refused"), fmt.Errorf("exit status 1")
+			}
+
+			err := p.BuildImportImage("app1", "buildsb", "nvcr.io/private/x:1.0", structs.BuildImportImageOptions{})
+			require.NoError(t, err)
+
+			b := waitForBuildStatus(t, p, "app1", "buildsb", "failed")
+			assert.Contains(t, b.Reason, "registry.internal:5000@pod-abc", "benign host:port@host must pass through unscrubbed")
+		})
+	})
+
+	t.Run("MultiService", func(t *testing.T) {
+		testProvider(t, func(p *k8s.Provider) {
+			kk, ok := p.Cluster.(*fake.Clientset)
+			require.True(t, ok)
+			require.NoError(t, appCreate(kk, "rack1", "app1"))
+			require.NoError(t, buildCreate(p.Convox, "rack1-app1", "buildm", "multisvc"))
+
+			var calls [][]string
+			*k8s.SkopeoExecForTest = func(ctx context.Context, args ...string) ([]byte, error) {
+				calls = append(calls, append([]string(nil), args...))
+				return nil, nil
+			}
+
+			err := p.BuildImportImage("app1", "buildm", "vllm/vllm-openai:v0.6.3", structs.BuildImportImageOptions{})
+			require.NoError(t, err)
+
+			waitForBuildStatus(t, p, "app1", "buildm", "complete")
+			require.Len(t, calls, 2, "one skopeo call per service")
+
+			dstSeen := map[string]bool{}
+			for _, call := range calls {
+				_, dst := assertArgsShape(t, call)
+				dstSeen[dst] = true
+			}
+			assert.True(t, dstSeen["docker://repo1:web.BUILDM"])
+			assert.True(t, dstSeen["docker://repo1:worker.BUILDM"])
+		})
+	})
+
+	t.Run("MultiServicePartialFailure", func(t *testing.T) {
+		testProvider(t, func(p *k8s.Provider) {
+			kk, ok := p.Cluster.(*fake.Clientset)
+			require.True(t, ok)
+			require.NoError(t, appCreate(kk, "rack1", "app1"))
+			require.NoError(t, buildCreate(p.Convox, "rack1-app1", "buildpf", "multisvc"))
+
+			var call int
+			*k8s.SkopeoExecForTest = func(ctx context.Context, args ...string) ([]byte, error) {
+				call++
+				if call == 2 {
+					return []byte("upstream 502"), fmt.Errorf("exit status 1")
+				}
+				return nil, nil
+			}
+
+			err := p.BuildImportImage("app1", "buildpf", "vllm/vllm-openai:v0.6.3", structs.BuildImportImageOptions{})
+			require.NoError(t, err)
+
+			b := waitForBuildStatus(t, p, "app1", "buildpf", "failed")
+			// Final Reason should name whichever service was iterated second (map order is not guaranteed).
+			assert.Regexp(t, `image relay failed for service (web|worker)`, b.Reason)
+			assert.Contains(t, b.Reason, "upstream 502")
+		})
+	})
+
+	t.Run("SvcImageOverride", func(t *testing.T) {
+		testProvider(t, func(p *k8s.Provider) {
+			kk, ok := p.Cluster.(*fake.Clientset)
+			require.True(t, ok)
+			require.NoError(t, appCreate(kk, "rack1", "app1"))
+			require.NoError(t, buildCreate(p.Convox, "rack1-app1", "buildso", "svcimage"))
+
+			var capturedSrc string
+			*k8s.SkopeoExecForTest = func(ctx context.Context, args ...string) ([]byte, error) {
+				src, _ := assertArgsShape(t, args)
+				capturedSrc = src
+				return nil, nil
+			}
+
+			err := p.BuildImportImage("app1", "buildso", "caller-provided/default:v1", structs.BuildImportImageOptions{})
+			require.NoError(t, err)
+
+			waitForBuildStatus(t, p, "app1", "buildso", "complete")
+			assert.Equal(t, "docker://override.example.com/baked:v1", capturedSrc, "svc.Image must override caller-provided imageRef")
+		})
+	})
+
+	t.Run("PanicInGoroutineFinalizesFailed", func(t *testing.T) {
+		testProvider(t, func(p *k8s.Provider) {
+			kk, ok := p.Cluster.(*fake.Clientset)
+			require.True(t, ok)
+			require.NoError(t, appCreate(kk, "rack1", "app1"))
+			require.NoError(t, buildCreate(p.Convox, "rack1-app1", "buildp", "basic"))
+
+			*k8s.SkopeoExecForTest = func(ctx context.Context, args ...string) ([]byte, error) {
+				panic("synthetic panic inside skopeoExec")
+			}
+
+			err := p.BuildImportImage("app1", "buildp", "vllm/vllm-openai:v0.6.3", structs.BuildImportImageOptions{})
+			require.NoError(t, err)
+
+			b := waitForBuildStatus(t, p, "app1", "buildp", "failed")
+			assert.Contains(t, b.Reason, "panic during image import")
+		})
+	})
+
+	t.Run("EmptyServicesRejected", func(t *testing.T) {
+		testProvider(t, func(p *k8s.Provider) {
+			kk, ok := p.Cluster.(*fake.Clientset)
+			require.True(t, ok)
+			require.NoError(t, appCreate(kk, "rack1", "app1"))
+
+			// Manifest that parses but has no services. `services: {}` is accepted by the loader.
+			emptySvc := &ca.Build{
+				ObjectMeta: am.ObjectMeta{Name: "buildes", Labels: map[string]string{"app": "app1"}},
+				Spec: ca.BuildSpec{
+					Manifest: "services: {}\n",
+					Started:  "20200101.000000.000000000",
+					Ended:    "20200101.000000.000000000",
+				},
+			}
+			_, err := p.Convox.ConvoxV1().Builds("rack1-app1").Create(emptySvc)
+			require.NoError(t, err)
+
+			err = p.BuildImportImage("app1", "buildes", "vllm/vllm-openai:v0.6.3", structs.BuildImportImageOptions{})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "no services to relay")
+		})
+	})
+
+	t.Run("RejectsReinvocationWhileRunning", func(t *testing.T) {
+		testProvider(t, func(p *k8s.Provider) {
+			kk, ok := p.Cluster.(*fake.Clientset)
+			require.True(t, ok)
+			require.NoError(t, appCreate(kk, "rack1", "app1"))
+			require.NoError(t, buildCreate(p.Convox, "rack1-app1", "buildrr", "basic"))
+
+			// First call transitions status to running synchronously before the
+			// goroutine launches; block the goroutine's skopeo until we've made
+			// the second call.
+			release := make(chan struct{})
+			*k8s.SkopeoExecForTest = func(ctx context.Context, args ...string) ([]byte, error) {
+				<-release
+				return nil, nil
+			}
+
+			err := p.BuildImportImage("app1", "buildrr", "vllm/vllm-openai:v0.6.3", structs.BuildImportImageOptions{})
+			require.NoError(t, err)
+
+			// Second call hits the running precondition and is rejected immediately.
+			err = p.BuildImportImage("app1", "buildrr", "vllm/vllm-openai:v0.6.3", structs.BuildImportImageOptions{})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "already importing")
+
+			// Let the first run finish so the test doesn't leak a blocked goroutine.
+			close(release)
+			waitForBuildStatus(t, p, "app1", "buildrr", "complete")
+		})
+	})
+
+	t.Run("InvalidImageRefRejected", func(t *testing.T) {
+		testProvider(t, func(p *k8s.Provider) {
+			kk, ok := p.Cluster.(*fake.Clientset)
+			require.True(t, ok)
+			require.NoError(t, appCreate(kk, "rack1", "app1"))
+			require.NoError(t, buildCreate(p.Convox, "rack1-app1", "buildiv", "basic"))
+
+			hostile := []string{
+				"--help",         // leading flag
+				"img;rm -rf /",   // shell metacharacters
+				"img with space", // whitespace
+				"a//b:1",         // double-slash
+				"a@-flag:1",      // @- smuggle
+				"a/b:-flag",      // :- smuggle
+				"a/-flag/b:1",    // /- smuggle
+				"img:",           // trailing colon
+				"img@",           // trailing at
+				"img/",           // trailing slash
+				"img::tag",       // double colon
+				"img@@digest",    // double at
+				"img:@bar",       // :@ junction
+				"img/@bar",       // /@ junction
+			}
+			for _, bad := range hostile {
+				err := p.BuildImportImage("app1", "buildiv", bad, structs.BuildImportImageOptions{})
+				require.Errorf(t, err, "expected rejection for %q", bad)
+				assert.Containsf(t, err.Error(), "invalid image ref", "wrong error for %q", bad)
+			}
+		})
+	})
+
+	t.Run("MissingImageParam", func(t *testing.T) {
+		testProvider(t, func(p *k8s.Provider) {
+			kk, ok := p.Cluster.(*fake.Clientset)
+			require.True(t, ok)
+			require.NoError(t, appCreate(kk, "rack1", "app1"))
+			require.NoError(t, buildCreate(p.Convox, "rack1-app1", "build4", "basic"))
+
+			err := p.BuildImportImage("app1", "build4", "", structs.BuildImportImageOptions{})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "image ref required")
+		})
+	})
+
+	t.Run("MissingManifest", func(t *testing.T) {
+		testProvider(t, func(p *k8s.Provider) {
+			kk, ok := p.Cluster.(*fake.Clientset)
+			require.True(t, ok)
+			require.NoError(t, appCreate(kk, "rack1", "app1"))
+
+			empty := &ca.Build{
+				ObjectMeta: am.ObjectMeta{
+					Name:   "build5",
+					Labels: map[string]string{"app": "app1"},
+				},
+				Spec: ca.BuildSpec{
+					Started: "20200101.000000.000000000",
+					Ended:   "20200101.000000.000000000",
+				},
+			}
+			_, err := p.Convox.ConvoxV1().Builds("rack1-app1").Create(empty)
+			require.NoError(t, err)
+
+			err = p.BuildImportImage("app1", "build5", "vllm/vllm-openai:v0.6.3", structs.BuildImportImageOptions{})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "has no manifest")
+		})
+	})
+
+	t.Run("BuildNotFound", func(t *testing.T) {
+		testProvider(t, func(p *k8s.Provider) {
+			kk, ok := p.Cluster.(*fake.Clientset)
+			require.True(t, ok)
+			require.NoError(t, appCreate(kk, "rack1", "app1"))
+
+			err := p.BuildImportImage("app1", "nonexistent", "vllm/vllm-openai:v0.6.3", structs.BuildImportImageOptions{})
+			require.Error(t, err)
+		})
+	})
 }

--- a/provider/k8s/export_test.go
+++ b/provider/k8s/export_test.go
@@ -1,0 +1,3 @@
+package k8s
+
+var SkopeoExecForTest = &skopeoExec

--- a/provider/k8s/pkg/apis/convox/v1/types.go
+++ b/provider/k8s/pkg/apis/convox/v1/types.go
@@ -31,6 +31,7 @@ type BuildSpec struct {
 	Logs        string `json:"logs"`
 	Manifest    string `json:"manifest"`
 	Process     string `json:"process"`
+	Reason      string `json:"reason"`
 	Release     string `json:"release"`
 	Started     string `json:"started"`
 	Status      string `json:"status"`

--- a/provider/k8s/template/system/crd.yml.tmpl
+++ b/provider/k8s/template/system/crd.yml.tmpl
@@ -27,6 +27,9 @@ spec:
                   type: string
                 process:
                   type: string
+                reason:
+                  type: string
+                  maxLength: 1024
                 release:
                   type: string
                 started:

--- a/provider/k8s/testdata/build-multisvc.yml
+++ b/provider/k8s/testdata/build-multisvc.yml
@@ -1,0 +1,11 @@
+description: multi-service
+ended: 20200101.000000.000000000
+manifest:
+  services:
+    web:
+      image: placeholder
+      port: 5000
+    worker:
+      image: placeholder
+      port: 6000
+started: 20200101.000000.000000000

--- a/provider/k8s/testdata/build-svcimage.yml
+++ b/provider/k8s/testdata/build-svcimage.yml
@@ -1,0 +1,8 @@
+description: per-service image override
+ended: 20200101.000000.000000000
+manifest:
+  services:
+    web:
+      image: override.example.com/baked:v1
+      port: 5000
+started: 20200101.000000.000000000

--- a/sdk/methods.go
+++ b/sdk/methods.go
@@ -262,6 +262,17 @@ func (c *Client) BuildImport(app string, r io.Reader) (*structs.Build, error) {
 	return v, err
 }
 
+func (c *Client) BuildImportImage(app, id, image string, opts structs.BuildImportImageOptions) error {
+	ro, err := stdsdk.MarshalOptions(opts)
+	if err != nil {
+		return err
+	}
+
+	ro.Params["image"] = image
+
+	return c.Post(fmt.Sprintf("/apps/%s/builds/%s/image", app, id), ro, nil)
+}
+
 func (c *Client) BuildList(app string, opts structs.BuildListOptions) (structs.Builds, error) {
 	var err error
 


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: Container Image Import from External Registries**

A new `convox builds import-image` command lets you import prebuilt container images from any public or private registry directly into a rack's internal registry. This enables deploying models and services from registries like NVIDIA NGC, Hugging Face, GitHub Container Registry, Quay, Docker Hub, and others without rebuilding from source.

The import runs asynchronously on the rack using [skopeo](https://github.com/containers/skopeo) to copy the image, with the CLI polling until the import completes. The resulting build can be promoted to a release just like any source-built image.

**How it works:**

1. The CLI creates a new build record on the rack
2. The rack launches a background `skopeo copy` from the source registry into the rack's internal registry (ECR, GCR, ACR, etc.)
3. The CLI polls the build status until the import completes or fails
4. On success, a release is automatically created and can be promoted

Source registry credentials are supported for private registries. Credentials are passed securely via a temporary authfile — they never appear on the process command line or in Kubernetes pod specs.

If an import fails, the failure reason is persisted on the Build record and surfaced in the CLI output, making it straightforward to diagnose issues like invalid credentials, missing tags, or network errors.

---

### Why is this important?

Many production workloads — particularly GPU inference services — ship as prebuilt container images from vendor registries rather than building from source. Previously, deploying these images on Convox required manual workarounds: pulling the image locally, re-tagging it, and pushing to the rack's registry.

`convox builds import-image` makes this a single command.

**Benefits:**

- **Deploy vendor images directly.** Import prebuilt images from NGC, Hugging Face, Docker Hub, ghcr.io, quay.io, or any OCI-compatible registry without an intermediate build step
- **Secure credential handling.** Source registry credentials are written to a temporary file with restricted permissions and cleaned up after use — never exposed via process arguments or pod specs
- **Full release lifecycle.** Imported images produce standard Convox builds and releases, so `convox releases promote`, rollback, and release history all work as expected
- **Failure diagnostics.** Import failures are recorded with a scrubbed reason message, so credential errors and network issues are easy to identify without exposing secrets

---

### How to use it?

Import a public image:

    $ convox builds import-image nvcr.io/nim/meta/llama3-8b-instruct:1.0.0 -a my-app -r rackName

Import from a private registry with credentials:

    $ convox builds import-image nvcr.io/nim/meta/llama3-8b-instruct:1.0.0 \
        --src-creds-user '$oauthtoken' \
        --src-creds-pass-env NGC_API_KEY \
        -a my-app -r rackName

Import with a custom manifest (for multi-service apps or image override):

    $ convox builds import-image ghcr.io/org/service:v2.1.0 \
        --manifest path/to/convox.yml \
        -a my-app -r rackName

Read the source password from stdin (recommended for CI pipelines):

    $ echo "$NGC_API_KEY" | convox builds import-image nvcr.io/nim/meta/llama3-8b-instruct:1.0.0 \
        --src-creds-user '$oauthtoken' \
        --src-creds-pass-stdin \
        -a my-app -r rackName

After the import completes, promote the resulting release:

    $ convox releases promote <release-id> -a my-app -r rackName

---

### Does it have a breaking change?

**No breaking changes** are introduced with this feature.

This is a purely additive change: a new CLI command, a new API endpoint, and a new field (`Reason`) on the Build CRD. Existing builds, releases, and workflows are unaffected. Racks that do not use this feature see no behavior change.

Older CLI versions communicating with a newer rack are unaffected — the new route simply does not exist for them. Newer CLI versions communicating with an older rack will receive a clear error indicating the rack needs to be updated.

---

### Requirements

This feature requires version `3.24.6` or later for the rack.

**Update the Rack:** Run `convox rack update 3.24.6 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.23.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
