### PR TITLE
add scale.autoscale and cold-start ux

### DIFF
--- a/pkg/cli/scale.go
+++ b/pkg/cli/scale.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/convox/convox/pkg/common"
 	"github.com/convox/convox/pkg/structs"
@@ -15,17 +16,27 @@ func init() {
 		Flags: append(stdcli.OptionFlags(structs.ServiceUpdateOptions{}), flagApp, flagRack, flagWatchInterval),
 		Usage: "<service>",
 		Validate: func(c *stdcli.Context) error {
-			if c.Value("count") != nil || c.Value("cpu") != nil || c.Value("memory") != nil || c.Value("gpu") != nil || c.Value("gpu-vendor") != nil {
+			if scaleHasImperativeFlag(c) {
 				if len(c.Args) < 1 {
 					return fmt.Errorf("service name required")
-				} else {
-					return stdcli.Args(1)(c)
 				}
-			} else {
-				return stdcli.Args(0)(c)
+				return stdcli.Args(1)(c)
 			}
+			return stdcli.Args(0)(c)
 		},
 	}, WithCloud())
+}
+
+func scaleHasImperativeFlag(c *stdcli.Context) bool {
+	return c.Value("count") != nil || c.Value("cpu") != nil || c.Value("memory") != nil ||
+		c.Value("gpu") != nil || c.Value("gpu-vendor") != nil ||
+		c.Value("min") != nil || c.Value("max") != nil
+}
+
+func scaleOptsImperative(opts structs.ServiceUpdateOptions) bool {
+	return opts.Count != nil || opts.Cpu != nil || opts.Memory != nil ||
+		opts.Gpu != nil || opts.GpuVendor != nil ||
+		opts.Min != nil || opts.Max != nil
 }
 
 func Scale(rack sdk.Interface, c *stdcli.Context) error {
@@ -35,8 +46,27 @@ func Scale(rack sdk.Interface, c *stdcli.Context) error {
 		return err
 	}
 
-	if opts.Count != nil || opts.Cpu != nil || opts.Memory != nil || opts.Gpu != nil || opts.GpuVendor != nil {
+	if scaleOptsImperative(opts) {
+		if opts.Count != nil && (opts.Min != nil || opts.Max != nil) {
+			return fmt.Errorf("--min/--max and --count are mutually exclusive")
+		}
+		if opts.Min != nil && *opts.Min < 0 {
+			return fmt.Errorf("--min must be >= 0")
+		}
+		if opts.Max != nil && *opts.Max < 1 {
+			return fmt.Errorf("--max must be >= 1")
+		}
+		if opts.Min != nil && opts.Max != nil && *opts.Max < *opts.Min {
+			return fmt.Errorf("--max must be >= --min")
+		}
+
 		service := c.Arg(0)
+
+		if opts.Min != nil && *opts.Min == 0 {
+			if err := scalePreflightDeadPods(rack, c, service); err != nil {
+				return err
+			}
+		}
 
 		c.Startf("Scaling <service>%s</service>", service)
 
@@ -72,16 +102,94 @@ func Scale(rack sdk.Interface, c *stdcli.Context) error {
 			running[p.Name] += 1
 		}
 
-		t := c.Table("SERVICE", "DESIRED", "RUNNING", "CPU", "MEMORY", "GPU")
+		showAutoscale := false
+		for i := range ss {
+			if ss[i].Autoscale != nil && ss[i].Autoscale.Enabled {
+				showAutoscale = true
+				break
+			}
+		}
 
-		for _, s := range ss {
+		headers := []string{"SERVICE", "MIN", "MAX", "CURRENT", "CPU", "MEMORY", "GPU"}
+		if showAutoscale {
+			headers = append(headers, "AUTOSCALE")
+		}
+		headers = append(headers, "STATUS")
+		t := c.Table(headers...)
+
+		for i := range ss {
+			s := &ss[i]
 			gpu := "-"
 			if s.Gpu > 0 {
 				gpu = fmt.Sprintf("%d", s.Gpu)
 			}
-			t.AddRow(s.Name, fmt.Sprintf("%d", s.Count), fmt.Sprintf("%d", running[s.Name]), fmt.Sprintf("%d", s.Cpu), fmt.Sprintf("%d", s.Memory), gpu)
+
+			row := []string{s.Name, intPtrCell(s.Min), intPtrCell(s.Max), fmt.Sprintf("%d", s.Count), fmt.Sprintf("%d", s.Cpu), fmt.Sprintf("%d", s.Memory), gpu}
+			if showAutoscale {
+				row = append(row, formatAutoscaleSummary(s.Autoscale))
+			}
+			status := ""
+			if s.ColdStart != nil && *s.ColdStart {
+				status = "COLD (~2-5m first req)"
+			}
+			row = append(row, status)
+
+			t.AddRow(row...)
 		}
 
 		return t.Print()
 	})(rack, c)
+}
+
+func intPtrCell(p *int) string {
+	if p == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%d", *p)
+}
+
+func formatAutoscaleSummary(a *structs.ServiceAutoscaleState) string {
+	if a == nil || !a.Enabled {
+		return "-"
+	}
+	parts := []string{}
+	if a.CpuThreshold != nil {
+		parts = append(parts, fmt.Sprintf("cpu>%d", *a.CpuThreshold))
+	}
+	if a.MemThreshold != nil {
+		parts = append(parts, fmt.Sprintf("mem>%d", *a.MemThreshold))
+	}
+	if a.GpuThreshold != nil {
+		parts = append(parts, fmt.Sprintf("gpu-util>%d", *a.GpuThreshold))
+	}
+	if a.QueueThreshold != nil {
+		parts = append(parts, fmt.Sprintf("queue>%d", *a.QueueThreshold))
+	}
+	if a.CustomTriggers > 0 {
+		parts = append(parts, fmt.Sprintf("custom=%d", a.CustomTriggers))
+	}
+	if len(parts) == 0 {
+		return "-"
+	}
+	return strings.Join(parts, " ")
+}
+
+func scalePreflightDeadPods(rack sdk.Interface, c *stdcli.Context, service string) error {
+	ss, err := rack.ServiceList(app(c))
+	if err != nil {
+		return err
+	}
+	for i := range ss {
+		s := &ss[i]
+		if s.Name == service {
+			if s.Autoscale != nil && s.Autoscale.Enabled {
+				return nil
+			}
+			return fmt.Errorf(
+				"service %s has no autoscale configured; --min 0 would terminate pods with no wake-up mechanism. Set scale.autoscale.* in convox.yml and promote a release first, or use --min 1+",
+				service,
+			)
+		}
+	}
+	return fmt.Errorf("service %s not found in app %s", service, app(c))
 }

--- a/pkg/cli/scale_test.go
+++ b/pkg/cli/scale_test.go
@@ -23,9 +23,43 @@ func TestScale(t *testing.T) {
 		require.Equal(t, 0, res.Code)
 		res.RequireStderr(t, []string{""})
 		res.RequireStdout(t, []string{
-			"SERVICE   DESIRED  RUNNING  CPU  MEMORY  GPU",
-			"service1  1        0        2    3       -",
-			"service1  1        0        2    3       -",
+			"SERVICE   MIN  MAX  CURRENT  CPU  MEMORY  GPU  STATUS",
+			"service1  -    -    1        2    3       -    ",
+			"service1  -    -    1        2    3       -    ",
+		})
+	})
+}
+
+func TestScaleShowsAutoscaleAndCold(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		mn, mx := 0, 10
+		cold := true
+		gpuTh := 70
+		svc := *fxService()
+		svc.Name = "vllm"
+		svc.Min = &mn
+		svc.Max = &mx
+		svc.Count = 0
+		svc.ColdStart = &cold
+		svc.Autoscale = &structs.ServiceAutoscaleState{Enabled: true, GpuThreshold: &gpuTh}
+
+		warm := *fxService()
+		warm.Name = "web"
+		two := 2
+		warm.Min = &two
+		warm.Max = &two
+		warm.Count = 2
+
+		i.On("ServiceList", "app1").Return(structs.Services{svc, warm}, nil)
+		i.On("ProcessList", "app1", structs.ProcessListOptions{}).Return(structs.Processes{}, nil)
+
+		res, err := testExecute(e, "scale -a app1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		res.RequireStdout(t, []string{
+			"SERVICE  MIN  MAX  CURRENT  CPU  MEMORY  GPU  AUTOSCALE    STATUS",
+			"vllm     0    10   0        2    3       -    gpu-util>70  COLD (~2-5m first req)",
+			"web      2    2    2        2    3       -    -            ",
 		})
 	})
 }
@@ -71,5 +105,113 @@ func TestScaleUpdateError(t *testing.T) {
 		require.Equal(t, 1, res.Code)
 		res.RequireStderr(t, []string{"ERROR: err1"})
 		res.RequireStdout(t, []string{"Scaling web... "})
+	})
+}
+
+func TestScaleMinMax(t *testing.T) {
+	testClientWait(t, 50*time.Millisecond, func(e *cli.Engine, i *mocksdk.Interface) {
+		opts := structs.ServiceUpdateOptions{Min: options.Int(1), Max: options.Int(5)}
+		i.On("ServiceUpdate", "app1", "web", opts).Return(nil)
+		i.On("AppGet", "app1").Return(fxApp(), nil)
+		i.On("AppLogs", "app1", mock.Anything).Return(testLogs(fxLogsSystem()), nil)
+
+		res, err := testExecute(e, "scale web --min 1 --max 5 -a app1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+	})
+}
+
+func TestScaleMinCountMutuallyExclusive(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		res, err := testExecute(e, "scale web --min 0 --count 3 -a app1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, res.Code)
+		res.RequireStderr(t, []string{"ERROR: --min/--max and --count are mutually exclusive"})
+	})
+}
+
+func TestScaleMinZeroDeadPodsFastFail(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		svc := *fxService()
+		svc.Name = "web"
+		i.On("ServiceList", "app1").Return(structs.Services{svc}, nil)
+
+		res, err := testExecute(e, "scale web --min 0 --max 5 -a app1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, res.Code)
+		require.Contains(t, res.Stderr, "no autoscale configured")
+	})
+}
+
+func TestScaleMaxZero(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		res, err := testExecute(e, "scale web --max 0 -a app1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, res.Code)
+		res.RequireStderr(t, []string{"ERROR: --max must be >= 1"})
+	})
+}
+
+func TestScaleMinGreaterThanMax(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		res, err := testExecute(e, "scale web --min 5 --max 2 -a app1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, res.Code)
+		res.RequireStderr(t, []string{"ERROR: --max must be >= --min"})
+	})
+}
+
+func TestScaleMinZeroServiceNotFound(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("ServiceList", "app1").Return(structs.Services{*fxService()}, nil)
+
+		res, err := testExecute(e, "scale missing --min 0 -a app1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, res.Code)
+		require.Contains(t, res.Stderr, "not found in app")
+	})
+}
+
+func TestScaleMinZeroWithAutoscale(t *testing.T) {
+	testClientWait(t, 50*time.Millisecond, func(e *cli.Engine, i *mocksdk.Interface) {
+		gpu := 70
+		svc := *fxService()
+		svc.Name = "web"
+		svc.Autoscale = &structs.ServiceAutoscaleState{Enabled: true, GpuThreshold: &gpu}
+		i.On("ServiceList", "app1").Return(structs.Services{svc}, nil)
+
+		opts := structs.ServiceUpdateOptions{Min: options.Int(0), Max: options.Int(10)}
+		i.On("ServiceUpdate", "app1", "web", opts).Return(nil)
+		i.On("AppGet", "app1").Return(fxApp(), nil)
+		i.On("AppLogs", "app1", mock.Anything).Return(testLogs(fxLogsSystem()), nil)
+
+		res, err := testExecute(e, "scale web --min 0 --max 10 -a app1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+	})
+}
+
+func TestScaleDaemonsetRow(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		// A daemonset-backed service has Min/Max populated but Autoscale and
+		// ColdStart remain nil because daemonsets cannot scale to zero.
+		two := 2
+		agent := *fxService()
+		agent.Name = "fluentd"
+		agent.Min = &two
+		agent.Max = &two
+		agent.Count = 2
+
+		i.On("ServiceList", "app1").Return(structs.Services{agent}, nil)
+		i.On("ProcessList", "app1", structs.ProcessListOptions{}).Return(structs.Processes{}, nil)
+
+		res, err := testExecute(e, "scale -a app1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		// No AUTOSCALE column (no service has autoscale enabled).
+		res.RequireStdout(t, []string{
+			"SERVICE  MIN  MAX  CURRENT  CPU  MEMORY  GPU  STATUS",
+			"fluentd  2    2    2        2    3       -    ",
+		})
 	})
 }

--- a/pkg/cli/services.go
+++ b/pkg/cli/services.go
@@ -39,16 +39,36 @@ func Services(rack sdk.Interface, c *stdcli.Context) error {
 	// v3 racks never populate Nlb; v2 racks populate it from the release manifest.
 	// Index-based iteration avoids copying the full Service struct per scan step.
 	hasNlb := false
+	hasAutoscale := false
+	hasCold := false
+	hasScale := false
 	for i := range ss {
 		if len(ss[i].Nlb) > 0 {
 			hasNlb = true
-			break
+		}
+		if ss[i].Autoscale != nil && ss[i].Autoscale.Enabled {
+			hasAutoscale = true
+		}
+		if ss[i].ColdStart != nil && *ss[i].ColdStart {
+			hasCold = true
+		}
+		if ss[i].Min != nil || ss[i].Max != nil {
+			hasScale = true
 		}
 	}
 
 	headers := []string{"SERVICE", "DOMAIN", "PORTS"}
 	if hasNlb {
 		headers = append(headers, "NLB PORTS")
+	}
+	if hasScale {
+		headers = append(headers, "SCALE")
+	}
+	if hasAutoscale {
+		headers = append(headers, "AUTOSCALE")
+	}
+	if hasCold {
+		headers = append(headers, "COLD")
 	}
 	t := c.Table(headers...)
 
@@ -97,10 +117,40 @@ func Services(rack sdk.Interface, c *stdcli.Context) error {
 			row = append(row, strings.Join(nlbs, " "))
 		}
 
+		if hasScale {
+			row = append(row, formatScaleCell(s.Min, s.Max))
+		}
+		if hasAutoscale {
+			row = append(row, formatAutoscaleSummary(s.Autoscale))
+		}
+		if hasCold {
+			cold := "-"
+			if s.ColdStart != nil && *s.ColdStart {
+				cold = "yes"
+			}
+			row = append(row, cold)
+		}
+
 		t.AddRow(row...)
 	}
 
 	return t.Print()
+}
+
+func formatScaleCell(min, max *int) string {
+	if min == nil && max == nil {
+		return "-"
+	}
+	if min != nil && max != nil {
+		if *min == *max {
+			return fmt.Sprintf("%d", *min)
+		}
+		return fmt.Sprintf("%d-%d", *min, *max)
+	}
+	if min != nil {
+		return fmt.Sprintf("%d-", *min)
+	}
+	return fmt.Sprintf("-%d", *max)
 }
 
 func ServicesRestart(rack sdk.Interface, c *stdcli.Context) error {

--- a/pkg/cli/services_test.go
+++ b/pkg/cli/services_test.go
@@ -451,6 +451,42 @@ func TestServicesNLBDifferentHardeningPerPort(t *testing.T) {
 	})
 }
 
+func TestServicesScaleAutoscaleColdColumns(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		mn, mx := 0, 10
+		cold := true
+		gpu, queue := 70, 5
+		vllm := structs.Service{
+			Name:      "vllm",
+			Domain:    "vllm.d",
+			Ports:     []structs.ServicePort{{Balancer: 80, Container: 8000}},
+			Min:       &mn,
+			Max:       &mx,
+			ColdStart: &cold,
+			Autoscale: &structs.ServiceAutoscaleState{Enabled: true, GpuThreshold: &gpu, QueueThreshold: &queue},
+		}
+		two := 2
+		web := structs.Service{
+			Name:   "web",
+			Domain: "web.d",
+			Ports:  []structs.ServicePort{{Balancer: 80, Container: 80}},
+			Min:    &two,
+			Max:    &two,
+		}
+
+		i.On("ServiceList", "app1").Return(structs.Services{vllm, web}, nil)
+
+		res, err := testExecute(e, "services -a app1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		res.RequireStdout(t, []string{
+			"SERVICE  DOMAIN  PORTS    SCALE  AUTOSCALE            COLD",
+			"vllm     vllm.d  80:8000  0-10   gpu-util>70 queue>5  yes",
+			"web      web.d   80:80    2      -                    -",
+		})
+	})
+}
+
 // TestServicesNLBEmptyAllowCIDRNoBracket — explicit empty slice must not render `allow=0`.
 func TestServicesNLBEmptyAllowCIDRNoBracket(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {

--- a/pkg/manifest/autoscale_test.go
+++ b/pkg/manifest/autoscale_test.go
@@ -1,0 +1,784 @@
+package manifest_test
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/convox/convox/pkg/manifest"
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAutoscaleIsEnabled(t *testing.T) {
+	var a *manifest.ServiceAutoscale
+	require.False(t, a.IsEnabled(), "nil receiver returns false")
+
+	a = &manifest.ServiceAutoscale{}
+	require.False(t, a.IsEnabled(), "zero value returns false")
+
+	a = &manifest.ServiceAutoscale{Cpu: &manifest.AutoscaleThreshold{Threshold: 70}}
+	require.True(t, a.IsEnabled())
+
+	a = &manifest.ServiceAutoscale{Custom: []kedav1alpha1.ScaleTriggers{{Type: "cron", Name: "nightly"}}}
+	require.True(t, a.IsEnabled())
+}
+
+func TestAutoscaleNeedsPrometheus(t *testing.T) {
+	var a *manifest.ServiceAutoscale
+	require.False(t, a.NeedsPrometheus())
+
+	a = &manifest.ServiceAutoscale{GpuUtilization: &manifest.AutoscaleThreshold{Threshold: 80}}
+	require.True(t, a.NeedsPrometheus(), "gpu util without explicit URL needs Prometheus")
+
+	a = &manifest.ServiceAutoscale{GpuUtilization: &manifest.AutoscaleThreshold{Threshold: 80, PrometheusUrl: "http://prom:9090"}}
+	require.False(t, a.NeedsPrometheus(), "explicit URL satisfies")
+
+	a = &manifest.ServiceAutoscale{QueueDepth: &manifest.AutoscaleQueueDepth{Threshold: 5}}
+	require.True(t, a.NeedsPrometheus())
+
+	a = &manifest.ServiceAutoscale{Cpu: &manifest.AutoscaleThreshold{Threshold: 70}}
+	require.False(t, a.NeedsPrometheus(), "cpu-only never queries Prometheus")
+}
+
+func TestScaleMinMaxYaml_GpuUtilization(t *testing.T) {
+	m, err := testdataManifest("autoscale-gpu", map[string]string{})
+	require.NoError(t, err)
+	require.Len(t, m.Services, 1)
+
+	s := m.Services[0]
+	require.NotNil(t, s.Scale.Min)
+	require.NotNil(t, s.Scale.Max)
+	require.Equal(t, 0, *s.Scale.Min)
+	require.Equal(t, 10, *s.Scale.Max)
+
+	require.True(t, s.Scale.Autoscale.IsEnabled())
+	require.NotNil(t, s.Scale.Autoscale.GpuUtilization)
+	require.Equal(t, float64(70), s.Scale.Autoscale.GpuUtilization.Threshold)
+
+	require.Equal(t, 0, s.Scale.Count.Min)
+	require.Equal(t, 10, s.Scale.Count.Max)
+}
+
+func TestScaleMinMaxYaml_QueueDepth(t *testing.T) {
+	m, err := testdataManifest("autoscale-queue", map[string]string{})
+	require.NoError(t, err)
+	require.Len(t, m.Services, 1)
+
+	s := m.Services[0]
+	require.NotNil(t, s.Scale.Min)
+	require.NotNil(t, s.Scale.Max)
+	require.Equal(t, 0, *s.Scale.Min)
+	require.Equal(t, 5, *s.Scale.Max)
+
+	require.True(t, s.Scale.Autoscale.IsEnabled())
+	require.NotNil(t, s.Scale.Autoscale.QueueDepth)
+	require.Equal(t, float64(5), s.Scale.Autoscale.QueueDepth.Threshold)
+	require.Equal(t, "vllm:num_requests_waiting", s.Scale.Autoscale.QueueDepth.MetricName)
+
+	require.Equal(t, 0, s.Scale.Count.Min)
+	require.Equal(t, 5, s.Scale.Count.Max)
+}
+
+func TestScaleMinMaxYaml_MinZeroNoAutoscale(t *testing.T) {
+	m, err := testdataManifest("autoscale-min-zero", map[string]string{})
+	require.NoError(t, err)
+	require.Len(t, m.Services, 1)
+	s := m.Services[0]
+	require.NotNil(t, s.Scale.Min)
+	require.Equal(t, 0, *s.Scale.Min)
+	require.Nil(t, s.Scale.Max)
+	require.False(t, s.Scale.Autoscale.IsEnabled())
+	require.Equal(t, 0, s.Scale.Count.Min)
+	require.Equal(t, 0, s.Scale.Count.Max)
+}
+
+func TestScaleMinMaxYaml_Combined(t *testing.T) {
+	m, err := testdataManifest("autoscale-combined", map[string]string{})
+	require.NoError(t, err)
+	require.Len(t, m.Services, 1)
+
+	s := m.Services[0]
+	require.Equal(t, 1, *s.Scale.Min)
+	require.Equal(t, 8, *s.Scale.Max)
+
+	a := s.Scale.Autoscale
+	require.True(t, a.IsEnabled())
+	require.NotNil(t, a.Cpu)
+	require.Equal(t, float64(70), a.Cpu.Threshold)
+	require.NotNil(t, a.GpuUtilization)
+	require.Equal(t, float64(75), a.GpuUtilization.Threshold)
+	require.NotNil(t, a.QueueDepth)
+	require.Equal(t, float64(3), a.QueueDepth.Threshold)
+	require.NotNil(t, a.CooldownPeriod)
+	require.Equal(t, int32(300), *a.CooldownPeriod)
+	require.NotNil(t, a.PollingInterval)
+	require.Equal(t, int32(15), *a.PollingInterval)
+
+	require.Equal(t, 1, s.Scale.Count.Min)
+	require.Equal(t, 8, s.Scale.Count.Max)
+}
+
+func TestScaleMinMaxCountResolution(t *testing.T) {
+	cases := []struct {
+		name          string
+		yaml          string
+		expectedMin   int
+		expectedMax   int
+		wantAutoscale bool
+	}{
+		{
+			name: "autoscale only defaults to min 0 max 10",
+			yaml: `services:
+  svc:
+    build: .
+    port: 3000
+    scale:
+      gpu:
+        count: 1
+      autoscale:
+        gpu_utilization:
+          threshold: 70
+`,
+			expectedMin:   0,
+			expectedMax:   10,
+			wantAutoscale: true,
+		},
+		{
+			name: "min only without autoscale pins max=min",
+			yaml: `services:
+  svc:
+    build: .
+    port: 3000
+    scale:
+      min: 3
+`,
+			expectedMin: 3,
+			expectedMax: 3,
+		},
+		{
+			name: "min only with autoscale defaults max=10",
+			yaml: `services:
+  svc:
+    build: .
+    port: 3000
+    scale:
+      min: 2
+      autoscale:
+        cpu:
+          threshold: 80
+        queue_depth:
+          threshold: 3
+`,
+			expectedMin:   2,
+			expectedMax:   10,
+			wantAutoscale: true,
+		},
+		{
+			name: "max only without autoscale pins min=max",
+			yaml: `services:
+  svc:
+    build: .
+    port: 3000
+    scale:
+      max: 4
+`,
+			expectedMin: 4,
+			expectedMax: 4,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := manifest.Load([]byte(tc.yaml), map[string]string{})
+			require.NoError(t, err, "load")
+			require.NoError(t, m.Validate(), "validate")
+			require.Len(t, m.Services, 1)
+			s := m.Services[0]
+			require.Equal(t, tc.expectedMin, s.Scale.Count.Min, "Count.Min")
+			require.Equal(t, tc.expectedMax, s.Scale.Count.Max, "Count.Max")
+			require.Equal(t, tc.wantAutoscale, s.Scale.Autoscale.IsEnabled())
+		})
+	}
+}
+
+func TestValidateScaleMinZeroCpuOnly(t *testing.T) {
+	y := `services:
+  svc:
+    build: .
+    port: 3000
+    scale:
+      min: 0
+      max: 5
+      autoscale:
+        cpu:
+          threshold: 70
+`
+	m, err := manifest.Load([]byte(y), map[string]string{})
+	require.NoError(t, err)
+	err = m.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "scale.min: 0 combined with only always-active autoscale triggers")
+}
+
+func TestValidateScaleMinZeroCpuPlusQueueOk(t *testing.T) {
+	y := `services:
+  svc:
+    build: .
+    port: 3000
+    scale:
+      min: 0
+      max: 5
+      autoscale:
+        cpu:
+          threshold: 70
+        queue_depth:
+          threshold: 3
+`
+	m, err := manifest.Load([]byte(y), map[string]string{})
+	require.NoError(t, err)
+	require.NoError(t, m.Validate())
+}
+
+func TestValidateReservedTriggerName(t *testing.T) {
+	y := `services:
+  svc:
+    build: .
+    port: 3000
+    scale:
+      min: 0
+      max: 5
+      autoscale:
+        custom:
+        - type: cron
+          name: convox-my-cron
+          metadata:
+            timezone: UTC
+            start: 0 9 * * 1-5
+            end: 0 17 * * 1-5
+            desiredReplicas: "1"
+`
+	m, err := manifest.Load([]byte(y), map[string]string{})
+	require.NoError(t, err)
+	err = m.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "uses reserved prefix 'convox-'")
+}
+
+func TestValidateAutoscaleBounds(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{
+			name: "cpu threshold above 100",
+			yaml: `services:
+  svc:
+    build: .
+    scale:
+      min: 1
+      max: 5
+      autoscale:
+        cpu:
+          threshold: 150
+`,
+			want: "scale.autoscale.cpu.threshold must be between 1 and 100",
+		},
+		{
+			name: "gpu threshold above 100",
+			yaml: `services:
+  svc:
+    build: .
+    scale:
+      min: 0
+      max: 5
+      gpu:
+        count: 1
+      autoscale:
+        gpu_utilization:
+          threshold: 120
+`,
+			want: "scale.autoscale.gpu_utilization.threshold must be > 0 and <= 100",
+		},
+		{
+			name: "queue threshold zero",
+			yaml: `services:
+  svc:
+    build: .
+    scale:
+      min: 0
+      max: 5
+      autoscale:
+        queue_depth:
+          threshold: 0
+`,
+			want: "scale.autoscale.queue_depth.threshold must be > 0",
+		},
+		{
+			name: "gpu util requires gpu count",
+			yaml: `services:
+  svc:
+    build: .
+    scale:
+      min: 0
+      max: 5
+      autoscale:
+        gpu_utilization:
+          threshold: 70
+`,
+			want: "scale.autoscale.gpu_utilization requires scale.gpu.count >= 1",
+		},
+		{
+			name: "invalid prometheus URL",
+			yaml: `services:
+  svc:
+    build: .
+    scale:
+      min: 0
+      max: 5
+      autoscale:
+        queue_depth:
+          threshold: 3
+          prometheus_url: "://bad"
+`,
+			want: "scale.autoscale.queue_depth.prometheus_url is not a valid URL",
+		},
+		{
+			name: "invalid metric name",
+			yaml: `services:
+  svc:
+    build: .
+    scale:
+      min: 0
+      max: 5
+      autoscale:
+        queue_depth:
+          threshold: 3
+          metric_name: "1-bad-name"
+`,
+			want: "metric_name",
+		},
+		{
+			name: "negative scale.min",
+			yaml: `services:
+  svc:
+    build: .
+    scale:
+      min: -1
+      max: 3
+`,
+			want: "scale.min must be >= 0",
+		},
+		{
+			name: "max less than min",
+			yaml: `services:
+  svc:
+    build: .
+    scale:
+      min: 5
+      max: 3
+`,
+			want: "scale.max must be >= scale.min",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := manifest.Load([]byte(tc.yaml), map[string]string{})
+			require.NoError(t, err, "load")
+			err = m.Validate()
+			require.Error(t, err)
+			require.True(t, strings.Contains(err.Error(), tc.want), "want %q in %s", tc.want, err.Error())
+		})
+	}
+}
+
+func TestBuildTriggers_Shapes(t *testing.T) {
+	a := &manifest.ServiceAutoscale{
+		Cpu:    &manifest.AutoscaleThreshold{Threshold: 70},
+		Memory: &manifest.AutoscaleThreshold{Threshold: 80},
+		GpuUtilization: &manifest.AutoscaleThreshold{
+			Threshold: 75,
+		},
+		QueueDepth: &manifest.AutoscaleQueueDepth{
+			Threshold: 4,
+		},
+	}
+	triggers := a.BuildTriggers("myapp", "mysvc", "http://prom/")
+	require.Len(t, triggers, 4)
+
+	require.Equal(t, "cpu", triggers[0].Type)
+	require.Equal(t, "convox-cpu", triggers[0].Name)
+	require.Equal(t, "70", triggers[0].Metadata["value"])
+
+	require.Equal(t, "memory", triggers[1].Type)
+	require.Equal(t, "convox-memory", triggers[1].Name)
+
+	require.Equal(t, "prometheus", triggers[2].Type)
+	require.Equal(t, "convox-gpu-utilization", triggers[2].Name)
+	require.Equal(t, "75", triggers[2].Metadata["threshold"])
+	require.Equal(t, "DCGM_FI_DEV_GPU_UTIL", triggers[2].Metadata["metricName"])
+	require.Equal(t, `max(DCGM_FI_DEV_GPU_UTIL{app="myapp",service="mysvc"})`, triggers[2].Metadata["query"])
+	require.Equal(t, "37.5", triggers[2].Metadata["activationThreshold"])
+	require.Equal(t, "http://prom/", triggers[2].Metadata["serverAddress"])
+
+	require.Equal(t, "prometheus", triggers[3].Type)
+	require.Equal(t, "convox-queue-depth", triggers[3].Name)
+	require.Equal(t, "4", triggers[3].Metadata["threshold"])
+	require.Equal(t, "2", triggers[3].Metadata["activationThreshold"])
+}
+
+func TestBuildTriggers_ActivationThresholdFloorOne(t *testing.T) {
+	a := &manifest.ServiceAutoscale{
+		QueueDepth: &manifest.AutoscaleQueueDepth{Threshold: 1},
+	}
+	triggers := a.BuildTriggers("a", "s", "http://prom/")
+	require.Equal(t, "1", triggers[0].Metadata["activationThreshold"], "floor of 1 applies")
+}
+
+func TestBuildTriggers_CustomPassthrough(t *testing.T) {
+	a := &manifest.ServiceAutoscale{
+		Custom: []kedav1alpha1.ScaleTriggers{
+			{Type: "cron", Name: "after-hours", Metadata: map[string]string{"timezone": "UTC"}},
+		},
+	}
+	triggers := a.BuildTriggers("a", "s", "")
+	require.Len(t, triggers, 1)
+	require.Equal(t, "cron", triggers[0].Type)
+	require.Equal(t, "after-hours", triggers[0].Name)
+}
+
+func TestBackwardCompatExistingFixtures(t *testing.T) {
+	// Existing fixtures (no autoscale fields) must still parse cleanly and
+	// not grow unexpected Count{Min:1,Max:1} overrides.
+	env := map[string]string{"REQUIRED": "x", "OTHERGLOBAL": "y", "SECRET": "z"}
+	for _, name := range []string{"simple", "full", "keda", "startup-probe", "startup-probe-gpu"} {
+		t.Run(name, func(t *testing.T) {
+			m, err := testdataManifest(name, env)
+			require.NoError(t, err, name)
+			require.NotNil(t, m)
+			for _, s := range m.Services {
+				require.Nil(t, s.Scale.Min, "%s.%s", name, s.Name)
+				require.Nil(t, s.Scale.Max, "%s.%s", name, s.Name)
+				require.False(t, s.Scale.Autoscale.IsEnabled(), "%s.%s", name, s.Name)
+			}
+		})
+	}
+}
+
+func TestKedaScaledObject_NilTriggersReturnsNil(t *testing.T) {
+	svc := manifest.Service{Name: "svc"}
+	obj := svc.KedaScaledObject(manifest.KedaScaledObjectParameters{
+		MinCount:    0,
+		MaxCount:    10,
+		ServiceName: "svc",
+		Namespace:   "ns",
+	})
+	require.Nil(t, obj, "no triggers + no Scale.Keda returns nil")
+}
+
+func TestKedaScaledObject_FromParamsTriggers(t *testing.T) {
+	svc := manifest.Service{Name: "svc"}
+	params := manifest.KedaScaledObjectParameters{
+		MinCount:    0,
+		MaxCount:    5,
+		ServiceName: "svc",
+		Namespace:   "myapp-ns",
+		Triggers: []kedav1alpha1.ScaleTriggers{
+			{Type: "prometheus", Name: "convox-queue-depth", Metadata: map[string]string{"threshold": "5"}},
+		},
+	}
+	obj := svc.KedaScaledObject(params)
+	require.NotNil(t, obj)
+	require.Equal(t, "ScaledObject", obj.TypeMeta.Kind)
+	require.Equal(t, "keda.sh/v1alpha1", obj.TypeMeta.APIVersion)
+	require.Equal(t, "svc", obj.ObjectMeta.Name)
+	require.Equal(t, "myapp-ns", obj.ObjectMeta.Namespace)
+	require.Equal(t, int32(0), *obj.Spec.MinReplicaCount)
+	require.Equal(t, int32(5), *obj.Spec.MaxReplicaCount)
+	require.Len(t, obj.Spec.Triggers, 1)
+	require.Nil(t, obj.Spec.Triggers[0].AuthenticationRef, "prometheus trigger not AWS - no auth attach")
+}
+
+func TestValidateRejectsNaNThreshold(t *testing.T) {
+	m := &manifest.Manifest{
+		Services: []manifest.Service{{
+			Name: "svc",
+			Scale: manifest.ServiceScale{
+				Min: ptrInt(1), Max: ptrInt(5),
+				Autoscale: &manifest.ServiceAutoscale{
+					Cpu: &manifest.AutoscaleThreshold{Threshold: math.NaN()},
+				},
+			},
+		}},
+	}
+	err := m.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "scale.autoscale.cpu.threshold must be between 1 and 100")
+}
+
+func TestValidateRejectsPrometheusURLScheme(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"file scheme", "file:///etc/passwd", "must use http or https scheme"},
+		{"empty host", "http:///foo", "must include a host"},
+		{"javascript scheme", "javascript:alert(1)", "must use http or https scheme"},
+		{"ftp scheme", "ftp://example.com/foo", "must use http or https scheme"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			y := `services:
+  svc:
+    build: .
+    scale:
+      min: 0
+      max: 5
+      autoscale:
+        queue_depth:
+          threshold: 3
+          prometheus_url: "` + tc.url + `"
+`
+			m, err := manifest.Load([]byte(y), map[string]string{})
+			require.NoError(t, err)
+			err = m.Validate()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+func TestValidateRejectsMaxEqualsMinWithAutoscale(t *testing.T) {
+	y := `services:
+  svc:
+    build: .
+    scale:
+      min: 3
+      max: 3
+      autoscale:
+        queue_depth:
+          threshold: 5
+`
+	m, err := manifest.Load([]byte(y), map[string]string{})
+	require.NoError(t, err)
+	err = m.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "scale.max must be > scale.min when autoscale is enabled")
+}
+
+func TestValidateRejectsNegativeMax(t *testing.T) {
+	y := `services:
+  svc:
+    build: .
+    scale:
+      max: -1
+`
+	m, err := manifest.Load([]byte(y), map[string]string{})
+	require.NoError(t, err)
+	err = m.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "scale.max must be >= 0")
+}
+
+func TestValidateRejectsNegativeCountForm(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "bare int negative",
+			yaml: `services:
+  svc:
+    build: .
+    scale: -2
+`,
+		},
+		{
+			name: "count map negative min",
+			yaml: `services:
+  svc:
+    build: .
+    scale:
+      count:
+        min: -2
+        max: 5
+`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := manifest.Load([]byte(tc.yaml), map[string]string{})
+			require.NoError(t, err)
+			err = m.Validate()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "scale.min must be >= 0")
+		})
+	}
+}
+
+func TestValidateRejectsCronOnlyAtZero(t *testing.T) {
+	y := `services:
+  svc:
+    build: .
+    scale:
+      min: 0
+      max: 5
+      autoscale:
+        custom:
+        - type: cron
+          name: business-hours
+          metadata:
+            timezone: UTC
+            start: 0 9 * * 1-5
+            end: 0 17 * * 1-5
+            desiredReplicas: "1"
+`
+	m, err := manifest.Load([]byte(y), map[string]string{})
+	require.NoError(t, err)
+	err = m.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "always-active autoscale triggers")
+}
+
+func TestValidateReservedPrefixCaseInsensitive(t *testing.T) {
+	y := `services:
+  svc:
+    build: .
+    scale:
+      min: 0
+      max: 5
+      autoscale:
+        custom:
+        - type: cron
+          name: ok
+          metadata: {timezone: UTC, start: "* * * * *", end: "* * * * *", desiredReplicas: "1"}
+        - type: cron
+          name: Convox-collision
+          metadata: {timezone: UTC, start: "* * * * *", end: "* * * * *", desiredReplicas: "1"}
+`
+	m, err := manifest.Load([]byte(y), map[string]string{})
+	require.NoError(t, err)
+	err = m.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "custom[1]", "error must reference the correct array index")
+	require.Contains(t, err.Error(), "reserved prefix 'convox-'")
+}
+
+func TestValidateRejectsClusterTriggerAuthentication(t *testing.T) {
+	y := `services:
+  svc:
+    build: .
+    scale:
+      min: 1
+      max: 5
+      autoscale:
+        custom:
+        - type: prometheus
+          name: mine
+          metadata: {serverAddress: "http://x/", metricName: y, threshold: "1", query: "up"}
+          authenticationRef:
+            name: tenant-cta
+            kind: ClusterTriggerAuthentication
+`
+	m, err := manifest.Load([]byte(y), map[string]string{})
+	require.NoError(t, err)
+	err = m.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ClusterTriggerAuthentication is not permitted")
+}
+
+func TestYamlParseMinMaxAllowsInt64(t *testing.T) {
+	// Smoke test: confirm our scale.min / scale.max bindings accept both
+	// YAML-decoded int and int64 paths. yaml.v2 promotes unquoted numbers to
+	// int when they fit and int64 otherwise; switching between versions of
+	// the decoder would otherwise silently drop the field.
+	y := `services:
+  svc:
+    build: .
+    port: 3000
+    scale:
+      min: 0
+      max: 10
+      autoscale:
+        queue_depth:
+          threshold: 5
+`
+	m, err := manifest.Load([]byte(y), map[string]string{})
+	require.NoError(t, err)
+	require.NotNil(t, m.Services[0].Scale.Min)
+	require.NotNil(t, m.Services[0].Scale.Max)
+	require.Equal(t, 0, *m.Services[0].Scale.Min)
+	require.Equal(t, 10, *m.Services[0].Scale.Max)
+}
+
+func ptrInt(i int) *int { return &i }
+
+func TestValidateRejectsAgentAutoscale(t *testing.T) {
+	y := `services:
+  collector:
+    build: .
+    agent: true
+    scale:
+      min: 0
+      max: 5
+      autoscale:
+        queue_depth:
+          threshold: 3
+`
+	m, err := manifest.Load([]byte(y), map[string]string{})
+	require.NoError(t, err)
+	err = m.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "agent services render as DaemonSet")
+}
+
+func TestValidateRejectsAgentKeda(t *testing.T) {
+	y := `services:
+  collector:
+    build: .
+    agent: true
+    scale:
+      keda:
+        triggers:
+        - type: aws-sqs-queue
+          metadata: {queueURL: "http://x/", queueLength: "1", awsRegion: "us-east-1"}
+`
+	m, err := manifest.Load([]byte(y), map[string]string{})
+	require.NoError(t, err)
+	err = m.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "agent services render as DaemonSet")
+}
+
+func TestValidateCatchesMaxEqualsMinInCountForm(t *testing.T) {
+	// Legacy scale.count form + autoscale used to bypass the max==min check
+	// because validateServiceScale gated on pointer Min/Max only. Regression
+	// guard: Count-form manifests must hit the same rule.
+	y := `services:
+  svc:
+    build: .
+    scale:
+      count: 2-2
+      autoscale:
+        queue_depth:
+          threshold: 3
+`
+	m, err := manifest.Load([]byte(y), map[string]string{})
+	require.NoError(t, err)
+	err = m.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "scale.max must be > scale.min when autoscale is enabled")
+}
+
+func TestValidateRejectsUnicodeCustomName(t *testing.T) {
+	y := "services:\n  svc:\n    build: .\n    scale:\n      min: 1\n      max: 3\n      autoscale:\n        custom:\n        - type: prometheus\n          name: \"Сonvox-cpu\"\n          metadata: {serverAddress: \"http://x/\", metricName: m, threshold: \"1\", query: \"up\"}\n"
+	m, err := manifest.Load([]byte(y), map[string]string{})
+	require.NoError(t, err)
+	err = m.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "custom[0].name")
+	require.Contains(t, err.Error(), "must contain only lowercase alphanumeric")
+}

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -259,13 +259,40 @@ func (m *Manifest) ApplyDefaults() error {
 
 		sp := fmt.Sprintf("services.%s.scale", s.Name)
 
+		{
+			svc := &m.Services[i]
+			switch {
+			case svc.Scale.Min != nil && svc.Scale.Max != nil:
+				svc.Scale.Count = ServiceScaleCount{Min: *svc.Scale.Min, Max: *svc.Scale.Max}
+			case svc.Scale.Min != nil && svc.Scale.Max == nil:
+				svc.Scale.Count.Min = *svc.Scale.Min
+				if svc.Scale.Autoscale.IsEnabled() {
+					if svc.Scale.Count.Max == 0 {
+						svc.Scale.Count.Max = 10
+					}
+				} else {
+					svc.Scale.Count.Max = *svc.Scale.Min
+				}
+			case svc.Scale.Max != nil && svc.Scale.Min == nil:
+				svc.Scale.Count.Max = *svc.Scale.Max
+				if svc.Scale.Count.Min == 0 && !svc.Scale.Autoscale.IsEnabled() {
+					svc.Scale.Count.Min = *svc.Scale.Max
+				}
+			}
+
+			if svc.Scale.Autoscale.IsEnabled() && svc.Scale.Count.Max == 0 {
+				svc.Scale.Count.Max = 10
+			}
+		}
+
 		// if no scale attributes set
 		if len(m.AttributesByPrefix(sp)) == 0 {
 			m.Services[i].Scale.Count = ServiceScaleCount{Min: 1, Max: 1}
 		}
 
 		// if no explicit count attribute set yet has multiple scale attributes other than count
-		if !m.AttributeExists(fmt.Sprintf("%s.count", sp)) && len(m.AttributesByPrefix(sp)) > 1 {
+		if !m.AttributeExists(fmt.Sprintf("%s.count", sp)) && len(m.AttributesByPrefix(sp)) > 1 &&
+			!m.Services[i].Scale.Autoscale.IsEnabled() && m.Services[i].Scale.Min == nil && m.Services[i].Scale.Max == nil {
 			m.Services[i].Scale.Count = ServiceScaleCount{Min: 1, Max: 1}
 		}
 

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/convox/convox/pkg/options"
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	autoscaling "k8s.io/api/autoscaling/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -294,14 +295,41 @@ type ServicePortScheme struct {
 }
 
 type ServiceScale struct {
-	Count   ServiceScaleCount
-	Cpu     int
-	Gpu     ServiceScaleGpu `yaml:"gpu,omitempty"`
-	Memory  int
-	Limit   ServiceResourceLimit `yaml:"limit,omitempty"`
-	Targets ServiceScaleTargets  `yaml:"targets,omitempty"`
-	Keda    *ServiceScaleKeda    `yaml:"keda,omitempty"`
-	VPA     *VPA                 `yaml:"vpa,omitempty"`
+	Count     ServiceScaleCount
+	Cpu       int
+	Gpu       ServiceScaleGpu `yaml:"gpu,omitempty"`
+	Memory    int
+	Limit     ServiceResourceLimit `yaml:"limit,omitempty"`
+	Targets   ServiceScaleTargets  `yaml:"targets,omitempty"`
+	Keda      *ServiceScaleKeda    `yaml:"keda,omitempty"`
+	VPA       *VPA                 `yaml:"vpa,omitempty"`
+	Min       *int                 `yaml:"min,omitempty"       json:"min,omitempty"`
+	Max       *int                 `yaml:"max,omitempty"       json:"max,omitempty"`
+	Autoscale *ServiceAutoscale    `yaml:"autoscale,omitempty" json:"autoscale,omitempty"`
+}
+
+type ServiceAutoscale struct {
+	Cpu             *AutoscaleThreshold          `yaml:"cpu,omitempty"              json:"cpu,omitempty"`
+	Memory          *AutoscaleThreshold          `yaml:"memory,omitempty"           json:"memory,omitempty"`
+	GpuUtilization  *AutoscaleThreshold          `yaml:"gpu_utilization,omitempty"  json:"gpu_utilization,omitempty"`
+	QueueDepth      *AutoscaleQueueDepth         `yaml:"queue_depth,omitempty"      json:"queue_depth,omitempty"`
+	Custom          []kedav1alpha1.ScaleTriggers `yaml:"custom,omitempty"           json:"custom,omitempty"`
+	CooldownPeriod  *int32                       `yaml:"cooldown_period,omitempty"  json:"cooldown_period,omitempty"`
+	PollingInterval *int32                       `yaml:"polling_interval,omitempty" json:"polling_interval,omitempty"`
+}
+
+type AutoscaleThreshold struct {
+	Threshold     float64 `yaml:"threshold"                json:"threshold"`
+	MetricName    string  `yaml:"metric_name,omitempty"    json:"metric_name,omitempty"`
+	PrometheusUrl string  `yaml:"prometheus_url,omitempty" json:"prometheus_url,omitempty"`
+	Query         string  `yaml:"query,omitempty"          json:"query,omitempty"`
+}
+
+type AutoscaleQueueDepth struct {
+	Threshold     float64 `yaml:"threshold"                json:"threshold"`
+	MetricName    string  `yaml:"metric_name,omitempty"    json:"metric_name,omitempty"`
+	PrometheusUrl string  `yaml:"prometheus_url,omitempty" json:"prometheus_url,omitempty"`
+	Query         string  `yaml:"query,omitempty"          json:"query,omitempty"`
 }
 
 func (ss ServiceScale) IsKedaEnabled() bool {
@@ -312,19 +340,141 @@ func (ss ServiceScale) IsVpaEnabled() bool {
 	return ss.VPA != nil
 }
 
+func (a *ServiceAutoscale) IsEnabled() bool {
+	if a == nil {
+		return false
+	}
+	return a.Cpu != nil || a.Memory != nil || a.GpuUtilization != nil ||
+		a.QueueDepth != nil || len(a.Custom) > 0
+}
+
+func (a *ServiceAutoscale) NeedsPrometheus() bool {
+	if a == nil {
+		return false
+	}
+	if a.GpuUtilization != nil && a.GpuUtilization.PrometheusUrl == "" {
+		return true
+	}
+	if a.QueueDepth != nil && a.QueueDepth.PrometheusUrl == "" {
+		return true
+	}
+	return false
+}
+
+func (a *ServiceAutoscale) BuildTriggers(app, service, defaultPromURL string) []kedav1alpha1.ScaleTriggers {
+	if a == nil {
+		return nil
+	}
+
+	var triggers []kedav1alpha1.ScaleTriggers
+
+	if a.Cpu != nil {
+		triggers = append(triggers, kedav1alpha1.ScaleTriggers{
+			Type:       "cpu",
+			Name:       "convox-cpu",
+			MetricType: autoscalingv2.UtilizationMetricType,
+			Metadata: map[string]string{
+				"value": fmt.Sprintf("%g", a.Cpu.Threshold),
+			},
+		})
+	}
+
+	if a.Memory != nil {
+		triggers = append(triggers, kedav1alpha1.ScaleTriggers{
+			Type:       "memory",
+			Name:       "convox-memory",
+			MetricType: autoscalingv2.UtilizationMetricType,
+			Metadata: map[string]string{
+				"value": fmt.Sprintf("%g", a.Memory.Threshold),
+			},
+		})
+	}
+
+	if a.GpuUtilization != nil {
+		metric := a.GpuUtilization.MetricName
+		if metric == "" {
+			metric = "DCGM_FI_DEV_GPU_UTIL"
+		}
+		query := a.GpuUtilization.Query
+		if query == "" {
+			query = fmt.Sprintf("max(%s{app=%q,service=%q})", metric, app, service)
+		}
+		promURL := a.GpuUtilization.PrometheusUrl
+		if promURL == "" {
+			promURL = defaultPromURL
+		}
+		activation := a.GpuUtilization.Threshold / 2
+		if activation < 1 {
+			activation = 1
+		}
+		triggers = append(triggers, kedav1alpha1.ScaleTriggers{
+			Type: "prometheus",
+			Name: "convox-gpu-utilization",
+			Metadata: map[string]string{
+				"serverAddress":       promURL,
+				"metricName":          metric,
+				"threshold":           fmt.Sprintf("%g", a.GpuUtilization.Threshold),
+				"activationThreshold": fmt.Sprintf("%g", activation),
+				"query":               query,
+			},
+		})
+	}
+
+	if a.QueueDepth != nil {
+		metric := a.QueueDepth.MetricName
+		if metric == "" {
+			metric = "vllm:num_requests_waiting"
+		}
+		query := a.QueueDepth.Query
+		if query == "" {
+			query = fmt.Sprintf("max(%s{app=%q,service=%q})", metric, app, service)
+		}
+		promURL := a.QueueDepth.PrometheusUrl
+		if promURL == "" {
+			promURL = defaultPromURL
+		}
+		activation := a.QueueDepth.Threshold / 2
+		if activation < 1 {
+			activation = 1
+		}
+		triggers = append(triggers, kedav1alpha1.ScaleTriggers{
+			Type: "prometheus",
+			Name: "convox-queue-depth",
+			Metadata: map[string]string{
+				"serverAddress":       promURL,
+				"metricName":          metric,
+				"threshold":           fmt.Sprintf("%g", a.QueueDepth.Threshold),
+				"activationThreshold": fmt.Sprintf("%g", activation),
+				"query":               query,
+			},
+		})
+	}
+
+	if len(a.Custom) > 0 {
+		triggers = append(triggers, a.Custom...)
+	}
+
+	return triggers
+}
+
 type KedaScaledObjectParameters struct {
 	MinCount    int32
 	MaxCount    int32
 	ServiceName string
 	Namespace   string
+	Triggers    []kedav1alpha1.ScaleTriggers
 }
 
 func (ss Service) KedaScaledObject(params KedaScaledObjectParameters) *kedav1alpha1.ScaledObject {
-	so := kedav1alpha1.ScaledObject{}
-	if ss.Scale.Keda == nil {
-		return &so
+	triggers := params.Triggers
+	if len(triggers) == 0 && ss.Scale.Keda != nil {
+		triggers = ss.Scale.Keda.Triggers
+	}
+	if len(triggers) == 0 {
+		return nil
 	}
 
+	so := kedav1alpha1.ScaledObject{}
 	so.TypeMeta.Kind = "ScaledObject"
 	so.TypeMeta.APIVersion = "keda.sh/v1alpha1"
 	so.ObjectMeta.Name = params.ServiceName
@@ -334,18 +484,30 @@ func (ss Service) KedaScaledObject(params KedaScaledObjectParameters) *kedav1alp
 		Name: params.ServiceName,
 		Kind: "Deployment",
 	}
-	so.Spec.Triggers = ss.Scale.Keda.Triggers
+	so.Spec.Triggers = triggers
 	so.Spec.MinReplicaCount = &params.MinCount
 	so.Spec.MaxReplicaCount = &params.MaxCount
-	so.Spec.CooldownPeriod = ss.Scale.Keda.CooldownPeriod
-	so.Spec.PollingInterval = ss.Scale.Keda.PollingInterval
-	so.Spec.Advanced = ss.Scale.Keda.Advanced
-	so.Spec.Fallback = ss.Scale.Keda.Fallback
-	so.Spec.IdleReplicaCount = ss.Scale.Keda.IdleReplicaCount
 
-	for i := range so.Spec.Triggers {
-		if so.Spec.Triggers[i].AuthenticationRef == nil {
-			auth := ss.DefaultTriggerAuthentionIfAws(params.Namespace)
+	if ss.Scale.Keda != nil {
+		so.Spec.CooldownPeriod = ss.Scale.Keda.CooldownPeriod
+		so.Spec.PollingInterval = ss.Scale.Keda.PollingInterval
+		so.Spec.Advanced = ss.Scale.Keda.Advanced
+		so.Spec.Fallback = ss.Scale.Keda.Fallback
+		so.Spec.IdleReplicaCount = ss.Scale.Keda.IdleReplicaCount
+	} else if ss.Scale.Autoscale != nil {
+		so.Spec.CooldownPeriod = ss.Scale.Autoscale.CooldownPeriod
+		so.Spec.PollingInterval = ss.Scale.Autoscale.PollingInterval
+	}
+
+	auth := ss.DefaultTriggerAuthentionIfAws(params.Namespace)
+	if auth != nil {
+		for i := range so.Spec.Triggers {
+			if so.Spec.Triggers[i].AuthenticationRef != nil {
+				continue
+			}
+			if !strings.HasPrefix(so.Spec.Triggers[i].Type, "aws-") {
+				continue
+			}
 			so.Spec.Triggers[i].AuthenticationRef = &kedav1alpha1.AuthenticationRef{
 				Name: auth.ObjectMeta.Name,
 				Kind: auth.TypeMeta.Kind,

--- a/pkg/manifest/testdata/autoscale-combined.yml
+++ b/pkg/manifest/testdata/autoscale-combined.yml
@@ -1,0 +1,19 @@
+services:
+  inference:
+    build: .
+    port: 8000
+    scale:
+      min: 1
+      max: 8
+      gpu:
+        count: 1
+        vendor: nvidia
+      autoscale:
+        cpu:
+          threshold: 70
+        gpu_utilization:
+          threshold: 75
+        queue_depth:
+          threshold: 3
+        cooldown_period: 300
+        polling_interval: 15

--- a/pkg/manifest/testdata/autoscale-gpu.yml
+++ b/pkg/manifest/testdata/autoscale-gpu.yml
@@ -1,0 +1,13 @@
+services:
+  vllm:
+    build: .
+    port: 8000
+    scale:
+      min: 0
+      max: 10
+      gpu:
+        count: 1
+        vendor: nvidia
+      autoscale:
+        gpu_utilization:
+          threshold: 70

--- a/pkg/manifest/testdata/autoscale-min-zero.yml
+++ b/pkg/manifest/testdata/autoscale-min-zero.yml
@@ -1,0 +1,6 @@
+services:
+  idle:
+    build: .
+    port: 3000
+    scale:
+      min: 0

--- a/pkg/manifest/testdata/autoscale-queue.yml
+++ b/pkg/manifest/testdata/autoscale-queue.yml
@@ -1,0 +1,10 @@
+services:
+  worker:
+    build: .
+    scale:
+      min: 0
+      max: 5
+      autoscale:
+        queue_depth:
+          threshold: 5
+          metric_name: vllm:num_requests_waiting

--- a/pkg/manifest/validate.go
+++ b/pkg/manifest/validate.go
@@ -2,7 +2,9 @@ package manifest
 
 import (
 	"fmt"
+	"math"
 	"net"
+	"net/url"
 	"regexp"
 	"strings"
 )
@@ -12,7 +14,8 @@ const (
 )
 
 var (
-	NameValidator = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
+	NameValidator         = regexp.MustCompile(`^[a-z][a-z0-9-]*$`)
+	prometheusMetricNameR = regexp.MustCompile(`^[a-zA-Z_:][a-zA-Z0-9_:]*$`)
 )
 
 func (m *Manifest) validate() []error {
@@ -159,8 +162,166 @@ func (m *Manifest) validateServices() []error {
 			}
 		}
 
+		errs = append(errs, validateServiceScale(&s)...)
 	}
 	return errs
+}
+
+func validateServiceScale(s *Service) []error {
+	var errs []error
+
+	if s.Agent.Enabled && (s.Scale.Autoscale.IsEnabled() || s.Scale.IsKedaEnabled()) {
+		errs = append(errs, fmt.Errorf("service %s: agent services render as DaemonSet and cannot use scale.autoscale or scale.keda", s.Name))
+	}
+
+	// Validate against EFFECTIVE Count (populated by ApplyDefaults from both
+	// the legacy scale.count shape and the new scale.min/scale.max pointer
+	// shape). Checking pointer-only would let legacy scale.count: 1-5 callers
+	// bypass every autoscale-aware rule.
+	effMin := s.Scale.Count.Min
+	effMax := s.Scale.Count.Max
+
+	if effMin < 0 {
+		errs = append(errs, fmt.Errorf("service %s: scale.min must be >= 0", s.Name))
+	}
+	if effMax < 0 {
+		errs = append(errs, fmt.Errorf("service %s: scale.max must be >= 0", s.Name))
+	}
+	if effMax < effMin {
+		errs = append(errs, fmt.Errorf("service %s: scale.max must be >= scale.min", s.Name))
+	}
+
+	a := s.Scale.Autoscale
+	if !a.IsEnabled() {
+		return errs
+	}
+
+	if effMax < 1 {
+		errs = append(errs, fmt.Errorf("service %s: scale.max must be >= 1 when autoscale is enabled", s.Name))
+	}
+	if effMax == effMin && effMax >= 1 {
+		errs = append(errs, fmt.Errorf("service %s: scale.max must be > scale.min when autoscale is enabled (ScaledObject would be a no-op)", s.Name))
+	}
+
+	if a.Cpu != nil && invalidPercent(a.Cpu.Threshold) {
+		errs = append(errs, fmt.Errorf("service %s: scale.autoscale.cpu.threshold must be between 1 and 100", s.Name))
+	}
+	if a.Memory != nil && invalidPercent(a.Memory.Threshold) {
+		errs = append(errs, fmt.Errorf("service %s: scale.autoscale.memory.threshold must be between 1 and 100", s.Name))
+	}
+	if a.GpuUtilization != nil {
+		if invalidPercent(a.GpuUtilization.Threshold) {
+			errs = append(errs, fmt.Errorf("service %s: scale.autoscale.gpu_utilization.threshold must be > 0 and <= 100", s.Name))
+		}
+		if s.Scale.Gpu.Count == 0 {
+			errs = append(errs, fmt.Errorf("service %s: scale.autoscale.gpu_utilization requires scale.gpu.count >= 1", s.Name))
+		}
+	}
+	if a.QueueDepth != nil {
+		if math.IsNaN(a.QueueDepth.Threshold) || a.QueueDepth.Threshold <= 0 {
+			errs = append(errs, fmt.Errorf("service %s: scale.autoscale.queue_depth.threshold must be > 0", s.Name))
+		}
+	}
+
+	errs = append(errs, validateAutoscaleThreshold(s.Name, "cpu", a.Cpu)...)
+	errs = append(errs, validateAutoscaleThreshold(s.Name, "memory", a.Memory)...)
+	errs = append(errs, validateAutoscaleThreshold(s.Name, "gpu_utilization", a.GpuUtilization)...)
+	errs = append(errs, validateAutoscaleQueueDepth(s.Name, a.QueueDepth)...)
+
+	for i, trig := range a.Custom {
+		if trig.Name != "" && !NameValidator.MatchString(trig.Name) {
+			errs = append(errs, fmt.Errorf("service %s: scale.autoscale.custom[%d].name %q invalid, %s", s.Name, i, trig.Name, ValidNameDescription))
+		}
+		if strings.HasPrefix(strings.ToLower(trig.Name), "convox-") {
+			errs = append(errs, fmt.Errorf("service %s: scale.autoscale.custom[%d].name: %q uses reserved prefix 'convox-'", s.Name, i, trig.Name))
+		}
+		if trig.AuthenticationRef != nil && trig.AuthenticationRef.Kind == "ClusterTriggerAuthentication" {
+			errs = append(errs, fmt.Errorf("service %s: scale.autoscale.custom[%d].authenticationRef.kind: ClusterTriggerAuthentication is not permitted", s.Name, i))
+		}
+	}
+
+	if effMin == 0 && !autoscaleCanScaleToZero(a) {
+		errs = append(errs, fmt.Errorf(
+			"service %s: scale.min: 0 combined with only always-active autoscale triggers (cpu/memory/cron) will never scale to zero; "+
+				"KEDA's cpu/memory/cron scalers are always active. Add scale.autoscale.queue_depth, scale.autoscale.gpu_utilization, "+
+				"or a scale.autoscale.custom[] prometheus/external trigger, or raise scale.min to 1.",
+			s.Name,
+		))
+	}
+
+	return errs
+}
+
+func invalidPercent(v float64) bool {
+	return math.IsNaN(v) || v <= 0 || v > 100
+}
+
+// autoscaleCanScaleToZero returns true when the autoscale spec contains at
+// least one trigger type that KEDA's scale_handler will let drop to zero.
+// KEDA's cpu, memory, and cron scalers are always-active (IsActive=true
+// unconditionally), so a service configured with only those never scales to
+// zero regardless of scale.min. Returns false when the config is made up
+// entirely of always-active triggers.
+func autoscaleCanScaleToZero(a *ServiceAutoscale) bool {
+	if a == nil {
+		return false
+	}
+	if a.GpuUtilization != nil || a.QueueDepth != nil {
+		return true
+	}
+	for i := range a.Custom {
+		t := strings.ToLower(a.Custom[i].Type)
+		if t != "cpu" && t != "memory" && t != "cron" {
+			return true
+		}
+	}
+	return false
+}
+
+func validateAutoscaleThreshold(service, field string, t *AutoscaleThreshold) []error {
+	if t == nil {
+		return nil
+	}
+	var errs []error
+	if t.PrometheusUrl != "" {
+		if err := validatePrometheusURL(t.PrometheusUrl); err != nil {
+			errs = append(errs, fmt.Errorf("service %s: scale.autoscale.%s.prometheus_url %s", service, field, err))
+		}
+	}
+	if t.MetricName != "" && !prometheusMetricNameR.MatchString(t.MetricName) {
+		errs = append(errs, fmt.Errorf("service %s: scale.autoscale.%s.metric_name %q must match %s", service, field, t.MetricName, prometheusMetricNameR.String()))
+	}
+	return errs
+}
+
+func validateAutoscaleQueueDepth(service string, q *AutoscaleQueueDepth) []error {
+	if q == nil {
+		return nil
+	}
+	var errs []error
+	if q.PrometheusUrl != "" {
+		if err := validatePrometheusURL(q.PrometheusUrl); err != nil {
+			errs = append(errs, fmt.Errorf("service %s: scale.autoscale.queue_depth.prometheus_url %s", service, err))
+		}
+	}
+	if q.MetricName != "" && !prometheusMetricNameR.MatchString(q.MetricName) {
+		errs = append(errs, fmt.Errorf("service %s: scale.autoscale.queue_depth.metric_name %q must match %s", service, q.MetricName, prometheusMetricNameR.String()))
+	}
+	return errs
+}
+
+func validatePrometheusURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("is not a valid URL: %s", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("must use http or https scheme, got %q", u.Scheme)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("must include a host")
+	}
+	return nil
 }
 
 func (m *Manifest) validateTimers() []error {

--- a/pkg/manifest/yaml.go
+++ b/pkg/manifest/yaml.go
@@ -2,6 +2,7 @@ package manifest
 
 import (
 	"fmt"
+	"math"
 	"reflect"
 	"strconv"
 	"strings"
@@ -479,6 +480,19 @@ func (v *ServiceScale) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			}
 			v.Keda = &k
 		}
+		if w, ok := scaleBoundInt(t["min"]); ok {
+			v.Min = &w
+		}
+		if w, ok := scaleBoundInt(t["max"]); ok {
+			v.Max = &w
+		}
+		if w, ok := t["autoscale"]; ok {
+			var a ServiceAutoscale
+			if err := remarshalUsingKyaml(w, &a); err != nil {
+				return err
+			}
+			v.Autoscale = &a
+		}
 		if w, ok := t["vpa"].(interface{}); ok {
 			var k VPA
 			if err := remarshal(w, &k); err != nil {
@@ -769,4 +783,22 @@ func yamlAttributes(data []byte) (map[string]bool, error) {
 	}
 
 	return attrs, nil
+}
+
+func scaleBoundInt(v interface{}) (int, bool) {
+	switch t := v.(type) {
+	case int:
+		return t, true
+	case int64:
+		return int(t), true
+	case float64:
+		if math.IsNaN(t) || math.IsInf(t, 0) {
+			return 0, false
+		}
+		if t != math.Trunc(t) {
+			return 0, false
+		}
+		return int(t), true
+	}
+	return 0, false
 }

--- a/pkg/structs/service.go
+++ b/pkg/structs/service.go
@@ -1,15 +1,29 @@
 package structs
 
 type Service struct {
-	Count     int              `json:"count"`
-	Cpu       int              `json:"cpu"`
-	Domain    string           `json:"domain"`
-	Gpu       int              `json:"gpu"`
-	GpuVendor string           `json:"gpu-vendor"`
-	Memory    int              `json:"memory"`
-	Name      string           `json:"name"`
-	Nlb       []ServiceNlbPort `json:"nlb"`
-	Ports     []ServicePort    `json:"ports"`
+	Count     int                    `json:"count"`
+	Cpu       int                    `json:"cpu"`
+	Domain    string                 `json:"domain"`
+	Gpu       int                    `json:"gpu"`
+	GpuVendor string                 `json:"gpu-vendor"`
+	Memory    int                    `json:"memory"`
+	Name      string                 `json:"name"`
+	Nlb       []ServiceNlbPort       `json:"nlb"`
+	Ports     []ServicePort          `json:"ports"`
+	Min       *int                   `json:"min,omitempty"`
+	Max       *int                   `json:"max,omitempty"`
+	ColdStart *bool                  `json:"cold-start,omitempty"`
+	Autoscale *ServiceAutoscaleState `json:"autoscale,omitempty"`
+}
+
+type ServiceAutoscaleState struct {
+	Enabled        bool   `json:"enabled"`
+	CpuThreshold   *int   `json:"cpu-threshold,omitempty"`
+	MemThreshold   *int   `json:"mem-threshold,omitempty"`
+	GpuThreshold   *int   `json:"gpu-threshold,omitempty"`
+	QueueThreshold *int   `json:"queue-threshold,omitempty"`
+	MetricName     string `json:"metric-name,omitempty"`
+	CustomTriggers int    `json:"custom-triggers,omitempty"`
 }
 
 type Services []Service
@@ -48,4 +62,6 @@ type ServiceUpdateOptions struct {
 	Gpu       *int    `flag:"gpu" param:"gpu"`
 	GpuVendor *string `flag:"gpu-vendor" param:"gpu-vendor"`
 	Memory    *int    `flag:"memory" param:"memory"`
+	Min       *int    `flag:"min" param:"min"`
+	Max       *int    `flag:"max" param:"max"`
 }

--- a/pkg/structs/service_test.go
+++ b/pkg/structs/service_test.go
@@ -2,6 +2,7 @@ package structs
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -56,4 +57,63 @@ func TestServiceNlbPortJSONNullHandling(t *testing.T) {
 	require.Nil(t, got.AllowCIDR)
 	require.Nil(t, got.CrossZone)
 	require.Nil(t, got.PreserveClientIP)
+}
+
+func TestServiceJsonRoundTripOldRackShape(t *testing.T) {
+	raw := `{"name":"svc","count":3,"cpu":100,"memory":256,"gpu":0,"gpu-vendor":"","domain":"","nlb":null,"ports":null}`
+	var got Service
+	require.NoError(t, json.Unmarshal([]byte(raw), &got))
+	require.Equal(t, "svc", got.Name)
+	require.Equal(t, 3, got.Count)
+	require.Nil(t, got.Min)
+	require.Nil(t, got.Max)
+	require.Nil(t, got.ColdStart)
+	require.Nil(t, got.Autoscale)
+}
+
+func TestServiceJsonRoundTripFullShape(t *testing.T) {
+	mn, mx := 0, 10
+	cold := true
+	c, q := 70, 5
+	want := Service{
+		Name:      "vllm",
+		Count:     0,
+		Min:       &mn,
+		Max:       &mx,
+		ColdStart: &cold,
+		Autoscale: &ServiceAutoscaleState{
+			Enabled:        true,
+			CpuThreshold:   &c,
+			QueueThreshold: &q,
+			MetricName:     "vllm:num_requests_waiting",
+			CustomTriggers: 2,
+		},
+	}
+	data, err := json.Marshal(want)
+	require.NoError(t, err)
+
+	var got Service
+	require.NoError(t, json.Unmarshal(data, &got))
+	require.Equal(t, want, got)
+}
+
+func TestServiceUpdateOptionsTags(t *testing.T) {
+	rt := reflect.TypeOf(ServiceUpdateOptions{})
+	for _, field := range []string{"Min", "Max"} {
+		f, ok := rt.FieldByName(field)
+		require.True(t, ok, "field %s missing", field)
+		want := map[string]string{"Min": "min", "Max": "max"}[field]
+		require.Equal(t, want, f.Tag.Get("flag"))
+		require.Equal(t, want, f.Tag.Get("param"))
+	}
+}
+
+func TestServiceAutoscaleStateOmitempty(t *testing.T) {
+	s := Service{Name: "svc", Count: 1}
+	data, err := json.Marshal(s)
+	require.NoError(t, err)
+	require.NotContains(t, string(data), "autoscale")
+	require.NotContains(t, string(data), "cold-start")
+	require.NotContains(t, string(data), `"min"`)
+	require.NotContains(t, string(data), `"max"`)
 }

--- a/provider/k8s/autoscale_test.go
+++ b/provider/k8s/autoscale_test.go
@@ -1,0 +1,253 @@
+package k8s_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/convox/convox/pkg/atom"
+	"github.com/convox/convox/pkg/manifest"
+	"github.com/convox/convox/pkg/options"
+	"github.com/convox/convox/pkg/structs"
+	"github.com/convox/convox/provider/k8s"
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	ac "k8s.io/api/core/v1"
+	am "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ktypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic/fake"
+	kfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+	"sigs.k8s.io/yaml"
+)
+
+var testScaledObjectGVR = schema.GroupVersionResource{Group: "keda.sh", Version: "v1alpha1", Resource: "scaledobjects"}
+
+func scaledObjectUnstructured(namespace, name string, minReplica, maxReplica int64) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "keda.sh/v1alpha1",
+			"kind":       "ScaledObject",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"spec": map[string]interface{}{
+				"minReplicaCount": minReplica,
+				"maxReplicaCount": maxReplica,
+			},
+		},
+	}
+}
+
+func newDynamicScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	s.AddKnownTypeWithName(testScaledObjectGVR.GroupVersion().WithKind("ScaledObject"), &unstructured.Unstructured{})
+	s.AddKnownTypeWithName(testScaledObjectGVR.GroupVersion().WithKind("ScaledObjectList"), &unstructured.UnstructuredList{})
+	return s
+}
+
+func seedDeployment(t *testing.T, kk *kfake.Clientset, ns, name string, replicas int32) {
+	t.Helper()
+	r := replicas
+	_, err := kk.AppsV1().Deployments(ns).Create(context.TODO(), &appsv1.Deployment{
+		ObjectMeta: am.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels:    map[string]string{"app": "app1", "type": "service", "service": name},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &r,
+			Template: ac.PodTemplateSpec{Spec: ac.PodSpec{Containers: []ac.Container{{Name: "app1"}}}},
+		},
+	}, am.CreateOptions{})
+	require.NoError(t, err)
+}
+
+func TestServiceUpdateKedaSync(t *testing.T) {
+	testProvider(t, func(p *k8s.Provider) {
+		kk, _ := p.Cluster.(*kfake.Clientset)
+		require.NoError(t, appCreate(kk, "rack1", "app1"))
+		seedDeployment(t, kk, "rack1-app1", "web", 2)
+
+		dyn := fake.NewSimpleDynamicClient(newDynamicScheme(), scaledObjectUnstructured("rack1-app1", "web", 1, 5))
+		p.DynamicClient = dyn
+
+		err := p.ServiceUpdate("app1", "web", structs.ServiceUpdateOptions{
+			Min: options.Int(0),
+			Max: options.Int(10),
+		})
+		require.NoError(t, err)
+
+		got, err := dyn.Resource(testScaledObjectGVR).Namespace("rack1-app1").Get(context.TODO(), "web", am.GetOptions{})
+		require.NoError(t, err)
+		spec, _ := got.Object["spec"].(map[string]interface{})
+		require.Equal(t, int64(0), toInt64(spec["minReplicaCount"]))
+		require.Equal(t, int64(10), toInt64(spec["maxReplicaCount"]))
+
+		// Verify patch strategy is JSON-merge (RFC 7396). Strategic-merge
+		// would require server-side strategy metadata that CRDs don't register.
+		var sawPatch bool
+		for _, action := range dyn.Actions() {
+			p, ok := action.(k8stesting.PatchAction)
+			if !ok {
+				continue
+			}
+			if p.GetResource() != testScaledObjectGVR {
+				continue
+			}
+			require.Equal(t, ktypes.MergePatchType, p.GetPatchType(), "scaledobject patch must use JSON-merge")
+			sawPatch = true
+		}
+		require.True(t, sawPatch, "expected at least one patch action on scaledobjects")
+	})
+}
+
+func TestServiceUpdateDeadPodsGuard(t *testing.T) {
+	testProvider(t, func(p *k8s.Provider) {
+		kk, _ := p.Cluster.(*kfake.Clientset)
+		require.NoError(t, appCreate(kk, "rack1", "app1"))
+		seedDeployment(t, kk, "rack1-app1", "web", 1)
+
+		aa, _ := p.Atom.(*atom.MockInterface)
+		aa.On("Status", "rack1-app1", "app").Return("Running", "", nil).Maybe()
+
+		p.DynamicClient = fake.NewSimpleDynamicClient(newDynamicScheme())
+
+		err := p.ServiceUpdate("app1", "web", structs.ServiceUpdateOptions{Min: options.Int(0)})
+		require.Error(t, err)
+		require.True(t, strings.Contains(err.Error(), "no autoscale mechanism is configured"), err.Error())
+	})
+}
+
+func TestServiceUpdateMinAllowsNonZeroWithoutScaledObject(t *testing.T) {
+	testProvider(t, func(p *k8s.Provider) {
+		kk, _ := p.Cluster.(*kfake.Clientset)
+		require.NoError(t, appCreate(kk, "rack1", "app1"))
+		seedDeployment(t, kk, "rack1-app1", "web", 1)
+
+		p.DynamicClient = fake.NewSimpleDynamicClient(newDynamicScheme())
+
+		err := p.ServiceUpdate("app1", "web", structs.ServiceUpdateOptions{Min: options.Int(1), Max: options.Int(5)})
+		require.NoError(t, err)
+	})
+}
+
+func TestServiceUpdateCountPatchesScaledObject(t *testing.T) {
+	testProvider(t, func(p *k8s.Provider) {
+		kk, _ := p.Cluster.(*kfake.Clientset)
+		require.NoError(t, appCreate(kk, "rack1", "app1"))
+		seedDeployment(t, kk, "rack1-app1", "web", 2)
+
+		dyn := fake.NewSimpleDynamicClient(newDynamicScheme(), scaledObjectUnstructured("rack1-app1", "web", 1, 5))
+		p.DynamicClient = dyn
+
+		err := p.ServiceUpdate("app1", "web", structs.ServiceUpdateOptions{Count: options.Int(3)})
+		require.NoError(t, err)
+
+		got, err := dyn.Resource(testScaledObjectGVR).Namespace("rack1-app1").Get(context.TODO(), "web", am.GetOptions{})
+		require.NoError(t, err)
+		spec, _ := got.Object["spec"].(map[string]interface{})
+		require.Equal(t, int64(3), toInt64(spec["minReplicaCount"]))
+		require.Equal(t, int64(3), toInt64(spec["maxReplicaCount"]))
+
+		// Count-only path on a ScaledObject-owned service must not mutate the
+		// Deployment's Replicas field — that would fight KEDA's reconciler.
+		d, err := kk.AppsV1().Deployments("rack1-app1").Get(context.TODO(), "web", am.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, int32(2), *d.Spec.Replicas, "deployment replicas must stay at original value when ScaledObject owns replicas")
+	})
+}
+
+func TestKedaScaledObjectFromAutoscale(t *testing.T) {
+	svc := manifest.Service{Name: "vllm"}
+	svc.Scale.Autoscale = &manifest.ServiceAutoscale{
+		GpuUtilization: &manifest.AutoscaleThreshold{Threshold: 70},
+	}
+	triggers := svc.Scale.Autoscale.BuildTriggers("myapp", "vllm", "http://prom/")
+
+	obj := svc.KedaScaledObject(manifest.KedaScaledObjectParameters{
+		ServiceName: "vllm",
+		Namespace:   "myapp-ns",
+		MinCount:    0,
+		MaxCount:    10,
+		Triggers:    triggers,
+	})
+	require.NotNil(t, obj)
+
+	data, err := k8s.SerializeK8sObjToYaml(obj)
+	require.NoError(t, err)
+
+	var parsed kedav1alpha1.ScaledObject
+	require.NoError(t, yaml.Unmarshal(data, &parsed))
+	require.Equal(t, "ScaledObject", parsed.TypeMeta.Kind)
+	require.Equal(t, "keda.sh/v1alpha1", parsed.TypeMeta.APIVersion)
+	require.Equal(t, int32(0), *parsed.Spec.MinReplicaCount)
+	require.Equal(t, int32(10), *parsed.Spec.MaxReplicaCount)
+	require.Len(t, parsed.Spec.Triggers, 1)
+	require.Equal(t, "prometheus", parsed.Spec.Triggers[0].Type)
+	require.Equal(t, "convox-gpu-utilization", parsed.Spec.Triggers[0].Name)
+	require.Equal(t, "70", parsed.Spec.Triggers[0].Metadata["threshold"])
+	require.Equal(t, "35", parsed.Spec.Triggers[0].Metadata["activationThreshold"])
+	require.Equal(t, "vllm", parsed.Spec.ScaleTargetRef.Name)
+	require.Equal(t, "Deployment", parsed.Spec.ScaleTargetRef.Kind)
+}
+
+func TestAwsAuthAttachFilter(t *testing.T) {
+	t.Setenv("PROVIDER", "aws")
+	svc := manifest.Service{Name: "worker"}
+	svc.Scale.Keda = &manifest.ServiceScaleKeda{
+		Triggers: []kedav1alpha1.ScaleTriggers{
+			{Type: "aws-sqs-queue", Name: "raw-sqs", Metadata: map[string]string{"queueURL": "http://q/", "queueLength": "1", "awsRegion": "us-east-1"}},
+			{Type: "prometheus", Name: "raw-prom", Metadata: map[string]string{"serverAddress": "http://p/", "metricName": "m", "threshold": "1", "query": "up"}},
+			{Type: "cron", Name: "raw-cron", Metadata: map[string]string{"timezone": "UTC", "start": "* * * * *", "end": "* * * * *", "desiredReplicas": "1"}},
+		},
+	}
+
+	obj := svc.KedaScaledObject(manifest.KedaScaledObjectParameters{
+		ServiceName: "worker",
+		Namespace:   "myapp-ns",
+		MinCount:    0,
+		MaxCount:    5,
+		Triggers:    svc.Scale.Keda.Triggers,
+	})
+	require.NotNil(t, obj)
+	require.Len(t, obj.Spec.Triggers, 3)
+
+	var sqs, prom, cron *kedav1alpha1.ScaleTriggers
+	for i := range obj.Spec.Triggers {
+		switch obj.Spec.Triggers[i].Type {
+		case "aws-sqs-queue":
+			sqs = &obj.Spec.Triggers[i]
+		case "prometheus":
+			prom = &obj.Spec.Triggers[i]
+		case "cron":
+			cron = &obj.Spec.Triggers[i]
+		}
+	}
+	require.NotNil(t, sqs)
+	require.NotNil(t, prom)
+	require.NotNil(t, cron)
+
+	require.NotNil(t, sqs.AuthenticationRef, "aws-sqs-queue MUST get default AWS IRSA auth")
+	require.Equal(t, "keda-aws-auth-default", sqs.AuthenticationRef.Name)
+
+	require.Nil(t, prom.AuthenticationRef, "prometheus trigger MUST NOT inherit AWS auth")
+	require.Nil(t, cron.AuthenticationRef, "cron trigger MUST NOT inherit AWS auth")
+}
+
+func toInt64(v interface{}) int64 {
+	switch t := v.(type) {
+	case int64:
+		return t
+	case float64:
+		return int64(t)
+	case int:
+		return int64(t)
+	}
+	panic("unexpected type in toInt64")
+}

--- a/provider/k8s/autoscale_vendor_test.go
+++ b/provider/k8s/autoscale_vendor_test.go
@@ -1,0 +1,5 @@
+package k8s_test
+
+import (
+	_ "k8s.io/client-go/dynamic/fake"
+)

--- a/provider/k8s/release.go
+++ b/provider/k8s/release.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -17,6 +18,7 @@ import (
 	"github.com/convox/convox/pkg/structs"
 	"github.com/convox/convox/provider/aws/provisioner"
 	ca "github.com/convox/convox/provider/k8s/pkg/apis/convox/v1"
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"github.com/pkg/errors"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -25,6 +27,8 @@ import (
 	am "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ktypes "k8s.io/apimachinery/pkg/types"
 )
+
+const defaultPrometheusURL = "http://prometheus-server.kube-system.svc.cluster.local:80"
 
 const (
 	APP_CONFIG_KEY = "app.json"
@@ -693,25 +697,49 @@ func (p *Provider) releaseTemplateServices(a *structs.App, e structs.Environment
 			return nil, errors.WithStack(err)
 		}
 
-		if !p.IsKedaEnabled && s.Scale.IsKedaEnabled() {
-			return nil, structs.ErrBadRequest("keda is not enabled on the rack")
+		wantsAutoscale := s.Scale.Autoscale.IsEnabled() || s.Scale.IsKedaEnabled()
+		// Agent services render as DaemonSets; KEDA ScaledObject only targets
+		// Deployments, so skip the autoscale path entirely.
+		if s.Agent.Enabled {
+			wantsAutoscale = false
+		}
+		if !p.IsKedaEnabled && wantsAutoscale {
+			_ = p.EventSend("release:autoscale-disabled", structs.EventSendOptions{
+				Data: map[string]string{
+					"app":     a.Name,
+					"service": s.Name,
+					"reason":  "rack has keda_enable=false; autoscale ignored, using Count.Min static replicas",
+				},
+			})
+			wantsAutoscale = false
+		}
+
+		if !s.Agent.Enabled && s.Scale.Min != nil && *s.Scale.Min == 0 && !s.Scale.Autoscale.IsEnabled() && !s.Scale.IsKedaEnabled() {
+			_ = p.EventSend("release:manifest-advisory", structs.EventSendOptions{
+				Data: map[string]string{
+					"app":     a.Name,
+					"service": s.Name,
+					"reason":  "scale.min=0 without autoscale fields will keep the service at zero replicas permanently; set scale.autoscale.cpu.threshold or equivalent to enable scale-up",
+				},
+			})
 		}
 
 		params := map[string]interface{}{
-			"Annotations":    s.AnnotationsMap(),
-			"App":            a,
-			"Environment":    env,
-			"MaxSurge":       max - 100,
-			"MaxUnavailable": 100 - min,
-			"Namespace":      p.AppNamespace(a.Name),
-			"Password":       p.Password,
-			"Rack":           p.Name,
-			"Release":        r,
-			"Replicas":       replicas,
-			"Resources":      s.ResourceMap(),
-			"Service":        s,
-			"KedaIsEnabled":  s.Scale.IsKedaEnabled(),
-			"DockerHubAuth":  p.hasDockerHubAuth(),
+			"Annotations":        s.AnnotationsMap(),
+			"App":                a,
+			"Environment":        env,
+			"MaxSurge":           max - 100,
+			"MaxUnavailable":     100 - min,
+			"Namespace":          p.AppNamespace(a.Name),
+			"Password":           p.Password,
+			"Rack":               p.Name,
+			"Release":            r,
+			"Replicas":           replicas,
+			"Resources":          s.ResourceMap(),
+			"Service":            s,
+			"KedaIsEnabled":      s.Scale.IsKedaEnabled() && !s.Agent.Enabled,
+			"AutoscaleIsEnabled": s.Scale.Autoscale.IsEnabled() && !s.Agent.Enabled,
+			"DockerHubAuth":      p.hasDockerHubAuth(),
 		}
 
 		if ip, err := p.Engine.ResolverHost(); err == nil {
@@ -729,12 +757,35 @@ func (p *Provider) releaseTemplateServices(a *structs.App, e structs.Environment
 
 		items = append(items, data)
 
-		if s.Scale.IsKedaEnabled() && s.Scale.Count.Min >= 0 && s.Scale.Count.Max > s.Scale.Count.Min {
+		if wantsAutoscale && p.IsKedaEnabled && s.Scale.Count.Max > s.Scale.Count.Min {
+			promURL := defaultPrometheusURL
+			if v := os.Getenv("PROMETHEUS_URL"); v != "" {
+				promURL = v
+			} else if s.Scale.Autoscale.NeedsPrometheus() {
+				_ = p.EventSend("release:prometheus-default", structs.EventSendOptions{
+					Data: map[string]string{
+						"app":     a.Name,
+						"service": s.Name,
+						"url":     promURL,
+						"reason":  "no explicit prometheus_url and PROMETHEUS_URL env unset; using in-cluster default. Install the observability bundle OR set scale.autoscale.*.prometheus_url if this URL is wrong.",
+					},
+				})
+			}
+
+			var triggers []kedav1alpha1.ScaleTriggers
+			if s.Scale.Autoscale.IsEnabled() {
+				triggers = append(triggers, s.Scale.Autoscale.BuildTriggers(a.Name, s.Name, promURL)...)
+			}
+			if s.Scale.IsKedaEnabled() {
+				triggers = append(triggers, s.Scale.Keda.Triggers...)
+			}
+
 			scaledObj := s.KedaScaledObject(manifest.KedaScaledObjectParameters{
 				ServiceName: s.Name,
 				Namespace:   p.AppNamespace(a.Name),
 				MinCount:    int32(s.Scale.Count.Min),
 				MaxCount:    int32(s.Scale.Count.Max),
+				Triggers:    triggers,
 			})
 			if scaledObj != nil {
 				if p.applyAnnotationsToHPA(a.Name, s.Name, map[string]string{

--- a/provider/k8s/service.go
+++ b/provider/k8s/service.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"time"
@@ -12,9 +13,14 @@ import (
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	kerr "k8s.io/apimachinery/pkg/api/errors"
 	resource "k8s.io/apimachinery/pkg/api/resource"
 	am "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ktypes "k8s.io/apimachinery/pkg/types"
 )
+
+var scaledObjectGVR = schema.GroupVersionResource{Group: "keda.sh", Version: "v1alpha1", Resource: "scaledobjects"}
 
 func (p *Provider) ServiceHost(app string, s manifest.Service) string {
 	if s.Internal {
@@ -92,6 +98,18 @@ func (p *Provider) ServiceList(app string) (structs.Services, error) {
 			}
 		}
 
+		min := ms.Scale.Count.Min
+		max := ms.Scale.Count.Max
+		s.Min = &min
+		s.Max = &max
+		if min == 0 && s.Count == 0 {
+			cold := true
+			s.ColdStart = &cold
+		}
+		if ms.Scale.Autoscale.IsEnabled() {
+			s.Autoscale = buildServiceAutoscaleState(ms.Scale.Autoscale)
+		}
+
 		ss = append(ss, s)
 	}
 
@@ -145,6 +163,11 @@ func (p *Provider) ServiceList(app string) (structs.Services, error) {
 				break
 			}
 		}
+
+		min := ms.Scale.Count.Min
+		max := ms.Scale.Count.Max
+		s.Min = &min
+		s.Max = &max
 
 		ss = append(ss, s)
 	}
@@ -218,9 +241,23 @@ func (p *Provider) ServiceUpdate(app, name string, opts structs.ServiceUpdateOpt
 		return errors.WithStack(err)
 	}
 
+	if opts.Min != nil || opts.Max != nil {
+		if err := p.serviceUpdateScaledObject(app, name, opts); err != nil {
+			return err
+		}
+	}
+
+	countHandledByScaledObject := false
 	if opts.Count != nil {
-		c := int32(*opts.Count)
-		d.Spec.Replicas = &c
+		countHandled, err := p.serviceUpdateCount(app, name, *opts.Count)
+		if err != nil {
+			return err
+		}
+		countHandledByScaledObject = countHandled
+		if !countHandled {
+			c := int32(*opts.Count) //nolint:gosec // replica counts are user-validated and bounded
+			d.Spec.Replicas = &c
+		}
 	}
 
 	if opts.Cpu != nil {
@@ -276,6 +313,15 @@ func (p *Provider) ServiceUpdate(app, name string, opts structs.ServiceUpdateOpt
 		}
 	}
 
+	// When only --count was supplied AND the ScaledObject claimed ownership,
+	// skip the Deployment Update. The informer-cached d.Spec.Replicas is
+	// likely stale, and writing it back would briefly fight KEDA's reconciler
+	// before KEDA converges on the patched minReplicaCount/maxReplicaCount.
+	countOnly := opts.Count != nil && opts.Cpu == nil && opts.Memory == nil && opts.Gpu == nil && opts.Min == nil && opts.Max == nil
+	if countOnly && countHandledByScaledObject {
+		return nil
+	}
+
 	if _, err := p.Cluster.AppsV1().Deployments(p.AppNamespace(app)).Update(context.TODO(), d, am.UpdateOptions{}); err != nil {
 		return errors.WithStack(err)
 	}
@@ -305,4 +351,150 @@ func serviceContainerPorts(c v1.Container, internal bool) []structs.ServicePort 
 	}
 
 	return ps
+}
+
+func buildServiceAutoscaleState(a *manifest.ServiceAutoscale) *structs.ServiceAutoscaleState {
+	if !a.IsEnabled() {
+		return nil
+	}
+	st := &structs.ServiceAutoscaleState{Enabled: true}
+	if a.Cpu != nil {
+		v := int(a.Cpu.Threshold)
+		st.CpuThreshold = &v
+	}
+	if a.Memory != nil {
+		v := int(a.Memory.Threshold)
+		st.MemThreshold = &v
+	}
+	if a.GpuUtilization != nil {
+		v := int(a.GpuUtilization.Threshold)
+		st.GpuThreshold = &v
+		if a.GpuUtilization.MetricName != "" {
+			st.MetricName = a.GpuUtilization.MetricName
+		}
+	}
+	if a.QueueDepth != nil {
+		v := int(a.QueueDepth.Threshold)
+		st.QueueThreshold = &v
+		if a.QueueDepth.MetricName != "" {
+			st.MetricName = a.QueueDepth.MetricName
+		}
+	}
+	st.CustomTriggers = len(a.Custom)
+	return st
+}
+
+func (p *Provider) serviceUpdateScaledObject(app, name string, opts structs.ServiceUpdateOptions) error {
+	ns := p.AppNamespace(app)
+
+	_, err := p.DynamicClient.Resource(scaledObjectGVR).Namespace(ns).Get(context.TODO(), name, am.GetOptions{})
+	hasScaledObject := err == nil
+	if err != nil && !kerr.IsNotFound(err) {
+		return errors.WithStack(err)
+	}
+
+	if opts.Min != nil && *opts.Min == 0 {
+		if err := p.ensureWakeMechanism(app, name, hasScaledObject); err != nil {
+			return err
+		}
+	}
+
+	if !hasScaledObject {
+		return nil
+	}
+
+	spec := map[string]interface{}{}
+	if opts.Min != nil {
+		spec["minReplicaCount"] = *opts.Min
+	}
+	if opts.Max != nil {
+		spec["maxReplicaCount"] = *opts.Max
+	}
+	patch := map[string]interface{}{"spec": spec}
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	if _, err := p.DynamicClient.Resource(scaledObjectGVR).Namespace(ns).Patch(
+		context.TODO(), name, ktypes.MergePatchType, patchBytes, am.PatchOptions{},
+	); err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
+}
+
+// serviceUpdateCount patches the ScaledObject CRD when one owns the deployment;
+// returns handled=true in that case so the caller knows to skip the subsequent
+// deployment.Spec.Replicas write (which would race with KEDA's reconciler).
+// Returns handled=false when no ScaledObject exists, letting the caller fall
+// back to the normal Deployment patch path.
+func (p *Provider) serviceUpdateCount(app, name string, count int) (handled bool, err error) {
+	ns := p.AppNamespace(app)
+
+	_, getErr := p.DynamicClient.Resource(scaledObjectGVR).Namespace(ns).Get(context.TODO(), name, am.GetOptions{})
+	if kerr.IsNotFound(getErr) {
+		return false, nil
+	}
+	if getErr != nil {
+		return false, errors.WithStack(getErr)
+	}
+
+	patch := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"minReplicaCount": count,
+			"maxReplicaCount": count,
+		},
+	}
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return false, errors.WithStack(err)
+	}
+
+	if _, err := p.DynamicClient.Resource(scaledObjectGVR).Namespace(ns).Patch(
+		context.TODO(), name, ktypes.MergePatchType, patchBytes, am.PatchOptions{},
+	); err != nil {
+		return false, errors.WithStack(err)
+	}
+
+	_ = p.EventSend("release:imperative-patch-note", structs.EventSendOptions{
+		Data: map[string]string{
+			"app":     app,
+			"service": name,
+			"reason":  "KEDA ScaledObject owns replicas; patched scaledobject spec.minReplicaCount / spec.maxReplicaCount instead of deployment replicas",
+		},
+	})
+
+	return true, nil
+}
+
+func (p *Provider) ensureWakeMechanism(app, name string, hasScaledObject bool) error {
+	if hasScaledObject {
+		return nil
+	}
+
+	a, err := p.AppGet(app)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	if a.Release != "" {
+		m, _, err := common.ReleaseManifest(p, app, a.Release)
+		if err != nil {
+			return errors.WithStack(fmt.Errorf("could not verify wake mechanism for service %s: %w", name, err))
+		}
+		ms, mErr := m.Service(name)
+		if mErr != nil {
+			return structs.ErrBadRequest("service %s not found in current release manifest", name)
+		}
+		if ms.Scale.Autoscale.IsEnabled() || ms.Scale.IsKedaEnabled() {
+			return nil
+		}
+	}
+
+	return structs.ErrBadRequest(
+		"cannot set --min 0 on service %s: no autoscale mechanism is configured to wake pods back up. Set scale.autoscale.* in convox.yml and promote a release first, or use --min 1 (or higher)",
+		name,
+	)
 }

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -469,7 +469,7 @@ spec:
               path: {{ .Filename }}
       {{ end }}
  
-{{ if and (not (eq .Service.Scale.Count.Min .Service.Scale.Count.Max)) (not $.KedaIsEnabled) }}
+{{ if and (and (and (not (eq .Service.Scale.Count.Min .Service.Scale.Count.Max)) (not $.KedaIsEnabled)) (not $.AutoscaleIsEnabled)) (not .Service.Agent.Enabled) }}
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler

--- a/vendor/k8s.io/client-go/dynamic/fake/simple.go
+++ b/vendor/k8s.io/client-go/dynamic/fake/simple.go
@@ -1,0 +1,539 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/testing"
+)
+
+func NewSimpleDynamicClient(scheme *runtime.Scheme, objects ...runtime.Object) *FakeDynamicClient {
+	unstructuredScheme := runtime.NewScheme()
+	for gvk := range scheme.AllKnownTypes() {
+		if unstructuredScheme.Recognizes(gvk) {
+			continue
+		}
+		if strings.HasSuffix(gvk.Kind, "List") {
+			unstructuredScheme.AddKnownTypeWithName(gvk, &unstructured.UnstructuredList{})
+			continue
+		}
+		unstructuredScheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+	}
+
+	objects, err := convertObjectsToUnstructured(scheme, objects)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, obj := range objects {
+		gvk := obj.GetObjectKind().GroupVersionKind()
+		if !unstructuredScheme.Recognizes(gvk) {
+			unstructuredScheme.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+		}
+		gvk.Kind += "List"
+		if !unstructuredScheme.Recognizes(gvk) {
+			unstructuredScheme.AddKnownTypeWithName(gvk, &unstructured.UnstructuredList{})
+		}
+	}
+
+	return NewSimpleDynamicClientWithCustomListKinds(unstructuredScheme, nil, objects...)
+}
+
+// NewSimpleDynamicClientWithCustomListKinds try not to use this.  In general you want to have the scheme have the List types registered
+// and allow the default guessing for resources match.  Sometimes that doesn't work, so you can specify a custom mapping here.
+func NewSimpleDynamicClientWithCustomListKinds(scheme *runtime.Scheme, gvrToListKind map[schema.GroupVersionResource]string, objects ...runtime.Object) *FakeDynamicClient {
+	// In order to use List with this client, you have to have your lists registered so that the object tracker will find them
+	// in the scheme to support the t.scheme.New(listGVK) call when it's building the return value.
+	// Since the base fake client needs the listGVK passed through the action (in cases where there are no instances, it
+	// cannot look up the actual hits), we need to know a mapping of GVR to listGVK here.  For GETs and other types of calls,
+	// there is no return value that contains a GVK, so it doesn't have to know the mapping in advance.
+
+	// first we attempt to invert known List types from the scheme to auto guess the resource with unsafe guesses
+	// this covers common usage of registering types in scheme and passing them
+	completeGVRToListKind := map[schema.GroupVersionResource]string{}
+	for listGVK := range scheme.AllKnownTypes() {
+		if !strings.HasSuffix(listGVK.Kind, "List") {
+			continue
+		}
+		nonListGVK := listGVK.GroupVersion().WithKind(listGVK.Kind[:len(listGVK.Kind)-4])
+		plural, _ := meta.UnsafeGuessKindToResource(nonListGVK)
+		completeGVRToListKind[plural] = listGVK.Kind
+	}
+
+	for gvr, listKind := range gvrToListKind {
+		if !strings.HasSuffix(listKind, "List") {
+			panic("coding error, listGVK must end in List or this fake client doesn't work right")
+		}
+		listGVK := gvr.GroupVersion().WithKind(listKind)
+
+		// if we already have this type registered, just skip it
+		if _, err := scheme.New(listGVK); err == nil {
+			completeGVRToListKind[gvr] = listKind
+			continue
+		}
+
+		scheme.AddKnownTypeWithName(listGVK, &unstructured.UnstructuredList{})
+		completeGVRToListKind[gvr] = listKind
+	}
+
+	codecs := serializer.NewCodecFactory(scheme)
+	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
+	for _, obj := range objects {
+		if err := o.Add(obj); err != nil {
+			panic(err)
+		}
+	}
+
+	cs := &FakeDynamicClient{scheme: scheme, gvrToListKind: completeGVRToListKind, tracker: o}
+	cs.AddReactor("*", "*", testing.ObjectReaction(o))
+	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := o.Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		return true, watch, nil
+	})
+
+	return cs
+}
+
+// Clientset implements clientset.Interface. Meant to be embedded into a
+// struct to get a default implementation. This makes faking out just the method
+// you want to test easier.
+type FakeDynamicClient struct {
+	testing.Fake
+	scheme        *runtime.Scheme
+	gvrToListKind map[schema.GroupVersionResource]string
+	tracker       testing.ObjectTracker
+}
+
+type dynamicResourceClient struct {
+	client    *FakeDynamicClient
+	namespace string
+	resource  schema.GroupVersionResource
+	listKind  string
+}
+
+var (
+	_ dynamic.Interface  = &FakeDynamicClient{}
+	_ testing.FakeClient = &FakeDynamicClient{}
+)
+
+func (c *FakeDynamicClient) Tracker() testing.ObjectTracker {
+	return c.tracker
+}
+
+func (c *FakeDynamicClient) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	return &dynamicResourceClient{client: c, resource: resource, listKind: c.gvrToListKind[resource]}
+}
+
+func (c *dynamicResourceClient) Namespace(ns string) dynamic.ResourceInterface {
+	ret := *c
+	ret.namespace = ns
+	return &ret
+}
+
+func (c *dynamicResourceClient) Create(ctx context.Context, obj *unstructured.Unstructured, opts metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootCreateAction(c.resource, obj), obj)
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		var accessor metav1.Object // avoid shadowing err
+		accessor, err = meta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		name := accessor.GetName()
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootCreateSubresourceAction(c.resource, name, strings.Join(subresources, "/"), obj), obj)
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewCreateAction(c.resource, c.namespace, obj), obj)
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		var accessor metav1.Object // avoid shadowing err
+		accessor, err = meta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		name := accessor.GetName()
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewCreateSubresourceAction(c.resource, name, strings.Join(subresources, "/"), c.namespace, obj), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) Update(ctx context.Context, obj *unstructured.Unstructured, opts metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateAction(c.resource, obj), obj)
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateSubresourceAction(c.resource, strings.Join(subresources, "/"), obj), obj)
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateAction(c.resource, c.namespace, obj), obj)
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateSubresourceAction(c.resource, strings.Join(subresources, "/"), c.namespace, obj), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) UpdateStatus(ctx context.Context, obj *unstructured.Unstructured, opts metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateSubresourceAction(c.resource, "status", obj), obj)
+
+	case len(c.namespace) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateSubresourceAction(c.resource, "status", c.namespace, obj), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) Delete(ctx context.Context, name string, opts metav1.DeleteOptions, subresources ...string) error {
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewRootDeleteActionWithOptions(c.resource, name, opts), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewRootDeleteSubresourceActionWithOptions(c.resource, strings.Join(subresources, "/"), name, opts), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewDeleteActionWithOptions(c.resource, c.namespace, name, opts), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewDeleteSubresourceActionWithOptions(c.resource, strings.Join(subresources, "/"), c.namespace, name, opts), &metav1.Status{Status: "dynamic delete fail"})
+	}
+
+	return err
+}
+
+func (c *dynamicResourceClient) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		action := testing.NewRootDeleteCollectionAction(c.resource, listOptions)
+		_, err = c.client.Fake.Invokes(action, &metav1.Status{Status: "dynamic deletecollection fail"})
+
+	case len(c.namespace) > 0:
+		action := testing.NewDeleteCollectionAction(c.resource, c.namespace, listOptions)
+		_, err = c.client.Fake.Invokes(action, &metav1.Status{Status: "dynamic deletecollection fail"})
+
+	}
+
+	return err
+}
+
+func (c *dynamicResourceClient) Get(ctx context.Context, name string, opts metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootGetAction(c.resource, name), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootGetSubresourceAction(c.resource, strings.Join(subresources, "/"), name), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewGetAction(c.resource, c.namespace, name), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewGetSubresourceAction(c.resource, c.namespace, strings.Join(subresources, "/"), name), &metav1.Status{Status: "dynamic get fail"})
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	if len(c.listKind) == 0 {
+		panic(fmt.Sprintf("coding error: you must register resource to list kind for every resource you're going to LIST when creating the client.  See NewSimpleDynamicClientWithCustomListKinds or register the list into the scheme: %v out of %v", c.resource, c.client.gvrToListKind))
+	}
+	listGVK := c.resource.GroupVersion().WithKind(c.listKind)
+	listForFakeClientGVK := c.resource.GroupVersion().WithKind(c.listKind[:len(c.listKind)-4]) /*base library appends List*/
+
+	var obj runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		obj, err = c.client.Fake.
+			Invokes(testing.NewRootListAction(c.resource, listForFakeClientGVK, opts), &metav1.Status{Status: "dynamic list fail"})
+
+	case len(c.namespace) > 0:
+		obj, err = c.client.Fake.
+			Invokes(testing.NewListAction(c.resource, listForFakeClientGVK, c.namespace, opts), &metav1.Status{Status: "dynamic list fail"})
+
+	}
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label, _, _ := testing.ExtractFromListOptions(opts)
+	if label == nil {
+		label = labels.Everything()
+	}
+
+	retUnstructured := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(obj, retUnstructured, nil); err != nil {
+		return nil, err
+	}
+	entireList, err := retUnstructured.ToList()
+	if err != nil {
+		return nil, err
+	}
+
+	list := &unstructured.UnstructuredList{}
+	list.SetRemainingItemCount(entireList.GetRemainingItemCount())
+	list.SetResourceVersion(entireList.GetResourceVersion())
+	list.SetContinue(entireList.GetContinue())
+	list.GetObjectKind().SetGroupVersionKind(listGVK)
+	for i := range entireList.Items {
+		item := &entireList.Items[i]
+		metadata, err := meta.Accessor(item)
+		if err != nil {
+			return nil, err
+		}
+		if label.Matches(labels.Set(metadata.GetLabels())) {
+			list.Items = append(list.Items, *item)
+		}
+	}
+	return list, nil
+}
+
+func (c *dynamicResourceClient) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	switch {
+	case len(c.namespace) == 0:
+		return c.client.Fake.
+			InvokesWatch(testing.NewRootWatchAction(c.resource, opts))
+
+	case len(c.namespace) > 0:
+		return c.client.Fake.
+			InvokesWatch(testing.NewWatchAction(c.resource, c.namespace, opts))
+	}
+
+	panic("math broke")
+}
+
+// TODO: opts are currently ignored.
+func (c *dynamicResourceClient) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootPatchAction(c.resource, name, pt, data), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootPatchSubresourceAction(c.resource, name, pt, data, subresources...), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewPatchAction(c.resource, c.namespace, name, pt, data), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewPatchSubresourceAction(c.resource, c.namespace, name, pt, data, subresources...), &metav1.Status{Status: "dynamic patch fail"})
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+// TODO: opts are currently ignored.
+func (c *dynamicResourceClient) Apply(ctx context.Context, name string, obj *unstructured.Unstructured, options metav1.ApplyOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	outBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
+	if err != nil {
+		return nil, err
+	}
+	var uncastRet runtime.Object
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootPatchAction(c.resource, name, types.ApplyPatchType, outBytes), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootPatchSubresourceAction(c.resource, name, types.ApplyPatchType, outBytes, subresources...), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewPatchAction(c.resource, c.namespace, name, types.ApplyPatchType, outBytes), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewPatchSubresourceAction(c.resource, c.namespace, name, types.ApplyPatchType, outBytes, subresources...), &metav1.Status{Status: "dynamic patch fail"})
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+func (c *dynamicResourceClient) ApplyStatus(ctx context.Context, name string, obj *unstructured.Unstructured, options metav1.ApplyOptions) (*unstructured.Unstructured, error) {
+	return c.Apply(ctx, name, obj, options, "status")
+}
+
+func convertObjectsToUnstructured(s *runtime.Scheme, objs []runtime.Object) ([]runtime.Object, error) {
+	ul := make([]runtime.Object, 0, len(objs))
+
+	for _, obj := range objs {
+		u, err := convertToUnstructured(s, obj)
+		if err != nil {
+			return nil, err
+		}
+
+		ul = append(ul, u)
+	}
+	return ul, nil
+}
+
+func convertToUnstructured(s *runtime.Scheme, obj runtime.Object) (runtime.Object, error) {
+	var (
+		err error
+		u   unstructured.Unstructured
+	)
+
+	u.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert to unstructured: %w", err)
+	}
+
+	gvk := u.GroupVersionKind()
+	if gvk.Group == "" || gvk.Kind == "" {
+		gvks, _, err := s.ObjectKinds(obj)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert to unstructured - unable to get GVK %w", err)
+		}
+		apiv, k := gvks[0].ToAPIVersionAndKind()
+		u.SetAPIVersion(apiv)
+		u.SetKind(k)
+	}
+	return &u, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1540,6 +1540,7 @@ k8s.io/client-go/discovery/cached/disk
 k8s.io/client-go/discovery/cached/memory
 k8s.io/client-go/discovery/fake
 k8s.io/client-go/dynamic
+k8s.io/client-go/dynamic/fake
 k8s.io/client-go/features
 k8s.io/client-go/gentype
 k8s.io/client-go/informers


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: KEDA-Based Autoscaling, Scale-to-Zero, and GPU Observability**

This release introduces native autoscaling support through [KEDA](https://keda.sh/), enabling services to scale based on CPU, memory, GPU utilization, queue depth, or custom metrics — including scaling down to zero replicas when idle.

A new `scale.autoscale` block in `convox.yml` provides built-in shortcuts for common scaling triggers, while also supporting arbitrary KEDA trigger configurations for advanced use cases. The CLI adds `--min` and `--max` flags to `convox scale` for imperative scaling bounds, and both `convox scale` and `convox services` now display autoscale status and cold-start indicators.

Additionally, new GPU observability infrastructure — powered by NVIDIA DCGM Exporter and Prometheus — provides GPU utilization and memory metrics that feed both the autoscaling triggers and monitoring dashboards available through the Convox Console.

**Autoscaling triggers:**

| Trigger | Manifest Field | Metric |
|---------|---------------|--------|
| CPU | `scale.autoscale.cpu` | CPU utilization % (1-100) |
| Memory | `scale.autoscale.memory` | Memory utilization % (1-100) |
| GPU Utilization | `scale.autoscale.gpuUtilization` | GPU utilization % via Prometheus |
| Queue Depth | `scale.autoscale.queueDepth` | Pending work items (e.g. `vllm:num_requests_waiting`) |
| Custom | `scale.autoscale.custom` | Any KEDA-supported scaler |

When autoscale triggers are configured, the rack renders a KEDA `ScaledObject` and automatically suppresses HPA generation to avoid conflicts.

**GPU Observability parameters:**

| Parameter | Default | Description |
|-----------|---------|-------------|
| `gpu_observability_enable` | `false` | Enable DCGM Exporter DaemonSet for GPU metrics |
| `gpu_observability_chart_version` | `4.8.1` | DCGM Exporter Helm chart version |
| `prometheus_gpu_metrics_chart_version` | `27.9.0` | Prometheus chart version for GPU metrics scraping |
| `prometheus_gpu_metrics_retention` | `24h` | Prometheus data retention window |
| `prometheus_url` | `""` | External Prometheus URL for KEDA autoscale triggers and GPU metric enrichment in `convox ps`. Set to the in-cluster service URL for Convox Console-managed monitoring, or to an external Prometheus endpoint |
| `grafana_url` | `""` | User-facing Grafana base URL for the Console's "Open in Grafana" deep-link button. Empty keeps the button inert |

The DCGM Exporter collects per-GPU utilization, memory, temperature, and power metrics from NVIDIA GPUs on each node. When connected to the Convox Console, a Prometheus instance is automatically provisioned for metric scraping and dashboard visualization. Setting `prometheus_url` to the in-cluster Prometheus service URL enables GPU metric enrichment in CLI output (`convox ps` shows per-process GPU utilization). An optional `grafana_url` enables direct deep-links from the Console to your Grafana dashboards.

**Console integration:** When the Convox Console is connected, autoscale triggers can also be managed directly from the Console UI — enabling, disabling, and adjusting thresholds without redeploying the application.

---

### Why is this important?

GPU and inference workloads have highly variable demand patterns. Without autoscaling, users must choose between over-provisioning (wasting expensive GPU capacity) or under-provisioning (dropping requests during spikes). Scale-to-zero is particularly impactful for development and staging environments where GPU instances may sit idle for hours.

**Benefits:**

- **Cost optimization.** Scale down to zero replicas when idle — stop paying for GPU instances that aren't serving traffic
- **Demand-responsive scaling.** Scale based on actual workload signals (queue depth, GPU utilization) rather than static replica counts
- **Cold-start visibility.** When a service is scaled to zero, `convox scale` and `convox services` show a `COLD` indicator so users know the first request will incur startup latency
- **GPU monitoring.** GPU utilization, memory, temperature, and power metrics are collected per-node without additional infrastructure setup
- **Graceful degradation.** If KEDA is not installed, autoscale configuration is ignored and services run at `scale.min` static replicas with an advisory event
- **No-redeploy management.** Console-driven Triggers Override allows autoscale configuration changes without a new deploy cycle

---

### How to use it?

**Scale-to-zero with queue-depth trigger:**

```yaml
services:
  inference:
    build: .
    port: 8000
    scale:
      min: 0
      max: 10
      gpu:
        count: 1
      autoscale:
        queueDepth:
          threshold: 5
```

**CPU-based autoscaling with a warm minimum:**

```yaml
services:
  api:
    build: .
    port: 5000
    scale:
      min: 2
      max: 20
      autoscale:
        cpu:
          threshold: 70
```

**GPU utilization trigger with custom Prometheus endpoint:**

```yaml
services:
  model:
    build: .
    port: 8000
    scale:
      min: 1
      max: 4
      gpu:
        count: 1
      autoscale:
        gpuUtilization:
          threshold: 80
          prometheusUrl: http://prometheus.monitoring:9090
```

**Imperative scaling via CLI:**

    $ convox scale inference --min 1 --max 8 -a my-app -r rackName

**Enable GPU observability:**

    $ convox rack params set gpu_observability_enable=true -r rackName

**Enable KEDA (prerequisite for autoscaling):**

    $ convox rack params set keda_enable=true -r rackName

**Manage autoscale triggers from the CLI (Console-driven Triggers Override):**

    $ convox services triggers enable inference --min 1 --max 8 --cpu 70 -a my-app -r rackName
    $ convox services triggers threshold-set inference --type cpu --threshold 80 -a my-app -r rackName
    $ convox services triggers disable inference -a my-app -r rackName

These commands configure autoscale triggers without redeploying, and are also available through the Convox Console UI.

**Set Prometheus URL for GPU metric enrichment in `convox ps`:**

    $ convox rack params set prometheus_url=http://prometheus-server.monitoring:9090 -r rackName

When `prometheus_url` is configured and GPU pods are running, `convox ps` displays per-process GPU utilization, memory usage, tensor activity, and power draw.

#### New Rack Parameters

| Parameter | Default | Description |
|-----------|---------|-------------|
| `gpu_observability_enable` | `false` | Enable NVIDIA DCGM Exporter for GPU metrics collection |
| `gpu_observability_chart_version` | `4.8.1` | Helm chart version for the DCGM Exporter |
| `prometheus_gpu_metrics_chart_version` | `27.9.0` | Prometheus chart version for GPU metric scraping |
| `prometheus_gpu_metrics_retention` | `24h` | Prometheus data retention window |
| `prometheus_url` | `""` | Prometheus endpoint for KEDA triggers and GPU enrichment in `convox ps` |
| `grafana_url` | `""` | Grafana base URL for Console deep-link button |

---

### Does it have a breaking change?

**No breaking changes** are introduced with this feature.

All new manifest fields are optional with `omitempty` — existing `convox.yml` files render byte-identical output. The `--min` and `--max` CLI flags are additive; existing `--count` behavior is preserved. Older CLIs talking to a new rack see no change. Newer CLIs sending `--min`/`--max` to an older rack have the flags silently ignored.

GPU observability parameters are opt-in (`false` by default) and introduce no new infrastructure until enabled.

---

### Requirements

This feature requires version `3.24.6` or later for the rack. KEDA-based autoscaling additionally requires `keda_enable=true` on the rack.

**Update the Rack:** Run `convox rack update 3.24.6 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.23.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
