### PR TITLE
add ecr_full_access and ecr_additional_policy_arn

### DIFF
--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -48,7 +48,7 @@ var awsKnownParams = map[string]bool{
 	"disable_image_manifest_cache": true, "disable_public_access": true,
 	"dcgm_scrape_interval": true,
 	"docker_hub_password":  true, "docker_hub_username": true,
-	"ebs_volume_encryption_enabled": true, "ecr_docker_hub_cache": true, "ecr_scan_on_push_enable": true,
+	"ebs_volume_encryption_enabled": true, "ecr_additional_policy_arn": true, "ecr_docker_hub_cache": true, "ecr_full_access": true, "ecr_scan_on_push_enable": true,
 	"efs_csi_driver_enable": true, "efs_csi_driver_version": true,
 	"eks_api_server_private_access_cidrs": true,
 	"eks_api_server_public_access_cidrs":  true,
@@ -185,6 +185,7 @@ var boolParams = map[string]bool{
 	"disable_public_access":           true,
 	"ebs_volume_encryption_enabled":   true,
 	"ecr_docker_hub_cache":            true,
+	"ecr_full_access":                 true,
 	"ecr_scan_on_push_enable":         true,
 	"efs_csi_driver_enable":           true,
 	"enable_private_access":           true,
@@ -324,6 +325,8 @@ var paramGroups = map[string]map[string]bool{
 		"disable_public_access":               true,
 		"docker_hub_password":                 true,
 		"ebs_volume_encryption_enabled":       true,
+		"ecr_additional_policy_arn":           true,
+		"ecr_full_access":                     true,
 		"ecr_scan_on_push_enable":             true,
 		"eks_api_server_private_access_cidrs": true,
 		"eks_api_server_public_access_cidrs":  true,
@@ -486,7 +489,9 @@ var paramGroups = map[string]map[string]bool{
 		"disable_image_manifest_cache": true,
 		"docker_hub_password":          true,
 		"docker_hub_username":          true,
+		"ecr_additional_policy_arn":    true,
 		"ecr_docker_hub_cache":         true,
+		"ecr_full_access":              true,
 		"ecr_scan_on_push_enable":      true,
 	},
 	"logging": {
@@ -641,6 +646,8 @@ var clearableParams = map[string]bool{
 	// Custom launch scripts — clear means "remove"
 	"user_data":     true,
 	"user_data_url": true,
+	// ECR — clear means "detach custom policy"
+	"ecr_additional_policy_arn": true,
 	// Feature gates — clear means "disable all"
 	"api_feature_gates": true,
 	// Private EKS — cleared by console during mode changes

--- a/pkg/rack/terraform.go
+++ b/pkg/rack/terraform.go
@@ -82,6 +82,7 @@ var preserveEmpty = map[string]bool{
 	"grafana_dashboard_var_namespace": true,
 	"grafana_dashboard_var_service":   true,
 	"grafana_dashboard_var_app":       true,
+	"ecr_additional_policy_arn":       true,
 }
 
 // PreserveEmptyParams returns a copy of the writeVars empty-preservation

--- a/terraform/api/aws/iam.tf
+++ b/terraform/api/aws/iam.tf
@@ -225,6 +225,18 @@ resource "aws_iam_role_policy" "api_ecr" {
   policy = data.aws_iam_policy_document.ecr.json
 }
 
+resource "aws_iam_role_policy_attachment" "api_ecr_full_access" {
+  count      = var.ecr_full_access ? 1 : 0
+  role       = aws_iam_role.api.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "api_ecr_additional" {
+  count      = var.ecr_additional_policy_arn != "" ? 1 : 0
+  role       = aws_iam_role.api.name
+  policy_arn = var.ecr_additional_policy_arn
+}
+
 resource "aws_iam_role_policy" "api_ec2_key_pair" {
   name   = "ec2_key_pair"
   role   = aws_iam_role.api.name

--- a/terraform/api/aws/variables.tf
+++ b/terraform/api/aws/variables.tf
@@ -73,6 +73,16 @@ variable "disable_image_manifest_cache" {
   default = false
 }
 
+variable "ecr_additional_policy_arn" {
+  type    = string
+  default = ""
+}
+
+variable "ecr_full_access" {
+  type    = bool
+  default = false
+}
+
 variable "ecr_scan_on_push_enable" {
   type    = bool
   default = false

--- a/terraform/rack/aws/main.tf
+++ b/terraform/rack/aws/main.tf
@@ -36,6 +36,8 @@ module "api" {
   domain                                    = try(module.router.endpoint, "") # terraform destroy sometimes failes to resolve the value
   domain_internal                           = module.router.endpoint_internal
   disable_image_manifest_cache              = var.disable_image_manifest_cache
+  ecr_additional_policy_arn                  = var.ecr_additional_policy_arn
+  ecr_full_access                           = var.ecr_full_access
   ecr_scan_on_push_enable                   = var.ecr_scan_on_push_enable
   ecr_docker_hub_cache_prefix               = var.ecr_docker_hub_cache_prefix
   efs_csi_driver_enable                     = var.efs_csi_driver_enable

--- a/terraform/rack/aws/variables.tf
+++ b/terraform/rack/aws/variables.tf
@@ -63,6 +63,16 @@ variable "disable_image_manifest_cache" {
   default = false
 }
 
+variable "ecr_additional_policy_arn" {
+  type    = string
+  default = ""
+}
+
+variable "ecr_full_access" {
+  type    = bool
+  default = false
+}
+
 variable "ecr_scan_on_push_enable" {
   type    = bool
   default = false

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -260,6 +260,8 @@ module "rack" {
   telemetry_map                             = local.telemetry_map
   telemetry_default_map                     = local.telemetry_default_map
   whitelist                                 = split(",", var.whitelist)
+  ecr_additional_policy_arn                  = var.ecr_additional_policy_arn
+  ecr_full_access                           = var.ecr_full_access
   ecr_scan_on_push_enable                   = var.ecr_scan_on_push_enable
   ecr_docker_hub_cache_prefix               = module.cluster.ecr_docker_hub_cache_prefix
   vpc_id                                    = module.cluster.vpc

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -132,6 +132,16 @@ variable "enable_private_access" {
   default = false
 }
 
+variable "ecr_additional_policy_arn" {
+  type    = string
+  default = ""
+}
+
+variable "ecr_full_access" {
+  type    = bool
+  default = false
+}
+
 variable "ecr_scan_on_push_enable" {
   type    = bool
   default = false


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: ECR Policy Customization Parameters**

Version 3.24.6 tightened ECR IAM permissions on the rack API role, replacing the broad `AmazonEC2ContainerRegistryFullAccess` managed policy with a scoped inline policy limited to `${rack_name}/*` and `${rack_name}-*` repositories. This affected users whose CI pipelines push pre-built images to bare-named ECR repos in the same account or reference them as `--cache-from` sources during `convox build`.

Two new rack parameters provide control over ECR IAM permissions:

| Parameter | Type | Default | Effect |
|-----------|------|---------|--------|
| `ecr_full_access` | bool | `false` | Re-attaches `AmazonEC2ContainerRegistryFullAccess` managed policy to the API role, restoring pre-3.24.6 behavior |
| `ecr_additional_policy_arn` | string | `""` | Attaches a user-provided IAM policy ARN to the API role for finer-grained ECR access control |

Both parameters create conditional `aws_iam_role_policy_attachment` resources gated by `count`, so disabling them cleanly detaches the policy with no orphaned resources.

---

### Why is this important?

The tightened ECR scope in 3.24.6 covers most use cases, but users with CI pipelines that reference ECR repos outside the rack's naming convention need a way to restore or customize permissions without downgrading.

**Benefits:**

- **Quick recovery path.** Users affected by the 3.24.6 change can restore full ECR access with a single `params set` command.
- **Fine-grained control.** The `ecr_additional_policy_arn` parameter lets users attach a custom policy scoped to exactly the repos their pipelines need, without granting blanket access.
- **Clearable.** The custom policy ARN can be cleared to detach it, making it safe to iterate on IAM policy configuration.

---

### How to use it?

**Restore full ECR access (pre-3.24.6 behavior):**

    $ convox rack params set ecr_full_access=true -r rackName

**Attach a custom scoped IAM policy:**

    $ convox rack params set ecr_additional_policy_arn=arn:aws:iam::123456789012:policy/my-ecr-repos -r rackName

**Clear a custom policy:**

    $ convox rack params set ecr_additional_policy_arn= -r rackName

#### New Rack Parameters

| Parameter | Default | Provider | Clearable | Description |
|-----------|---------|----------|-----------|-------------|
| `ecr_full_access` | `false` | AWS | No | Re-attaches the `AmazonEC2ContainerRegistryFullAccess` managed policy |
| `ecr_additional_policy_arn` | `""` | AWS | Yes | Attaches a user-provided IAM policy ARN for custom ECR access |

Both parameters appear in the `security` and `registry` parameter groups.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this feature. Both parameters default to `false` / `""`, which preserves the 3.24.6 scoped behavior. Existing racks see zero new IAM resources on upgrade.

**Downgrade safety:** The `reconcileVarsWithModule` mechanism strips unrecognized variables on downgrade. If the parameters were enabled before downgrading, Terraform cleanly destroys the policy attachment(s) via `DetachRolePolicy`.

---

### Requirements

This feature requires version `3.24.7` or later for the rack.

**Update the Rack:** Run `convox rack update 3.24.7 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.23.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
