### PR TITLE
recover deploys from invalid service port patch

### DIFF
--- a/pkg/atom/atom.go
+++ b/pkg/atom/atom.go
@@ -489,20 +489,31 @@ func applyTemplate(namespace string, data []byte, filter string) ([]byte, error)
 	}
 
 	out, err := kubectlApply(data, args...)
-	fmt.Printf("string(out): %+v\n", string(out))
 	if err != nil {
-		fmt.Printf("err: %+v\n", err)
-		if !strings.Contains(string(out), "is immutable") {
+		if !isRecoverableApplyError(out) {
 			return out, errors.WithStack(err)
 		}
 
-		out, err := kubectlApply(data, "--force")
+		fmt.Printf("ns=atom at=applyTemplate ns=%q force-recreate=true\n", namespace)
+
+		out, err = kubectlApply(data, "--force")
 		if err != nil {
 			return out, errors.WithStack(err)
 		}
 	}
 
 	return out, nil
+}
+
+// isRecoverableApplyError reports whether a failed kubectl apply can be retried with --force
+// (delete + recreate): an immutable-field change, or a strategic-merge patch that deletes a
+// required field because last-applied-configuration was written by an older rack (kubernetes #105610).
+func isRecoverableApplyError(out []byte) bool {
+	s := string(out)
+	if strings.Contains(s, "is immutable") {
+		return true
+	}
+	return strings.Contains(s, "error when applying patch") && strings.Contains(s, `"$patch":"delete"`)
 }
 
 func extractConditions(data []byte) ([]aa.AtomCondition, error) {

--- a/pkg/atom/atom_test.go
+++ b/pkg/atom/atom_test.go
@@ -134,6 +134,54 @@ func TestApply(t *testing.T) {
 	})
 }
 
+func TestIsRecoverableApplyError(t *testing.T) {
+	cases := []struct {
+		name string
+		out  string
+		want bool
+	}{
+		{
+			name: "duplicate service port strategic-merge delete (k8s #105610)",
+			out: `Error from server (Invalid): error when applying patch:` +
+				`{"spec":{"$setElementOrder/ports":[{"port":8080}],"ports":[{"$patch":"delete","name":"main","port":8080}]}}` +
+				` to:` + "\n" +
+				`for: "STDIN": error when patching "STDIN": Service "web" is invalid: spec.ports: Required value`,
+			want: true,
+		},
+		{
+			name: "immutable field",
+			out:  `The Service "web" is invalid: spec.clusterIP: Invalid value: "": field is immutable`,
+			want: true,
+		},
+		{
+			name: "genuinely invalid object must NOT force-recreate",
+			out:  `The Service "web" is invalid: spec.ports[0].port: Invalid value: 99999999: must be between 1 and 65535`,
+			want: false,
+		},
+		{
+			name: "patch failure without delete directive must NOT force-recreate",
+			out: `Error from server: error when applying patch:` +
+				`{"spec":{"$setElementOrder/ports":[{"port":8080}]}}` +
+				` to:` + "\n" +
+				`for: "STDIN": error when patching "STDIN": Service "web" is invalid: spec.ports: Required value`,
+			want: false,
+		},
+		{
+			name: "clean apply output",
+			out:  "service/web configured\n",
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRecoverableApplyError([]byte(tc.out)); got != tc.want {
+				t.Fatalf("isRecoverableApplyError() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func atomCreate(ac av.Interface, namespace, name, status, version string, spec aa.AtomSpec) error {
 	_, err := ac.AtomV1().Atoms(namespace).Create(context.Background(), &aa.Atom{
 		ObjectMeta: am.ObjectMeta{


### PR DESCRIPTION
### What is the fix?

**Fix: Recover deploys from an invalid Service-port apply patch**

Deploys could fail with `spec.ports: Required value` after a rack crossed the 3.24.4 boundary, for any service that declared the same port number in both the singular `port:` and the `ports:` list:

```yaml
services:
  web:
    port: 8080
    ports:
      - 8080
```

This is a narrow edge condition. It affects only apps that declared the same port number in both `port:` and a `ports:` entry (commonly when fronting the service with a custom `balancers:` block) and were last deployed on a pre-3.24.4 rack. The vast majority of apps are unaffected.

**When this happens:**

| Condition | Detail |
|-----------|--------|
| Service shape | Same port number in both `port:` and a `ports:` entry |
| Rack history | App was last deployed on a pre-3.24.4 rack (stored the old two-port shape) |
| Trigger | First deploy on a 3.24.4+ rack, where port dedup renders a single port |
| Symptom | `kubectl apply` three-way merge removes the only port; API server rejects with `spec.ports: Required value` |

3.24.4 added port deduplication, so the configuration above now renders one port instead of two. The stored `last-applied-configuration` still held two same-numbered ports, and the client-side merge hit a Kubernetes limitation (the Service-port merge key is the port number alone, [kubernetes/kubernetes#105610](https://github.com/kubernetes/kubernetes/issues/105610)), producing a patch that deleted the only remaining port.

**The fix:** the apply path now detects this invalid-patch signature and retries with `kubectl apply --force`, recreating the affected object from the valid, deduplicated template and writing a fresh `last-applied-configuration`. Every later deploy is an ordinary no-op merge.

| Behavior | Before | After |
|----------|--------|-------|
| Duplicate-port deploy after 3.24.4 | Hard fails (`spec.ports: Required value`) | Recovers automatically within the same deploy |
| `is immutable` recovery | Retried with `--force` | Unchanged |
| Genuinely invalid object | Hard fails | Hard fails (safety guard requires a strategic-merge delete directive) |

---

### Why is this important?

Affected apps could not deploy after the rack upgrade, and the error was opaque. The recovery is automatic and bounded, so users redeploy once and the app comes up normally with no manual steps.

**Benefits:**

- **Automatic, single-deploy recovery.** No failed deploy, no manual annotation surgery.
- **Bounded impact.** Only the affected internal Service is recreated (its in-cluster IP is reallocated for a few seconds); callers reconnect by DNS name. Deployments, autoscalers, and balancer Services are untouched.
- **Safe.** A real validation error still fails fast; only the duplicate-port merge signature triggers the recreate.

---

### Does it have a breaking change?

**No breaking changes** are introduced. The recovery runs only after an apply has already failed with the duplicate-port signature, so successful deploys are unaffected.

---

### Requirements

This fix requires version `3.24.8` or later for the rack.

**Update the Rack:** Run `convox rack update 3.24.8 -r rackName` to update to this version. Affected apps recover on their next deploy.

_Note that your rack must already be on at least version `3.23.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
