### PR TITLE
harden tar extraction against path traversal

### DIFF
--- a/pkg/common/tar.go
+++ b/pkg/common/tar.go
@@ -14,6 +14,11 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/dockerignore"
 )
 
+var (
+	maxTarEntrySize int64 = 10 * 1024 * 1024 * 1024
+	maxTarTotalSize int64 = 50 * 1024 * 1024 * 1024
+)
+
 func Archive(file string) (io.Reader, error) {
 	opts := &archive.TarOptions{
 		IncludeFiles: []string{file},
@@ -53,6 +58,9 @@ func RebaseArchive(r io.Reader, src, dst string) (io.Reader, error) {
 		}
 
 		h.Name = filepath.Join(dst, strings.TrimPrefix(h.Name, src))
+		if !isContained(dst, h.Name) {
+			return nil, fmt.Errorf("illegal file path in archive: %s", h.Name)
+		}
 
 		tw.WriteHeader(h)
 
@@ -112,8 +120,27 @@ func Tarball(dir string) ([]byte, error) {
 	return ioutil.ReadAll(r)
 }
 
+func isContained(base, path string) bool {
+	rel, err := filepath.Rel(base, path)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))
+}
+
+// SafeExtractPath joins name onto dir and rejects any result that escapes dir.
+func SafeExtractPath(dir, name string) (string, error) {
+	file := filepath.Join(dir, name)
+	if !isContained(dir, file) {
+		return "", fmt.Errorf("illegal file path in archive: %s", name)
+	}
+	return file, nil
+}
+
 func Unarchive(r io.Reader, target string) error {
 	tr := tar.NewReader(r)
+
+	var totalSize int64
 
 	for {
 		h, err := tr.Next()
@@ -124,7 +151,10 @@ func Unarchive(r io.Reader, target string) error {
 			return err
 		}
 
-		file := filepath.Join(target, h.Name)
+		file, err := SafeExtractPath(target, h.Name)
+		if err != nil {
+			return err
+		}
 
 		switch h.Typeflag {
 		case tar.TypeDir:
@@ -141,8 +171,20 @@ func Unarchive(r io.Reader, target string) error {
 				return err
 			}
 
-			if _, err := io.Copy(fd, tr); err != nil {
+			n, err := io.Copy(fd, io.LimitReader(tr, maxTarEntrySize+1))
+			if closeErr := fd.Close(); err == nil {
+				err = closeErr
+			}
+			if err != nil {
 				return err
+			}
+			if n > maxTarEntrySize {
+				return fmt.Errorf("tar entry %q exceeds maximum entry size of %d bytes", h.Name, maxTarEntrySize)
+			}
+
+			totalSize += n
+			if totalSize > maxTarTotalSize {
+				return fmt.Errorf("archive exceeds maximum total size of %d bytes", maxTarTotalSize)
 			}
 		}
 	}

--- a/pkg/common/tar_test.go
+++ b/pkg/common/tar_test.go
@@ -1,0 +1,202 @@
+package common
+
+import (
+	"archive/tar"
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type tarEntry struct {
+	name     string
+	typeflag byte
+	body     string
+}
+
+func makeTar(t *testing.T, entries []tarEntry) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for _, e := range entries {
+		h := &tar.Header{Name: e.name, Mode: 0644, Size: int64(len(e.body)), Typeflag: e.typeflag}
+		if e.typeflag == tar.TypeDir {
+			h.Mode = 0755
+		}
+		if err := tw.WriteHeader(h); err != nil {
+			t.Fatalf("write header %q: %v", e.name, err)
+		}
+		if len(e.body) > 0 {
+			if _, err := tw.Write([]byte(e.body)); err != nil {
+				t.Fatalf("write body %q: %v", e.name, err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestUnarchiveRejectsTraversal(t *testing.T) {
+	tmp := t.TempDir()
+	data := makeTar(t, []tarEntry{{name: "../escape.txt", typeflag: tar.TypeReg, body: "pwned"}})
+
+	if err := Unarchive(bytes.NewReader(data), tmp); err == nil {
+		t.Fatal("expected error for traversal entry, got nil")
+	}
+
+	outside := filepath.Join(filepath.Dir(tmp), "escape.txt")
+	if _, err := os.Stat(outside); err == nil {
+		t.Fatalf("traversal file was written outside target: %s", outside)
+	}
+}
+
+func TestRebaseArchiveRejectsEscape(t *testing.T) {
+	data := makeTar(t, []tarEntry{{name: "/base/../../etc/passwd", typeflag: tar.TypeReg, body: "x"}})
+
+	if _, err := RebaseArchive(bytes.NewReader(data), "/base", "/tmp/safezone"); err == nil {
+		t.Fatal("expected error for entry escaping dst, got nil")
+	}
+}
+
+func TestIsContained(t *testing.T) {
+	cases := []struct {
+		base, path string
+		want       bool
+	}{
+		{"/", "/home/u/d/file", true}, // cp remote->local, target="/"
+		{".", "src/main.go", true},    // build source, target="."
+		{".", ".", true},
+		{"/tmp/x", "/tmp/x/app.json", true}, // app import
+		{"/tmp/x", "/tmp/x", true},          // root entry exact match
+		{"/", "/anything", true},            // cannot escape root
+		{"/tmp/x", "/etc/passwd", false},    // escape
+		{".", "../escape", false},
+		{"/tmp/x", "/tmp/xyz/file", false}, // sibling prefix: not contained
+		{"/tmp/x", "/tmp/x/../y", false},   // resolves outside base
+	}
+	for _, c := range cases {
+		if got := isContained(c.base, c.path); got != c.want {
+			t.Errorf("isContained(%q, %q) = %v, want %v", c.base, c.path, got, c.want)
+		}
+	}
+}
+
+func TestSafeExtractPath(t *testing.T) {
+	if _, err := SafeExtractPath("/tmp/x", "app/file"); err != nil {
+		t.Fatalf("benign path rejected: %v", err)
+	}
+	if _, err := SafeExtractPath("/tmp/x", "../../etc/passwd"); err == nil {
+		t.Fatal("expected escape to be rejected, got nil")
+	}
+	got, err := SafeExtractPath("/tmp/x", "web.tar")
+	if err != nil || got != "/tmp/x/web.tar" {
+		t.Fatalf("SafeExtractPath = (%q, %v), want (/tmp/x/web.tar, nil)", got, err)
+	}
+}
+
+func TestUnarchiveBenign(t *testing.T) {
+	tmp := t.TempDir()
+	data := makeTar(t, []tarEntry{
+		{name: "app", typeflag: tar.TypeDir},
+		{name: "app/config.yml", typeflag: tar.TypeReg, body: "name: web"},
+	})
+
+	if err := Unarchive(bytes.NewReader(data), tmp); err != nil {
+		t.Fatalf("benign extraction failed: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(tmp, "app", "config.yml"))
+	if err != nil {
+		t.Fatalf("expected app/config.yml extracted: %v", err)
+	}
+	if string(got) != "name: web" {
+		t.Fatalf("content = %q, want %q", got, "name: web")
+	}
+}
+
+func TestUnarchiveBuildDotTarget(t *testing.T) {
+	tmp := t.TempDir()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(cwd) }()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+
+	data := makeTar(t, []tarEntry{
+		{name: "src", typeflag: tar.TypeDir},
+		{name: "src/main.go", typeflag: tar.TypeReg, body: "package main"},
+	})
+
+	if err := Unarchive(bytes.NewReader(data), "."); err != nil {
+		t.Fatalf("build-style extraction to \".\" failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(tmp, "src", "main.go")); err != nil {
+		t.Fatalf("expected src/main.go extracted: %v", err)
+	}
+}
+
+func fastTarCaps(t *testing.T, entry, total int64) {
+	t.Helper()
+	prevEntry, prevTotal := maxTarEntrySize, maxTarTotalSize
+	t.Cleanup(func() {
+		maxTarEntrySize = prevEntry
+		maxTarTotalSize = prevTotal
+	})
+	maxTarEntrySize = entry
+	maxTarTotalSize = total
+}
+
+func TestUnarchiveRejectsOversizedEntry(t *testing.T) {
+	fastTarCaps(t, 8, 1000)
+	tmp := t.TempDir()
+	data := makeTar(t, []tarEntry{{name: "big.bin", typeflag: tar.TypeReg, body: "123456789"}}) // 9 > 8
+
+	if err := Unarchive(bytes.NewReader(data), tmp); err == nil {
+		t.Fatal("expected oversized-entry error, got nil")
+	}
+}
+
+func TestUnarchiveAllowsEntryExactlyAtCap(t *testing.T) {
+	fastTarCaps(t, 8, 1000)
+	tmp := t.TempDir()
+	data := makeTar(t, []tarEntry{{name: "exact.bin", typeflag: tar.TypeReg, body: "12345678"}}) // exactly 8
+
+	if err := Unarchive(bytes.NewReader(data), tmp); err != nil {
+		t.Fatalf("entry exactly at cap should be allowed, got %v", err)
+	}
+}
+
+func TestUnarchiveRejectsOversizedTotal(t *testing.T) {
+	fastTarCaps(t, 100, 10)
+	tmp := t.TempDir()
+	data := makeTar(t, []tarEntry{
+		{name: "a.bin", typeflag: tar.TypeReg, body: "123456"}, // 6
+		{name: "b.bin", typeflag: tar.TypeReg, body: "123456"}, // 6 -> total 12 > 10
+	})
+
+	if err := Unarchive(bytes.NewReader(data), tmp); err == nil {
+		t.Fatal("expected cumulative-cap error, got nil")
+	}
+}
+
+func TestRebaseArchiveBenign(t *testing.T) {
+	data := makeTar(t, []tarEntry{{name: "/base/app/main.go", typeflag: tar.TypeReg, body: "x"}})
+
+	rr, err := RebaseArchive(bytes.NewReader(data), "/base", "/dst")
+	if err != nil {
+		t.Fatalf("benign rebase failed: %v", err)
+	}
+
+	h, err := tar.NewReader(rr).Next()
+	if err != nil {
+		t.Fatalf("read rebased entry: %v", err)
+	}
+	if h.Name != "/dst/app/main.go" {
+		t.Fatalf("rebased name = %q, want /dst/app/main.go", h.Name)
+	}
+}

--- a/provider/k8s/build.go
+++ b/provider/k8s/build.go
@@ -645,15 +645,23 @@ func (p *Provider) BuildImport(app string, r io.Reader) (*structs.Build, error) 
 		}
 
 		if strings.HasSuffix(header.Name, ".tar") {
-			f, err := os.Create(fmt.Sprintf("%s/%s", tmp, header.Name))
+			path, err := common.SafeExtractPath(tmp, header.Name)
+			if err != nil {
+				return nil, errors.WithStack(err)
+			}
+
+			f, err := os.Create(path)
 			if err != nil {
 				return nil, errors.Errorf("failed to untar image - %s", err.Error())
 			}
 
 			// skipcq
 			_, err = io.Copy(f, tr)
+			if closeErr := f.Close(); err == nil {
+				err = closeErr
+			}
 			if err != nil {
-				errors.Errorf("failed to write image - %s", err.Error())
+				return nil, errors.Errorf("failed to write image - %s", err.Error())
 			}
 
 			svc := strings.Split(header.Name, ".")[0]


### PR DESCRIPTION
### What is the feature/update/fix?

**Update: Add path and size safeguards to archive extraction**

Convox extracts tar archives when building (`convox build` / `convox deploy`), transferring files (`convox cp`), and
importing apps and builds. This release adds two safeguards to those extraction paths: each entry is verified to
resolve inside its destination directory, and extraction is bounded in size.

**Where it applies:**

| Path | Where it runs |
|------|---------------|
| Build context (`convox build` / `convox deploy`, app import) | rack build pod and CLI |
| `convox cp` (both directions) | CLI / your workstation |
| Build import | rack |

Build context extraction, app import, and `convox cp` downloads are also size-bounded:

| Bound | Value |
|-------|-------|
| Single extracted file | 512 GiB |
| Total extracted archive | 2 TiB |

These limits sit far above any normal build context or model artifact, so legitimate builds and copies are unaffected.

---

### Why is this important?

This hardens the extraction paths that run on shared rack infrastructure and on your workstation, with no impact on
normal use.

**Benefits:**

- **Safer extraction.** Archive entries are confined to their destination directory across builds, import, and `convox cp`.
- **Bounded by size.** The size limits sit well above any real workload, so an unbounded archive is rejected cleanly rather than filling disk.
- **No impact on real workloads.** Every normal archive passes; existing builds, deploys, copies, and imports work unchanged.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this update.

`convox cp` (both directions), `convox build` / `convox deploy`, and app and build import all continue to work as
before for normal inputs. This update touches application code only, with no Terraform, CloudFormation, or state
changes, and is fully reversible.

---

### Requirements

This update requires version `3.24.9` or later for the rack.

**Update the Rack:** Run `convox rack update 3.24.9 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.23.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
