### PR TITLE
Add Pod Security Admission params

### DIFF
--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -67,6 +67,7 @@ var awsKnownParams = map[string]bool{
 	"high_availability": true,
 	"idle_timeout":      true, "image": true,
 	"imds_http_hop_limit": true, "imds_http_tokens": true,
+	"pod_security_standard": true, "pod_security_mode": true,
 	"imds_tags_enable": true, "internal_router": true, "contour_internal_tls": true,
 	"internet_gateway_id": true, "k8s_version": true,
 	"karpenter_arch": true, "karpenter_auth_mode": true,
@@ -342,6 +343,8 @@ var paramGroups = map[string]map[string]bool{
 		"imds_http_hop_limit":                 true,
 		"imds_http_tokens":                    true,
 		"imds_tags_enable":                    true,
+		"pod_security_standard":               true,
+		"pod_security_mode":                   true,
 		"key_pair_name":                       true,
 		"nlb_security_group":                  true,
 		"pod_identity_agent_enable":           true,
@@ -662,6 +665,8 @@ var clearableParams = map[string]bool{
 	"user_data_url": true,
 	// ECR — clear means "detach custom policy"
 	"ecr_additional_policy_arn": true,
+	// PSA standard: clear removes the namespace label
+	"pod_security_standard": true,
 	// Feature gates — clear means "disable all"
 	"api_feature_gates": true,
 	// Private EKS — cleared by console during mode changes
@@ -1355,6 +1360,14 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 		}
 	}
 
+	if v, has := params["pod_security_standard"]; has && v != "" && v != "baseline" && v != "restricted" {
+		return fmt.Errorf("param 'pod_security_standard' must be 'baseline' or 'restricted'")
+	}
+
+	if v, has := params["pod_security_mode"]; has && v != "warn" && v != "audit" && v != "enforce" {
+		return fmt.Errorf("param 'pod_security_mode' must be 'warn', 'audit', or 'enforce'")
+	}
+
 	if v, has := params["node_capacity_type"]; has && v != "" {
 		lower := strings.ToLower(v)
 		if lower != "on_demand" && lower != "spot" && lower != "mixed" {
@@ -1433,6 +1446,20 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 		if params["router_type"] == "contour" {
 			fmt.Fprintf(os.Stderr, "WARNING: Router access logs will use Envoy default format. The access_log_retention_in_days param will not apply until a follow-up fluentd update.\n")
 		}
+	}
+
+	effectivePodSecurityStandard := currentParams["pod_security_standard"]
+	if v, ok := params["pod_security_standard"]; ok {
+		effectivePodSecurityStandard = v
+	}
+	effectivePodSecurityMode := currentParams["pod_security_mode"]
+	if v, ok := params["pod_security_mode"]; ok {
+		effectivePodSecurityMode = v
+	}
+	if effectivePodSecurityMode == "enforce" && effectivePodSecurityStandard != "" {
+		fmt.Fprintf(os.Stderr, "WARNING: pod_security_mode=enforce rejects non-conforming app pods at admission.\n")
+		fmt.Fprintf(os.Stderr, "Any service that sets a violating securityContext will fail to deploy.\n")
+		fmt.Fprintf(os.Stderr, "restricted with enforce also rejects default convox pods. Roll out warn, then audit, then enforce.\n")
 	}
 
 	if v, has := params["access_log_retention_in_days"]; has && v != "" {

--- a/pkg/cli/rack_param_belt_test.go
+++ b/pkg/cli/rack_param_belt_test.go
@@ -444,3 +444,43 @@ func parseCoalesceLiteral(t *testing.T, path, variable string) (string, bool) {
 	}
 	return string(m[1]), true
 }
+
+func TestValidateAndMutateParams_PodSecurity(t *testing.T) {
+	accept := []map[string]string{
+		{"pod_security_standard": "baseline"},
+		{"pod_security_standard": "restricted"},
+		{"pod_security_standard": ""},
+		{"pod_security_mode": "warn"},
+		{"pod_security_mode": "audit"},
+		{"pod_security_mode": "enforce"},
+		{"pod_security_standard": "baseline", "pod_security_mode": "warn"},
+		{"pod_security_standard": "restricted", "pod_security_mode": "enforce"},
+	}
+	for _, p := range accept {
+		if err := validateAndMutateParams(p, "aws", map[string]string{}, false); err != nil {
+			t.Errorf("expected accept for %v, got %v", p, err)
+		}
+	}
+
+	if err := validateAndMutateParams(
+		map[string]string{"pod_security_mode": "enforce"}, "aws",
+		map[string]string{"pod_security_standard": "baseline"}, false,
+	); err != nil {
+		t.Errorf("expected accept for enforce with effective standard, got %v", err)
+	}
+
+	reject := []map[string]string{
+		{"pod_security_standard": "bogus"},
+		{"pod_security_standard": "Baseline"},
+		{"pod_security_standard": "BASELINE"},
+		{"pod_security_standard": " baseline"},
+		{"pod_security_mode": "bogus"},
+		{"pod_security_mode": "Enforce"},
+		{"pod_security_mode": ""},
+	}
+	for _, p := range reject {
+		if err := validateAndMutateParams(p, "aws", map[string]string{}, false); err == nil {
+			t.Errorf("expected reject for %v, got nil", p)
+		}
+	}
+}

--- a/pkg/rack/terraform.go
+++ b/pkg/rack/terraform.go
@@ -83,6 +83,7 @@ var preserveEmpty = map[string]bool{
 	"grafana_dashboard_var_service":   true,
 	"grafana_dashboard_var_app":       true,
 	"ecr_additional_policy_arn":       true,
+	"pod_security_standard":           true,
 	"contour_cpu_request":             true,
 	"contour_memory_request":          true,
 	"envoy_cpu_request":               true,

--- a/provider/aws/build.go
+++ b/provider/aws/build.go
@@ -26,7 +26,10 @@ func (p *Provider) BuildLogs(app, id string, opts structs.LogsOptions) (io.ReadC
 
 	switch b.Status {
 	case "running":
-		return p.ProcessLogs(app, b.Process, opts)
+		// Delegate to the embedded k8s BuildLogs so a running build's logs
+		// stream from the build pod's namespace (the dedicated build namespace
+		// under PSA enforce, the app namespace otherwise).
+		return p.Provider.BuildLogs(app, id, opts)
 	default:
 		u, err := url.Parse(b.Logs)
 		if err != nil {

--- a/provider/k8s/app.go
+++ b/provider/k8s/app.go
@@ -2,7 +2,9 @@ package k8s
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -162,6 +164,19 @@ func (p *Provider) AppDelete(name string) error {
 	}
 
 	if err := p.Cluster.CoreV1().Namespaces().Delete(context.TODO(), p.AppNamespace(name), am.DeleteOptions{}); err != nil {
+		return errors.WithStack(err)
+	}
+
+	// Delete the dedicated build namespace if present. The type=build label guards
+	// against an app literally named build-<name> whose namespace name collides
+	// with this one.
+	if bns, err := p.Cluster.CoreV1().Namespaces().Get(context.TODO(), p.buildNamespace(name), am.GetOptions{}); err == nil {
+		if bns.Labels["type"] == "build" {
+			if err := p.Cluster.CoreV1().Namespaces().Delete(context.TODO(), p.buildNamespace(name), am.DeleteOptions{}); err != nil && !ae.IsNotFound(err) {
+				return errors.WithStack(err)
+			}
+		}
+	} else if !ae.IsNotFound(err) {
 		return errors.WithStack(err)
 	}
 
@@ -343,6 +358,73 @@ func (p *Provider) AppNamespace(app string) string {
 		}
 		return fmt.Sprintf("%s-%s", p.Name, app)
 	}
+}
+
+// buildNamespace returns a deterministic, length-safe namespace dedicated to an
+// app's build pod. The natural form can exceed the 63-character namespace limit
+// for long names, so fall back to a hashed form that stays within the limit.
+func (p *Provider) buildNamespace(app string) string {
+	natural := fmt.Sprintf("%s-build-%s", p.Name, app)
+	if p.ContextTID() != "" {
+		natural = fmt.Sprintf("%s-build-%s-%s", p.Name, p.ContextTID(), app)
+	}
+	if len(natural) <= 63 {
+		return natural
+	}
+	sum := sha256.Sum256([]byte(natural))
+	prefix := natural
+	if len(prefix) > 54 {
+		prefix = prefix[:54]
+	}
+	return strings.TrimRight(prefix, "-") + "-" + hex.EncodeToString(sum[:])[:8]
+}
+
+// processBuildNamespace returns where the build pod runs. Under PSA enforce the
+// app namespace's label would reject the build pod, so the build runs in a
+// dedicated unlabeled namespace; otherwise it runs in the app namespace as before.
+func (p *Provider) processBuildNamespace(app string) string {
+	if p.PodSecurityStandard != "" && p.PodSecurityMode == "enforce" {
+		return p.buildNamespace(app)
+	}
+	return p.AppNamespace(app)
+}
+
+func (p *Provider) ensureBuildNamespace(app string) error {
+	name := p.buildNamespace(app)
+
+	ns := &ac.Namespace{
+		ObjectMeta: am.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{"name": app, "type": "build"},
+		},
+	}
+
+	if p.ContextTID() != "" {
+		ns.Labels["tid"] = p.ContextTID()
+	}
+
+	_, err := p.Cluster.CoreV1().Namespaces().Create(context.TODO(), ns, am.CreateOptions{})
+	if err == nil {
+		return nil
+	}
+
+	if !ae.IsAlreadyExists(err) {
+		return errors.WithStack(err)
+	}
+
+	// The name already exists. Confirm it is our build namespace and not a
+	// collision with another app's namespace (an app named build-<app>) before
+	// a build pod is created in it.
+	existing, gerr := p.Cluster.CoreV1().Namespaces().Get(context.TODO(), name, am.GetOptions{})
+	if gerr != nil {
+		return errors.WithStack(gerr)
+	}
+
+	if existing.Labels["type"] != "build" {
+		return errors.WithStack(fmt.Errorf("build namespace %q collides with an existing namespace; rename the app", name))
+	}
+
+	return nil
 }
 
 func (p *Provider) NamespaceApp(namespace string) (string, error) {

--- a/provider/k8s/app_psa_test.go
+++ b/provider/k8s/app_psa_test.go
@@ -1,0 +1,123 @@
+package k8s_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/convox/convox/pkg/atom"
+	"github.com/convox/convox/pkg/structs"
+	"github.com/convox/convox/provider/k8s"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	am "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestEnsureBuildNamespaceUnlabeled(t *testing.T) {
+	testProvider(t, func(p *k8s.Provider) {
+		require.NoError(t, p.EnsureBuildNamespaceForTest("app1"))
+
+		kk, _ := p.Cluster.(*fake.Clientset)
+		ns, err := kk.CoreV1().Namespaces().Get(context.TODO(), "rack1-build-app1", am.GetOptions{})
+		require.NoError(t, err)
+
+		for k := range ns.Labels {
+			assert.NotContains(t, k, "pod-security.kubernetes.io", "build namespace must not carry a PSA label")
+		}
+		assert.Equal(t, "build", ns.Labels["type"])
+		_, hasApp := ns.Labels["app"]
+		assert.False(t, hasApp, "build namespace must omit the app label to avoid budget double-count")
+
+		// idempotent: a second ensure does not error
+		require.NoError(t, p.EnsureBuildNamespaceForTest("app1"))
+	})
+}
+
+func TestAppDeleteBuildNamespaceCollisionSafe(t *testing.T) {
+	testProvider(t, func(p *k8s.Provider) {
+		aa, _ := p.Atom.(*atom.MockInterface)
+		kk, _ := p.Cluster.(*fake.Clientset)
+
+		require.NoError(t, appCreate(kk, "rack1", "app1"))
+		// A separate real app whose namespace name (rack1-build-app1) collides
+		// with app1's build-namespace name. Deleting app1 must NOT delete it.
+		require.NoError(t, appCreate(kk, "rack1", "build-app1"))
+
+		aa.On("Status", "rack1-app1", "app").Return("Updating", "R1234567", nil).Once()
+
+		require.NoError(t, p.AppDelete("app1"))
+
+		_, err := kk.CoreV1().Namespaces().Get(context.TODO(), "rack1-app1", am.GetOptions{})
+		require.Error(t, err)
+
+		_, err = kk.CoreV1().Namespaces().Get(context.TODO(), "rack1-build-app1", am.GetOptions{})
+		require.NoError(t, err, "a different app's live namespace must survive AppDelete of the colliding app")
+	})
+}
+
+func TestProcessBuildNamespace(t *testing.T) {
+	cases := []struct {
+		name     string
+		standard string
+		mode     string
+		want     string
+	}{
+		{name: "off", standard: "", mode: "warn", want: "rack1-app1"},
+		{name: "warn", standard: "baseline", mode: "warn", want: "rack1-app1"},
+		{name: "audit", standard: "baseline", mode: "audit", want: "rack1-app1"},
+		{name: "enforce", standard: "baseline", mode: "enforce", want: "rack1-build-app1"},
+		{name: "restricted-enforce", standard: "restricted", mode: "enforce", want: "rack1-build-app1"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			testProvider(t, func(p *k8s.Provider) {
+				p.PodSecurityStandard = tc.standard
+				p.PodSecurityMode = tc.mode
+				assert.Equal(t, tc.want, p.ProcessBuildNamespaceForTest("app1"))
+			})
+		})
+	}
+}
+
+func TestAppCreatePodSecurity(t *testing.T) {
+	cases := []struct {
+		name     string
+		standard string
+		mode     string
+		want     string
+		absent   bool
+	}{
+		{name: "baseline-warn", standard: "baseline", mode: "warn", want: "pod-security.kubernetes.io/warn: baseline"},
+		{name: "baseline-enforce", standard: "baseline", mode: "enforce", want: "pod-security.kubernetes.io/enforce: baseline"},
+		{name: "restricted-audit", standard: "restricted", mode: "audit", want: "pod-security.kubernetes.io/audit: restricted"},
+		{name: "default-off", standard: "", mode: "warn", absent: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			testProvider(t, func(p *k8s.Provider) {
+				p.PodSecurityStandard = tc.standard
+				p.PodSecurityMode = tc.mode
+
+				aa, _ := p.Atom.(*atom.MockInterface)
+				aa.On("Apply", "rack1-app1", "app", mock.Anything).Return(nil).Once().Run(func(args mock.Arguments) {
+					cfg, _ := args.Get(2).(*atom.ApplyConfig)
+					rendered := string(cfg.Template)
+					if tc.absent {
+						assert.NotContains(t, rendered, "pod-security.kubernetes.io/")
+					} else {
+						assert.Contains(t, rendered, tc.want)
+						assert.Equal(t, 1, strings.Count(rendered, "pod-security.kubernetes.io/"))
+					}
+				})
+				aa.On("Status", "rack1-app1", "app").Return("Updating", "R1234567", nil).Times(3)
+
+				_, err := p.AppCreate("app1", structs.AppCreateOptions{})
+				require.NoError(t, err)
+			})
+		})
+	}
+}

--- a/provider/k8s/build.go
+++ b/provider/k8s/build.go
@@ -738,7 +738,7 @@ func (p *Provider) BuildLogs(app, id string, opts structs.LogsOptions) (io.ReadC
 		if b.Process == "" {
 			return nil, fmt.Errorf("build %s has running status but no process ID", id)
 		}
-		return p.ProcessLogs(app, b.Process, opts)
+		return p.processLogsNamespace(p.processBuildNamespace(app), b.Process, opts)
 	case "created":
 		return p.buildLogsStreamFromCreated(app, id, opts)
 	default:
@@ -800,7 +800,7 @@ func (p *Provider) streamBuildLogsFromCreated(w io.WriteCloser, app, id string, 
 				}
 				tick.Stop()
 				heartbeat.Stop()
-				p.streamProcessLogs(w, app, b.Process, opts)
+				p.streamProcessLogs(w, p.processBuildNamespace(app), b.Process, opts)
 				return
 			case "failed", "complete":
 				p.writeStoredBuildLogs(w, app, id, b)

--- a/provider/k8s/export_test.go
+++ b/provider/k8s/export_test.go
@@ -680,3 +680,16 @@ func HashParamValueForTest(p *Provider, value string) string {
 func ResetRackUIDCacheForTest(namespace string) {
 	rackUIDByNamespace.Delete(namespace)
 }
+
+// ProcessBuildNamespaceForTest exposes processBuildNamespace so external tests
+// can assert the build-pod namespace routing under Pod Security Admission.
+func (p *Provider) ProcessBuildNamespaceForTest(app string) string {
+	return p.processBuildNamespace(app)
+}
+
+// EnsureBuildNamespaceForTest exposes ensureBuildNamespace so external tests can
+// assert the dedicated build namespace is created unlabeled by PSA and without an
+// app label (which would double-count the budget accumulator).
+func (p *Provider) EnsureBuildNamespaceForTest(app string) error {
+	return p.ensureBuildNamespace(app)
+}

--- a/provider/k8s/k8s.go
+++ b/provider/k8s/k8s.go
@@ -101,6 +101,8 @@ type Provider struct {
 	Router                              string
 	RouterType                          string
 	ProxyProtocol                       bool
+	PodSecurityStandard                 string
+	PodSecurityMode                     string
 	ContourInternalTLS                  bool
 	Socket                              string
 	Storage                             string
@@ -233,6 +235,8 @@ func FromEnv() (*Provider, error) {
 		Router:                           os.Getenv("ROUTER"),
 		RouterType:                       common.CoalesceString(os.Getenv("ROUTER_TYPE"), "nginx"),
 		ProxyProtocol:                    os.Getenv("PROXY_PROTOCOL") == "true",
+		PodSecurityStandard:              os.Getenv("POD_SECURITY_STANDARD"),
+		PodSecurityMode:                  common.CoalesceString(os.Getenv("POD_SECURITY_MODE"), "warn"),
 		ContourInternalTLS:               os.Getenv("CONTOUR_INTERNAL_TLS") == "true",
 		Socket:                           common.CoalesceString(os.Getenv("SOCKET"), "/var/run/docker.sock"),
 		Storage:                          common.CoalesceString(os.Getenv("STORAGE"), "/var/storage"),

--- a/provider/k8s/process.go
+++ b/provider/k8s/process.go
@@ -142,7 +142,11 @@ func (p *Provider) ProcessExec(app, pid, command string, rw io.ReadWriter, opts 
 }
 
 func (p *Provider) ProcessGet(app, pid string) (*structs.Process, error) {
-	pd, err := p.GetPodFromInformer(pid, p.AppNamespace(app))
+	return p.processGet(p.AppNamespace(app), app, pid)
+}
+
+func (p *Provider) processGet(ns, app, pid string) (*structs.Process, error) {
+	pd, err := p.GetPodFromInformer(pid, ns)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -152,7 +156,7 @@ func (p *Provider) ProcessGet(app, pid string) (*structs.Process, error) {
 		return nil, errors.WithStack(err)
 	}
 
-	m, err := p.MetricsClient.MetricsV1beta1().PodMetricses(p.AppNamespace(app)).Get(context.TODO(), pid, am.GetOptions{})
+	m, err := p.MetricsClient.MetricsV1beta1().PodMetricses(ns).Get(context.TODO(), pid, am.GetOptions{})
 	if err != nil {
 		p.logger.Errorf("failed to fetch pod metrics: %s", err)
 	} else if m != nil && len(m.Containers) > 0 {
@@ -275,14 +279,18 @@ func (p *Provider) ProcessList(app string, opts structs.ProcessListOptions) (str
 }
 
 func (p *Provider) ProcessLogs(app, pid string, opts structs.LogsOptions) (io.ReadCloser, error) {
+	return p.processLogsNamespace(p.AppNamespace(app), pid, opts)
+}
+
+func (p *Provider) processLogsNamespace(ns, pid string, opts structs.LogsOptions) (io.ReadCloser, error) {
 	r, w := io.Pipe()
 
-	go p.streamProcessLogs(w, app, pid, opts)
+	go p.streamProcessLogs(w, ns, pid, opts)
 
 	return r, nil
 }
 
-func (p *Provider) streamProcessLogs(w io.WriteCloser, app, pid string, opts structs.LogsOptions) {
+func (p *Provider) streamProcessLogs(w io.WriteCloser, ns, pid string, opts structs.LogsOptions) {
 	defer w.Close() // skipcq
 
 	lopts := &ac.PodLogOptions{
@@ -313,7 +321,7 @@ pendingLoop:
 				return
 			}
 		case <-tick.C:
-			pp, err := p.GetPodFromInformer(pid, p.AppNamespace(app))
+			pp, err := p.GetPodFromInformer(pid, ns)
 			if err != nil {
 				fmt.Printf("err: %+v\n", err)
 				fmt.Fprintf(w, "waiting for build pod...\n")
@@ -332,7 +340,7 @@ pendingLoop:
 	pendingHeartbeat.Stop()
 
 	for {
-		r, err := p.Cluster.CoreV1().Pods(p.AppNamespace(app)).GetLogs(pid, lopts).Stream(context.TODO())
+		r, err := p.Cluster.CoreV1().Pods(ns).GetLogs(pid, lopts).Stream(context.TODO())
 		if err != nil {
 			fmt.Printf("err: %+v\n", err)
 			fmt.Fprintf(w, "build log stream interrupted, retrying...\n")
@@ -391,6 +399,19 @@ func (p *Provider) ProcessRun(app, service string, opts structs.ProcessRunOption
 	if !opts.IsBuild {
 		if err := p.budgetCircuitBreakerTripped(app); err != nil {
 			return nil, errors.WithStack(err)
+		}
+	}
+
+	// Build pods run in a dedicated namespace under PSA enforce so the app
+	// namespace's enforce label does not reject them. Ensure it before
+	// podSpecFromRunOptions, which writes the pull secret into this namespace.
+	createNs := p.AppNamespace(app)
+	if opts.IsBuild {
+		createNs = p.processBuildNamespace(app)
+		if createNs != p.AppNamespace(app) {
+			if err := p.ensureBuildNamespace(app); err != nil {
+				return nil, errors.WithStack(err)
+			}
 		}
 	}
 
@@ -500,7 +521,7 @@ func (p *Provider) ProcessRun(app, service string, opts structs.ProcessRunOption
 		pod.ObjectMeta.Labels["service-type"] = "build"
 	}
 
-	pd, err := p.Cluster.CoreV1().Pods(p.AppNamespace(app)).Create(
+	pd, err := p.Cluster.CoreV1().Pods(createNs).Create(
 		context.TODO(),
 		pod,
 		am.CreateOptions{},
@@ -509,7 +530,7 @@ func (p *Provider) ProcessRun(app, service string, opts structs.ProcessRunOption
 		return nil, errors.WithStack(err)
 	}
 
-	ps, err := p.ProcessGet(app, pd.ObjectMeta.Name)
+	ps, err := p.processGet(createNs, app, pd.Name)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -873,7 +894,11 @@ func (p *Provider) podSpecFromRunOptions(app, service string, opts structs.Proce
 	}
 
 	if p.hasDockerHubAuth() {
-		if err := p.ensureDockerHubSecret(p.AppNamespace(app)); err != nil {
+		secretNs := p.AppNamespace(app)
+		if opts.IsBuild {
+			secretNs = p.processBuildNamespace(app)
+		}
+		if err := p.ensureDockerHubSecret(secretNs); err != nil {
 			return nil, errors.WithStack(err)
 		}
 

--- a/provider/k8s/release.go
+++ b/provider/k8s/release.go
@@ -452,11 +452,13 @@ func (p *Provider) releaseTemplateApp(a *structs.App, opts structs.ReleasePromot
 	}
 
 	params := map[string]interface{}{
-		"Locked":     a.Locked,
-		"Name":       a.Name,
-		"Namespace":  p.AppNamespace(a.Name),
-		"Owner":      owner,
-		"Parameters": a.Parameters,
+		"Locked":              a.Locked,
+		"Name":                a.Name,
+		"Namespace":           p.AppNamespace(a.Name),
+		"Owner":               owner,
+		"Parameters":          a.Parameters,
+		"PodSecurityStandard": p.PodSecurityStandard,
+		"PodSecurityMode":     p.PodSecurityMode,
 	}
 
 	data, err := p.RenderTemplate("app/app", params)

--- a/provider/k8s/template/app/app.yml.tmpl
+++ b/provider/k8s/template/app/app.yml.tmpl
@@ -8,6 +8,9 @@ metadata:
   labels:
     type: app
     name: {{.Name}}
+    {{ if .PodSecurityStandard }}
+    pod-security.kubernetes.io/{{ .PodSecurityMode }}: {{ .PodSecurityStandard }}
+    {{ end }}
   ownerReferences:
   - apiVersion: v1 # TODO: populate from .Owner
     blockOwnerDeletion: true

--- a/terraform/api/aws/main.tf
+++ b/terraform/api/aws/main.tf
@@ -75,6 +75,8 @@ module "k8s" {
     FEATURE_GATES                             = var.api_feature_gates
     ROUTER_TYPE                               = var.router_type
     PROXY_PROTOCOL                            = var.proxy_protocol
+    POD_SECURITY_STANDARD                     = var.pod_security_standard
+    POD_SECURITY_MODE                         = var.pod_security_mode
     CONTOUR_INTERNAL_TLS                      = var.contour_internal_tls
   }
 }

--- a/terraform/api/aws/variables.tf
+++ b/terraform/api/aws/variables.tf
@@ -219,6 +219,16 @@ variable "router_type" {
   default = "nginx"
 }
 
+variable "pod_security_standard" {
+  type    = string
+  default = ""
+}
+
+variable "pod_security_mode" {
+  type    = string
+  default = "warn"
+}
+
 variable "proxy_protocol" {
   default = false
 }

--- a/terraform/rack/aws/main.tf
+++ b/terraform/rack/aws/main.tf
@@ -71,6 +71,8 @@ module "api" {
   webhook_signing_key                       = var.webhook_signing_key
   api_feature_gates                         = var.api_feature_gates
   router_type                               = var.router_type
+  pod_security_standard                     = var.pod_security_standard
+  pod_security_mode                         = var.pod_security_mode
   cert_duration                             = var.cert_duration
   proxy_protocol                            = var.proxy_protocol
   contour_internal_tls                      = var.contour_internal_tls

--- a/terraform/rack/aws/variables.tf
+++ b/terraform/rack/aws/variables.tf
@@ -269,6 +269,16 @@ variable "router_type" {
   default = "nginx"
 }
 
+variable "pod_security_standard" {
+  type    = string
+  default = ""
+}
+
+variable "pod_security_mode" {
+  type    = string
+  default = "warn"
+}
+
 variable "cert_duration" {
   type    = string
   default = "2160h"

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -315,6 +315,8 @@ module "rack" {
   vpa_enable                                = var.vpa_enable
   webhook_signing_key                       = var.webhook_signing_key
   router_type                               = var.router_type
+  pod_security_standard                     = var.pod_security_standard
+  pod_security_mode                         = var.pod_security_mode
   cert_duration                             = var.cert_duration
   contour_cpu_request                       = var.contour_cpu_request
   contour_memory_request                    = var.contour_memory_request

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -454,6 +454,16 @@ variable "router_type" {
   default = "nginx"
 }
 
+variable "pod_security_standard" {
+  type    = string
+  default = ""
+}
+
+variable "pod_security_mode" {
+  type    = string
+  default = "warn"
+}
+
 variable "contour_cpu_request" {
   type    = string
   default = "100m"


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: Pod Security Admission for App Namespaces**

Two new opt-in AWS rack parameters apply a Kubernetes [Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/) standard to every app namespace on the rack. The standard defaults to empty, so racks that do not opt in see no change in behavior.

When a standard is set, the rack adds the `pod-security.kubernetes.io/<mode>: <standard>` label to each app namespace on its next deploy, and Kubernetes evaluates the app's pods against the selected standard in the selected mode. Clearing the standard removes the label on the next deploy.

**New Rack Parameters:**

| Parameter | Default | Description |
|-----------|---------|-------------|
| `pod_security_standard` | `""` (off) | Pod Security Standard applied to app namespaces. Set to `baseline` or `restricted` to enable; leave empty for no PSA labeling. |
| `pod_security_mode` | `warn` | How the standard is applied when one is set: `warn` (API-response warnings only), `audit` (audit-log annotations only), or `enforce` (rejects non-conforming pods at admission). |

Both parameters apply to AWS racks in this release; other providers do not accept them.

**Behavior details:**

- `warn` and `audit` are observe-only and never block a deploy.
- Under `enforce`, each app's builds run in a dedicated per-app build namespace, so `convox build` and `convox deploy` continue to work normally. Build pods therefore do not appear in `convox ps` for the app while a build runs. With the default settings or `warn`/`audit`, builds run in the app namespace as before.
- Setting `enforce` prints a CLI warning describing the impact on app pods.
- The standard and mode are rack-wide; there is no per-app override.

---

### Why is this important?

Pod Security Admission is the built-in Kubernetes mechanism for controlling the security posture of pods per namespace. These parameters let users adopt it across all Convox app namespaces with a single rack setting instead of labeling namespaces by hand.

**Benefits:**

- **Rack-wide hardening option.** Apply a Kubernetes Pod Security Standard to every app workload with one parameter change.
- **Gradual rollout.** Start with `warn`, review the warnings, move to `audit`, and tighten to `enforce` only after workloads are confirmed clean.
- **Fast recovery.** If an `enforce` configuration blocks deploys, set `pod_security_mode=warn`; the label remains but no longer rejects pods, and apps deploy again immediately.
- **Zero impact unless enabled.** With `pod_security_standard` unset, app namespaces are rendered exactly as before.

---

### How to use it?

Enable a standard in the default `warn` mode:

```
$ convox rack params set pod_security_standard=baseline -r rackName
```

Tighten the mode once workloads are clean:

```
$ convox rack params set pod_security_mode=audit -r rackName
$ convox rack params set pod_security_mode=enforce -r rackName
```

Disable PSA labeling:

```
$ convox rack params set pod_security_standard= -r rackName
```

**Choosing a standard:** `baseline` in `enforce` mode passes a default Convox service, so a service is only affected if it requests host access or elevated privileges. `restricted` requires securityContext settings beyond what a default Convox service pod carries, so pair `restricted` with `warn` or `audit` for visibility rather than `enforce`.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this feature.

Both parameters are purely additive with safe defaults. With `pod_security_standard` unset (the default), app namespaces and admission behavior are unchanged, so upgrading is a no-op for existing racks. The new Terraform variables configure the rack API only and create no cloud resources, and they are removed cleanly if a rack is later moved to an earlier version.

---

### Requirements

This feature requires version `3.24.10` or later for the rack.

**Update the Rack:** Run `convox rack update 3.24.10 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.23.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
