### PR TITLE
add imagePullSecrets for private registries

### DIFF
--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -26,48 +26,82 @@ const (
 type Service struct {
 	Name string `yaml:"-"`
 
-	Agent              ServiceAgent           `yaml:"agent,omitempty"`
-	Annotations        Annotations            `yaml:"annotations,omitempty"`
-	Build              ServiceBuild           `yaml:"build,omitempty"`
-	Certificate        Certificate            `yaml:"certificate,omitempty"`
-	Command            string                 `yaml:"command,omitempty"`
-	ConfigMounts       ConfigMounts           `yaml:"configMounts,omitempty"`
-	Deployment         ServiceDeployment      `yaml:"deployment,omitempty"`
-	DnsConfig          ServiceDnsConfig       `yaml:"dnsConfig,omitempty"`
-	Domains            ServiceDomains         `yaml:"domain,omitempty"`
-	Drain              int                    `yaml:"drain,omitempty"`
-	DisableHostUsers   bool                   `yaml:"disableHostUsers,omitempty"`
-	Environment        Environment            `yaml:"environment,omitempty"`
-	GrpcHealthEnabled  bool                   `yaml:"grpcHealthEnabled,omitempty"`
-	Health             ServiceHealth          `yaml:"health,omitempty"`
-	Liveness           ServiceLiveness        `yaml:"liveness,omitempty"`
-	StartupProbe       ServiceStartupProbe    `yaml:"startupProbe,omitempty"`
-	Image              string                 `yaml:"image,omitempty"`
-	Init               bool                   `yaml:"init,omitempty"`
-	InitContainer      *InitContainer         `yaml:"initContainer,omitempty"`
-	Internal           bool                   `yaml:"internal,omitempty"`
-	InternalRouter     bool                   `yaml:"internalRouter,omitempty"`
-	IngressAnnotations Annotations            `yaml:"ingressAnnotations,omitempty"`
-	Labels             Labels                 `yaml:"labels,omitempty"`
-	NodeAffinityLabels Affinities             `yaml:"nodeAffinityLabels,omitempty"`
-	NodeSelectorLabels Labels                 `yaml:"nodeSelectorLabels,omitempty"`
-	Lifecycle          ServiceLifecycle       `yaml:"lifecycle,omitempty"`
-	Port               ServicePortScheme      `yaml:"port,omitempty"`
-	Ports              []ServicePortProtocol  `yaml:"ports,omitempty"`
-	Privileged         bool                   `yaml:"privileged,omitempty"`
-	Resources          []string               `yaml:"resources,omitempty"`
-	SecurityContext    ServiceSecurityContext `yaml:"securityContext,omitempty"`
-	Scale              ServiceScale           `yaml:"scale,omitempty"`
-	Singleton          bool                   `yaml:"singleton,omitempty"`
-	Sticky             bool                   `yaml:"sticky,omitempty"`
-	Termination        ServiceTermination     `yaml:"termination,omitempty"`
-	Test               string                 `yaml:"test,omitempty"`
-	Timeout            int                    `yaml:"timeout,omitempty"`
-	Tls                ServiceTls             `yaml:"tls,omitempty"`
-	Volumes            []string               `yaml:"volumes,omitempty"`
-	VolumeOptions      []VolumeOption         `yaml:"volumeOptions,omitempty"`
-	Whitelist          string                 `yaml:"whitelist,omitempty"`
-	AccessControl      AccessControlOptions   `yaml:"accessControl,omitempty"`
+	Agent              ServiceAgent             `yaml:"agent,omitempty"`
+	Annotations        Annotations              `yaml:"annotations,omitempty"`
+	Build              ServiceBuild             `yaml:"build,omitempty"`
+	Certificate        Certificate              `yaml:"certificate,omitempty"`
+	Command            string                   `yaml:"command,omitempty"`
+	ConfigMounts       ConfigMounts             `yaml:"configMounts,omitempty"`
+	Deployment         ServiceDeployment        `yaml:"deployment,omitempty"`
+	DnsConfig          ServiceDnsConfig         `yaml:"dnsConfig,omitempty"`
+	Domains            ServiceDomains           `yaml:"domain,omitempty"`
+	Drain              int                      `yaml:"drain,omitempty"`
+	DisableHostUsers   bool                     `yaml:"disableHostUsers,omitempty"`
+	Environment        Environment              `yaml:"environment,omitempty"`
+	GrpcHealthEnabled  bool                     `yaml:"grpcHealthEnabled,omitempty"`
+	Health             ServiceHealth            `yaml:"health,omitempty"`
+	Liveness           ServiceLiveness          `yaml:"liveness,omitempty"`
+	StartupProbe       ServiceStartupProbe      `yaml:"startupProbe,omitempty"`
+	Image              string                   `yaml:"image,omitempty"`
+	ImagePullSecrets   []ServiceImagePullSecret `yaml:"imagePullSecrets,omitempty" json:"imagePullSecrets,omitempty"`
+	Init               bool                     `yaml:"init,omitempty"`
+	InitContainer      *InitContainer           `yaml:"initContainer,omitempty"`
+	Internal           bool                     `yaml:"internal,omitempty"`
+	InternalRouter     bool                     `yaml:"internalRouter,omitempty"`
+	IngressAnnotations Annotations              `yaml:"ingressAnnotations,omitempty"`
+	Labels             Labels                   `yaml:"labels,omitempty"`
+	NodeAffinityLabels Affinities               `yaml:"nodeAffinityLabels,omitempty"`
+	NodeSelectorLabels Labels                   `yaml:"nodeSelectorLabels,omitempty"`
+	Lifecycle          ServiceLifecycle         `yaml:"lifecycle,omitempty"`
+	Port               ServicePortScheme        `yaml:"port,omitempty"`
+	Ports              []ServicePortProtocol    `yaml:"ports,omitempty"`
+	Privileged         bool                     `yaml:"privileged,omitempty"`
+	Resources          []string                 `yaml:"resources,omitempty"`
+	SecurityContext    ServiceSecurityContext   `yaml:"securityContext,omitempty"`
+	Scale              ServiceScale             `yaml:"scale,omitempty"`
+	Singleton          bool                     `yaml:"singleton,omitempty"`
+	Sticky             bool                     `yaml:"sticky,omitempty"`
+	Termination        ServiceTermination       `yaml:"termination,omitempty"`
+	Test               string                   `yaml:"test,omitempty"`
+	Timeout            int                      `yaml:"timeout,omitempty"`
+	Tls                ServiceTls               `yaml:"tls,omitempty"`
+	Volumes            []string                 `yaml:"volumes,omitempty"`
+	VolumeOptions      []VolumeOption           `yaml:"volumeOptions,omitempty"`
+	Whitelist          string                   `yaml:"whitelist,omitempty"`
+	AccessControl      AccessControlOptions     `yaml:"accessControl,omitempty"`
+}
+
+// ServiceImagePullSecret declares a private-registry credential for pulling a
+// service's container image. Password is the literal credential (quick-test
+// path). PasswordEnv references an app env var holding the credential and is
+// the recommended form. Exactly one must be set.
+//
+// Password is intentionally excluded from JSON marshaling (`json:"-"`) so that
+// it cannot leak through any API boundary that encodes Service as JSON. The
+// yaml tag keeps Password parseable so users can write `password: literal`
+// in convox.yml, but a custom MarshalYAML method strips it on the way back
+// out — any code path that yaml.Marshals a Service (tests, future tooling,
+// debug dumps) will NOT emit the literal credential.
+type ServiceImagePullSecret struct {
+	Registry    string `yaml:"registry" json:"registry"`
+	Username    string `yaml:"username" json:"username"`
+	Password    string `yaml:"password,omitempty" json:"-"`
+	PasswordEnv string `yaml:"passwordEnv,omitempty" json:"passwordEnv,omitempty"`
+}
+
+// MarshalYAML strips the literal Password from any yaml.Marshal output.
+// Parsing (default UnmarshalYAML) is unaffected — the yaml tag still binds
+// the field for reads. This is purely an egress guard.
+func (s ServiceImagePullSecret) MarshalYAML() (interface{}, error) {
+	return struct {
+		Registry    string `yaml:"registry"`
+		Username    string `yaml:"username"`
+		PasswordEnv string `yaml:"passwordEnv,omitempty"`
+	}{
+		Registry:    s.Registry,
+		Username:    s.Username,
+		PasswordEnv: s.PasswordEnv,
+	}, nil
 }
 
 type Affinities []Affinity
@@ -850,6 +884,49 @@ func (ss Services) Routable() Services {
 
 type AccessControlOptions struct {
 	AWSPodIdentity *AWSPodIdentityOptions `yaml:"awsPodIdentity,omitempty"`
+}
+
+// registryHostValidator matches a lowercase DNS hostname with optional port.
+// Rejects uppercase letters, schemes, and paths.
+var registryHostValidator = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*(:[0-9]+)?$`)
+
+func (s ServiceImagePullSecret) Validate() error {
+	if strings.TrimSpace(s.Registry) == "" {
+		return fmt.Errorf("registry is required")
+	}
+
+	if strings.Contains(s.Registry, "://") {
+		return fmt.Errorf("registry %q must not include a scheme (drop http:// or https://)", s.Registry)
+	}
+
+	if strings.Contains(s.Registry, "/") {
+		return fmt.Errorf("registry %q must not include a path (use the host only)", s.Registry)
+	}
+
+	if s.Registry != strings.ToLower(s.Registry) {
+		return fmt.Errorf("registry %q must be lowercase", s.Registry)
+	}
+
+	if !registryHostValidator.MatchString(s.Registry) {
+		return fmt.Errorf("registry %q is not a valid registry hostname", s.Registry)
+	}
+
+	if strings.TrimSpace(s.Username) == "" {
+		return fmt.Errorf("username is required")
+	}
+
+	hasPassword := s.Password != ""
+	hasPasswordEnv := s.PasswordEnv != ""
+
+	if hasPassword && hasPasswordEnv {
+		return fmt.Errorf("use passwordEnv to reference an env var, OR password for a literal value, not both")
+	}
+
+	if !hasPassword && !hasPasswordEnv {
+		return fmt.Errorf("password or passwordEnv is required")
+	}
+
+	return nil
 }
 
 type AWSPodIdentityOptions struct {

--- a/pkg/manifest/service_test.go
+++ b/pkg/manifest/service_test.go
@@ -1,0 +1,364 @@
+package manifest_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/convox/convox/pkg/manifest"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestServiceImagePullSecretValidate(t *testing.T) {
+	cases := []struct {
+		name    string
+		sec     manifest.ServiceImagePullSecret
+		wantErr string
+	}{
+		{
+			name:    "ok passwordEnv",
+			sec:     manifest.ServiceImagePullSecret{Registry: "nvcr.io", Username: "$oauthtoken", PasswordEnv: "NGC_API_KEY"},
+			wantErr: "",
+		},
+		{
+			name:    "ok literal password",
+			sec:     manifest.ServiceImagePullSecret{Registry: "quay.io", Username: "robot", Password: "s3cret"},
+			wantErr: "",
+		},
+		{
+			name:    "ok registry with port",
+			sec:     manifest.ServiceImagePullSecret{Registry: "harbor.corp:5000", Username: "u", Password: "p"},
+			wantErr: "",
+		},
+		{
+			name:    "both password and passwordEnv",
+			sec:     manifest.ServiceImagePullSecret{Registry: "nvcr.io", Username: "u", Password: "p", PasswordEnv: "E"},
+			wantErr: "use passwordEnv to reference an env var, OR password for a literal value, not both",
+		},
+		{
+			name:    "neither password nor passwordEnv",
+			sec:     manifest.ServiceImagePullSecret{Registry: "nvcr.io", Username: "u"},
+			wantErr: "password or passwordEnv is required",
+		},
+		{
+			name:    "uppercase registry rejected",
+			sec:     manifest.ServiceImagePullSecret{Registry: "NVCR.IO", Username: "u", Password: "p"},
+			wantErr: "must be lowercase",
+		},
+		{
+			name:    "http scheme rejected",
+			sec:     manifest.ServiceImagePullSecret{Registry: "http://nvcr.io", Username: "u", Password: "p"},
+			wantErr: "must not include a scheme",
+		},
+		{
+			name:    "https scheme rejected",
+			sec:     manifest.ServiceImagePullSecret{Registry: "https://nvcr.io", Username: "u", Password: "p"},
+			wantErr: "must not include a scheme",
+		},
+		{
+			name:    "path rejected",
+			sec:     manifest.ServiceImagePullSecret{Registry: "nvcr.io/nim", Username: "u", Password: "p"},
+			wantErr: "must not include a path",
+		},
+		{
+			name:    "invalid dns label",
+			sec:     manifest.ServiceImagePullSecret{Registry: "bad..registry", Username: "u", Password: "p"},
+			wantErr: "is not a valid registry hostname",
+		},
+		{
+			name:    "empty username",
+			sec:     manifest.ServiceImagePullSecret{Registry: "nvcr.io", Password: "p"},
+			wantErr: "username is required",
+		},
+		{
+			name:    "empty registry",
+			sec:     manifest.ServiceImagePullSecret{Username: "u", Password: "p"},
+			wantErr: "registry is required",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.sec.Validate()
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestServiceImagePullSecretsDuplicateRegistryRejected(t *testing.T) {
+	// Two imagePullSecrets for the SAME registry on the SAME service would
+	// produce identical Secret names and the second silently overwrites the
+	// first during kubectl apply. Validation must reject the ambiguity at
+	// convox.yml parse time.
+	y := []byte(`services:
+  nim:
+    image: nvcr.io/foo:latest
+    imagePullSecrets:
+      - registry: nvcr.io
+        username: a
+        password: p1
+      - registry: nvcr.io
+        username: b
+        password: p2
+`)
+	m, err := manifest.Load(y, map[string]string{})
+	require.NoError(t, err)
+	err = m.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate")
+	require.Contains(t, err.Error(), "nvcr.io")
+}
+
+func TestServiceImagePullSecretsYAMLRoundTripNonSecretFields(t *testing.T) {
+	// Round-tripping a Service through yaml.Marshal → yaml.Unmarshal MUST
+	// preserve registry/username/passwordEnv. Password is an egress-guard
+	// exception — see TestServiceImagePullSecretPasswordDroppedOnYAMLMarshal.
+	in := manifest.Service{
+		Name: "nim",
+		ImagePullSecrets: []manifest.ServiceImagePullSecret{
+			{
+				Registry:    "nvcr.io",
+				Username:    "$oauthtoken",
+				PasswordEnv: "NGC_API_KEY",
+			},
+			{
+				Registry: "quay.io",
+				Username: "robot",
+			},
+		},
+	}
+
+	data, err := yaml.Marshal(&in)
+	require.NoError(t, err)
+
+	var out manifest.Service
+	require.NoError(t, yaml.Unmarshal(data, &out))
+
+	require.Len(t, out.ImagePullSecrets, 2)
+	require.Equal(t, "nvcr.io", out.ImagePullSecrets[0].Registry)
+	require.Equal(t, "$oauthtoken", out.ImagePullSecrets[0].Username)
+	require.Equal(t, "NGC_API_KEY", out.ImagePullSecrets[0].PasswordEnv)
+	require.Equal(t, "quay.io", out.ImagePullSecrets[1].Registry)
+	require.Equal(t, "robot", out.ImagePullSecrets[1].Username)
+}
+
+// TestServiceImagePullSecretPasswordDroppedOnYAMLMarshal locks in the
+// defensive egress guard: a Service containing a literal Password MUST NOT
+// re-serialize that password when yaml.Marshal is called on the struct.
+// The user's raw convox.yml bytes are preserved separately as Release.Manifest;
+// this test protects any in-process code path that chooses to marshal the
+// parsed struct (tests, debug prints, future tooling) from leaking creds.
+func TestServiceImagePullSecretPasswordDroppedOnYAMLMarshal(t *testing.T) {
+	const sentinel = "SENTINEL_LEAK_VIA_YAML_MARSHAL"
+
+	in := manifest.Service{
+		Name: "nim",
+		ImagePullSecrets: []manifest.ServiceImagePullSecret{
+			{Registry: "nvcr.io", Username: "u", Password: sentinel},
+		},
+	}
+
+	data, err := yaml.Marshal(&in)
+	require.NoError(t, err)
+
+	require.NotContains(t, string(data), sentinel, "yaml.Marshal of Service leaked literal password:\n%s", string(data))
+	require.NotContains(t, string(data), "password:", "yaml.Marshal of Service emitted password key:\n%s", string(data))
+}
+
+// TestServiceImagePullSecretLiteralPasswordParsesFromYAML confirms that the
+// defensive MarshalYAML does not break the parse path — users writing
+// `password: literal` in convox.yml still populate the field correctly.
+func TestServiceImagePullSecretLiteralPasswordParsesFromYAML(t *testing.T) {
+	y := []byte(`services:
+  nim:
+    image: nvcr.io/foo:latest
+    imagePullSecrets:
+      - registry: nvcr.io
+        username: u
+        password: parsed-literal
+`)
+	m, err := manifest.Load(y, map[string]string{})
+	require.NoError(t, err)
+	require.NoError(t, m.Validate())
+
+	svc, err := m.Service("nim")
+	require.NoError(t, err)
+	require.Len(t, svc.ImagePullSecrets, 1)
+	require.Equal(t, "parsed-literal", svc.ImagePullSecrets[0].Password)
+}
+
+func TestServiceImagePullSecretsOmitempty(t *testing.T) {
+	s := manifest.Service{Name: "web"}
+
+	data, err := yaml.Marshal(&s)
+	require.NoError(t, err)
+
+	if strings.Contains(string(data), "imagePullSecrets") {
+		t.Errorf("empty ImagePullSecrets should be omitted, got:\n%s", string(data))
+	}
+}
+
+func TestServiceImagePullSecretPasswordNotInJSON(t *testing.T) {
+	const sentinel = "SENTINEL_LEAK_DO_NOT_LOG"
+
+	sec := manifest.ServiceImagePullSecret{
+		Registry: "nvcr.io",
+		Username: "u",
+		Password: sentinel,
+	}
+
+	data, err := json.Marshal(&sec)
+	require.NoError(t, err)
+
+	if strings.Contains(string(data), sentinel) {
+		t.Errorf("sentinel password leaked through json.Marshal:\n%s", string(data))
+	}
+	if strings.Contains(string(data), "password") {
+		t.Errorf("password field leaked through json.Marshal:\n%s", string(data))
+	}
+}
+
+// TestServicePasswordNotInJSONViaNestedMarshal exercises the realistic leak
+// surface: json-encoding a manifest.Service value whose ImagePullSecrets
+// slice contains a sentinel password. The `json:"-"` tag on the nested
+// Password field must survive nested marshaling.
+func TestServicePasswordNotInJSONViaNestedMarshal(t *testing.T) {
+	const sentinel = "SENTINEL_LEAK_VIA_NESTED_SERVICE"
+
+	s := manifest.Service{
+		Name: "nim",
+		ImagePullSecrets: []manifest.ServiceImagePullSecret{
+			{Registry: "nvcr.io", Username: "u", Password: sentinel},
+			{Registry: "quay.io", Username: "b", Password: sentinel + "_2"},
+		},
+	}
+
+	data, err := json.Marshal(&s)
+	require.NoError(t, err)
+
+	if strings.Contains(string(data), sentinel) {
+		t.Errorf("sentinel password leaked through nested json.Marshal of Service:\n%s", string(data))
+	}
+	if strings.Contains(string(data), "password") {
+		t.Errorf("password key leaked through nested json.Marshal of Service:\n%s", string(data))
+	}
+}
+
+// TestManifestLoadImagePullSecrets exercises the real customer flow:
+// convox.yml BYTES → Manifest.Load() → field populated + Validate passes.
+func TestManifestLoadImagePullSecrets(t *testing.T) {
+	y := []byte(`services:
+  nim:
+    image: nvcr.io/foo:latest
+    imagePullSecrets:
+      - registry: nvcr.io
+        username: $oauthtoken
+        passwordEnv: NGC_API_KEY
+      - registry: quay.io
+        username: robot
+        password: literal
+`)
+	m, err := manifest.Load(y, map[string]string{})
+	require.NoError(t, err)
+	require.NoError(t, m.Validate())
+
+	svc, err := m.Service("nim")
+	require.NoError(t, err)
+	require.Len(t, svc.ImagePullSecrets, 2)
+	require.Equal(t, "nvcr.io", svc.ImagePullSecrets[0].Registry)
+	require.Equal(t, "$oauthtoken", svc.ImagePullSecrets[0].Username)
+	require.Equal(t, "NGC_API_KEY", svc.ImagePullSecrets[0].PasswordEnv)
+	require.Equal(t, "", svc.ImagePullSecrets[0].Password)
+	require.Equal(t, "quay.io", svc.ImagePullSecrets[1].Registry)
+	require.Equal(t, "literal", svc.ImagePullSecrets[1].Password)
+}
+
+// TestManifestValidateImagePullSecretsHookSurfacesErrors confirms the
+// validation hook in validateServices propagates per-entry errors with the
+// service name and index prefix so users can find the offending entry.
+func TestManifestValidateImagePullSecretsHookSurfacesErrors(t *testing.T) {
+	y := []byte(`services:
+  web:
+    image: public/image:latest
+  nim:
+    image: nvcr.io/foo:latest
+    imagePullSecrets:
+      - registry: NVCR.IO
+        username: u
+        password: p
+`)
+	m, err := manifest.Load(y, map[string]string{})
+	require.NoError(t, err)
+	err = m.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "service nim imagePullSecrets[0]")
+	require.Contains(t, err.Error(), "must be lowercase")
+}
+
+// TestManifestValidateImagePullSecretsMultipleServicesIsolated confirms that
+// validation state (seen-registries, error accumulator) does not leak
+// between services — each service's duplicate-registry set is independent.
+func TestManifestValidateImagePullSecretsMultipleServicesIsolated(t *testing.T) {
+	// Both services declare nvcr.io. Neither should trigger a duplicate
+	// error because the duplicate check is PER service, not across services.
+	y := []byte(`services:
+  a:
+    image: nvcr.io/foo:latest
+    imagePullSecrets:
+      - registry: nvcr.io
+        username: u
+        password: p
+  b:
+    image: nvcr.io/bar:latest
+    imagePullSecrets:
+      - registry: nvcr.io
+        username: u
+        password: p
+`)
+	m, err := manifest.Load(y, map[string]string{})
+	require.NoError(t, err)
+	require.NoError(t, m.Validate())
+}
+
+// TestServiceImagePullSecretRegistryEdgeCases locks in rejections for
+// hostname-shaped-but-invalid values that the regex must catch.
+func TestServiceImagePullSecretRegistryEdgeCases(t *testing.T) {
+	bad := []string{
+		"-example.com", // leading dash
+		"example-.com", // trailing dash on label
+		".example.com", // leading dot
+		"example.com.", // trailing dot
+		"foo_bar.io",   // underscore
+		"a..b.io",      // consecutive dots
+		"example com",  // space
+	}
+	for _, r := range bad {
+		t.Run(r, func(t *testing.T) {
+			sec := manifest.ServiceImagePullSecret{Registry: r, Username: "u", Password: "p"}
+			require.Error(t, sec.Validate(), "expected %q to fail validation", r)
+		})
+	}
+
+	good := []string{
+		"nvcr.io",
+		"quay.io",
+		"ghcr.io",
+		"gcr.io",
+		"registry.example.com",
+		"harbor.corp:5000",
+		"127.0.0.1:5000",
+		"localhost:5000",
+	}
+	for _, r := range good {
+		t.Run(r, func(t *testing.T) {
+			sec := manifest.ServiceImagePullSecret{Registry: r, Username: "u", Password: "p"}
+			require.NoError(t, sec.Validate(), "expected %q to pass validation", r)
+		})
+	}
+}

--- a/pkg/manifest/validate.go
+++ b/pkg/manifest/validate.go
@@ -148,6 +148,20 @@ func (m *Manifest) validateServices() []error {
 			errs = append(errs, fmt.Errorf("service %s: %s", s.Name, err))
 		}
 
+		seenRegistries := map[string]int{}
+		for i := range s.ImagePullSecrets {
+			if err := s.ImagePullSecrets[i].Validate(); err != nil {
+				errs = append(errs, fmt.Errorf("service %s imagePullSecrets[%d]: %s", s.Name, i, err))
+				continue
+			}
+			reg := strings.ToLower(s.ImagePullSecrets[i].Registry)
+			if prev, has := seenRegistries[reg]; has {
+				errs = append(errs, fmt.Errorf("service %s imagePullSecrets[%d]: duplicate registry %q (also declared at index %d); each registry may be declared at most once per service", s.Name, i, s.ImagePullSecrets[i].Registry, prev))
+				continue
+			}
+			seenRegistries[reg] = i
+		}
+
 		for i := range s.ConfigMounts {
 			cm := &s.ConfigMounts[i]
 			if err := cm.Validate(); err != nil {

--- a/provider/k8s/image_pull_secrets.go
+++ b/provider/k8s/image_pull_secrets.go
@@ -1,0 +1,137 @@
+package k8s
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/convox/convox/pkg/manifest"
+	"github.com/pkg/errors"
+	ac "k8s.io/api/core/v1"
+	am "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const maxSecretNameLen = 253
+
+var registrySlugReplacer = strings.NewReplacer(".", "-", ":", "-", "/", "-")
+
+// renderImagePullSecrets emits a Kubernetes Secret of kind
+// kubernetes.io/dockerconfigjson for each entry in service.ImagePullSecrets.
+// It returns the serialized YAML blocks (appended to the atom apply manifest
+// so prune-on-remove works automatically via atom=<hash> labelling) and the
+// generated Secret names (added to the Pod spec's imagePullSecrets list
+// alongside docker-hub-authentication).
+//
+// Passwords sourced from passwordEnv are resolved via envResolver, which must
+// expose the already-merged service-scoped environment. A missing env var
+// returns a clear error naming the variable and the service.
+func renderImagePullSecrets(app, namespace string, service *manifest.Service, envResolver func(string) (string, bool)) ([][]byte, []string, error) {
+	if service == nil || len(service.ImagePullSecrets) == 0 {
+		return nil, nil, nil
+	}
+
+	blocks := make([][]byte, 0, len(service.ImagePullSecrets))
+	names := make([]string, 0, len(service.ImagePullSecrets))
+
+	for i, sec := range service.ImagePullSecrets {
+		password := sec.Password
+		if sec.PasswordEnv != "" {
+			v, ok := envResolver(sec.PasswordEnv)
+			if !ok || v == "" {
+				return nil, nil, fmt.Errorf("service %s imagePullSecrets[%d]: env var %s is not set; run 'convox env set %s=<value> -a %s' and retry the promote", service.Name, i, sec.PasswordEnv, sec.PasswordEnv, app)
+			}
+			password = v
+		}
+
+		payload, err := buildDockerConfigJSON(sec.Registry, sec.Username, password)
+		if err != nil {
+			return nil, nil, errors.WithStack(err)
+		}
+
+		name := imagePullSecretName(app, service.Name, sec.Registry)
+
+		secretObj := &ac.Secret{
+			TypeMeta: am.TypeMeta{
+				Kind:       "Secret",
+				APIVersion: "v1",
+			},
+			ObjectMeta: am.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels: map[string]string{
+					"system":  "convox",
+					"app":     app,
+					"service": service.Name,
+					"type":    "image-pull",
+				},
+			},
+			Type: ac.SecretTypeDockerConfigJson,
+			Data: map[string][]byte{
+				ac.DockerConfigJsonKey: payload,
+			},
+		}
+
+		y, err := SerializeK8sObjToYaml(secretObj)
+		if err != nil {
+			return nil, nil, errors.WithStack(err)
+		}
+
+		blocks = append(blocks, y)
+		names = append(names, name)
+	}
+
+	return blocks, names, nil
+}
+
+// imagePullSecretName generates a deterministic K8s Secret name of the form
+// `convox-<app>-<service>-pull-<registry-slug>`, where <registry-slug> is the
+// registry host with `.`, `:`, and `/` replaced by `-`. Enforces the K8s
+// 253-char name limit with a sha256 suffix if the full name overflows.
+func imagePullSecretName(app, service, registry string) string {
+	slug := registrySlug(registry)
+	full := fmt.Sprintf("convox-%s-%s-pull-%s", app, service, slug)
+	if len(full) <= maxSecretNameLen {
+		return full
+	}
+	h := sha256.Sum256([]byte(full))
+	suffix := fmt.Sprintf("-%x", h[:4])
+	truncated := strings.TrimRight(full[:maxSecretNameLen-len(suffix)], "-")
+	return truncated + suffix
+}
+
+func registrySlug(registry string) string {
+	return strings.ToLower(registrySlugReplacer.Replace(registry))
+}
+
+// imagePullSecretNames returns just the Secret names that
+// renderImagePullSecrets would have produced. Used by code paths that need
+// the Pod-spec references (timer render, convox run) but where the Secrets
+// themselves were already emitted by releaseTemplateServices.
+func imagePullSecretNames(app, service string, secrets []manifest.ServiceImagePullSecret) []string {
+	if len(secrets) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(secrets))
+	for _, sec := range secrets {
+		names = append(names, imagePullSecretName(app, service, sec.Registry))
+	}
+	return names
+}
+
+// buildDockerConfigJSON produces the bytes of a .dockerconfigjson payload for
+// a single registry. json.Marshal escapes the credential strings correctly
+// (passwords containing `"`, `\\`, etc. round-trip safely, unlike the
+// fmt.Sprintf form used by ensureDockerHubSecret for the rack-wide auth).
+func buildDockerConfigJSON(registry, username, password string) ([]byte, error) {
+	auth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
+	cfg := map[string]interface{}{
+		"auths": map[string]interface{}{
+			registry: map[string]string{
+				"auth": auth,
+			},
+		},
+	}
+	return json.Marshal(cfg)
+}

--- a/provider/k8s/image_pull_secrets_test.go
+++ b/provider/k8s/image_pull_secrets_test.go
@@ -1,0 +1,257 @@
+package k8s
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/convox/convox/pkg/manifest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImagePullSecretName(t *testing.T) {
+	t.Run("short registry", func(t *testing.T) {
+		n := imagePullSecretName("myai", "nim", "nvcr.io")
+		require.Equal(t, "convox-myai-nim-pull-nvcr-io", n)
+	})
+
+	t.Run("registry with port", func(t *testing.T) {
+		n := imagePullSecretName("myai", "nim", "harbor.corp:5000")
+		require.Equal(t, "convox-myai-nim-pull-harbor-corp-5000", n)
+	})
+
+	t.Run("stays under 253 chars", func(t *testing.T) {
+		n := imagePullSecretName(
+			strings.Repeat("a", 100),
+			strings.Repeat("b", 100),
+			"very-long.registry.example.com",
+		)
+		require.LessOrEqual(t, len(n), 253)
+	})
+
+	t.Run("truncated name never ends in dash before suffix", func(t *testing.T) {
+		// Engineer a truncation that lands on a dash: app+service+slug get
+		// chopped mid-token at a position where the last kept char is a `-`.
+		// Before the trim fix, output was `...a--<hash>` (double dash), which
+		// though DNS-1123-valid is anomalous and can confuse operator tooling.
+		svc := strings.Repeat("s", 100)
+		registry := strings.Repeat("a.", 70) + "b"
+		n := imagePullSecretName("myai", svc, registry)
+		require.LessOrEqual(t, len(n), 253)
+		require.NotContains(t, n, "--", "truncated name contains consecutive dashes: %s", n)
+	})
+}
+
+func TestBuildDockerConfigJSON(t *testing.T) {
+	payload, err := buildDockerConfigJSON("nvcr.io", "$oauthtoken", "s3cret")
+	require.NoError(t, err)
+
+	var parsed struct {
+		Auths map[string]struct {
+			Auth string `json:"auth"`
+		} `json:"auths"`
+	}
+	require.NoError(t, json.Unmarshal(payload, &parsed))
+
+	entry, ok := parsed.Auths["nvcr.io"]
+	require.True(t, ok, "nvcr.io entry missing from auths")
+	decoded, err := base64.StdEncoding.DecodeString(entry.Auth)
+	require.NoError(t, err)
+	require.Equal(t, "$oauthtoken:s3cret", string(decoded))
+}
+
+func TestBuildDockerConfigJSONHandlesSpecialChars(t *testing.T) {
+	// Password with quote, backslash, newline — json.Marshal must escape, not break.
+	payload, err := buildDockerConfigJSON("r.io", `u"ser`, "p\\n\"pass")
+	require.NoError(t, err)
+	require.True(t, json.Valid(payload), "payload must be valid JSON")
+}
+
+func envMap(m map[string]string) func(string) (string, bool) {
+	return func(k string) (string, bool) {
+		v, ok := m[k]
+		return v, ok
+	}
+}
+
+func TestRenderImagePullSecretsEmpty(t *testing.T) {
+	svc := &manifest.Service{Name: "nim"}
+
+	blocks, names, err := renderImagePullSecrets("myai", "rack1-myai", svc, envMap(nil))
+	require.NoError(t, err)
+	require.Nil(t, blocks)
+	require.Nil(t, names)
+}
+
+func TestRenderImagePullSecretsLiteralPassword(t *testing.T) {
+	svc := &manifest.Service{
+		Name: "nim",
+		ImagePullSecrets: []manifest.ServiceImagePullSecret{
+			{Registry: "nvcr.io", Username: "$oauthtoken", Password: "nvapi-literal"},
+		},
+	}
+
+	blocks, names, err := renderImagePullSecrets("myai", "rack1-myai", svc, envMap(nil))
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+	require.Equal(t, []string{"convox-myai-nim-pull-nvcr-io"}, names)
+
+	y := string(blocks[0])
+	require.Contains(t, y, "kind: Secret")
+	require.Contains(t, y, "type: kubernetes.io/dockerconfigjson")
+	require.Contains(t, y, "name: convox-myai-nim-pull-nvcr-io")
+	require.Contains(t, y, "namespace: rack1-myai")
+}
+
+func TestRenderImagePullSecretsPasswordEnv(t *testing.T) {
+	svc := &manifest.Service{
+		Name: "nim",
+		ImagePullSecrets: []manifest.ServiceImagePullSecret{
+			{Registry: "nvcr.io", Username: "$oauthtoken", PasswordEnv: "NGC_API_KEY"},
+		},
+	}
+
+	env := envMap(map[string]string{"NGC_API_KEY": "nvapi-envsourced"})
+
+	blocks, names, err := renderImagePullSecrets("myai", "rack1-myai", svc, env)
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+	require.Len(t, names, 1)
+
+	// YAML data values are base64-encoded. The dockerconfigjson payload ITSELF
+	// contains a base64-encoded user:pass auth field. Decode both layers and
+	// verify the resolved env value reaches the innermost user:pass tuple.
+	y := string(blocks[0])
+	idx := strings.Index(y, ".dockerconfigjson:")
+	require.Greater(t, idx, 0)
+	rest := strings.TrimSpace(y[idx+len(".dockerconfigjson:"):])
+	if nl := strings.Index(rest, "\n"); nl >= 0 {
+		rest = rest[:nl]
+	}
+	outer, err := base64.StdEncoding.DecodeString(strings.TrimSpace(rest))
+	require.NoError(t, err)
+
+	var cfg struct {
+		Auths map[string]struct {
+			Auth string `json:"auth"`
+		} `json:"auths"`
+	}
+	require.NoError(t, json.Unmarshal(outer, &cfg))
+
+	entry, ok := cfg.Auths["nvcr.io"]
+	require.True(t, ok)
+	userpass, err := base64.StdEncoding.DecodeString(entry.Auth)
+	require.NoError(t, err)
+	require.Equal(t, "$oauthtoken:nvapi-envsourced", string(userpass))
+}
+
+func TestRenderImagePullSecretsMissingEnvErrors(t *testing.T) {
+	svc := &manifest.Service{
+		Name: "nim",
+		ImagePullSecrets: []manifest.ServiceImagePullSecret{
+			{Registry: "nvcr.io", Username: "$oauthtoken", PasswordEnv: "NGC_API_KEY"},
+		},
+	}
+
+	_, _, err := renderImagePullSecrets("myai", "rack1-myai", svc, envMap(nil))
+	require.Error(t, err)
+	msg := err.Error()
+	require.Contains(t, msg, "NGC_API_KEY", "error must name the env var")
+	require.Contains(t, msg, "nim", "error must name the service")
+	require.Contains(t, msg, "imagePullSecrets[0]", "error must name the index")
+	require.Contains(t, msg, "convox env set", "error must hint at the fix")
+	require.Contains(t, msg, "-a myai", "error must bake the actual app name, not a <app> placeholder")
+	require.NotContains(t, msg, "<app>", "error must substitute the app parameter, not leave a literal placeholder")
+}
+
+func TestRenderImagePullSecretsEmptyEnvStringErrors(t *testing.T) {
+	svc := &manifest.Service{
+		Name: "nim",
+		ImagePullSecrets: []manifest.ServiceImagePullSecret{
+			{Registry: "nvcr.io", Username: "$oauthtoken", PasswordEnv: "NGC_API_KEY"},
+		},
+	}
+
+	env := envMap(map[string]string{"NGC_API_KEY": ""})
+	_, _, err := renderImagePullSecrets("myai", "rack1-myai", svc, env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "NGC_API_KEY")
+}
+
+func TestRenderImagePullSecretsMultipleRegistries(t *testing.T) {
+	svc := &manifest.Service{
+		Name: "nim",
+		ImagePullSecrets: []manifest.ServiceImagePullSecret{
+			{Registry: "nvcr.io", Username: "$oauthtoken", PasswordEnv: "NGC_API_KEY"},
+			{Registry: "quay.io", Username: "robot", Password: "lit"},
+		},
+	}
+
+	env := envMap(map[string]string{"NGC_API_KEY": "nvapi-aaa"})
+
+	blocks, names, err := renderImagePullSecrets("myai", "rack1-myai", svc, env)
+	require.NoError(t, err)
+	require.Len(t, blocks, 2)
+	require.Equal(t, []string{
+		"convox-myai-nim-pull-nvcr-io",
+		"convox-myai-nim-pull-quay-io",
+	}, names)
+
+	// Locked ordering: blocks[i] YAML must carry the Secret name listed at
+	// names[i]. A regression that shuffled blocks vs names would still pass
+	// a Len-only check but produce a Pod referencing Secrets that don't
+	// exist in the cluster.
+	require.Contains(t, string(blocks[0]), "name: "+names[0])
+	require.NotContains(t, string(blocks[0]), "name: "+names[1])
+	require.Contains(t, string(blocks[1]), "name: "+names[1])
+	require.NotContains(t, string(blocks[1]), "name: "+names[0])
+}
+
+func TestImagePullSecretNamesMatchesRender(t *testing.T) {
+	// The run-Pod path and timer path use imagePullSecretNames() (names only),
+	// while releaseTemplateServices uses renderImagePullSecrets() (names + YAML).
+	// Both must agree on the generated names or the Pod will reference a
+	// Secret that doesn't exist.
+	svc := &manifest.Service{
+		Name: "nim",
+		ImagePullSecrets: []manifest.ServiceImagePullSecret{
+			{Registry: "nvcr.io", Username: "u", Password: "p"},
+			{Registry: "quay.io", Username: "u", Password: "p"},
+			{Registry: "harbor.corp:5000", Username: "u", Password: "p"},
+		},
+	}
+
+	_, renderNames, err := renderImagePullSecrets("myai", "rack1-myai", svc, envMap(nil))
+	require.NoError(t, err)
+
+	namesOnly := imagePullSecretNames("myai", "nim", svc.ImagePullSecrets)
+	require.Equal(t, renderNames, namesOnly)
+}
+
+func TestImagePullSecretNamesEmpty(t *testing.T) {
+	require.Nil(t, imagePullSecretNames("myai", "nim", nil))
+	require.Nil(t, imagePullSecretNames("myai", "nim", []manifest.ServiceImagePullSecret{}))
+}
+
+func TestRenderImagePullSecretsSentinelLeak(t *testing.T) {
+	const sentinel = "SENTINEL_LEAK_DO_NOT_LOG_12345"
+
+	svc := &manifest.Service{
+		Name: "nim",
+		ImagePullSecrets: []manifest.ServiceImagePullSecret{
+			{Registry: "nvcr.io", Username: "$oauthtoken", Password: sentinel},
+		},
+	}
+
+	blocks, _, err := renderImagePullSecrets("myai", "rack1-myai", svc, envMap(nil))
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+
+	// The sentinel password must never appear in plaintext — only inside the
+	// base64-encoded dockerconfigjson blob. Grep the raw YAML for the
+	// sentinel string; it must not be there.
+	if strings.Contains(string(blocks[0]), sentinel) {
+		t.Errorf("sentinel password leaked to YAML output:\n%s", string(blocks[0]))
+	}
+}

--- a/provider/k8s/process.go
+++ b/provider/k8s/process.go
@@ -803,6 +803,17 @@ func (p *Provider) podSpecFromRunOptions(app, service string, opts structs.Proce
 		s.ImagePullSecrets = append(s.ImagePullSecrets, ac.LocalObjectReference{Name: "docker-hub-authentication"})
 	}
 
+	// Per-service private-registry pull secrets declared in convox.yml.
+	// The Secrets themselves are created by the release promote flow; here we
+	// only reference them so convox run Pods can pull from those registries.
+	if m, _, merr := common.AppManifest(p, app); merr == nil {
+		if sm, serr := m.Service(service); serr == nil {
+			for _, name := range imagePullSecretNames(app, service, sm.ImagePullSecrets) {
+				s.ImagePullSecrets = append(s.ImagePullSecrets, ac.LocalObjectReference{Name: name})
+			}
+		}
+	}
+
 	if opts.Volumes != nil && opts.UseServiceVolume == nil {
 		var vs []string
 

--- a/provider/k8s/release.go
+++ b/provider/k8s/release.go
@@ -697,21 +697,31 @@ func (p *Provider) releaseTemplateServices(a *structs.App, e structs.Environment
 			return nil, structs.ErrBadRequest("keda is not enabled on the rack")
 		}
 
+		ipsBlocks, ipsNames, err := renderImagePullSecrets(a.Name, p.AppNamespace(a.Name), &s, func(k string) (string, bool) {
+			v, ok := env[k]
+			return v, ok
+		})
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		items = append(items, ipsBlocks...)
+
 		params := map[string]interface{}{
-			"Annotations":    s.AnnotationsMap(),
-			"App":            a,
-			"Environment":    env,
-			"MaxSurge":       max - 100,
-			"MaxUnavailable": 100 - min,
-			"Namespace":      p.AppNamespace(a.Name),
-			"Password":       p.Password,
-			"Rack":           p.Name,
-			"Release":        r,
-			"Replicas":       replicas,
-			"Resources":      s.ResourceMap(),
-			"Service":        s,
-			"KedaIsEnabled":  s.Scale.IsKedaEnabled(),
-			"DockerHubAuth":  p.hasDockerHubAuth(),
+			"Annotations":          s.AnnotationsMap(),
+			"App":                  a,
+			"Environment":          env,
+			"MaxSurge":             max - 100,
+			"MaxUnavailable":       100 - min,
+			"Namespace":            p.AppNamespace(a.Name),
+			"Password":             p.Password,
+			"Rack":                 p.Name,
+			"Release":              r,
+			"Replicas":             replicas,
+			"Resources":            s.ResourceMap(),
+			"Service":              s,
+			"KedaIsEnabled":        s.Scale.IsKedaEnabled(),
+			"DockerHubAuth":        p.hasDockerHubAuth(),
+			"ImagePullSecretNames": ipsNames,
 		}
 
 		if ip, err := p.Engine.ResolverHost(); err == nil {
@@ -797,15 +807,16 @@ func (p *Provider) releaseTemplateTimer(a *structs.App, e structs.Environment, r
 	}
 
 	params := map[string]interface{}{
-		"Annotations":   t.AnnotationsMap(),
-		"App":           a,
-		"Namespace":     p.AppNamespace(a.Name),
-		"Rack":          p.Name,
-		"Release":       r,
-		"Resources":     s.ResourceMap(),
-		"Service":       s,
-		"Timer":         t,
-		"DockerHubAuth": p.hasDockerHubAuth(),
+		"Annotations":          t.AnnotationsMap(),
+		"App":                  a,
+		"Namespace":            p.AppNamespace(a.Name),
+		"Rack":                 p.Name,
+		"Release":              r,
+		"Resources":            s.ResourceMap(),
+		"Service":              s,
+		"Timer":                t,
+		"DockerHubAuth":        p.hasDockerHubAuth(),
+		"ImagePullSecretNames": imagePullSecretNames(a.Name, s.Name, s.ImagePullSecrets),
 	}
 
 	if ip, err := p.Engine.ResolverHost(); err == nil {

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -161,9 +161,14 @@ spec:
         {{ end }}
         {{ end }}
       {{ end }}
-      {{ if .DockerHubAuth }}
+      {{ if or .DockerHubAuth .ImagePullSecretNames }}
       imagePullSecrets:
+      {{ if .DockerHubAuth }}
       - name: docker-hub-authentication
+      {{ end }}
+      {{ range .ImagePullSecretNames }}
+      - name: {{ . }}
+      {{ end }}
       {{ end }}
       serviceAccountName: {{.Service.Name}}
       shareProcessNamespace: {{.Service.Init}}

--- a/provider/k8s/template/app/timer.yml.tmpl
+++ b/provider/k8s/template/app/timer.yml.tmpl
@@ -127,9 +127,14 @@ spec:
             {{ end }}
             {{ end }}
           {{ end }}
-          {{ if .DockerHubAuth }}
+          {{ if or .DockerHubAuth .ImagePullSecretNames }}
           imagePullSecrets:
+          {{ if .DockerHubAuth }}
           - name: docker-hub-authentication
+          {{ end }}
+          {{ range .ImagePullSecretNames }}
+          - name: {{ . }}
+          {{ end }}
           {{ end }}
           restartPolicy: Never
           shareProcessNamespace: {{.Service.Init}}


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: Private Registry Authentication via `imagePullSecrets` in convox.yml**

Services can now declare private registry credentials directly in `convox.yml` using a new `imagePullSecrets` field. This enables pulling container images from any authenticated OCI-compatible registry — including NVIDIA NGC, GitHub Container Registry, Quay.io, Harbor, JFrog Artifactory, and private Docker Hub repositories.

Each entry creates a per-service Kubernetes `dockerconfigjson` Secret that is automatically referenced by the service's Deployment, any associated timers (CronJobs), and one-off pods launched via `convox run`. Secrets are managed as part of the release lifecycle: they are created on deploy and automatically pruned when removed from `convox.yml`.

Two credential modes are supported:

| Mode | Field | Use Case |
|------|-------|----------|
| **Environment variable** (recommended) | `passwordEnv` | References an app env var — credential stays in `convox env`, not in the manifest |
| **Literal** | `password` | Inline credential for quick testing — stripped from API responses as a safety measure |

---

### Why is this important?

Deploying from private registries previously required manual Kubernetes Secret creation outside the Convox workflow. This was error-prone and didn't integrate with Convox's release lifecycle — secrets could drift, get orphaned, or be missing from `convox run` pods.

**Benefits:**

- **Declarative and version-controlled.** Registry credentials are declared alongside the service definition, so the entire deployment configuration lives in one place
- **Secure by default.** The `passwordEnv` pattern keeps credentials in `convox env` (encrypted at rest) rather than committed to source. The literal `password` field is excluded from JSON marshaling so it cannot leak through API responses
- **Full lifecycle coverage.** Secrets are applied to services, timers, and `convox run` pods automatically — no manual Secret management needed
- **Any OCI registry.** Works with any registry that supports Docker v2 authentication, including NGC (`nvcr.io`), ghcr.io, quay.io, Amazon ECR (cross-account), GCR, Harbor, and Artifactory

---

### How to use it?

Add `imagePullSecrets` to a service in `convox.yml`:

```yaml
services:
  inference:
    image: nvcr.io/nim/meta/llama3-8b-instruct:1.0.0
    port: 8000
    imagePullSecrets:
      - registry: nvcr.io
        username: $oauthtoken
        passwordEnv: NGC_API_KEY
```

Set the credential via `convox env`:

    $ convox env set NGC_API_KEY=nvapi-xxxxxxxxxxxx -a my-app -r rackName

Deploy or promote to apply:

    $ convox releases promote <release-id> -a my-app -r rackName

Multiple registries per service are supported:

```yaml
services:
  multi:
    image: quay.io/private/api:latest
    imagePullSecrets:
      - registry: quay.io
        username: robot-account
        passwordEnv: QUAY_TOKEN
      - registry: nvcr.io
        username: $oauthtoken
        passwordEnv: NGC_API_KEY
```

---

### Does it have a breaking change?

**No breaking changes** are introduced with this feature.

This is a purely additive change. Existing `convox.yml` files without `imagePullSecrets` render byte-identical Kubernetes manifests. The new field is optional with no defaults that change behavior.

On a rack downgrade to a version without this feature, the field is silently ignored during manifest parsing — the service falls back to the rack's default Docker Hub authentication. No Terraform variables, Helm releases, or CloudFormation parameters are introduced.

---

### Requirements

This feature requires version `3.24.6` or later for the rack.

**Update the Rack:** Run `convox rack update 3.24.6 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.23.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
