### PR TITLE
Add minimal-privilege build node role param

### DIFF
--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -39,7 +39,7 @@ var awsKnownParams = map[string]bool{
 	"additional_karpenter_nodepools_config": true, "additional_node_groups_config": true,
 	"api_feature_gates": true, "availability_zones": true,
 	"aws_ebs_csi_driver_version": true, "build_disable_convox_resolver": true,
-	"build_node_enabled": true, "build_node_min_count": true,
+	"build_node_enabled": true, "build_node_minimal_role_enabled": true, "build_node_min_count": true,
 	"build_node_type": true, "buildkit_host_path_cache_enable": true,
 	"cert_duration": true, "cidr": true,
 	"convox_domain_tls_cert_disable": true, "convox_rack_domain": true,
@@ -179,6 +179,7 @@ var boolParams = map[string]bool{
 	"azure_files_enable":              true,
 	"build_disable_convox_resolver":   true,
 	"build_node_enabled":              true,
+	"build_node_minimal_role_enabled": true,
 	"buildkit_host_path_cache_enable": true,
 	"convox_domain_tls_cert_disable":  true,
 	"cost_tracking_enable":            true,
@@ -327,6 +328,7 @@ var paramGroups = map[string]map[string]bool{
 	"security": {
 		// v3 native (snake_case)
 		"access_id":                           true,
+		"build_node_minimal_role_enabled":     true, // dual-listed in build
 		"disable_public_access":               true,
 		"docker_hub_password":                 true,
 		"ebs_volume_encryption_enabled":       true,
@@ -463,6 +465,7 @@ var paramGroups = map[string]map[string]bool{
 		"build_disable_convox_resolver":     true,
 		"build_node_enabled":                true,
 		"build_node_min_count":              true,
+		"build_node_minimal_role_enabled":   true, // dual-listed in security
 		"build_node_type":                   true,
 		"buildkit_enabled":                  true,
 		"buildkit_host_path_cache_enable":   true,

--- a/terraform/cluster/aws/ecr_pull_through.tf
+++ b/terraform/cluster/aws/ecr_pull_through.tf
@@ -58,3 +58,10 @@ resource "aws_iam_role_policy_attachment" "karpenter_nodes_ecr_pull_through" {
   role       = aws_iam_role.karpenter_nodes[0].name
   policy_arn = aws_iam_policy.ecr_pull_through[0].arn
 }
+
+resource "aws_iam_role_policy_attachment" "karpenter_build_nodes_ecr_pull_through" {
+  count = local.build_minimal_role_enabled && var.ecr_docker_hub_cache && var.docker_hub_username != "" && var.docker_hub_password != "" ? 1 : 0
+
+  role       = aws_iam_role.karpenter_build_nodes[0].name
+  policy_arn = aws_iam_policy.ecr_pull_through[0].arn
+}

--- a/terraform/cluster/aws/karpenter_iam.tf
+++ b/terraform/cluster/aws/karpenter_iam.tf
@@ -1,6 +1,10 @@
 # Karpenter IAM roles and policies
 # All resources gated on var.karpenter_enabled
 
+locals {
+  build_minimal_role_enabled = var.karpenter_enabled && var.build_node_minimal_role_enabled
+}
+
 ###############################################################################
 # Controller IAM Role (IRSA — same OIDC trust pattern as lbc.tf)
 ###############################################################################
@@ -194,7 +198,7 @@ data "aws_iam_policy_document" "karpenter_controller_ec2" {
     actions = [
       "iam:PassRole",
     ]
-    resources = [aws_iam_role.karpenter_nodes[0].arn]
+    resources = local.build_minimal_role_enabled ? [aws_iam_role.karpenter_nodes[0].arn, aws_iam_role.karpenter_build_nodes[0].arn] : [aws_iam_role.karpenter_nodes[0].arn]
     condition {
       test     = "StringEquals"
       variable = "iam:PassedToService"
@@ -401,4 +405,107 @@ resource "aws_eks_access_entry" "karpenter_nodes" {
   principal_arn = aws_iam_role.karpenter_nodes[0].arn
   type          = "EC2_LINUX"
   tags          = local.tags
+}
+
+###############################################################################
+# Minimal-privilege build node role (build_node_minimal_role_enabled)
+# Drops EBS-CSI and pod-identity vs the shared roles; build nodes need neither.
+###############################################################################
+
+resource "aws_iam_role" "karpenter_build_nodes" {
+  count = local.build_minimal_role_enabled ? 1 : 0
+
+  name               = "${var.name}-build-nodes"
+  assume_role_policy = data.aws_iam_policy_document.assume_ec2.json
+  path               = "/convox/"
+  tags               = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "karpenter_build_nodes_worker" {
+  count = local.build_minimal_role_enabled ? 1 : 0
+
+  role       = aws_iam_role.karpenter_build_nodes[0].name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "karpenter_build_nodes_cni" {
+  count = local.build_minimal_role_enabled ? 1 : 0
+
+  role       = aws_iam_role.karpenter_build_nodes[0].name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKS_CNI_Policy"
+}
+
+resource "aws_iam_role_policy_attachment" "karpenter_build_nodes_ecr" {
+  count = local.build_minimal_role_enabled ? 1 : 0
+
+  role       = aws_iam_role.karpenter_build_nodes[0].name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
+resource "aws_iam_role_policy_attachment" "karpenter_build_nodes_ssm" {
+  count = local.build_minimal_role_enabled ? 1 : 0
+
+  role       = aws_iam_role.karpenter_build_nodes[0].name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+# Detach the role from any instance profile (Karpenter- or managed-node-group-owned)
+# before DeleteRole runs on toggle-off, so the destroy does not hit DeleteConflict.
+resource "null_resource" "karpenter_build_nodes_cleanup" {
+  count = local.build_minimal_role_enabled ? 1 : 0
+
+  depends_on = [aws_iam_role.karpenter_build_nodes]
+
+  triggers = {
+    role_name = aws_iam_role.karpenter_build_nodes[0].name
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = <<-EOF
+      ROLE="${self.triggers.role_name}"
+      for P in $(aws iam list-instance-profiles-for-role --role-name "$ROLE" --query 'InstanceProfiles[].InstanceProfileName' --output text 2>/dev/null); do
+        aws iam remove-role-from-instance-profile --instance-profile-name "$P" --role-name "$ROLE" 2>/dev/null || true
+      done
+      true
+    EOF
+  }
+}
+
+# Idempotent EC2_LINUX access entry (mirrors null_resource.eks_access_entry_nodes).
+# The role is shared by Karpenter instances and additional build node groups, so a
+# describe-then-create tolerates EKS auto-registering the managed-node-group role.
+resource "null_resource" "karpenter_build_nodes_access_entry" {
+  count = local.build_minimal_role_enabled ? 1 : 0
+
+  depends_on = [null_resource.karpenter_access_config, aws_iam_role.karpenter_build_nodes]
+
+  triggers = {
+    cluster_name  = aws_eks_cluster.cluster.name
+    principal_arn = aws_iam_role.karpenter_build_nodes[0].arn
+    region        = data.aws_region.current.name
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOF
+      set -e
+      C="${self.triggers.cluster_name}"
+      R="${self.triggers.region}"
+      P="${self.triggers.principal_arn}"
+      if aws eks describe-access-entry --cluster-name "$C" --principal-arn "$P" --region "$R" >/dev/null 2>&1; then
+        echo "Access entry already exists for $P - skipping"
+      else
+        aws eks create-access-entry --cluster-name "$C" --principal-arn "$P" --type EC2_LINUX --region "$R" || \
+          aws eks describe-access-entry --cluster-name "$C" --principal-arn "$P" --region "$R" >/dev/null 2>&1
+      fi
+    EOF
+  }
+
+  provisioner "local-exec" {
+    when    = destroy
+    command = <<-EOF
+      aws eks delete-access-entry --cluster-name "${self.triggers.cluster_name}" --principal-arn "${self.triggers.principal_arn}" --region "${self.triggers.region}" 2>/dev/null || true
+      true
+    EOF
+  }
 }

--- a/terraform/cluster/aws/karpenter_nodepool.tf
+++ b/terraform/cluster/aws/karpenter_nodepool.tf
@@ -284,7 +284,7 @@ resource "kubectl_manifest" "karpenter_ec2nodeclass_build" {
   yaml_body = templatefile("${path.module}/templates/karpenter-ec2nodeclass.yaml.tpl", {
     name                       = "build"
     cluster_name               = var.name
-    karpenter_node_role_name   = aws_iam_role.karpenter_nodes[0].name
+    karpenter_node_role_name   = local.build_minimal_role_enabled ? aws_iam_role.karpenter_build_nodes[0].name : aws_iam_role.karpenter_nodes[0].name
     karpenter_node_volume_type = var.karpenter_node_volume_type
     karpenter_effective_disk   = local.karpenter_effective_disk
     ebs_encrypted              = var.ebs_volume_encryption_enabled
@@ -301,6 +301,7 @@ resource "kubectl_manifest" "karpenter_ec2nodeclass_build" {
     aws_ec2_tag.private_subnets_karpenter,
     aws_ec2_tag.public_subnets_karpenter,
     aws_ec2_tag.cluster_sg_karpenter,
+    null_resource.karpenter_build_nodes_access_entry,
   ]
 }
 

--- a/terraform/cluster/aws/node_groups.tf
+++ b/terraform/cluster/aws/node_groups.tf
@@ -215,7 +215,7 @@ resource "random_id" "build_node_additional" {
     ami_id              = each.value.ami_id
     private_subnets_ids = join("-", local.private_subnets_ids)
     public_subnets_ids  = join("-", local.public_subnets_ids)
-    role_arn            = replace(aws_iam_role.nodes.arn, "role/convox/", "role/") # eks barfs on roles with paths
+    role_arn            = local.build_minimal_role_enabled ? replace(aws_iam_role.karpenter_build_nodes[0].arn, "role/convox/", "role/") : replace(aws_iam_role.nodes.arn, "role/convox/", "role/") # eks barfs on roles with paths
     tags                = try(jsonencode(each.value.tags), "")
   }
 }

--- a/terraform/cluster/aws/variables.tf
+++ b/terraform/cluster/aws/variables.tf
@@ -34,6 +34,11 @@ variable "build_node_enabled" {
   type    = bool
 }
 
+variable "build_node_minimal_role_enabled" {
+  type    = bool
+  default = false
+}
+
 variable "build_node_type" {
   type = string
 }

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -124,6 +124,7 @@ module "cluster" {
   build_arm_type                      = local.build_arm_type
   availability_zones                  = var.availability_zones
   build_node_enabled                  = var.build_node_enabled
+  build_node_minimal_role_enabled     = var.build_node_minimal_role_enabled
   build_node_min_count                = var.build_node_min_count
   build_node_type                     = var.build_node_type != "" ? var.build_node_type : var.node_type
   cidr                                = var.cidr

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -35,6 +35,11 @@ variable "build_node_enabled" {
   type    = bool
 }
 
+variable "build_node_minimal_role_enabled" {
+  type    = bool
+  default = false
+}
+
 variable "buildkit_host_path_cache_enable" {
   default = false
   type    = bool


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: Minimal-Privilege IAM Role for AWS Build Nodes**

This release adds an opt-in rack parameter that gives Karpenter build nodes on AWS their own dedicated least-privilege IAM role instead of sharing the workload node role. When enabled, build nodes join the cluster with a `rackName-build-nodes` role carrying only the four AWS managed policies a build node needs: EKS join, CNI networking, read-only ECR, and SSM.

**What enabling it does:**

- Creates the `rackName-build-nodes` IAM role with `AmazonEKSWorkerNodePolicy`, `AmazonEKS_CNI_Policy`, `AmazonEC2ContainerRegistryReadOnly`, and `AmazonSSMManagedInstanceCore` attached, and registers an EKS access entry so nodes using the role can join the cluster. Registration waits out IAM propagation of the newly created role, so enabling the parameter applies cleanly in a single rack update.
- Points the Karpenter build EC2NodeClass and any node groups defined in `additional_build_groups_config` at the new role.
- Extends the Karpenter controller's `iam:PassRole` permission to cover the new role.
- Attaches the Docker Hub pull-through cache policy to the new role when `ecr_docker_hub_cache` is configured with Docker Hub credentials, so cached pulls keep working.

The dedicated role omits the EBS CSI and pod-identity policies that the shared roles carry. Build nodes are ephemeral, run only build pods (which authenticate to ECR with a build-scoped token rather than the node role), and mount no persistent EBS volumes, so neither policy is needed.

The parameter appears under both `convox rack params -g build` and `convox rack params -g security`.

---

### Why is this important?

Build nodes run image builds from application Dockerfiles. Scoping their instance role to only what a build needs follows the principle of least privilege and keeps the permissions available on those instances to the minimum.

**Benefits:**

- **Least-privilege build infrastructure.** Build node instances carry only the permissions needed to join the cluster, handle pod networking, pull images, and support SSM access.
- **No change unless enabled.** The parameter defaults to `false`; an existing rack that upgrades and never sets it plans and applies with zero infrastructure change.
- **Cleanly reversible.** Setting the parameter back to `false` repoints build nodes to the shared role and removes the dedicated role automatically, with no manual cleanup required.

---

### How to use it?

Enable the dedicated build node role:

    $ convox rack params set build_node_minimal_role_enabled=true -r rackName

Return to the shared node role:

    $ convox rack params set build_node_minimal_role_enabled=false -r rackName

**Considerations:**

- The parameter applies to AWS racks with Karpenter enabled. It is inert on other providers and on racks without Karpenter.
- If a build reads AWS credentials from the build node's instance role (for example, running `aws s3 cp` inside a Dockerfile without explicit credentials), enabling this parameter removes that access. Pass credentials explicitly through build args or app secrets instead.
- If `additional_build_groups_config` node groups are configured, enabling or disabling the parameter recreates those node groups once because their node role changes. Toggle during a quiet period, since builds in flight on those nodes may be interrupted.

#### New Rack Parameters

| Parameter | Default | Description |
|-----------|---------|-------------|
| `build_node_minimal_role_enabled` | `false` | When `true` on an AWS rack with Karpenter enabled, build nodes use a dedicated `rackName-build-nodes` IAM role carrying only `AmazonEKSWorkerNodePolicy`, `AmazonEKS_CNI_Policy`, `AmazonEC2ContainerRegistryReadOnly`, and `AmazonSSMManagedInstanceCore`. When `false`, build nodes continue using the shared node role. |

---

### Does it have a breaking change?

**No breaking changes** are introduced with this feature.

The parameter defaults to `false`, and racks that upgrade without setting it see no infrastructure change. When enabled, the only behavior difference is on the build nodes themselves: builds that depended on the node instance role for AWS API access should pass credentials explicitly instead.

---

### Requirements

This feature requires version `3.24.10` or later for the rack.

**Update the Rack:** Run `convox rack update 3.24.10 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.23.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
