### PR TITLE
Add system readonly rootfs rack param

### DIFF
--- a/assets/provider/aws/params.yaml
+++ b/assets/provider/aws/params.yaml
@@ -81,6 +81,11 @@ Groups:
         type: boolean
         description: Enables encryption for EBS volumes on primary node disks using
           AWS-managed keys for data at rest encryption
+      - name: system_readonly_rootfs_enabled
+        default: "false"
+        type: boolean
+        description: Runs the Convox system containers (api, atom, resolver) with a
+          read-only root filesystem for the container image layer
       - name: nlb_security_group
         default: "null"
         sideNote: AWS default created unless set

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -104,7 +104,7 @@ var awsKnownParams = map[string]bool{
 	"schedule_rack_scale_down": true, "schedule_rack_scale_up": true,
 	"settings": true, "ssl_ciphers": true,
 	"ssl_protocols": true, "sync_tf_now": true,
-	"syslog": true, "tags": true,
+	"syslog": true, "system_readonly_rootfs_enabled": true, "tags": true,
 	"telemetry": true, "terraform_update_timeout": true,
 	"user_data": true, "user_data_url": true,
 	"vpa_enable": true, "vpc_cni_version": true,
@@ -201,6 +201,7 @@ var boolParams = map[string]bool{
 	"karpenter_consolidation_enabled": true,
 	"keda_enable":                     true,
 	"pod_identity_agent_enable":       true,
+	"system_readonly_rootfs_enabled":  true,
 	"telemetry":                       true,
 	"vpa_enable":                      true,
 }
@@ -351,6 +352,7 @@ var paramGroups = map[string]map[string]bool{
 		"secret_key":                          true,
 		"ssl_ciphers":                         true,
 		"ssl_protocols":                       true,
+		"system_readonly_rootfs_enabled":      true,
 		"tags":                                true, // dual-listed in cost
 		"token":                               true,
 		"webhook_signing_key":                 true,

--- a/terraform/api/aws/main.tf
+++ b/terraform/api/aws/main.tf
@@ -32,6 +32,7 @@ module "k8s" {
   router_type                     = var.router_type
   cert_duration                   = var.cert_duration
   karpenter_enabled               = var.karpenter_enabled
+  system_readonly_rootfs_enabled  = var.system_readonly_rootfs_enabled
   metrics_scraper_host            = var.metrics_scraper_host
   namespace                       = var.namespace
   prometheus_url                  = var.prometheus_url

--- a/terraform/api/aws/variables.tf
+++ b/terraform/api/aws/variables.tf
@@ -115,6 +115,11 @@ variable "karpenter_enabled" {
   default = false
 }
 
+variable "system_readonly_rootfs_enabled" {
+  type    = bool
+  default = false
+}
+
 variable "keda_enable" {
   type    = bool
   default = false

--- a/terraform/api/k8s/atom.tf
+++ b/terraform/api/k8s/atom.tf
@@ -114,11 +114,42 @@ resource "kubernetes_deployment" "atom" {
           image             = "${var.image}:${var.release}"
           image_pull_policy = "IfNotPresent"
 
+          dynamic "security_context" {
+            for_each = var.system_readonly_rootfs_enabled ? [1] : []
+            content {
+              read_only_root_filesystem = true
+            }
+          }
+
+          dynamic "env" {
+            for_each = var.system_readonly_rootfs_enabled ? [1] : []
+            content {
+              name  = "HOME"
+              value = "/tmp"
+            }
+          }
+
+          dynamic "volume_mount" {
+            for_each = var.system_readonly_rootfs_enabled ? { "tmp-dir" = "/tmp" } : {}
+            content {
+              name       = volume_mount.key
+              mount_path = volume_mount.value
+            }
+          }
+
           resources {
             requests = {
               cpu    = "32m"
               memory = "32Mi"
             }
+          }
+        }
+
+        dynamic "volume" {
+          for_each = var.system_readonly_rootfs_enabled ? { "tmp-dir" = "/tmp" } : {}
+          content {
+            name = volume.key
+            empty_dir {}
           }
         }
       }

--- a/terraform/api/k8s/main.tf
+++ b/terraform/api/k8s/main.tf
@@ -213,6 +213,21 @@ resource "kubernetes_deployment" "api" {
           image             = "${var.image}:${var.release}"
           image_pull_policy = "IfNotPresent"
 
+          dynamic "security_context" {
+            for_each = var.system_readonly_rootfs_enabled ? [1] : []
+            content {
+              read_only_root_filesystem = true
+            }
+          }
+
+          dynamic "env" {
+            for_each = var.system_readonly_rootfs_enabled ? [1] : []
+            content {
+              name  = "HOME"
+              value = "/tmp"
+            }
+          }
+
           env {
             name  = "BUILDKIT_ENABLED"
             value = var.buildkit_enabled
@@ -403,6 +418,14 @@ resource "kubernetes_deployment" "api" {
               mount_path = volume.value
             }
           }
+
+          dynamic "volume_mount" {
+            for_each = var.system_readonly_rootfs_enabled ? { "tmp-dir" = "/tmp", "var-tmp-dir" = "/var/tmp" } : {}
+            content {
+              name       = volume_mount.key
+              mount_path = volume_mount.value
+            }
+          }
         }
 
         volume {
@@ -422,6 +445,14 @@ resource "kubernetes_deployment" "api" {
             persistent_volume_claim {
               claim_name = "api-${volume.key}"
             }
+          }
+        }
+
+        dynamic "volume" {
+          for_each = var.system_readonly_rootfs_enabled ? { "tmp-dir" = "/tmp", "var-tmp-dir" = "/var/tmp" } : {}
+          content {
+            name = volume.key
+            empty_dir {}
           }
         }
 

--- a/terraform/api/k8s/variables.tf
+++ b/terraform/api/k8s/variables.tf
@@ -79,6 +79,11 @@ variable "karpenter_enabled" {
   default = false
 }
 
+variable "system_readonly_rootfs_enabled" {
+  type    = bool
+  default = false
+}
+
 variable "labels" {
   default = {}
 }

--- a/terraform/rack/aws/main.tf
+++ b/terraform/rack/aws/main.tf
@@ -48,6 +48,7 @@ module "api" {
   metrics_scraper_host                      = module.metrics.metrics_scraper_host
   image                                     = var.image
   karpenter_enabled                         = var.karpenter_enabled
+  system_readonly_rootfs_enabled            = var.system_readonly_rootfs_enabled
   keda_enable                               = var.keda_enable
   name                                      = var.name
   rack_name                                 = var.rack_name
@@ -94,14 +95,15 @@ module "resolver" {
     kubernetes = kubernetes
   }
 
-  docker_hub_authentication = module.k8s.docker_hub_authentication
-  high_availability         = var.high_availability
-  image                     = var.image
-  internal_router           = var.internal_router
-  karpenter_enabled         = var.karpenter_enabled
-  namespace                 = module.k8s.namespace
-  rack                      = var.name
-  release                   = var.release
+  docker_hub_authentication      = module.k8s.docker_hub_authentication
+  high_availability              = var.high_availability
+  image                          = var.image
+  internal_router                = var.internal_router
+  karpenter_enabled              = var.karpenter_enabled
+  system_readonly_rootfs_enabled = var.system_readonly_rootfs_enabled
+  namespace                      = module.k8s.namespace
+  rack                           = var.name
+  release                        = var.release
 }
 
 module "router" {

--- a/terraform/rack/aws/variables.tf
+++ b/terraform/rack/aws/variables.tf
@@ -127,6 +127,11 @@ variable "karpenter_enabled" {
   default = false
 }
 
+variable "system_readonly_rootfs_enabled" {
+  type    = bool
+  default = false
+}
+
 variable "keda_enable" {
   type    = bool
   default = false

--- a/terraform/resolver/aws/main.tf
+++ b/terraform/resolver/aws/main.tf
@@ -5,12 +5,13 @@ module "k8s" {
     kubernetes = kubernetes
   }
 
-  docker_hub_authentication = var.docker_hub_authentication
-  image                     = var.image
-  internal_router           = var.internal_router
-  karpenter_enabled         = var.karpenter_enabled
-  namespace                 = var.namespace
-  rack                      = var.rack
-  release                   = var.release
-  replicas                  = var.high_availability ? 2 : 1
+  docker_hub_authentication      = var.docker_hub_authentication
+  image                          = var.image
+  internal_router                = var.internal_router
+  karpenter_enabled              = var.karpenter_enabled
+  system_readonly_rootfs_enabled = var.system_readonly_rootfs_enabled
+  namespace                      = var.namespace
+  rack                           = var.rack
+  release                        = var.release
+  replicas                       = var.high_availability ? 2 : 1
 }

--- a/terraform/resolver/aws/variables.tf
+++ b/terraform/resolver/aws/variables.tf
@@ -15,6 +15,11 @@ variable "karpenter_enabled" {
   default = false
 }
 
+variable "system_readonly_rootfs_enabled" {
+  type    = bool
+  default = false
+}
+
 variable "internal_router" {
   type    = bool
   default = false

--- a/terraform/resolver/k8s/main.tf
+++ b/terraform/resolver/k8s/main.tf
@@ -151,6 +151,13 @@ resource "kubernetes_deployment" "resolver" {
           image             = "${var.image}:${var.release}"
           image_pull_policy = "IfNotPresent"
 
+          dynamic "security_context" {
+            for_each = var.system_readonly_rootfs_enabled ? [1] : []
+            content {
+              read_only_root_filesystem = true
+            }
+          }
+
           env {
             name = "NAMESPACE"
             value_from {

--- a/terraform/resolver/k8s/variables.tf
+++ b/terraform/resolver/k8s/variables.tf
@@ -38,6 +38,11 @@ variable "karpenter_enabled" {
   default = false
 }
 
+variable "system_readonly_rootfs_enabled" {
+  type    = bool
+  default = false
+}
+
 variable "internal_router" {
   type    = bool
   default = false

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -262,6 +262,7 @@ module "rack" {
   build_disable_convox_resolver             = var.build_disable_convox_resolver
   cost_tracking_enable                      = var.cost_tracking_enable
   karpenter_enabled                         = var.karpenter_enabled == "true"
+  system_readonly_rootfs_enabled            = var.system_readonly_rootfs_enabled
   build_node_enabled                        = var.build_node_enabled
   buildkit_host_path_cache_enable           = var.buildkit_host_path_cache_enable
   cluster                                   = module.cluster.id

--- a/terraform/system/aws/telemetry.tf
+++ b/terraform/system/aws/telemetry.tf
@@ -126,6 +126,7 @@ locals {
     ssl_ciphers = var.ssl_ciphers
     ssl_protocols = var.ssl_protocols
     syslog = var.syslog
+    system_readonly_rootfs_enabled = var.system_readonly_rootfs_enabled
     tags = var.tags
     telemetry = var.telemetry
     terraform_update_timeout = var.terraform_update_timeout
@@ -262,6 +263,7 @@ locals {
     ssl_ciphers = ""
     ssl_protocols = ""
     syslog = ""
+    system_readonly_rootfs_enabled = "false"
     tags = ""
     telemetry = "false"
     terraform_update_timeout = "2h"

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -228,6 +228,11 @@ variable "imds_tags_enable" {
   default = false
 }
 
+variable "system_readonly_rootfs_enabled" {
+  type    = bool
+  default = false
+}
+
 variable "internet_gateway_id" {
   default = ""
 }


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: Read-Only Root Filesystem for System Components**

This release adds a new opt-in AWS rack parameter, `system_readonly_rootfs_enabled`, that runs the Convox system containers (api, atom, and resolver) with `readOnlyRootFilesystem: true` and provisions the writable scratch space those containers need. This brings the rack control plane in line with the read-only root filesystem hardening recommended by the EKS Best Practices Guide and the CIS Kubernetes Benchmark, and matches the equivalent control already available on V2 racks.

**When enabled:**

| Container | Read-only root filesystem | Writable scratch provisioned |
|-----------|---------------------------|------------------------------|
| api | yes | `emptyDir` volumes at `/tmp` and `/var/tmp`, with `HOME` set to `/tmp` |
| atom | yes | `emptyDir` volume at `/tmp`, with `HOME` set to `/tmp` |
| resolver | yes | none needed (no runtime root filesystem writes) |

With the parameter at its default (`false`), the api, atom, and resolver pod templates render identically to the previous release, so upgrading a rack that never sets the parameter does not modify or restart those pods.

---

### Why is this important?

A read-only root filesystem ensures the contents of a container image cannot be modified at runtime, which is a standard hardening control for workloads that do not need to write to their own filesystem.

**Benefits:**

- **Control plane hardening.** The api, atom, and resolver system containers run with an immutable root filesystem, limiting what can be written inside those containers at runtime.
- **Compliance alignment.** Satisfies the read-only root filesystem recommendation in the EKS Best Practices Guide and the CIS Kubernetes Benchmark for the Convox system components.
- **No impact by default.** The parameter defaults to `false`, so existing racks are completely unaffected until you opt in.
- **Fully reversible.** The only conditionally created objects are pod-local `emptyDir` volumes, so setting the parameter back to `false` removes them on the next update with nothing left behind.

---

### How to use it?

Enable the parameter on your rack:

    $ convox rack params set system_readonly_rootfs_enabled=true -r rackName

Enabling changes the api, atom, and resolver pod templates, so those deployments perform one rolling update. To return to the previous behavior:

    $ convox rack params set system_readonly_rootfs_enabled=false -r rackName

The CLI validates the value as a boolean and rejects anything else with a clear error.

#### New Rack Parameters

| Parameter | Default | Description |
|-----------|---------|-------------|
| `system_readonly_rootfs_enabled` | `false` | When `true`, runs the api, atom, and resolver system containers with a read-only root filesystem and mounts the writable `emptyDir` scratch space they need. |

---

### Does it have a breaking change?

**No breaking changes** are introduced with this feature.

The parameter is additive with a `false` default at every module level, and the default renders the system pod templates unchanged from the previous release. The nginx router, fluentd, the metrics components, and application containers are not affected. Users continue to control the read-only root filesystem setting for their own services via `services.<name>.securityContext.readOnlyRootFilesystem` in `convox.yml`.

---

### Requirements

This feature requires version `3.24.10` or later for the rack.

**Update the Rack:** Run `convox rack update 3.24.10 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.23.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
