### PR TITLE
throttle FilterLogEvents polling in streamLogs

### DIFF
--- a/provider/aws/log.go
+++ b/provider/aws/log.go
@@ -218,7 +218,7 @@ func (p *Provider) streamLogs(ctx context.Context, w io.WriteCloser, group, stre
 			if err != nil {
 				switch awsErrorCode(err) {
 				case "ThrottlingException", "ResourceNotFoundException":
-					time.Sleep(1 * time.Second)
+					time.Sleep(3 * time.Second)
 					continue
 				default:
 					return err
@@ -245,6 +245,14 @@ func (p *Provider) streamLogs(ctx context.Context, w io.WriteCloser, group, stre
 			}
 
 			req.NextToken = res.NextToken
+
+			if res.NextToken != nil {
+				time.Sleep(2 * time.Second)
+			} else if len(es) == 0 {
+				time.Sleep(5 * time.Second)
+			} else {
+				time.Sleep(1 * time.Second)
+			}
 
 			if res.NextToken == nil {
 				if !follow {


### PR DESCRIPTION
### What is the feature/update/fix?

**Fix: CloudWatch Log Streaming Rate Limiting**

The `streamLogs` function in the AWS provider polled CloudWatch `FilterLogEvents` with no sleep on the success path. This caused 40+ API calls per second per active log-streaming goroutine (each Console log viewer tab or `convox logs` session), saturating the per-account `FilterLogEvents` rate limit and generating excessive CloudTrail events.

This fix adds sleep intervals on every code path through the polling loop:

| Condition | Sleep | Before | Rationale |
|-----------|-------|--------|-----------|
| ThrottlingException / ResourceNotFoundException | 3s | 1s | 1s was too aggressive for a rate-limited API |
| Paginating (NextToken present) | 2s | 0s | Paces pagination through large backlogs |
| No new events (idle) | 5s | 0s | Avoids unnecessary calls when nothing is happening |
| Got events, no more pages | 1s | 0s | Prevents tight loop under sustained log activity |

**Expected impact on API call rate:**

| Scenario | Before | After |
|----------|--------|-------|
| Active log stream | ~40 calls/s | ~1 call/s |
| Idle log stream | ~40 calls/s | ~0.2 calls/s |
| Paginating through backlog | ~40 calls/s | ~0.5 calls/s |

Log delivery latency increases from near-instant to 1-5 seconds, which is acceptable for a polling-based system. CloudWatch itself has 1-3 second ingestion latency, so sub-second polling was never delivering faster results.

---

### Why is this important?

**Benefits:**

- **Rate limit headroom.** Accounts with multiple racks or concurrent log viewers were hitting `FilterLogEvents` throttling, causing log gaps and errors. The 40x reduction in call volume eliminates this.
- **Lower CloudTrail noise.** Each `FilterLogEvents` call generates a CloudTrail event. Accounts with active logging were generating millions of unnecessary events per day.
- **Cost reduction.** CloudTrail data events and CloudWatch API calls both contribute to AWS billing. The reduction is proportional to the call rate decrease.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this fix. Log events, ordering, and deduplication behavior are unchanged. The only observable difference is that new log lines may appear 1-5 seconds after they are written rather than sub-second.

No API, CLI, struct, or parameter changes. No state changes. Safe to upgrade or downgrade with no migration steps.

---

### Requirements

This fix requires version `3.24.7` or later for the rack.

**Update the Rack:** Run `convox rack update 3.24.7 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.23.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
