### PR TITLE
Add per-build-nodepool IMDS hardening params

### DIFF
--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -73,6 +73,7 @@ var awsKnownParams = map[string]bool{
 	"karpenter_build_capacity_types": true, "karpenter_build_consolidate_after": true,
 	"karpenter_build_cpu_limit": true, "karpenter_build_instance_families": true,
 	"karpenter_build_instance_sizes": true, "karpenter_build_memory_limit_gb": true,
+	"karpenter_build_imds_tokens": true, "karpenter_build_imds_hop_limit": true,
 	"karpenter_build_node_labels": true, "karpenter_capacity_types": true,
 	"karpenter_config": true, "karpenter_consolidate_after": true,
 	"karpenter_consolidation_enabled": true, "karpenter_cpu_limit": true,
@@ -342,6 +343,8 @@ var paramGroups = map[string]map[string]bool{
 		"imds_http_hop_limit":                 true,
 		"imds_http_tokens":                    true,
 		"imds_tags_enable":                    true,
+		"karpenter_build_imds_hop_limit":      true, // dual-listed in build
+		"karpenter_build_imds_tokens":         true, // dual-listed in build
 		"key_pair_name":                       true,
 		"nlb_security_group":                  true,
 		"pod_identity_agent_enable":           true,
@@ -469,6 +472,8 @@ var paramGroups = map[string]map[string]bool{
 		"karpenter_build_capacity_types":    true,
 		"karpenter_build_consolidate_after": true,
 		"karpenter_build_cpu_limit":         true,
+		"karpenter_build_imds_hop_limit":    true, // dual-listed in security
+		"karpenter_build_imds_tokens":       true, // dual-listed in security
 		"karpenter_build_instance_families": true,
 		"karpenter_build_instance_sizes":    true,
 		"karpenter_build_memory_limit_gb":   true,
@@ -642,9 +647,10 @@ var clearableParams = map[string]bool{
 	"ssl_ciphers":   true,
 	"ssl_protocols": true,
 	// Optional overrides — clear means "use auto/default"
-	"build_node_type":         true,
-	"key_pair_name":           true,
-	"nginx_additional_config": true,
+	"build_node_type":             true,
+	"key_pair_name":               true,
+	"nginx_additional_config":     true,
+	"karpenter_build_imds_tokens": true,
 	// Credentials — clear means "remove auth"
 	"docker_hub_username": true,
 	"docker_hub_password": true,
@@ -1558,6 +1564,7 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 			"karpenter_build_capacity_types", "karpenter_build_cpu_limit",
 			"karpenter_build_memory_limit_gb", "karpenter_node_taints",
 			"karpenter_node_labels", "karpenter_build_node_labels",
+			"karpenter_build_imds_tokens", "karpenter_build_imds_hop_limit",
 		}
 		for _, rk := range karpenterRevalidateKeys {
 			if _, inCall := params[rk]; !inCall {
@@ -1655,6 +1662,19 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 		n, err := strconv.Atoi(v)
 		if err != nil || n <= 0 {
 			return fmt.Errorf("karpenter_build_memory_limit_gb must be a positive integer")
+		}
+	}
+
+	if v, ok := params["karpenter_build_imds_tokens"]; ok && v != "" {
+		if v != "optional" && v != "required" {
+			return fmt.Errorf("param 'karpenter_build_imds_tokens' must be 'optional' or 'required'")
+		}
+	}
+
+	if v, ok := params["karpenter_build_imds_hop_limit"]; ok && v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			return fmt.Errorf("karpenter_build_imds_hop_limit must be a non-negative integer")
 		}
 	}
 

--- a/pkg/cli/rack_karpenter_test.go
+++ b/pkg/cli/rack_karpenter_test.go
@@ -802,6 +802,66 @@ func TestValidateAndMutateParams_BuildMemoryLimitGb(t *testing.T) {
 	}
 }
 
+// === Tests for karpenter_build_imds_tokens and karpenter_build_imds_hop_limit ===
+
+func TestValidateAndMutateParams_BuildImdsTokens(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+		errMsg  string
+	}{
+		{"optional is valid", "optional", false, ""},
+		{"required is valid", "required", false, ""},
+		{"empty is valid (clearable inherit)", "", false, ""},
+		{"junk rejected", "banana", true, "must be 'optional' or 'required'"},
+		{"REQUIRED rejected (case-sensitive)", "REQUIRED", true, "must be 'optional' or 'required'"},
+		{"Optional rejected (case-sensitive)", "Optional", true, "must be 'optional' or 'required'"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := map[string]string{"karpenter_build_imds_tokens": tt.value}
+			err := validateAndMutateParams(params, "aws", map[string]string{}, false)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("karpenter_build_imds_tokens=%q: got err=%v, wantErr=%v", tt.value, err, tt.wantErr)
+			}
+			if tt.wantErr && err != nil && tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
+				t.Errorf("error %q should contain %q", err.Error(), tt.errMsg)
+			}
+		})
+	}
+}
+
+func TestValidateAndMutateParams_BuildImdsHopLimit(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+		errMsg  string
+	}{
+		{"zero is valid (inherit sentinel)", "0", false, ""},
+		{"one is valid", "1", false, ""},
+		{"two is valid", "2", false, ""},
+		{"three is valid", "3", false, ""},
+		{"negative rejected", "-1", true, "must be a non-negative integer"},
+		{"not a number rejected", "abc", true, "must be a non-negative integer"},
+		{"decimal rejected", "1.5", true, "must be a non-negative integer"},
+		{"empty rejected (non-clearable)", "", true, "requires an explicit value"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := map[string]string{"karpenter_enabled": "true", "karpenter_build_imds_hop_limit": tt.value}
+			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"}, false)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("karpenter_build_imds_hop_limit=%q: got err=%v, wantErr=%v", tt.value, err, tt.wantErr)
+			}
+			if tt.wantErr && err != nil && tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
+				t.Errorf("error %q should contain %q", err.Error(), tt.errMsg)
+			}
+		})
+	}
+}
+
 // === Tests for karpenter_memory_limit_gb ===
 
 func TestValidateAndMutateParams_MemoryLimitGb(t *testing.T) {
@@ -1643,6 +1703,20 @@ func TestValidateAndMutateParams_KarpenterReenableValidation(t *testing.T) {
 			"karpenter_cpu_limit must be a positive integer",
 		},
 		{
+			"stale invalid build_imds_hop_limit in currentParams caught on re-enable",
+			map[string]string{"karpenter_enabled": "true", "karpenter_auth_mode": "true"},
+			map[string]string{"karpenter_auth_mode": "true", "karpenter_build_imds_hop_limit": "-5"},
+			true,
+			"karpenter_build_imds_hop_limit must be a non-negative integer",
+		},
+		{
+			"stale invalid build_imds_tokens in currentParams caught on re-enable",
+			map[string]string{"karpenter_enabled": "true", "karpenter_auth_mode": "true"},
+			map[string]string{"karpenter_auth_mode": "true", "karpenter_build_imds_tokens": "banana"},
+			true,
+			"must be 'optional' or 'required'",
+		},
+		{
 			"valid currentParams pass re-enable validation",
 			map[string]string{"karpenter_enabled": "true", "karpenter_auth_mode": "true"},
 			map[string]string{"karpenter_auth_mode": "true", "karpenter_capacity_types": "on-demand"},
@@ -1699,6 +1773,21 @@ func TestValidateAndMutateParams_KarpenterReenableValidation(t *testing.T) {
 			t.Error("injected key karpenter_cpu_limit should have been removed from params after validation")
 		}
 	})
+}
+
+func TestValidateAndMutateParams_BuildImdsParamsNotLaunchTemplateConflict(t *testing.T) {
+	// The build-only IMDS params must NOT be in ltParams, so setting them with
+	// karpenter_enabled=true on a non-HA rack is accepted. currentParams supplies
+	// high_availability=false (read by the gate) and karpenter_auth_mode=true.
+	params := map[string]string{
+		"karpenter_enabled":              "true",
+		"karpenter_build_imds_tokens":    "required",
+		"karpenter_build_imds_hop_limit": "1",
+	}
+	currentParams := map[string]string{"high_availability": "false", "karpenter_auth_mode": "true"}
+	if err := validateAndMutateParams(params, "aws", currentParams, false); err != nil {
+		t.Errorf("build IMDS params alongside karpenter_enabled=true on non-HA rack should be accepted, got: %v", err)
+	}
 }
 
 func TestCheckRackNameRegex(t *testing.T) {
@@ -1955,6 +2044,7 @@ func TestValidateAndMutateParams_EmptyParamRejection(t *testing.T) {
 		{"empty karpenter_memory_limit_gb", "karpenter_memory_limit_gb", "", true, "requires an explicit value"},
 		{"empty karpenter_build_cpu_limit", "karpenter_build_cpu_limit", "", true, "requires an explicit value"},
 		{"empty karpenter_build_memory_limit_gb", "karpenter_build_memory_limit_gb", "", true, "requires an explicit value"},
+		{"empty karpenter_build_imds_hop_limit", "karpenter_build_imds_hop_limit", "", true, "requires an explicit value"},
 		{"empty karpenter_consolidate_after", "karpenter_consolidate_after", "", true, "requires an explicit value"},
 		{"empty karpenter_build_consolidate_after", "karpenter_build_consolidate_after", "", true, "requires an explicit value"},
 		{"empty karpenter_node_expiry", "karpenter_node_expiry", "", true, "requires an explicit value"},
@@ -2006,6 +2096,7 @@ func TestValidateAndMutateParams_EmptyClearableParams(t *testing.T) {
 		{"karpenter_instance_sizes", "karpenter_instance_sizes"},
 		{"karpenter_build_instance_families", "karpenter_build_instance_families"},
 		{"karpenter_build_instance_sizes", "karpenter_build_instance_sizes"},
+		{"karpenter_build_imds_tokens", "karpenter_build_imds_tokens"},
 	}
 
 	for _, tt := range clearable {

--- a/pkg/rack/terraform.go
+++ b/pkg/rack/terraform.go
@@ -42,6 +42,7 @@ var preserveEmpty = map[string]bool{
 	"karpenter_node_labels":               true,
 	"karpenter_node_taints":               true,
 	"karpenter_build_node_labels":         true,
+	"karpenter_build_imds_tokens":         true,
 	"karpenter_instance_families":         true,
 	"karpenter_instance_sizes":            true,
 	"karpenter_build_instance_families":   true,

--- a/terraform/cluster/aws/karpenter_nodepool.tf
+++ b/terraform/cluster/aws/karpenter_nodepool.tf
@@ -25,6 +25,9 @@ locals {
     trimspace(split("=", pair)[0]) => trimspace(split("=", pair)[1])
   }
 
+  build_imds_tokens    = var.karpenter_build_imds_tokens != "" ? var.karpenter_build_imds_tokens : var.imds_http_tokens
+  build_imds_hop_limit = var.karpenter_build_imds_hop_limit > 0 ? var.karpenter_build_imds_hop_limit : var.imds_http_hop_limit
+
   ###########################################################################
   # karpenter_config overrides — decode user JSON (empty = no overrides)
   ###########################################################################
@@ -288,8 +291,8 @@ resource "kubectl_manifest" "karpenter_ec2nodeclass_build" {
     karpenter_node_volume_type = var.karpenter_node_volume_type
     karpenter_effective_disk   = local.karpenter_effective_disk
     ebs_encrypted              = var.ebs_volume_encryption_enabled
-    imds_http_tokens           = var.imds_http_tokens
-    imds_http_hop_limit        = var.imds_http_hop_limit
+    imds_http_tokens           = local.build_imds_tokens
+    imds_http_hop_limit        = local.build_imds_hop_limit
     extra_tags                 = var.tags
   })
 

--- a/terraform/cluster/aws/variables.tf
+++ b/terraform/cluster/aws/variables.tf
@@ -239,6 +239,16 @@ variable "karpenter_build_node_labels" {
   default = ""
 }
 
+variable "karpenter_build_imds_tokens" {
+  type    = string
+  default = ""
+}
+
+variable "karpenter_build_imds_hop_limit" {
+  type    = number
+  default = 0
+}
+
 variable "additional_karpenter_nodepools" {
   type    = list(map(any))
   default = []

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -166,6 +166,8 @@ module "cluster" {
   karpenter_build_memory_limit_gb     = var.karpenter_build_memory_limit_gb
   karpenter_build_consolidate_after   = var.karpenter_build_consolidate_after
   karpenter_build_node_labels         = var.karpenter_build_node_labels
+  karpenter_build_imds_tokens         = var.karpenter_build_imds_tokens
+  karpenter_build_imds_hop_limit      = var.karpenter_build_imds_hop_limit
   additional_karpenter_nodepools      = local.additional_karpenter_nodepools
   keda_enable                         = var.keda_enable
   key_pair_name                       = var.key_pair_name

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -358,6 +358,16 @@ variable "karpenter_build_node_labels" {
   default = ""
 }
 
+variable "karpenter_build_imds_tokens" {
+  type    = string
+  default = ""
+}
+
+variable "karpenter_build_imds_hop_limit" {
+  type    = number
+  default = 0
+}
+
 variable "additional_karpenter_nodepools_config" {
   type    = string
   default = ""


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: Independent IMDS Configuration for the Build Nodepool on AWS**

This release adds two opt-in rack parameters that set the EC2 Instance Metadata Service (IMDS) options on the Karpenter build nodepool independently of the rest of the rack. Build nodes run user-supplied Dockerfile instructions during `convox build` and `convox deploy`, and these parameters let you require IMDSv2 session tokens or set the metadata hop limit on those nodes without changing the cluster-wide defaults.

When neither parameter is set, the build nodepool inherits the rack-wide `imds_http_tokens` and `imds_http_hop_limit` settings exactly as before. Only the build nodepool is affected; the workload nodepool, any additional Karpenter nodepools, the system node group, and the rack-wide IMDS parameters keep their existing values. The parameters apply to AWS racks running Karpenter with dedicated build nodes enabled (`build_node_enabled=true`) and have no effect on other configurations or providers.

---

### Why is this important?

Build nodes are where user-defined build steps execute, so they often warrant stricter instance-metadata settings than the nodes running application workloads. These parameters let you tighten the build environment without touching anything else.

**Benefits:**

- **Targeted hardening.** Require IMDSv2 or reduce the metadata hop limit on build nodes only, leaving the settings your application workloads rely on unchanged.
- **Container-level metadata control.** A hop limit of `1` keeps IMDSv2 responses from traversing the extra network hop into containers, which typically restricts instance-metadata access to the node itself.
- **Safe rollout.** Changing either parameter rolls build nodes onto the new metadata options through Karpenter; in-flight builds complete on the existing nodes and new builds land on the reconfigured ones.
- **Fully reversible.** Restoring the defaults returns the build nodepool to the inherited rack-wide options with no manual cleanup.

---

### How to use it?

Require IMDSv2 session tokens on build nodes:

    $ convox rack params set karpenter_build_imds_tokens=required -r rackName

Apply both options together:

    $ convox rack params set karpenter_build_imds_tokens=required karpenter_build_imds_hop_limit=1 -r rackName

Return to the inherited rack-wide settings:

    $ convox rack params set karpenter_build_imds_tokens="" karpenter_build_imds_hop_limit=0 -r rackName

Both parameters are listed under the `security` and `build` parameter groups:

    $ convox rack params -g security -r rackName

Before enabling `required` tokens or a hop limit of `1`, confirm that your build steps do not read instance metadata directly without IMDSv2 session tokens (for example, through an older SDK or a plain HTTP request to the metadata endpoint). Build steps that need AWS credentials should use the mechanisms Convox already provides rather than the node's instance metadata.

This feature pairs with the `build_node_minimal_role_enabled` parameter shipping in the same release: that parameter controls the build nodes' IAM role, while these control their instance-metadata options, and they can be enabled together.

#### New Rack Parameters

| Parameter | Default | Description |
|-----------|---------|-------------|
| `karpenter_build_imds_tokens` | `""` | IMDS token mode for the build nodepool. Accepts `optional` or `required`. When empty, the build nodepool inherits the rack-wide `imds_http_tokens` setting. |
| `karpenter_build_imds_hop_limit` | `0` | IMDS PUT response hop limit for the build nodepool. Accepts a non-negative integer (typically `1` when set). When `0`, the build nodepool inherits the rack-wide `imds_http_hop_limit` setting. |

---

### Does it have a breaking change?

**No breaking changes** are introduced with this feature.

Both parameters default to inheriting the existing rack-wide settings, so a rack that upgrades and never sets them renders an identical build nodepool configuration. Unsetting the parameters restores the inherited options, and the change is safe to apply and reverse without any manual state changes.

---

### Requirements

This feature requires version `3.24.10` or later for the rack.

**Update the Rack:** Run `convox rack update 3.24.10 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.23.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
