### PR TITLE
Release/3.24.7

### DIFF
--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -50,6 +50,7 @@ var awsKnownParams = map[string]bool{
 	"docker_hub_password":  true, "docker_hub_username": true,
 	"ebs_volume_encryption_enabled": true, "ecr_additional_policy_arn": true, "ecr_docker_hub_cache": true, "ecr_full_access": true, "ecr_scan_on_push_enable": true,
 	"efs_csi_driver_enable": true, "efs_csi_driver_version": true,
+	"eks_access_entries":                  true,
 	"eks_api_server_private_access_cidrs": true,
 	"eks_api_server_public_access_cidrs":  true,
 	"eks_log_types":                       true,
@@ -328,6 +329,7 @@ var paramGroups = map[string]map[string]bool{
 		"ecr_additional_policy_arn":           true,
 		"ecr_full_access":                     true,
 		"ecr_scan_on_push_enable":             true,
+		"eks_access_entries":                  true,
 		"eks_api_server_private_access_cidrs": true,
 		"eks_api_server_public_access_cidrs":  true,
 		"eks_log_types":                       true,
@@ -1365,13 +1367,16 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 
 	// karpenter_auth_mode and karpenter_enabled are type=string in TF (not bool).
 	// Reject junk values — only "true" or "false" are valid.
-	for _, boolishParam := range []string{"karpenter_auth_mode", "karpenter_enabled"} {
+	for _, boolishParam := range []string{"eks_access_entries", "karpenter_auth_mode", "karpenter_enabled"} {
 		if v, ok := params[boolishParam]; ok && v != "" && v != "true" && v != "false" {
 			return fmt.Errorf("param '%s' must be 'true' or 'false'", boolishParam)
 		}
 	}
 
-	// karpenter_auth_mode: one-way migration (cannot be disabled once enabled)
+	if params["eks_access_entries"] == "false" && currentParams["eks_access_entries"] == "true" {
+		return fmt.Errorf("eks_access_entries cannot be disabled once enabled (AWS EKS access config migration is one-way)")
+	}
+
 	if params["karpenter_auth_mode"] == "false" && currentParams["karpenter_auth_mode"] == "true" {
 		return fmt.Errorf("karpenter_auth_mode cannot be disabled once enabled (AWS EKS access config migration is one-way)")
 	}

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -48,7 +48,7 @@ var awsKnownParams = map[string]bool{
 	"disable_image_manifest_cache": true, "disable_public_access": true,
 	"dcgm_scrape_interval": true,
 	"docker_hub_password":  true, "docker_hub_username": true,
-	"ebs_volume_encryption_enabled": true, "ecr_docker_hub_cache": true, "ecr_scan_on_push_enable": true,
+	"ebs_volume_encryption_enabled": true, "ecr_additional_policy_arn": true, "ecr_docker_hub_cache": true, "ecr_full_access": true, "ecr_scan_on_push_enable": true,
 	"efs_csi_driver_enable": true, "efs_csi_driver_version": true,
 	"eks_api_server_private_access_cidrs": true,
 	"eks_api_server_public_access_cidrs":  true,
@@ -185,6 +185,7 @@ var boolParams = map[string]bool{
 	"disable_public_access":           true,
 	"ebs_volume_encryption_enabled":   true,
 	"ecr_docker_hub_cache":            true,
+	"ecr_full_access":                 true,
 	"ecr_scan_on_push_enable":         true,
 	"efs_csi_driver_enable":           true,
 	"enable_private_access":           true,
@@ -324,6 +325,8 @@ var paramGroups = map[string]map[string]bool{
 		"disable_public_access":               true,
 		"docker_hub_password":                 true,
 		"ebs_volume_encryption_enabled":       true,
+		"ecr_additional_policy_arn":           true,
+		"ecr_full_access":                     true,
 		"ecr_scan_on_push_enable":             true,
 		"eks_api_server_private_access_cidrs": true,
 		"eks_api_server_public_access_cidrs":  true,
@@ -486,7 +489,9 @@ var paramGroups = map[string]map[string]bool{
 		"disable_image_manifest_cache": true,
 		"docker_hub_password":          true,
 		"docker_hub_username":          true,
+		"ecr_additional_policy_arn":    true,
 		"ecr_docker_hub_cache":         true,
+		"ecr_full_access":              true,
 		"ecr_scan_on_push_enable":      true,
 	},
 	"logging": {
@@ -641,6 +646,8 @@ var clearableParams = map[string]bool{
 	// Custom launch scripts — clear means "remove"
 	"user_data":     true,
 	"user_data_url": true,
+	// ECR — clear means "detach custom policy"
+	"ecr_additional_policy_arn": true,
 	// Feature gates — clear means "disable all"
 	"api_feature_gates": true,
 	// Private EKS — cleared by console during mode changes

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -1383,9 +1383,28 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 
 	// karpenter_enabled=true requires karpenter_auth_mode=true — either already
 	// applied or being set in the same call.
-	if params["karpenter_enabled"] == "true" && currentParams["karpenter_enabled"] != "true" {
-		if currentParams["karpenter_auth_mode"] != "true" && params["karpenter_auth_mode"] != "true" {
+	if params["karpenter_enabled"] == "true" && !strings.EqualFold(currentParams["karpenter_enabled"], "true") {
+		if !strings.EqualFold(currentParams["karpenter_auth_mode"], "true") && params["karpenter_auth_mode"] != "true" {
 			return fmt.Errorf("karpenter_enabled=true requires karpenter_auth_mode=true.\n  Either include both: convox rack params set karpenter_auth_mode=true karpenter_enabled=true\n  Or set karpenter_auth_mode=true first and wait for the update to complete")
+		}
+	}
+
+	if params["karpenter_enabled"] == "true" && !strings.EqualFold(currentParams["karpenter_enabled"], "true") {
+		currentNCT := strings.ToLower(currentParams["node_capacity_type"])
+		if currentNCT != "" && currentNCT != "on_demand" {
+			if strings.EqualFold(currentParams["karpenter_auth_mode"], "true") || params["karpenter_auth_mode"] == "true" {
+				return fmt.Errorf("karpenter_enabled=true requires node_capacity_type=ON_DEMAND to prevent a node\nscheduling deadlock during node group replacement.\n  Current node_capacity_type is %s. First run:\n    convox rack params set node_capacity_type=ON_DEMAND\n  Wait for the update to complete, then enable Karpenter:\n    convox rack params set karpenter_enabled=true", currentParams["node_capacity_type"])
+			}
+			return fmt.Errorf("karpenter_enabled=true requires node_capacity_type=ON_DEMAND to prevent a node\nscheduling deadlock during node group replacement.\n  Current node_capacity_type is %s. First run:\n    convox rack params set karpenter_auth_mode=true node_capacity_type=ON_DEMAND\n  Wait for the update to complete, then enable Karpenter:\n    convox rack params set karpenter_enabled=true", currentParams["node_capacity_type"])
+		}
+		if v, ok := params["node_capacity_type"]; ok && !strings.EqualFold(v, "on_demand") {
+			return fmt.Errorf("karpenter_enabled=true requires node_capacity_type=ON_DEMAND to prevent a node\nscheduling deadlock during node group replacement.\n  Cannot set node_capacity_type=%s in the same call as karpenter_enabled=true.\n  Set node_capacity_type=ON_DEMAND first and wait for the update to complete", v)
+		}
+	}
+
+	if strings.EqualFold(currentParams["karpenter_enabled"], "true") && params["karpenter_enabled"] != "false" {
+		if v, ok := params["node_capacity_type"]; ok && !strings.EqualFold(v, "on_demand") {
+			return fmt.Errorf("node_capacity_type cannot be set to %s while Karpenter is enabled.\n  Karpenter requires ON_DEMAND system nodes. To use %s capacity, disable\n  Karpenter first: convox rack params set karpenter_enabled=false", v, v)
 		}
 	}
 

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -1398,13 +1398,39 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 			return fmt.Errorf("karpenter_enabled=true requires node_capacity_type=ON_DEMAND to prevent a node\nscheduling deadlock during node group replacement.\n  Current node_capacity_type is %s. First run:\n    convox rack params set karpenter_auth_mode=true node_capacity_type=ON_DEMAND\n  Wait for the update to complete, then enable Karpenter:\n    convox rack params set karpenter_enabled=true", currentParams["node_capacity_type"])
 		}
 		if v, ok := params["node_capacity_type"]; ok && !strings.EqualFold(v, "on_demand") {
-			return fmt.Errorf("karpenter_enabled=true requires node_capacity_type=ON_DEMAND to prevent a node\nscheduling deadlock during node group replacement.\n  Cannot set node_capacity_type=%s in the same call as karpenter_enabled=true.\n  Set node_capacity_type=ON_DEMAND first and wait for the update to complete", v)
+			return fmt.Errorf("karpenter_enabled=true requires node_capacity_type=ON_DEMAND to prevent a node\nscheduling deadlock during node group replacement.\n  Cannot set node_capacity_type=%s in the same call as karpenter_enabled=true.\n  Set node_capacity_type=ON_DEMAND first, wait for the update to complete, then enable Karpenter", v)
 		}
 	}
 
 	if strings.EqualFold(currentParams["karpenter_enabled"], "true") && params["karpenter_enabled"] != "false" {
 		if v, ok := params["node_capacity_type"]; ok && !strings.EqualFold(v, "on_demand") {
 			return fmt.Errorf("node_capacity_type cannot be set to %s while Karpenter is enabled.\n  Karpenter requires ON_DEMAND system nodes. To use %s capacity, disable\n  Karpenter first: convox rack params set karpenter_enabled=false", v, v)
+		}
+	}
+
+	if params["karpenter_enabled"] == "true" && !strings.EqualFold(currentParams["karpenter_enabled"], "true") &&
+		strings.EqualFold(currentParams["high_availability"], "false") {
+		ltParams := []string{
+			"gpu_tag_enable",
+			"imds_http_tokens",
+			"imds_http_hop_limit",
+			"imds_tags_enable",
+			"ebs_volume_encryption_enabled",
+			"user_data",
+			"user_data_url",
+			"kubelet_registry_pull_qps",
+			"kubelet_registry_burst",
+			"key_pair_name",
+		}
+		var conflicts []string
+		for _, p := range ltParams {
+			if _, ok := params[p]; ok {
+				conflicts = append(conflicts, p)
+			}
+		}
+		if len(conflicts) > 0 {
+			return fmt.Errorf("cannot change launch template settings in the same call as karpenter_enabled=true on\n  a non-HA rack (single node). These params trigger a node rolling update that can\n  deadlock with the Karpenter taint on undersized nodes:\n    %s\n  Set them in a separate call first, wait for the update to complete, then enable Karpenter",
+				strings.Join(conflicts, ", "))
 		}
 	}
 

--- a/pkg/cli/rack_karpenter_test.go
+++ b/pkg/cli/rack_karpenter_test.go
@@ -27,7 +27,7 @@ func TestValidateAndMutateParams_BudgetRegex(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			params := map[string]string{
-				"karpenter_enabled":              "true",
+				"karpenter_enabled":                 "true",
 				"karpenter_disruption_budget_nodes": tt.value,
 			}
 			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"}, false)
@@ -60,7 +60,7 @@ func TestValidateAndMutateParams_TaintFormat(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			params := map[string]string{
-				"karpenter_enabled":    "true",
+				"karpenter_enabled":     "true",
 				"karpenter_node_taints": tt.value,
 			}
 			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"}, false)
@@ -761,7 +761,7 @@ func TestValidateAndMutateParams_BuildCpuLimit(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			params := map[string]string{
-				"karpenter_enabled":        "true",
+				"karpenter_enabled":         "true",
 				"karpenter_build_cpu_limit": tt.value,
 			}
 			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"}, false)
@@ -1440,6 +1440,88 @@ func TestValidateAndMutateParams_KarpenterAuthMode(t *testing.T) {
 	}
 }
 
+func TestValidateAndMutateParams_EksAccessEntries(t *testing.T) {
+	tests := []struct {
+		name          string
+		params        map[string]string
+		currentParams map[string]string
+		provider      string
+		wantErr       bool
+		errMsg        string
+	}{
+		{
+			"disabling eks_access_entries once enabled is rejected",
+			map[string]string{"eks_access_entries": "false"},
+			map[string]string{"eks_access_entries": "true"},
+			"aws",
+			true,
+			"eks_access_entries cannot be disabled once enabled",
+		},
+		{
+			"enabling eks_access_entries from false is allowed",
+			map[string]string{"eks_access_entries": "true"},
+			map[string]string{"eks_access_entries": "false"},
+			"aws",
+			false,
+			"",
+		},
+		{
+			"enabling eks_access_entries when not previously set is allowed",
+			map[string]string{"eks_access_entries": "true"},
+			map[string]string{},
+			"aws",
+			false,
+			"",
+		},
+		{
+			"eks_access_entries=true is idempotent",
+			map[string]string{"eks_access_entries": "true"},
+			map[string]string{"eks_access_entries": "true"},
+			"aws",
+			false,
+			"",
+		},
+		{
+			"empty eks_access_entries when enabled is blocked",
+			map[string]string{"eks_access_entries": ""},
+			map[string]string{"eks_access_entries": "true"},
+			"aws",
+			true,
+			"requires an explicit value",
+		},
+		{
+			"invalid eks_access_entries value is rejected",
+			map[string]string{"eks_access_entries": "banana"},
+			map[string]string{},
+			"aws",
+			true,
+			"must be 'true' or 'false'",
+		},
+		{
+			"eks_access_entries on non-AWS provider is rejected",
+			map[string]string{"eks_access_entries": "true"},
+			map[string]string{},
+			"gcp",
+			true,
+			"unknown parameter",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAndMutateParams(tt.params, tt.provider, tt.currentParams, false)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("got err=%v, wantErr=%v", err, tt.wantErr)
+			}
+			if tt.wantErr && err != nil && tt.errMsg != "" {
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errMsg)
+				}
+			}
+		})
+	}
+}
+
 func TestValidateAndMutateParams_KarpenterNonDedicatedNodeGroups(t *testing.T) {
 	dedicatedTrue := `[{"type":"m5.large","dedicated":true,"label":"gpu"}]`
 	dedicatedFalse := `[{"type":"m5.large","dedicated":false}]`
@@ -1480,7 +1562,7 @@ func TestValidateAndMutateParams_KarpenterNonDedicatedNodeGroups(t *testing.T) {
 		{
 			"enabling karpenter with dedicated=true in new config succeeds",
 			map[string]string{
-				"karpenter_enabled":            "true",
+				"karpenter_enabled":             "true",
 				"additional_node_groups_config": dedicatedTrue,
 			},
 			map[string]string{"karpenter_auth_mode": "true"},
@@ -1490,7 +1572,7 @@ func TestValidateAndMutateParams_KarpenterNonDedicatedNodeGroups(t *testing.T) {
 		{
 			"enabling karpenter with dedicated=false in new config is an error",
 			map[string]string{
-				"karpenter_enabled":            "true",
+				"karpenter_enabled":             "true",
 				"additional_node_groups_config": dedicatedFalse,
 			},
 			map[string]string{"karpenter_auth_mode": "true"},
@@ -1500,7 +1582,7 @@ func TestValidateAndMutateParams_KarpenterNonDedicatedNodeGroups(t *testing.T) {
 		{
 			"new config overrides current params (new config has dedicated=true)",
 			map[string]string{
-				"karpenter_enabled":            "true",
+				"karpenter_enabled":             "true",
 				"additional_node_groups_config": dedicatedTrue,
 			},
 			map[string]string{"karpenter_auth_mode": "true", "additional_node_groups_config": noDedicatedFieldB64},

--- a/pkg/rack/terraform.go
+++ b/pkg/rack/terraform.go
@@ -82,6 +82,7 @@ var preserveEmpty = map[string]bool{
 	"grafana_dashboard_var_namespace": true,
 	"grafana_dashboard_var_service":   true,
 	"grafana_dashboard_var_app":       true,
+	"ecr_additional_policy_arn":       true,
 }
 
 // PreserveEmptyParams returns a copy of the writeVars empty-preservation

--- a/provider/aws/log.go
+++ b/provider/aws/log.go
@@ -218,7 +218,7 @@ func (p *Provider) streamLogs(ctx context.Context, w io.WriteCloser, group, stre
 			if err != nil {
 				switch awsErrorCode(err) {
 				case "ThrottlingException", "ResourceNotFoundException":
-					time.Sleep(1 * time.Second)
+					time.Sleep(3 * time.Second)
 					continue
 				default:
 					return err
@@ -245,6 +245,14 @@ func (p *Provider) streamLogs(ctx context.Context, w io.WriteCloser, group, stre
 			}
 
 			req.NextToken = res.NextToken
+
+			if res.NextToken != nil {
+				time.Sleep(2 * time.Second)
+			} else if len(es) == 0 {
+				time.Sleep(5 * time.Second)
+			} else {
+				time.Sleep(1 * time.Second)
+			}
 
 			if res.NextToken == nil {
 				if !follow {

--- a/terraform/api/aws/iam.tf
+++ b/terraform/api/aws/iam.tf
@@ -225,6 +225,18 @@ resource "aws_iam_role_policy" "api_ecr" {
   policy = data.aws_iam_policy_document.ecr.json
 }
 
+resource "aws_iam_role_policy_attachment" "api_ecr_full_access" {
+  count      = var.ecr_full_access ? 1 : 0
+  role       = aws_iam_role.api.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "api_ecr_additional" {
+  count      = var.ecr_additional_policy_arn != "" ? 1 : 0
+  role       = aws_iam_role.api.name
+  policy_arn = var.ecr_additional_policy_arn
+}
+
 resource "aws_iam_role_policy" "api_ec2_key_pair" {
   name   = "ec2_key_pair"
   role   = aws_iam_role.api.name

--- a/terraform/api/aws/variables.tf
+++ b/terraform/api/aws/variables.tf
@@ -73,6 +73,16 @@ variable "disable_image_manifest_cache" {
   default = false
 }
 
+variable "ecr_additional_policy_arn" {
+  type    = string
+  default = ""
+}
+
+variable "ecr_full_access" {
+  type    = bool
+  default = false
+}
+
 variable "ecr_scan_on_push_enable" {
   type    = bool
   default = false

--- a/terraform/cluster/aws/dcgm.tf
+++ b/terraform/cluster/aws/dcgm.tf
@@ -21,7 +21,7 @@ resource "kubernetes_config_map" "dcgm_metrics_convox" {
 
 resource "helm_release" "dcgm_exporter" {
   depends_on = [
-    null_resource.wait_k8s_api,
+    null_resource.wait_eks_addons,
     helm_release.nvidia_device_plugin,
     kubernetes_config_map.dcgm_metrics_convox,
   ]

--- a/terraform/cluster/aws/karpenter.tf
+++ b/terraform/cluster/aws/karpenter.tf
@@ -14,7 +14,7 @@ resource "helm_release" "karpenter_crd" {
   count = var.karpenter_auth_mode ? 1 : 0
 
   depends_on = [
-    null_resource.wait_k8s_api,
+    null_resource.wait_eks_addons,
     aws_iam_role.karpenter_controller,
     aws_iam_role_policy.karpenter_controller_ec2,
     aws_iam_role_policy.karpenter_controller_iam,

--- a/terraform/cluster/aws/keda.tf
+++ b/terraform/cluster/aws/keda.tf
@@ -58,7 +58,7 @@ resource "aws_iam_role_policy" "keda_aws_scalar" {
 
 resource "helm_release" "keda" {
   depends_on = [
-    null_resource.wait_k8s_api,
+    null_resource.wait_eks_addons,
     aws_eks_node_group.cluster,
   ]
 

--- a/terraform/cluster/aws/lbc.tf
+++ b/terraform/cluster/aws/lbc.tf
@@ -58,7 +58,7 @@ resource "kubernetes_service_account" "lbc" {
 
 resource "helm_release" "aws_lbc" {
   depends_on = [
-    null_resource.wait_k8s_api,
+    null_resource.wait_eks_addons,
     aws_iam_role.lbc,
     aws_iam_role_policy.lbc_policy,
     aws_eks_node_group.cluster,

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -342,7 +342,7 @@ resource "null_resource" "wait_k8s_cluster" {
 # back to http://localhost:80) because every provider reads host from
 # aws_eks_cluster.cluster.endpoint.
 resource "null_resource" "karpenter_access_config" {
-  count = var.karpenter_auth_mode ? 1 : 0
+  count = (var.karpenter_auth_mode || var.eks_access_entries) ? 1 : 0
 
   triggers = {
     cluster_name = aws_eks_cluster.cluster.name
@@ -392,6 +392,34 @@ resource "null_resource" "karpenter_access_config" {
     aws_eks_cluster.cluster,
     null_resource.wait_k8s_cluster,
   ]
+}
+
+data "aws_iam_session_context" "current" {
+  count = var.eks_access_entries ? 1 : 0
+  arn   = data.aws_caller_identity.current.arn
+}
+
+resource "aws_eks_access_entry" "terraform_caller" {
+  count = var.eks_access_entries ? 1 : 0
+
+  depends_on = [null_resource.karpenter_access_config]
+
+  cluster_name  = aws_eks_cluster.cluster.name
+  principal_arn = data.aws_iam_session_context.current[0].issuer_arn
+  type          = "STANDARD"
+  tags          = local.tags
+}
+
+resource "aws_eks_access_policy_association" "terraform_caller" {
+  count = var.eks_access_entries ? 1 : 0
+
+  cluster_name  = aws_eks_cluster.cluster.name
+  principal_arn = aws_eks_access_entry.terraform_caller[0].principal_arn
+  policy_arn    = "arn:${data.aws_partition.current.partition}:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+
+  access_scope {
+    type = "cluster"
+  }
 }
 
 # resource "local_file" "kubeconfig" {

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -468,6 +468,47 @@ resource "null_resource" "eks_access_entry" {
 
 }
 
+resource "null_resource" "eks_access_entry_nodes" {
+  count = var.eks_access_entries ? 1 : 0
+
+  depends_on = [null_resource.karpenter_access_config]
+
+  triggers = {
+    cluster_name  = aws_eks_cluster.cluster.name
+    principal_arn = aws_iam_role.nodes.arn
+    region        = data.aws_region.current.name
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOF
+      set -e
+      CLUSTER="${self.triggers.cluster_name}"
+      REGION="${self.triggers.region}"
+      PRINCIPAL="${self.triggers.principal_arn}"
+
+      if aws eks describe-access-entry --cluster-name "$CLUSTER" --principal-arn "$PRINCIPAL" --region "$REGION" >/dev/null 2>&1; then
+        echo "Access entry already exists for $PRINCIPAL - skipping creation"
+      else
+        echo "Creating EC2_LINUX access entry for nodes role $PRINCIPAL..."
+        aws eks create-access-entry \
+          --cluster-name "$CLUSTER" \
+          --principal-arn "$PRINCIPAL" \
+          --type EC2_LINUX \
+          --region "$REGION" || {
+            if aws eks describe-access-entry --cluster-name "$CLUSTER" --principal-arn "$PRINCIPAL" --region "$REGION" >/dev/null 2>&1; then
+              echo "Access entry was created concurrently - continuing"
+            else
+              echo "ERROR: Failed to create nodes access entry" >&2
+              exit 1
+            fi
+          }
+      fi
+
+      echo "Nodes access entry setup complete"
+    EOF
+  }
+}
+
 # resource "local_file" "kubeconfig" {
 #   depends_on = [
 #     aws_eks_node_group.cluster,

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -466,16 +466,6 @@ resource "null_resource" "eks_access_entry" {
     EOF
   }
 
-  provisioner "local-exec" {
-    when    = destroy
-    command = <<-EOF
-      aws eks delete-access-entry \
-        --cluster-name "${self.triggers.cluster_name}" \
-        --principal-arn "${self.triggers.principal_arn}" \
-        --region "${self.triggers.region}" 2>&1 || true
-      echo "Access entry removed (or did not exist)"
-    EOF
-  }
 }
 
 # resource "local_file" "kubeconfig" {

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -559,7 +559,7 @@ resource "aws_launch_template" "cluster-build" {
 
 module "ebs_csi_driver_controller" {
   depends_on = [
-    null_resource.wait_k8s_api
+    null_resource.wait_eks_addons
   ]
 
   source = "github.com/convox/terraform-kubernetes-ebs-csi-driver?ref=f14bbe0b1185a638d7b2609bb0a690f2bfa72420"

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -356,7 +356,7 @@ resource "null_resource" "karpenter_access_config" {
       CURRENT=$(aws eks describe-cluster --name "$CLUSTER" --region "$REGION" \
         --query 'cluster.accessConfig.authenticationMode' --output text 2>/dev/null || echo "UNKNOWN")
       if [ "$CURRENT" = "API_AND_CONFIG_MAP" ] || [ "$CURRENT" = "API" ]; then
-        echo "EKS access config already $CURRENT — skipping"
+        echo "EKS access config already $CURRENT - skipping"
       else
         echo "Updating EKS access config from $CURRENT to API_AND_CONFIG_MAP..."
         aws eks update-cluster-config \
@@ -378,7 +378,7 @@ resource "null_resource" "karpenter_access_config" {
           sleep 5
         done
         if [ "$VERIFIED" != "API_AND_CONFIG_MAP" ] && [ "$VERIFIED" != "API" ]; then
-          echo "ERROR: Auth mode not verified after 60s — still $VERIFIED"
+          echo "ERROR: Auth mode not verified after 60s, still $VERIFIED"
           exit 1
         fi
         echo "Waiting for access entry API propagation..."
@@ -399,26 +399,82 @@ data "aws_iam_session_context" "current" {
   arn   = data.aws_caller_identity.current.arn
 }
 
-resource "aws_eks_access_entry" "terraform_caller" {
+resource "null_resource" "eks_access_entry" {
   count = var.eks_access_entries ? 1 : 0
 
   depends_on = [null_resource.karpenter_access_config]
 
-  cluster_name  = aws_eks_cluster.cluster.name
-  principal_arn = data.aws_iam_session_context.current[0].issuer_arn
-  type          = "STANDARD"
-  tags          = local.tags
-}
+  triggers = {
+    cluster_name  = aws_eks_cluster.cluster.name
+    principal_arn = data.aws_iam_session_context.current[0].issuer_arn
+    region        = data.aws_region.current.name
+    partition     = data.aws_partition.current.partition
+  }
 
-resource "aws_eks_access_policy_association" "terraform_caller" {
-  count = var.eks_access_entries ? 1 : 0
+  provisioner "local-exec" {
+    command = <<-EOF
+      set -e
+      CLUSTER="${self.triggers.cluster_name}"
+      REGION="${self.triggers.region}"
+      PRINCIPAL="${self.triggers.principal_arn}"
+      POLICY_ARN="arn:${self.triggers.partition}:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
 
-  cluster_name  = aws_eks_cluster.cluster.name
-  principal_arn = aws_eks_access_entry.terraform_caller[0].principal_arn
-  policy_arn    = "arn:${data.aws_partition.current.partition}:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+      if aws eks describe-access-entry --cluster-name "$CLUSTER" --principal-arn "$PRINCIPAL" --region "$REGION" >/dev/null 2>&1; then
+        echo "Access entry already exists for $PRINCIPAL - skipping creation"
+      else
+        echo "Creating access entry for $PRINCIPAL..."
+        aws eks create-access-entry \
+          --cluster-name "$CLUSTER" \
+          --principal-arn "$PRINCIPAL" \
+          --type STANDARD \
+          --region "$REGION" || {
+            if aws eks describe-access-entry --cluster-name "$CLUSTER" --principal-arn "$PRINCIPAL" --region "$REGION" >/dev/null 2>&1; then
+              echo "Access entry was created concurrently - continuing"
+            else
+              echo "ERROR: Failed to create access entry" >&2
+              exit 1
+            fi
+          }
+      fi
 
-  access_scope {
-    type = "cluster"
+      EXISTING=$(aws eks list-associated-access-policies \
+        --cluster-name "$CLUSTER" \
+        --principal-arn "$PRINCIPAL" \
+        --region "$REGION" \
+        --query "associatedAccessPolicies[?policyArn=='$POLICY_ARN'].policyArn" \
+        --output text) || {
+          echo "ERROR: Failed to list access policies" >&2
+          exit 1
+        }
+
+      if [ -n "$EXISTING" ]; then
+        echo "Policy $POLICY_ARN already associated - skipping"
+      else
+        echo "Associating policy $POLICY_ARN..."
+        aws eks associate-access-policy \
+          --cluster-name "$CLUSTER" \
+          --principal-arn "$PRINCIPAL" \
+          --policy-arn "$POLICY_ARN" \
+          --access-scope type=cluster \
+          --region "$REGION" || {
+            echo "ERROR: Failed to associate access policy" >&2
+            exit 1
+          }
+      fi
+
+      echo "EKS access entry setup complete"
+    EOF
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = <<-EOF
+      aws eks delete-access-entry \
+        --cluster-name "${self.triggers.cluster_name}" \
+        --principal-arn "${self.triggers.principal_arn}" \
+        --region "${self.triggers.region}" 2>&1 || true
+      echo "Access entry removed (or did not exist)"
+    EOF
   }
 }
 

--- a/terraform/cluster/aws/nvidia.tf
+++ b/terraform/cluster/aws/nvidia.tf
@@ -1,6 +1,6 @@
 resource "helm_release" "nvidia_device_plugin" {
   depends_on = [
-    null_resource.wait_k8s_api,
+    null_resource.wait_eks_addons,
   ]
 
   count = var.nvidia_device_plugin_enable ? 1 : 0

--- a/terraform/cluster/aws/outputs.tf
+++ b/terraform/cluster/aws/outputs.tf
@@ -38,7 +38,10 @@ output "vpc" {
 }
 
 output "eks_addons" {
-  value = [aws_eks_addon.coredns.id, aws_eks_addon.vpc_cni.id, aws_eks_addon.kube_proxy.id]
+  value = concat(
+    [aws_eks_addon.coredns.id, aws_eks_addon.vpc_cni.id, aws_eks_addon.kube_proxy.id],
+    [for ng in aws_eks_node_group.cluster : ng.id]
+  )
 }
 
 output "lbc_helm_id" {

--- a/terraform/cluster/aws/variables.tf
+++ b/terraform/cluster/aws/variables.tf
@@ -108,6 +108,11 @@ variable "internet_gateway_id" {
   default = ""
 }
 
+variable "eks_access_entries" {
+  type    = bool
+  default = false
+}
+
 variable "karpenter_auth_mode" {
   type    = bool
   default = false

--- a/terraform/cluster/aws/vpa.tf
+++ b/terraform/cluster/aws/vpa.tf
@@ -10,7 +10,7 @@ locals {
 
 resource "helm_release" "vpa" {
   depends_on = [
-    null_resource.wait_k8s_api,
+    null_resource.wait_eks_addons,
     aws_eks_node_group.cluster,
   ]
 

--- a/terraform/rack/aws/main.tf
+++ b/terraform/rack/aws/main.tf
@@ -36,6 +36,8 @@ module "api" {
   domain                                    = try(module.router.endpoint, "") # terraform destroy sometimes failes to resolve the value
   domain_internal                           = module.router.endpoint_internal
   disable_image_manifest_cache              = var.disable_image_manifest_cache
+  ecr_additional_policy_arn                  = var.ecr_additional_policy_arn
+  ecr_full_access                           = var.ecr_full_access
   ecr_scan_on_push_enable                   = var.ecr_scan_on_push_enable
   ecr_docker_hub_cache_prefix               = var.ecr_docker_hub_cache_prefix
   efs_csi_driver_enable                     = var.efs_csi_driver_enable

--- a/terraform/rack/aws/variables.tf
+++ b/terraform/rack/aws/variables.tf
@@ -63,6 +63,16 @@ variable "disable_image_manifest_cache" {
   default = false
 }
 
+variable "ecr_additional_policy_arn" {
+  type    = string
+  default = ""
+}
+
+variable "ecr_full_access" {
+  type    = bool
+  default = false
+}
+
 variable "ecr_scan_on_push_enable" {
   type    = bool
   default = false

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -260,6 +260,8 @@ module "rack" {
   telemetry_map                             = local.telemetry_map
   telemetry_default_map                     = local.telemetry_default_map
   whitelist                                 = split(",", var.whitelist)
+  ecr_additional_policy_arn                  = var.ecr_additional_policy_arn
+  ecr_full_access                           = var.ecr_full_access
   ecr_scan_on_push_enable                   = var.ecr_scan_on_push_enable
   ecr_docker_hub_cache_prefix               = module.cluster.ecr_docker_hub_cache_prefix
   vpc_id                                    = module.cluster.vpc

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -172,8 +172,12 @@ module "cluster" {
 }
 
 resource "null_resource" "wait_for_cluster" {
+  triggers = {
+    cluster_ready = join(",", module.cluster.eks_addons)
+  }
+
   provisioner "local-exec" {
-    command = "sleep 1 && echo ${module.cluster.eks_addons[0]}"
+    command = "echo cluster_ready"
   }
 }
 

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -102,6 +102,7 @@ module "cluster" {
   imds_http_tokens                    = var.imds_http_tokens
   imds_http_hop_limit                 = var.imds_http_hop_limit
   imds_tags_enable                    = var.imds_tags_enable
+  eks_access_entries                   = var.eks_access_entries == "true"
   karpenter_auth_mode                 = var.karpenter_auth_mode == "true"
   karpenter_enabled                   = var.karpenter_enabled == "true"
   karpenter_instance_families         = var.karpenter_instance_families

--- a/terraform/system/aws/telemetry.tf
+++ b/terraform/system/aws/telemetry.tf
@@ -34,6 +34,7 @@ locals {
     ecr_scan_on_push_enable = var.ecr_scan_on_push_enable
     efs_csi_driver_enable = var.efs_csi_driver_enable
     efs_csi_driver_version = var.efs_csi_driver_version
+    eks_access_entries = var.eks_access_entries
     eks_api_server_private_access_cidrs = var.eks_api_server_private_access_cidrs
     eks_api_server_public_access_cidrs = var.eks_api_server_public_access_cidrs
     eks_log_types = var.eks_log_types
@@ -169,6 +170,7 @@ locals {
     ecr_scan_on_push_enable = "false"
     efs_csi_driver_enable = "false"
     efs_csi_driver_version = "v2.3.0-eksbuild.2"
+    eks_access_entries = "false"
     eks_api_server_private_access_cidrs = ""
     eks_api_server_public_access_cidrs = "0.0.0.0/0"
     eks_log_types = ""

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -227,6 +227,11 @@ variable "internet_gateway_id" {
   default = ""
 }
 
+variable "eks_access_entries" {
+  type    = string
+  default = "false"
+}
+
 variable "karpenter_auth_mode" {
   type    = string
   default = "false"

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -132,6 +132,16 @@ variable "enable_private_access" {
   default = false
 }
 
+variable "ecr_additional_policy_arn" {
+  type    = string
+  default = ""
+}
+
+variable "ecr_full_access" {
+  type    = bool
+  default = false
+}
+
 variable "ecr_scan_on_push_enable" {
   type    = bool
   default = false


### PR DESCRIPTION
### What is the feature/update/fix?

**Update: Karpenter Enablement CLI Validation Guards**

Adds several new CLI-level validation rules to `convox rack params set` that prevent edge case TF failures when enabling Karpenter.  These guards catch parameter combinations that would cause scheduling deadlocks or stuck rack updates, and provide actionable error messages with the correct remediation steps.  In all circumstances the only new requirement is a bunched `convox rack params set` command must be broken across two separate `convox rack params set` runs

**New validations:**

| Guard | Trigger | Error behavior |
|-------|---------|----------------|
| `node_capacity_type` must be `ON_DEMAND` when enabling Karpenter | `karpenter_enabled=true` with `node_capacity_type` set to anything other than `ON_DEMAND` | Rejects with step-by-step instructions to set `ON_DEMAND` first |
| Cannot change `node_capacity_type` while Karpenter is active | Any `node_capacity_type` change when `karpenter_enabled=true` | Rejects with instruction to disable Karpenter first |
| Launch template params blocked on non-HA single-node racks | `karpenter_enabled=true` combined with launch template params (`gpu_tag_enable`, `imds_http_tokens`, `imds_http_hop_limit`, `imds_tags_enable`, `ebs_volume_encryption_enabled`, `user_data`, `user_data_url`, `kubelet_registry_pull_qps`, `kubelet_registry_burst`, `key_pair_name`) on racks with `high_availability=false` | Rejects with list of conflicting params and instructions to set them separately first |
| `eks_access_entries` one-way guard | `eks_access_entries=false` when currently `true` | Rejects with explanation that EKS auth mode migration is irreversible |

**Improved existing validations:**

| Change | Detail |
|--------|--------|
| Case-insensitive param comparison | Existing `karpenter_enabled` and `karpenter_auth_mode` checks now use `strings.EqualFold` to handle uppercase/lowercase values from different Terraform state formats |
| `eks_access_entries` added to boolish validation | Rejects junk values (only `"true"` or `"false"` accepted) |

---

### Why is this important?

**Benefits:**

- **Prevents scheduling deadlocks.** Enabling Karpenter with `SPOT` or mixed capacity types can deadlock node replacement because Karpenter taints the old node group while the replacement may not schedule due to capacity constraints.
- **Prevents stuck single-node racks.** On non-HA racks (one node), combining `karpenter_enabled=true` with launch template changes triggers a rolling update on the single node while Karpenter simultaneously taints it, leaving no schedulable nodes.
- **Actionable errors.** Every rejection includes the exact commands to run in the correct order, eliminating guesswork.

---

### Does it have a breaking change?

**No breaking changes** for users following the documented Karpenter enablement workflow. These validations only reject parameter combinations that would have resulted in broken rack states. Users who previously set these combinations successfully (due to favorable timing) are unaffected on existing racks.

The `strings.EqualFold` improvement is purely additive and handles edge cases where Terraform state stored boolean values in mixed case.

---

### Requirements

This update requires version `3.24.7` or later for the rack.

**Update the Rack:** Run `convox rack update 3.24.7 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.23.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._


---

- Closes #1027 
- Closes #1028 
- Closes #1029 