### PR TITLE
Reconcile GPU node labels

### DIFF
--- a/provider/k8s/controller_node.go
+++ b/provider/k8s/controller_node.go
@@ -34,6 +34,7 @@ type NodeController struct {
 	provider   *Provider
 	controller *kctl.Controller
 
+	stopMu sync.Mutex
 	stopCh chan struct{}
 	nodeCh chan string
 
@@ -48,7 +49,6 @@ type NodeController struct {
 func NewNodeController(p *Provider) (*NodeController, error) {
 	nc := &NodeController{
 		provider:     p,
-		stopCh:       make(chan struct{}),
 		nodeCh:       make(chan string, 50),
 		nodeMap:      &sync.Map{},
 		logger:       logger.New("ns=node-controller"),
@@ -87,11 +87,56 @@ func (c *NodeController) Run() {
 func (c *NodeController) Start() error {
 	c.start = time.Now().UTC()
 
+	c.stopMu.Lock()
+	if c.stopCh != nil {
+		close(c.stopCh)
+	}
+	c.stopCh = make(chan struct{})
+	stopCh := c.stopCh
+	c.stopMu.Unlock()
+
+	go c.runGpuLabelReconciler(stopCh)
+
 	return nil
 }
 
 func (c *NodeController) Stop() error {
+	c.stopMu.Lock()
+	if c.stopCh != nil {
+		close(c.stopCh)
+		c.stopCh = nil
+	}
+	c.stopMu.Unlock()
+
 	return nil
+}
+
+func (c *NodeController) runGpuLabelReconciler(stopCh <-chan struct{}) {
+	c.ReconcileGpuLabels()
+
+	ticker := time.NewTicker(1 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			c.ReconcileGpuLabels()
+		case <-stopCh:
+			return
+		}
+	}
+}
+
+func (c *NodeController) ReconcileGpuLabels() {
+	nodes, err := c.provider.Cluster.CoreV1().Nodes().List(c.provider.ctx, am.ListOptions{})
+	if err != nil {
+		c.logger.Errorf("failed to list nodes for gpu label reconciliation: %s", err)
+		return
+	}
+
+	for i := range nodes.Items {
+		c.AddGpuLabel(&nodes.Items[i])
+	}
 }
 
 func (c *NodeController) Add(obj interface{}) error {

--- a/provider/k8s/controller_node.go
+++ b/provider/k8s/controller_node.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 	ac "k8s.io/api/core/v1"
 	am "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	appsv1 "k8s.io/client-go/applyconfigurations/apps/v1"
 	corev1 "k8s.io/client-go/applyconfigurations/core/v1"
@@ -158,7 +157,7 @@ func (c *NodeController) Add(obj interface{}) error {
 	return nil
 }
 
-func (c *NodeController) Delete(obj interface{}) error {
+func (*NodeController) Delete(obj interface{}) error {
 	nd, err := assertNode(obj)
 	if err != nil {
 		return errors.WithStack(err)
@@ -168,7 +167,7 @@ func (c *NodeController) Delete(obj interface{}) error {
 	return nil
 }
 
-func (c *NodeController) Update(prev, cur interface{}) error {
+func (c *NodeController) Update(_, cur interface{}) error {
 	nd, err := assertNode(cur)
 	if err != nil {
 		return errors.WithStack(err)
@@ -338,7 +337,7 @@ func (c *NodeController) PatchNodeLabel(nd *ac.Node, key, value string) error {
 		return fmt.Errorf("Error marshaling patch: %v", err)
 	}
 
-	_, err = c.provider.Cluster.CoreV1().Nodes().Patch(c.provider.ctx, nd.Name, types.StrategicMergePatchType, patchBytes, v1.PatchOptions{})
+	_, err = c.provider.Cluster.CoreV1().Nodes().Patch(c.provider.ctx, nd.Name, types.StrategicMergePatchType, patchBytes, am.PatchOptions{})
 	if err != nil {
 		return fmt.Errorf("Error patching node: %v", err)
 	}

--- a/provider/k8s/controller_node_test.go
+++ b/provider/k8s/controller_node_test.go
@@ -17,7 +17,7 @@ type gpuLabelEngine struct {
 	MockEngine
 }
 
-func (e *gpuLabelEngine) GPUIntanceList(instanceTypes []string) ([]string, error) {
+func (*gpuLabelEngine) GPUIntanceList(instanceTypes []string) ([]string, error) {
 	return instanceTypes, nil
 }
 

--- a/provider/k8s/controller_node_test.go
+++ b/provider/k8s/controller_node_test.go
@@ -1,0 +1,49 @@
+package k8s
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/convox/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+type gpuLabelEngine struct {
+	MockEngine
+}
+
+func (e *gpuLabelEngine) GPUIntanceList(instanceTypes []string) ([]string, error) {
+	return instanceTypes, nil
+}
+
+func TestNodeControllerReconcileGpuLabels(t *testing.T) {
+	cluster := fake.NewSimpleClientset(&corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gpu-node",
+			Labels: map[string]string{
+				"node.kubernetes.io/instance-type": "Standard_nc24ads_a100_v4",
+			},
+		},
+	})
+
+	nc := &NodeController{
+		provider: &Provider{
+			Cluster: cluster,
+			Engine:  &gpuLabelEngine{},
+			ctx:     context.Background(),
+		},
+		nodeMap: &sync.Map{},
+		logger:  logger.New("ns=node-controller-test"),
+	}
+
+	nc.ReconcileGpuLabels()
+
+	node, err := cluster.CoreV1().Nodes().Get(context.Background(), "gpu-node", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "nvidia", node.Labels["convox.io/gpu-vendor"])
+}


### PR DESCRIPTION
## Summary
- Add periodic reconciliation for GPU node labels while the node controller is leader.
- Keep the existing add/update event path, but make `convox.io/gpu-vendor=nvidia` self-heal if node events are missed or labels arrive late.
- Add a focused test covering GPU label reconciliation on an Azure A100-style instance type.

## Context
We saw newly provisioned Azure A100 nodes with `node.kubernetes.io/instance-type=Standard_nc24ads_a100_v4` and `convox.io/label=a100x1`, but without `convox.io/gpu-vendor=nvidia`. Because the NVIDIA device plugin DaemonSet requires that label, it did not schedule on the new nodes and Kubernetes did not advertise `nvidia.com/gpu` until the nodes were manually labeled.

Fixes #1025.

## Test plan
- Not run locally: Go toolchain (`go`/`gofmt`) is not available in this environment.