### PR TITLE
add eks access entries rack param

### DIFF
--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -50,6 +50,7 @@ var awsKnownParams = map[string]bool{
 	"docker_hub_password":  true, "docker_hub_username": true,
 	"ebs_volume_encryption_enabled": true, "ecr_docker_hub_cache": true, "ecr_scan_on_push_enable": true,
 	"efs_csi_driver_enable": true, "efs_csi_driver_version": true,
+	"eks_access_entries":                  true,
 	"eks_api_server_private_access_cidrs": true,
 	"eks_api_server_public_access_cidrs":  true,
 	"eks_log_types":                       true,
@@ -325,6 +326,7 @@ var paramGroups = map[string]map[string]bool{
 		"docker_hub_password":                 true,
 		"ebs_volume_encryption_enabled":       true,
 		"ecr_scan_on_push_enable":             true,
+		"eks_access_entries":                  true,
 		"eks_api_server_private_access_cidrs": true,
 		"eks_api_server_public_access_cidrs":  true,
 		"eks_log_types":                       true,
@@ -1358,13 +1360,16 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 
 	// karpenter_auth_mode and karpenter_enabled are type=string in TF (not bool).
 	// Reject junk values — only "true" or "false" are valid.
-	for _, boolishParam := range []string{"karpenter_auth_mode", "karpenter_enabled"} {
+	for _, boolishParam := range []string{"eks_access_entries", "karpenter_auth_mode", "karpenter_enabled"} {
 		if v, ok := params[boolishParam]; ok && v != "" && v != "true" && v != "false" {
 			return fmt.Errorf("param '%s' must be 'true' or 'false'", boolishParam)
 		}
 	}
 
-	// karpenter_auth_mode: one-way migration (cannot be disabled once enabled)
+	if params["eks_access_entries"] == "false" && currentParams["eks_access_entries"] == "true" {
+		return fmt.Errorf("eks_access_entries cannot be disabled once enabled (AWS EKS access config migration is one-way)")
+	}
+
 	if params["karpenter_auth_mode"] == "false" && currentParams["karpenter_auth_mode"] == "true" {
 		return fmt.Errorf("karpenter_auth_mode cannot be disabled once enabled (AWS EKS access config migration is one-way)")
 	}

--- a/pkg/cli/rack_karpenter_test.go
+++ b/pkg/cli/rack_karpenter_test.go
@@ -27,7 +27,7 @@ func TestValidateAndMutateParams_BudgetRegex(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			params := map[string]string{
-				"karpenter_enabled":              "true",
+				"karpenter_enabled":                 "true",
 				"karpenter_disruption_budget_nodes": tt.value,
 			}
 			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"}, false)
@@ -60,7 +60,7 @@ func TestValidateAndMutateParams_TaintFormat(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			params := map[string]string{
-				"karpenter_enabled":    "true",
+				"karpenter_enabled":     "true",
 				"karpenter_node_taints": tt.value,
 			}
 			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"}, false)
@@ -761,7 +761,7 @@ func TestValidateAndMutateParams_BuildCpuLimit(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			params := map[string]string{
-				"karpenter_enabled":        "true",
+				"karpenter_enabled":         "true",
 				"karpenter_build_cpu_limit": tt.value,
 			}
 			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"}, false)
@@ -1440,6 +1440,88 @@ func TestValidateAndMutateParams_KarpenterAuthMode(t *testing.T) {
 	}
 }
 
+func TestValidateAndMutateParams_EksAccessEntries(t *testing.T) {
+	tests := []struct {
+		name          string
+		params        map[string]string
+		currentParams map[string]string
+		provider      string
+		wantErr       bool
+		errMsg        string
+	}{
+		{
+			"disabling eks_access_entries once enabled is rejected",
+			map[string]string{"eks_access_entries": "false"},
+			map[string]string{"eks_access_entries": "true"},
+			"aws",
+			true,
+			"eks_access_entries cannot be disabled once enabled",
+		},
+		{
+			"enabling eks_access_entries from false is allowed",
+			map[string]string{"eks_access_entries": "true"},
+			map[string]string{"eks_access_entries": "false"},
+			"aws",
+			false,
+			"",
+		},
+		{
+			"enabling eks_access_entries when not previously set is allowed",
+			map[string]string{"eks_access_entries": "true"},
+			map[string]string{},
+			"aws",
+			false,
+			"",
+		},
+		{
+			"eks_access_entries=true is idempotent",
+			map[string]string{"eks_access_entries": "true"},
+			map[string]string{"eks_access_entries": "true"},
+			"aws",
+			false,
+			"",
+		},
+		{
+			"empty eks_access_entries when enabled is blocked",
+			map[string]string{"eks_access_entries": ""},
+			map[string]string{"eks_access_entries": "true"},
+			"aws",
+			true,
+			"requires an explicit value",
+		},
+		{
+			"invalid eks_access_entries value is rejected",
+			map[string]string{"eks_access_entries": "banana"},
+			map[string]string{},
+			"aws",
+			true,
+			"must be 'true' or 'false'",
+		},
+		{
+			"eks_access_entries on non-AWS provider is rejected",
+			map[string]string{"eks_access_entries": "true"},
+			map[string]string{},
+			"gcp",
+			true,
+			"unknown parameter",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAndMutateParams(tt.params, tt.provider, tt.currentParams, false)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("got err=%v, wantErr=%v", err, tt.wantErr)
+			}
+			if tt.wantErr && err != nil && tt.errMsg != "" {
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errMsg)
+				}
+			}
+		})
+	}
+}
+
 func TestValidateAndMutateParams_KarpenterNonDedicatedNodeGroups(t *testing.T) {
 	dedicatedTrue := `[{"type":"m5.large","dedicated":true,"label":"gpu"}]`
 	dedicatedFalse := `[{"type":"m5.large","dedicated":false}]`
@@ -1480,7 +1562,7 @@ func TestValidateAndMutateParams_KarpenterNonDedicatedNodeGroups(t *testing.T) {
 		{
 			"enabling karpenter with dedicated=true in new config succeeds",
 			map[string]string{
-				"karpenter_enabled":            "true",
+				"karpenter_enabled":             "true",
 				"additional_node_groups_config": dedicatedTrue,
 			},
 			map[string]string{"karpenter_auth_mode": "true"},
@@ -1490,7 +1572,7 @@ func TestValidateAndMutateParams_KarpenterNonDedicatedNodeGroups(t *testing.T) {
 		{
 			"enabling karpenter with dedicated=false in new config is an error",
 			map[string]string{
-				"karpenter_enabled":            "true",
+				"karpenter_enabled":             "true",
 				"additional_node_groups_config": dedicatedFalse,
 			},
 			map[string]string{"karpenter_auth_mode": "true"},
@@ -1500,7 +1582,7 @@ func TestValidateAndMutateParams_KarpenterNonDedicatedNodeGroups(t *testing.T) {
 		{
 			"new config overrides current params (new config has dedicated=true)",
 			map[string]string{
-				"karpenter_enabled":            "true",
+				"karpenter_enabled":             "true",
 				"additional_node_groups_config": dedicatedTrue,
 			},
 			map[string]string{"karpenter_auth_mode": "true", "additional_node_groups_config": noDedicatedFieldB64},

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -342,7 +342,7 @@ resource "null_resource" "wait_k8s_cluster" {
 # back to http://localhost:80) because every provider reads host from
 # aws_eks_cluster.cluster.endpoint.
 resource "null_resource" "karpenter_access_config" {
-  count = var.karpenter_auth_mode ? 1 : 0
+  count = (var.karpenter_auth_mode || var.eks_access_entries) ? 1 : 0
 
   triggers = {
     cluster_name = aws_eks_cluster.cluster.name
@@ -392,6 +392,34 @@ resource "null_resource" "karpenter_access_config" {
     aws_eks_cluster.cluster,
     null_resource.wait_k8s_cluster,
   ]
+}
+
+data "aws_iam_session_context" "current" {
+  count = var.eks_access_entries ? 1 : 0
+  arn   = data.aws_caller_identity.current.arn
+}
+
+resource "aws_eks_access_entry" "terraform_caller" {
+  count = var.eks_access_entries ? 1 : 0
+
+  depends_on = [null_resource.karpenter_access_config]
+
+  cluster_name  = aws_eks_cluster.cluster.name
+  principal_arn = data.aws_iam_session_context.current[0].issuer_arn
+  type          = "STANDARD"
+  tags          = local.tags
+}
+
+resource "aws_eks_access_policy_association" "terraform_caller" {
+  count = var.eks_access_entries ? 1 : 0
+
+  cluster_name  = aws_eks_cluster.cluster.name
+  principal_arn = aws_eks_access_entry.terraform_caller[0].principal_arn
+  policy_arn    = "arn:${data.aws_partition.current.partition}:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+
+  access_scope {
+    type = "cluster"
+  }
 }
 
 # resource "local_file" "kubeconfig" {

--- a/terraform/cluster/aws/variables.tf
+++ b/terraform/cluster/aws/variables.tf
@@ -108,6 +108,11 @@ variable "internet_gateway_id" {
   default = ""
 }
 
+variable "eks_access_entries" {
+  type    = bool
+  default = false
+}
+
 variable "karpenter_auth_mode" {
   type    = bool
   default = false

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -102,6 +102,7 @@ module "cluster" {
   imds_http_tokens                    = var.imds_http_tokens
   imds_http_hop_limit                 = var.imds_http_hop_limit
   imds_tags_enable                    = var.imds_tags_enable
+  eks_access_entries                   = var.eks_access_entries == "true"
   karpenter_auth_mode                 = var.karpenter_auth_mode == "true"
   karpenter_enabled                   = var.karpenter_enabled == "true"
   karpenter_instance_families         = var.karpenter_instance_families

--- a/terraform/system/aws/telemetry.tf
+++ b/terraform/system/aws/telemetry.tf
@@ -34,6 +34,7 @@ locals {
     ecr_scan_on_push_enable = var.ecr_scan_on_push_enable
     efs_csi_driver_enable = var.efs_csi_driver_enable
     efs_csi_driver_version = var.efs_csi_driver_version
+    eks_access_entries = var.eks_access_entries
     eks_api_server_private_access_cidrs = var.eks_api_server_private_access_cidrs
     eks_api_server_public_access_cidrs = var.eks_api_server_public_access_cidrs
     eks_log_types = var.eks_log_types
@@ -169,6 +170,7 @@ locals {
     ecr_scan_on_push_enable = "false"
     efs_csi_driver_enable = "false"
     efs_csi_driver_version = "v2.3.0-eksbuild.2"
+    eks_access_entries = "false"
     eks_api_server_private_access_cidrs = ""
     eks_api_server_public_access_cidrs = "0.0.0.0/0"
     eks_log_types = ""

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -217,6 +217,11 @@ variable "internet_gateway_id" {
   default = ""
 }
 
+variable "eks_access_entries" {
+  type    = string
+  default = "false"
+}
+
 variable "karpenter_auth_mode" {
   type    = string
   default = "false"


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: EKS Access Entries Support**

Adds a new `eks_access_entries` rack parameter that creates EKS Access Entries for both the IAM role managing the rack and the nodes IAM role. This enables users to migrate from the legacy `aws-auth` ConfigMap to the newer EKS Access Entries API for cluster authentication, without losing Convox's ability to manage the cluster or schedule workloads on nodes.

When enabled:

| Action | Detail |
|--------|--------|
| Auth mode switch | Sets EKS authentication mode to `API_AND_CONFIG_MAP` (reuses the existing Karpenter auth mode switch, idempotent) |
| Caller access entry | Creates a `STANDARD` type entry for the Terraform caller's IAM role with `AmazonEKSClusterAdminPolicy` (cluster-wide scope) |
| Nodes access entry | Creates an `EC2_LINUX` type entry for the nodes IAM role, ensuring node registration works without `aws-auth` |

The parameter is one-way: it cannot be disabled once enabled, matching the irreversible nature of the EKS auth mode migration.

**Interaction with Karpenter:**

| `karpenter_auth_mode` | `eks_access_entries` | Auth mode switch | Karpenter node entry | Caller access entry | Nodes access entry |
|---|---|---|---|---|---|
| false | false | No | No | No | No |
| true | false | Yes | Yes | No | No |
| false | true | Yes | No | Yes | Yes |
| true | true | Yes | Yes | Yes | Yes |

---

### Why is this important?

The `aws-auth` ConfigMap approach to EKS authentication can be accidentally deleted, requires Kubernetes API access to modify, and lacks CloudTrail audit logging. EKS Access Entries operate at the AWS API layer, are AWS-managed, provide CloudTrail audit logging, and cannot be disrupted by Kubernetes-level operations.

**Benefits:**

- **Migration path.** Users can adopt EKS Access Entries for their Convox-managed clusters without manual IAM and EKS configuration.
- **Full coverage.** Both the managing IAM role and the nodes role get access entries, so users can safely delete the `aws-auth` ConfigMap after enabling.
- **Karpenter compatibility.** The parameter works alongside existing Karpenter auth mode configuration with no conflicts.
- **Idempotent and safe.** All shell provisioners check for existing entries before creating, handling concurrent operations gracefully.

---

### How to use it?

**Enable EKS Access Entries:**

    $ convox rack params set eks_access_entries=true -r rackName

After the update completes, verify the entries exist:

    $ aws eks list-access-entries --cluster-name <cluster-name> --region <region>

Once verified, users may optionally remove the `aws-auth` ConfigMap entries for the managed roles. However, keeping the `aws-auth` ConfigMap in place provides a fallback if you ever need to downgrade to a rack version before 3.24.7. See the "Does it have a breaking change?" section for detailed downgrade considerations before removing it.

**For racks already using Karpenter**, the auth mode is already `API_AND_CONFIG_MAP`. Enabling `eks_access_entries` adds the caller and nodes access entries without re-running the auth mode switch.

#### New Rack Parameters

| Parameter | Type | Default | Provider | One-way | Description |
|-----------|------|---------|----------|---------|-------------|
| `eks_access_entries` | bool | `false` | AWS | Yes | Creates EKS access entries for the rack's managing IAM role and nodes role |

---

### Does it have a breaking change?

**No breaking changes** are introduced with this feature. The parameter defaults to `false`, creating zero new resources on upgrade. Existing authentication via `aws-auth` ConfigMap continues to work regardless of this setting.

**One-way migration:** Once enabled, the parameter cannot be set back to `false` via `convox rack params set`. This is enforced at the CLI level because the underlying AWS changes are irreversible:

1. The EKS authentication mode switch from `CONFIG_MAP` to `API_AND_CONFIG_MAP` cannot be reversed by AWS.
2. While individual access entries _can_ be deleted via the AWS API, doing so without the `aws-auth` ConfigMap as a fallback would lock Convox out of the cluster.

**Downgrade considerations:**

Downgrading to a rack version without the `eks_access_entries` variable is only safe if the user has **not** deleted the `aws-auth` ConfigMap and has **not** switched the cluster to `API` only mode. Here is what happens on downgrade:

| User action after enabling | Downgrade safe? | Detail |
|----------------------------|-----------------|--------|
| No changes (kept `aws-auth`, kept `API_AND_CONFIG_MAP`) | Yes | The `reconcileVarsWithModule` mechanism strips the variable. Access entries and auth mode persist in AWS (the provisioners are create-only with no destroy counterpart). Authentication falls back to the `aws-auth` ConfigMap, which continues to work under `API_AND_CONFIG_MAP`. |
| Deleted `aws-auth` ConfigMap (still `API_AND_CONFIG_MAP`) | Risky | The access entries persist and continue to grant access. However, Convox will no longer manage or recreate these entries on the downgraded version. If the entries are ever removed (manually, by a cleanup script, or by AWS), there is no automated recovery path and no `aws-auth` fallback. |
| Switched cluster to `API` only mode | Not safe | The `aws-auth` ConfigMap is completely disabled under `API` mode. If the access entries are ever lost, the rack loses cluster access with no recovery path short of AWS support or manual re-creation of the entries. |

**Recommendation:** Do not delete the `aws-auth` ConfigMap or switch to `API` only mode unless you are committed to staying on 3.24.7 or later. If you plan to maintain the ability to downgrade, keep the `aws-auth` ConfigMap in place as a fallback.

---

### Requirements

This feature requires version `3.24.7` or later for the rack.

**Update the Rack:** Run `convox rack update 3.24.7 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.23.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
