### PR TITLE
bound AWS streamLogs missing-group log retry

### DIFF
--- a/provider/aws/log.go
+++ b/provider/aws/log.go
@@ -17,6 +17,11 @@ import (
 
 var sequenceTokens sync.Map
 
+var (
+	logRetrySleep              = 3 * time.Second
+	resourceNotFoundMaxRetries = 20
+)
+
 func (p *Provider) Log(name, stream string, ts time.Time, message string) error {
 	group := p.appLogGroup(name)
 
@@ -203,6 +208,7 @@ func (p *Provider) streamLogs(ctx context.Context, w io.WriteCloser, group, stre
 	}
 
 	seen := map[string]bool{}
+	rnf := 0
 
 	for {
 		select {
@@ -217,13 +223,25 @@ func (p *Provider) streamLogs(ctx context.Context, w io.WriteCloser, group, stre
 			res, err := p.CloudWatchLogs.FilterLogEvents(req)
 			if err != nil {
 				switch awsErrorCode(err) {
-				case "ThrottlingException", "ResourceNotFoundException":
-					time.Sleep(3 * time.Second)
+				case "ThrottlingException":
+					time.Sleep(logRetrySleep)
+					continue
+				case "ResourceNotFoundException":
+					// The group is created on the app's first log write, so a fresh
+					// tail may briefly miss; retry bounded rather than forever (a group
+					// that never appears would otherwise be a permanent FilterLogEvents storm).
+					rnf++
+					if rnf >= resourceNotFoundMaxRetries {
+						return nil
+					}
+					time.Sleep(logRetrySleep)
 					continue
 				default:
 					return err
 				}
 			}
+
+			rnf = 0
 
 			es := []*cloudwatchlogs.FilteredLogEvent{}
 

--- a/provider/aws/log_internal_test.go
+++ b/provider/aws/log_internal_test.go
@@ -1,0 +1,156 @@
+package aws
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	mocks "github.com/convox/convox/pkg/mock/aws"
+	"github.com/convox/convox/pkg/structs"
+	"github.com/stretchr/testify/mock"
+)
+
+func rnfError() error {
+	return awserr.New("ResourceNotFoundException", "The specified log group does not exist.", nil)
+}
+
+func throttleError() error {
+	return awserr.New("ThrottlingException", "Rate exceeded", nil)
+}
+
+func fastLogRetries(t *testing.T, max int) {
+	prevSleep, prevMax := logRetrySleep, resourceNotFoundMaxRetries
+	t.Cleanup(func() {
+		logRetrySleep = prevSleep
+		resourceNotFoundMaxRetries = prevMax
+	})
+	logRetrySleep = time.Millisecond
+	resourceNotFoundMaxRetries = max
+}
+
+// streamLogs must STOP retrying a log group that does not exist, instead of
+// looping FilterLogEvents forever (the missing-group storm on fluentd-disabled
+// racks). Against the pre-fix code this hangs and the test times out.
+func TestStreamLogsStopsOnMissingLogGroup(t *testing.T) {
+	fastLogRetries(t, 3)
+
+	m := &mocks.CloudWatchLogsAPI{}
+	m.On("FilterLogEvents", mock.Anything).Return((*cloudwatchlogs.FilterLogEventsOutput)(nil), rnfError())
+	p := &Provider{CloudWatchLogs: m}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r, w := io.Pipe()
+	go func() { _, _ = io.Copy(io.Discard, r) }()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- p.streamLogs(ctx, w, "/convox/rack/missing", "", structs.LogsOptions{})
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected nil on missing group, got %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		cancel()
+		<-done
+		t.Fatal("streamLogs did not stop on a persistently-missing log group (infinite ResourceNotFound retry)")
+	}
+	m.AssertNumberOfCalls(t, "FilterLogEvents", 3)
+}
+
+// A successful FilterLogEvents must reset the consecutive-miss counter, so an
+// eventual-consistency blip while a group is being created never kills a tail.
+func TestStreamLogsResourceNotFoundResetsOnSuccess(t *testing.T) {
+	fastLogRetries(t, 3)
+
+	follow := true
+	withEvent := &cloudwatchlogs.FilterLogEventsOutput{
+		Events: []*cloudwatchlogs.FilteredLogEvent{
+			{EventId: aws.String("e1"), Timestamp: aws.Int64(1), Message: aws.String("hi")},
+		},
+	}
+
+	m := &mocks.CloudWatchLogsAPI{}
+	m.On("FilterLogEvents", mock.Anything).Return((*cloudwatchlogs.FilterLogEventsOutput)(nil), rnfError()).Once()
+	m.On("FilterLogEvents", mock.Anything).Return((*cloudwatchlogs.FilterLogEventsOutput)(nil), rnfError()).Once()
+	m.On("FilterLogEvents", mock.Anything).Return(withEvent, nil).Once() // success: resets the counter
+	m.On("FilterLogEvents", mock.Anything).Return((*cloudwatchlogs.FilterLogEventsOutput)(nil), rnfError())
+	p := &Provider{CloudWatchLogs: m}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r, w := io.Pipe()
+	go func() { _, _ = io.Copy(io.Discard, r) }()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- p.streamLogs(ctx, w, "/convox/rack/eventual", "", structs.LogsOptions{Follow: &follow})
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+	case <-time.After(6 * time.Second):
+		cancel()
+		<-done
+		t.Fatal("streamLogs did not return")
+	}
+	// 2 RNF, 1 success (reset), then 3 RNF to hit the cap = 6 calls.
+	// Without the reset it would stop at 4 calls.
+	m.AssertNumberOfCalls(t, "FilterLogEvents", 6)
+}
+
+// ThrottlingException is transient and must NOT be bounded by the
+// ResourceNotFound cap.
+func TestStreamLogsThrottlingNotBounded(t *testing.T) {
+	fastLogRetries(t, 3)
+
+	withEvent := &cloudwatchlogs.FilterLogEventsOutput{
+		Events: []*cloudwatchlogs.FilteredLogEvent{
+			{EventId: aws.String("e1"), Timestamp: aws.Int64(1), Message: aws.String("hi")},
+		},
+	}
+
+	m := &mocks.CloudWatchLogsAPI{}
+	for i := 0; i < 5; i++ { // more throttles than the RNF cap
+		m.On("FilterLogEvents", mock.Anything).Return((*cloudwatchlogs.FilterLogEventsOutput)(nil), throttleError()).Once()
+	}
+	m.On("FilterLogEvents", mock.Anything).Return(withEvent, nil) // success (no NextToken), follow=false -> return
+	p := &Provider{CloudWatchLogs: m}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r, w := io.Pipe()
+	go func() { _, _ = io.Copy(io.Discard, r) }()
+
+	noFollow := false
+	done := make(chan error, 1)
+	go func() {
+		done <- p.streamLogs(ctx, w, "/convox/rack/app", "", structs.LogsOptions{Follow: &noFollow})
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+	case <-time.After(6 * time.Second):
+		cancel()
+		<-done
+		t.Fatal("streamLogs did not return after throttles cleared")
+	}
+	// 5 throttles (not bounded by the cap of 3) + 1 success = 6 calls.
+	m.AssertNumberOfCalls(t, "FilterLogEvents", 6)
+}


### PR DESCRIPTION
### What is the feature/update/fix?

**Fix: Bound log-stream retries when a CloudWatch log group is not present**

An app's CloudWatch log group is created on its first log line, so a log tail opened right after a deploy briefly
waits for that group to appear. The log streamer now bounds this wait, ending cleanly after about a minute if the
group is not present rather than continuing to retry. This is most relevant on racks configured for external logging
(`fluentd_disable=true`), where app output is shipped elsewhere and the per-app CloudWatch group is not created.

The retry counter resets on any successful read, so a healthy tail is never cut short and freshly deployed apps
stream logs exactly as before.

---

### Why is this important?

Log streaming is now more predictable and uses the CloudWatch API more conservatively, with no change for normal
tailing.

**Benefits:**

- **Predictable log tails.** A tail against a log group that is not present ends cleanly instead of waiting indefinitely.
- **Conservative CloudWatch usage.** Bounded retries keep CloudWatch read volume low on racks that ship logs externally.
- **No change for normal logging.** The post-deploy window where a new app's log group is still being created is preserved.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this fix.

Log streaming for apps that write to CloudWatch is unchanged. This change is AWS V3 only and touches application code
only, with no Terraform, CloudFormation, rack parameter, or state changes.

---

### Requirements

This fix requires version `3.24.9` or later for the rack.

**Update the Rack:** Run `convox rack update 3.24.9 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.23.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
