### PR TITLE
fix and modernize CI workflows

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -14,7 +14,7 @@ jobs:
         provider: [aws]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: AWS secrets
         run: ci/secrets.sh
         env:
@@ -23,12 +23,14 @@ jobs:
       - name: System dependencies
         run: ci/dependencies.sh
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.24'
       - name: Cache / download Go modules
+        working-directory: ci
         run: go mod download
       - name: AWS cleanup
+        working-directory: ci
         run: |
           go run .
         env:
@@ -41,7 +43,7 @@ jobs:
       fail-fast: false
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: do secrets
         run: ci/secrets.sh
         env:

--- a/.github/workflows/cleanup_azure.yml
+++ b/.github/workflows/cleanup_azure.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: azure secrets
         run: ci/secrets.sh
         env:

--- a/.github/workflows/cleanup_gcp.yml
+++ b/.github/workflows/cleanup_gcp.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: gcp secrets
         run: ci/secrets.sh
         env:

--- a/.github/workflows/daily_test.yml
+++ b/.github/workflows/daily_test.yml
@@ -18,7 +18,7 @@ jobs:
           - gcp
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: name
         run: echo "RACK_NAME=ci-$(date +"%Y%m%d%H%M%S")" >> $GITHUB_ENV
       - name: provider

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,40 +7,26 @@ on:
 jobs:
   release:
     runs-on: ubuntu-22.04
-    outputs:
-      upload_url: ${{ steps.release.outputs.upload_url }}
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: golang-1.24
-        uses: actions/setup-go@v3
+      - name: golang-1.25
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       - name: version
         run: echo "VERSION=$(echo ${{ github.ref }} | awk -F/ '{print $3}')" >> $GITHUB_ENV
       - name: Install libudev-dev
         run: sudo apt-get update && sudo apt-get install -y libudev-dev
-      - name: changelog
-        id: changelog
-        run: |
-          changelog=$(git log --pretty="* %s" ...$(git describe --abbrev=0 HEAD~))
-          echo ${changelog}
-          changelog="${changelog//'%'/'%25'}"
-          changelog="${changelog//$'\n'/'%0A'}"
-          changelog="${changelog//$'\r'/'%0D'}"
-          echo "::set-output name=text::${changelog}"
       - name: release
-        id: release
-        uses: ddollar/create-release@master
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          body: ${{ steps.changelog.outputs.text }}
-          prerelease: true
-          release_name: "${{ env.VERSION }}"
-          tag_name: ${{ env.VERSION }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git log --pretty="* %s" ...$(git describe --abbrev=0 HEAD~) > /tmp/changelog.txt
+          cat /tmp/changelog.txt
+          gh release create "${VERSION}" --prerelease --title "${VERSION}" --notes-file /tmp/changelog.txt
       - name: tools
         run: make tools
       - name: cli
@@ -72,15 +58,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: version
         run: echo "VERSION=$(echo ${{ github.ref }} | awk -F/ '{print $3}')" >> $GITHUB_ENV
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: login
         run: docker login --username "${DOCKER_USERNAME}" --password "${DOCKER_PASSWORD}"
         env:
@@ -99,7 +85,7 @@ jobs:
     runs-on: ubuntu-22.04-arm
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: version
@@ -158,84 +144,78 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/download-artifact@v4
         with:
           name: convox-linux-amd64
+      - name: version
+        run: echo "VERSION=$(echo ${{ github.ref }} | awk -F/ '{print $3}')" >> $GITHUB_ENV
       - name: release
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        uses: actions/upload-release-asset@v1.0.2
-        with:
-          asset_content_type: application/octet-stream
-          asset_name: convox-linux
-          asset_path: ./convox-linux-amd64
-          upload_url: "${{ needs.release.outputs.upload_url }}"
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          mv ./convox-linux-amd64 ./convox-linux
+          gh release upload "${VERSION}" ./convox-linux --clobber
   release-cli-linux-arm64:
     needs:
       - release
     runs-on: ubuntu-22.04
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/download-artifact@v4
         with:
           name: convox-linux-arm64
+      - name: version
+        run: echo "VERSION=$(echo ${{ github.ref }} | awk -F/ '{print $3}')" >> $GITHUB_ENV
       - name: release
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        uses: actions/upload-release-asset@v1.0.2
-        with:
-          asset_content_type: application/octet-stream
-          asset_name: convox-linux-arm64
-          asset_path: ./convox-linux-arm64
-          upload_url: "${{ needs.release.outputs.upload_url }}"
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: gh release upload "${VERSION}" ./convox-linux-arm64 --clobber
   release-cli-macos:
     needs:
       - release
     runs-on: ubuntu-22.04
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/download-artifact@v4
         with:
           name: convox-darwin-amd64
+      - name: version
+        run: echo "VERSION=$(echo ${{ github.ref }} | awk -F/ '{print $3}')" >> $GITHUB_ENV
       - name: release
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        uses: actions/upload-release-asset@v1.0.2
-        with:
-          asset_content_type: application/octet-stream
-          asset_name: convox-macos
-          asset_path: ./convox-darwin-amd64
-          upload_url: "${{ needs.release.outputs.upload_url }}"
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          mv ./convox-darwin-amd64 ./convox-macos
+          gh release upload "${VERSION}" ./convox-macos --clobber
   release-cli-macos-arm64:
     needs:
       - release
     runs-on: ubuntu-22.04
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/download-artifact@v4
         with:
           name: convox-darwin-arm64
+      - name: version
+        run: echo "VERSION=$(echo ${{ github.ref }} | awk -F/ '{print $3}')" >> $GITHUB_ENV
       - name: release
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        uses: actions/upload-release-asset@v1.0.2
-        with:
-          asset_content_type: application/octet-stream
-          asset_name: convox-macos-arm64
-          asset_path: ./convox-darwin-arm64
-          upload_url: "${{ needs.release.outputs.upload_url }}"
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          mv ./convox-darwin-arm64 ./convox-macos-arm64
+          gh release upload "${VERSION}" ./convox-macos-arm64 --clobber
   ci:
     if: github.repository == 'convox/convox' && !contains(github.ref_name, 'rc')
     needs:
@@ -276,7 +256,7 @@ jobs:
             provider: azure
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: version
         run: echo "VERSION=$(echo ${{ github.ref }} | awk -F/ '{print $3}')" >> $GITHUB_ENV
       - name: name
@@ -320,7 +300,7 @@ jobs:
       suffix: downgrade
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: version
         run: echo "VERSION=$(echo ${{ github.ref }} | awk -F/ '{print $3}')" >> $GITHUB_ENV
       - name: name
@@ -368,7 +348,7 @@ jobs:
       suffix: upgrade
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: version
         run: echo "VERSION=$(echo ${{ github.ref }} | awk -F/ '{print $3}')" >> $GITHUB_ENV
       - name: name
@@ -415,7 +395,7 @@ jobs:
       suffix: ssh
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: version
         run: echo "VERSION=$(echo ${{ github.ref }} | awk -F/ '{print $3}')" >> $GITHUB_ENV
       - name: name

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,20 +5,20 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install libudev-dev
         run: sudo apt-get update && sudo apt-get install -y libudev-dev
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: build
         run: docker buildx build --platform linux/amd64,linux/arm64 .
   test:
     runs-on: ubuntu-22.04
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install libudev-dev
         run: sudo apt-get update && sudo apt-get install -y libudev-dev
       - name: test
@@ -27,11 +27,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: checkout
-        uses: actions/checkout@v3
-      - name: golang-1.24
-        uses: actions/setup-go@v3
+        uses: actions/checkout@v4
+      - name: golang-1.25
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       - name: Install libudev-dev
         run: sudo apt-get update && sudo apt-get install -y libudev-dev
       - name: tools

--- a/ci/azure_cleanup.sh
+++ b/ci/azure_cleanup.sh
@@ -15,7 +15,13 @@ az account set --subscription ${ARM_SUBSCRIPTION_ID}
 
 clusters=$(az aks list --query "[?starts_with(name, 'ci')].{name: name, resourceGroup: resourceGroup}" -o tsv)
 
-echo "$clusters" | while read -r name resourceGroup; do
+if [ -z "$clusters" ]; then
+  echo "No ci AKS clusters to delete"
+  exit 0
+fi
+
+while read -r name resourceGroup; do
+  [ -z "$name" ] && continue
   echo "Deleting AKS cluster: $name in resource group $resourceGroup"
   az aks delete --name "$name" --resource-group "$resourceGroup" --yes --no-wait
-done
+done <<< "$clusters"

--- a/ci/cli.sh
+++ b/ci/cli.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -ex -o pipefail
 
-# download appropriate cli version
-curl -L https://github.com/convox/convox/releases/download/${VERSION}/convox-linux -o /tmp/convox && \
+# resolve the latest release tag when VERSION is unset (same source install_last_release.sh uses)
+if [ -z "${VERSION}" ]; then
+  VERSION=$(curl -fsSL https://api.github.com/repos/convox/convox/releases/latest | jq -r '.tag_name')
+fi
+if [ -z "${VERSION}" ] || [ "${VERSION}" = "null" ]; then
+  echo "could not resolve latest convox release tag" >&2
+  exit 1
+fi
+
+# download appropriate cli version (-f so an HTTP error aborts instead of saving the error page as the binary)
+curl -fL https://github.com/convox/convox/releases/download/${VERSION}/convox-linux -o /tmp/convox && \
   sudo mv /tmp/convox /usr/bin/convox && sudo chmod +x /usr/bin/convox

--- a/ci/dependencies.sh
+++ b/ci/dependencies.sh
@@ -5,14 +5,14 @@ set -ex -o pipefail
 sudo apt-get update && sudo apt-get -y install jq unzip
 
 # install docker
-curl -s https://download.docker.com/linux/static/stable/x86_64/docker-20.10.21.tgz | sudo tar -C /usr/bin --strip-components 1 -xz
+curl -s https://download.docker.com/linux/static/stable/x86_64/docker-29.5.2.tgz | sudo tar -C /usr/bin --strip-components 1 -xz
 
-# install kubectl
-curl -Ls https://storage.googleapis.com/kubernetes-release/release/v1.22.0/bin/linux/amd64/kubectl -o /tmp/kubectl && \
+# install kubectl (match the rack's EKS k8s_version)
+curl -Ls https://dl.k8s.io/release/v1.34.8/bin/linux/amd64/kubectl -o /tmp/kubectl && \
 	sudo mv /tmp/kubectl /usr/bin/kubectl && sudo chmod +x /usr/bin/kubectl
 
-# install terraform
-curl -L https://releases.hashicorp.com/terraform/0.13.2/terraform_0.13.2_linux_amd64.zip -o terraform.zip && \
+# install terraform (1.x required by the hashicorp/aws 5.x provider the modules pin)
+curl -L https://releases.hashicorp.com/terraform/1.15.5/terraform_1.15.5_linux_amd64.zip -o terraform.zip && \
 	unzip terraform.zip -d /tmp && sudo mv /tmp/terraform /usr/bin/terraform && rm terraform.zip
 
 # install latest aws cli

--- a/ci/gcp_cleanup.sh
+++ b/ci/gcp_cleanup.sh
@@ -19,11 +19,17 @@ gcloud auth activate-service-account --key-file=/tmp/g-key.json
 
 gcloud config set project ${GOOGLE_PROJECT}
 
-gcloud config set compute/region ${GOOGLE_REGION}+
+gcloud config set compute/region ${GOOGLE_REGION}
 
-clusters=$(gcloud container clusters list --format="value(name,zone)" --filter="name:ci*")
+clusters=$(gcloud container clusters list --format="value(name,zone)" --filter="name ~ ^ci")
 
-echo "$clusters" | while read -r name zone; do
+if [ -z "$clusters" ]; then
+  echo "No ci GKE clusters to delete"
+  exit 0
+fi
+
+while read -r name zone; do
+  [ -z "$name" ] && continue
   echo "Deleting GKE cluster: $name in zone $zone"
   gcloud container clusters delete "$name" --zone="$zone" --quiet
-done
+done <<< "$clusters"


### PR DESCRIPTION
# Fix and modernize CI workflows

The scheduled CI workflows had rotted (all failing daily). This repairs them, fixes the next-layer rot in
`daily_test`, and modernizes the release pipeline off a departed founder's personal-repo action. All changes are
CI-only (no rack binary, no Terraform/CloudFormation/state).

## Failing workflows repaired

| Workflow | Root cause | Fix |
|----------|-----------|-----|
| `daily_test` | `ci/cli.sh` downloaded the CLI with an unset `${VERSION}`, getting a 404 page that `curl -L` (no `-f`) saved as the binary. | Resolve the latest tag from the GitHub API and add `-f`. |
| `cleanup_aws_do` | `go run .` ran at the repo root instead of the `ci/` cleanup module. | `working-directory: ci`. |
| `cleanup_azure` / `cleanup_gcp` | An empty cloud-list result still iterated the delete loop once with a blank name. | Guard the empty list; gcp also gets a corrected filter and a stray `+` removed. |

## Next-layer rot in `daily_test`

`ci/dependencies.sh` pinned tooling too old to run the current rack install: terraform `0.13.2 -> 1.15.5` (the
modules pin `hashicorp/aws` 5.100.0, which needs terraform >= 1.0), kubectl `v1.22.0 -> v1.34.8` (matches the rack's
EKS `k8s_version` 1.34), docker `20.10.21 -> 29.5.2`.

## Release pipeline modernization

`release.yml` depended on `ddollar/create-release@master` (a moving `master` pin on a former founder's personal repo)
and the archived `actions/upload-release-asset@v1.0.2`. Both are replaced with GitHub-native `gh release create` /
`gh release upload` (pre-installed on runners, no third-party trust, no Node deprecation), the deprecated
`::set-output` is removed, and the release asset names are preserved exactly (`convox-linux`, `convox-linux-arm64`,
`convox-macos`, `convox-macos-arm64`).

## Node20 deprecation

Bumped `actions/checkout@v3 -> v4`, `actions/setup-go@v3 -> v5`, and `docker/setup-qemu/buildx@v2 -> v3` across the
touched workflows ahead of GitHub's 2026-06-16 forced Node24 migration. (`lint.yml` was already current.)