### PR TITLE
Add karpenter_node_os Bottlerocket option for workload nodes

### DIFF
--- a/assets/provider/aws/params.yaml
+++ b/assets/provider/aws/params.yaml
@@ -605,6 +605,13 @@ Groups:
           - gp3
           - io1
           - io2
+      - name: karpenter_node_os
+        default: al2023
+        type: string
+        description: Node OS for Karpenter workload nodes. al2023 (default) or bottlerocket.
+        allowedValues:
+          - al2023
+          - bottlerocket
       - name: karpenter_node_labels
         optional: true
         default: "null"

--- a/docs/configuration/rack-parameters/aws/README.md
+++ b/docs/configuration/rack-parameters/aws/README.md
@@ -70,6 +70,7 @@ Parameters are grouped by category below. Every parameter links to its own refer
 | [karpenter_node_disk](/configuration/rack-parameters/aws/karpenter_node_disk)       | EBS volume size for Karpenter-provisioned nodes. See [Karpenter](/configuration/scaling/karpenter). |
 | [karpenter_node_expiry](/configuration/rack-parameters/aws/karpenter_node_expiry)   | Maximum Karpenter node lifetime before replacement. See [Karpenter](/configuration/scaling/karpenter). |
 | [karpenter_node_labels](/configuration/rack-parameters/aws/karpenter_node_labels)   | Custom labels for Karpenter workload nodes. See [Karpenter](/configuration/scaling/karpenter). |
+| [karpenter_node_os](/configuration/rack-parameters/aws/karpenter_node_os)           | Node OS (al2023 or bottlerocket) for Karpenter workload nodes. See [Karpenter](/configuration/scaling/karpenter). |
 | [karpenter_node_taints](/configuration/rack-parameters/aws/karpenter_node_taints)   | Custom taints for Karpenter workload nodes. See [Karpenter](/configuration/scaling/karpenter). |
 | [karpenter_node_volume_type](/configuration/rack-parameters/aws/karpenter_node_volume_type) | EBS volume type for Karpenter-provisioned nodes. See [Karpenter](/configuration/scaling/karpenter). |
 

--- a/docs/configuration/rack-parameters/aws/karpenter_node_os.md
+++ b/docs/configuration/rack-parameters/aws/karpenter_node_os.md
@@ -1,0 +1,44 @@
+---
+title: "karpenter_node_os"
+description: "The karpenter_node_os AWS rack parameter selects the node operating system for Karpenter workload nodes, al2023 (default) or bottlerocket."
+slug: karpenter_node_os
+url: /configuration/rack-parameters/aws/karpenter_node_os
+---
+
+# karpenter_node_os
+
+## Description
+
+The `karpenter_node_os` parameter selects the node operating system for [Karpenter](/configuration/scaling/karpenter)-provisioned workload nodes.
+
+- `al2023`: Amazon Linux 2023 (default).
+- `bottlerocket`: The EKS-optimized Bottlerocket AMI, a minimal, container-focused, hardened node OS (immutable root filesystem, enforcing SELinux, no shell or SSH, signed atomic updates).
+
+When set to `bottlerocket`, the workload `EC2NodeClass` selects the Bottlerocket AMI and provisions the two volumes Bottlerocket requires: a small `gp3` OS volume on `/dev/xvda` and a data volume on `/dev/xvdb` (sized by [karpenter_node_disk](/configuration/rack-parameters/aws/karpenter_node_disk), falling back to [node_disk](/configuration/rack-parameters/aws/node_disk)) that holds container images, logs, and ephemeral storage. The data volume uses [karpenter_node_volume_type](/configuration/rack-parameters/aws/karpenter_node_volume_type); the OS volume is always `gp3`. Both volumes follow [ebs_volume_encryption_enabled](/configuration/rack-parameters/aws/ebs_volume_encryption_enabled).
+
+This parameter applies only to the workload NodePool and only when [karpenter_enabled](/configuration/rack-parameters/aws/karpenter_enabled) is `true`. System nodes, build nodes, additional node groups, and additional Karpenter NodePools remain on Amazon Linux 2023.
+
+## Default Value
+
+The default value is `al2023`.
+
+## Setting the Parameter
+
+```bash
+$ convox rack params set karpenter_node_os=bottlerocket -r rackName
+Setting parameters... OK
+```
+
+Changing this value re-renders the workload `EC2NodeClass`. Karpenter detects the AMI drift and gracefully replaces workload nodes, respecting PodDisruptionBudgets. Switching back to `al2023` rolls the nodes back.
+
+## Additional Information
+
+- **Validation:** Must be `al2023` or `bottlerocket`.
+- **Operations on Bottlerocket:** there is no SSH or host shell. Host-level access is through the AWS SSM session manager and `apiclient`, which requires SSM permissions on the node role.
+- **GPU workloads** should stay on `al2023`; GPU on Bottlerocket is not yet supported.
+
+## See Also
+
+- [Karpenter](/configuration/scaling/karpenter) for the full Karpenter configuration reference
+- [karpenter_node_disk](/configuration/rack-parameters/aws/karpenter_node_disk)
+- [karpenter_node_volume_type](/configuration/rack-parameters/aws/karpenter_node_volume_type)

--- a/docs/configuration/scaling/karpenter.md
+++ b/docs/configuration/scaling/karpenter.md
@@ -126,6 +126,7 @@ These parameters control how Karpenter provisions nodes for your application Ser
 |-----------|------|---------|------------|-------------|
 | `karpenter_node_disk` | number | `0` | >= 0 | EBS volume size in GiB for Karpenter-provisioned nodes. `0` inherits the Rack's [`node_disk`](/configuration/rack-parameters/aws/node_disk) value. |
 | `karpenter_node_volume_type` | string | `gp3` | `gp2`, `gp3`, `io1`, `io2` | EBS volume type for Karpenter-provisioned nodes. |
+| `karpenter_node_os` | string | `al2023` | `al2023`, `bottlerocket` | Node OS for the workload NodePool. `bottlerocket` selects the EKS-optimized Bottlerocket AMI and the required two-volume layout (gp3 OS volume on /dev/xvda, data volume on /dev/xvdb). AWS V3, Karpenter only. |
 
 ### Labels and Taints
 

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -80,8 +80,9 @@ var awsKnownParams = map[string]bool{
 	"karpenter_instance_families": true, "karpenter_instance_sizes": true,
 	"karpenter_memory_limit_gb": true, "karpenter_node_disk": true,
 	"karpenter_node_expiry": true, "karpenter_node_labels": true,
-	"karpenter_node_taints": true, "karpenter_node_volume_type": true,
-	"keda_enable": true, "key_pair_name": true,
+	"karpenter_node_os": true, "karpenter_node_taints": true,
+	"karpenter_node_volume_type": true,
+	"keda_enable":                true, "key_pair_name": true,
 	"kube_proxy_version": true, "kubelet_registry_burst": true,
 	"kubelet_registry_pull_qps": true, "max_on_demand_count": true,
 	"min_on_demand_count":     true,
@@ -267,6 +268,7 @@ var paramGroups = map[string]map[string]bool{
 		"karpenter_node_disk":                   true,
 		"karpenter_node_expiry":                 true,
 		"karpenter_node_labels":                 true,
+		"karpenter_node_os":                     true,
 		"karpenter_node_taints":                 true,
 		"karpenter_node_volume_type":            true,
 		"keda_enable":                           true,
@@ -1542,6 +1544,14 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 		if !validVolTypes[v] {
 			return fmt.Errorf("param 'karpenter_node_volume_type' must be gp2, gp3, io1, or io2")
 		}
+	}
+
+	if v, has := params["karpenter_node_os"]; has && v != "" {
+		lower := strings.ToLower(v)
+		if lower != "al2023" && lower != "bottlerocket" {
+			return fmt.Errorf("param 'karpenter_node_os' must be 'al2023' or 'bottlerocket'")
+		}
+		params["karpenter_node_os"] = lower
 	}
 
 	// Karpenter parameter validation

--- a/pkg/cli/rack_validate_test.go
+++ b/pkg/cli/rack_validate_test.go
@@ -308,6 +308,40 @@ func TestValidateAndMutateParams_KarpenterNodeVolumeType(t *testing.T) {
 	}
 }
 
+func TestValidateAndMutateParams_KarpenterNodeOS(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+		want    string
+	}{
+		{"al2023 valid", "al2023", false, "al2023"},
+		{"bottlerocket valid", "bottlerocket", false, "bottlerocket"},
+		{"BOTTLEROCKET normalized", "BOTTLEROCKET", false, "bottlerocket"},
+		{"AL2023 normalized", "AL2023", false, "al2023"},
+		{"junk rejected", "ubuntu", true, ""},
+		{"empty rejected", "", true, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := map[string]string{"karpenter_node_os": tt.value}
+			err := validateAndMutateParams(params, "aws", map[string]string{}, false)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tt.value)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.value, err)
+			}
+			if got := params["karpenter_node_os"]; got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestValidateAndMutateParams_WebhookSigningKey_AllProviders(t *testing.T) {
 	for _, provider := range []string{"aws", "gcp", "azure", "do", "metal", "local"} {
 		t.Run(provider, func(t *testing.T) {

--- a/terraform/cluster/aws/karpenter_nodepool.tf
+++ b/terraform/cluster/aws/karpenter_nodepool.tf
@@ -4,6 +4,8 @@
 locals {
   karpenter_effective_disk = var.karpenter_node_disk > 0 ? var.karpenter_node_disk : var.node_disk
 
+  karpenter_is_bottlerocket = var.karpenter_node_os == "bottlerocket"
+
   # Parse workload NodePool custom labels from "k1=v1,k2=v2" to map
   karpenter_workload_extra_labels = {
     for pair in compact(split(",", var.karpenter_node_labels)) :
@@ -125,15 +127,34 @@ locals {
   # Workload EC2NodeClass — build defaults, merge overrides, force protected fields
   ###########################################################################
 
-  # blockDeviceMappings: override or params
-  ec2_default_block_devices = [{
-    deviceName = "/dev/xvda"
-    ebs = {
-      volumeType = var.karpenter_node_volume_type
-      volumeSize = "${local.karpenter_effective_disk}Gi"
-      encrypted  = var.ebs_volume_encryption_enabled
-    }
-  }]
+  # blockDeviceMappings: Bottlerocket needs two volumes (OS + data); still overridable
+  ec2_default_block_devices = local.karpenter_is_bottlerocket ? [
+    {
+      deviceName = "/dev/xvda"
+      ebs = {
+        volumeType = "gp3"
+        volumeSize = "4Gi"
+        encrypted  = var.ebs_volume_encryption_enabled
+      }
+    },
+    {
+      deviceName = "/dev/xvdb"
+      ebs = {
+        volumeType = var.karpenter_node_volume_type
+        volumeSize = "${local.karpenter_effective_disk}Gi"
+        encrypted  = var.ebs_volume_encryption_enabled
+      }
+    },
+    ] : [
+    {
+      deviceName = "/dev/xvda"
+      ebs = {
+        volumeType = var.karpenter_node_volume_type
+        volumeSize = "${local.karpenter_effective_disk}Gi"
+        encrypted  = var.ebs_volume_encryption_enabled
+      }
+    },
+  ]
   ec2_final_block_devices = lookup(local.kc_ec2, "blockDeviceMappings", local.ec2_default_block_devices)
 
   # metadataOptions: override or params
@@ -152,8 +173,9 @@ locals {
     { Name = "${var.name}/karpenter/workload", Rack = var.name },
   )
 
-  # amiSelectorTerms: override or default
-  ec2_final_ami = lookup(local.kc_ec2, "amiSelectorTerms", [{ alias = "al2023@latest" }])
+  # amiSelectorTerms: OS-aware default, still overridable
+  ec2_default_ami = local.karpenter_is_bottlerocket ? [{ alias = "bottlerocket@latest" }] : [{ alias = "al2023@latest" }]
+  ec2_final_ami   = lookup(local.kc_ec2, "amiSelectorTerms", local.ec2_default_ami)
 
   # Optional fields from override only (no individual params for these)
   ec2_optional_fields = merge(

--- a/terraform/cluster/aws/variables.tf
+++ b/terraform/cluster/aws/variables.tf
@@ -188,6 +188,11 @@ variable "karpenter_node_volume_type" {
   default = "gp3"
 }
 
+variable "karpenter_node_os" {
+  type    = string
+  default = "al2023"
+}
+
 variable "karpenter_node_labels" {
   type    = string
   default = ""

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -156,6 +156,7 @@ module "cluster" {
   karpenter_disruption_budget_nodes   = var.karpenter_disruption_budget_nodes
   karpenter_node_disk                 = var.karpenter_node_disk
   karpenter_node_volume_type          = var.karpenter_node_volume_type
+  karpenter_node_os                   = var.karpenter_node_os
   karpenter_node_labels               = var.karpenter_node_labels
   karpenter_node_taints               = var.karpenter_node_taints
   karpenter_config                    = var.karpenter_config != "" ? try(base64decode(var.karpenter_config), var.karpenter_config) : "{}"

--- a/terraform/system/aws/telemetry.tf
+++ b/terraform/system/aws/telemetry.tf
@@ -82,6 +82,7 @@ locals {
     karpenter_node_disk = var.karpenter_node_disk
     karpenter_node_expiry = var.karpenter_node_expiry
     karpenter_node_labels = var.karpenter_node_labels
+    karpenter_node_os = var.karpenter_node_os
     karpenter_node_taints = var.karpenter_node_taints
     karpenter_node_volume_type = var.karpenter_node_volume_type
     keda_enable = var.keda_enable
@@ -218,6 +219,7 @@ locals {
     karpenter_node_disk = "0"
     karpenter_node_expiry = "720h"
     karpenter_node_labels = ""
+    karpenter_node_os = "al2023"
     karpenter_node_taints = ""
     karpenter_node_volume_type = "gp3"
     keda_enable = "false"

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -308,6 +308,11 @@ variable "karpenter_node_volume_type" {
   default = "gp3"
 }
 
+variable "karpenter_node_os" {
+  type    = string
+  default = "al2023"
+}
+
 variable "karpenter_node_labels" {
   type    = string
   default = ""


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: Bottlerocket node OS option for Karpenter workload nodes**

This release adds an opt-in AWS rack parameter, `karpenter_node_os`, that switches the Karpenter workload NodePool from the default Amazon Linux 2023 AMI to the EKS-optimized Bottlerocket AMI. Bottlerocket is a minimal, container-focused node OS with an immutable root filesystem, enforcing SELinux, no shell or SSH access, and signed atomic updates, which makes it a useful option for security and compliance-focused racks.

When set to `bottlerocket`, the workload `EC2NodeClass` selects the Bottlerocket AMI (`amiSelectorTerms` alias `bottlerocket@latest`) and automatically renders the two-volume disk layout Bottlerocket expects: a 4 GiB `gp3` OS volume on `/dev/xvda` and a data volume on `/dev/xvdb` that holds container images, logs, and ephemeral storage. The data volume is sized by `karpenter_node_disk` (falling back to `node_disk`) and uses `karpenter_node_volume_type`, and both volumes honor `ebs_volume_encryption_enabled`. This means the disk size you configure applies to the volume where container data actually lives, no manual block device configuration required.

**Scope:**

- **Workload NodePool only.** System nodes, build nodes, managed additional node groups, and additional Karpenter NodePools remain on Amazon Linux 2023.
- **Fully overridable.** The AMI alias and block device mappings can still be customized through the existing `karpenter_config` parameter for users who need full control.
- **GPU workloads should stay on `al2023`.** The Bottlerocket NVIDIA variant is not yet supported.

---

### Why is this important?

Bottlerocket gives security and compliance-focused teams a hardened, purpose-built container OS for their workload nodes, and Convox applies the correct disk layout for it automatically.

**Benefits:**

- **Hardened node OS.** Immutable root filesystem, enforcing SELinux, no shell or SSH, and a minimal package footprint reduce the attack surface of every workload node.
- **Correct disk layout out of the box.** Bottlerocket separates the OS and container data onto two volumes; Convox renders both automatically and applies your configured disk size to the container data volume.
- **Reversible in either direction.** Changing the parameter re-renders the workload `EC2NodeClass`, and Karpenter gracefully cordons, drains, and replaces nodes while respecting PodDisruptionBudgets.
- **No impact unless you opt in.** With the default `al2023`, every existing rack renders identically to before.

---

### How to use it?

Switch the Karpenter workload NodePool to Bottlerocket:

    $ convox rack params set karpenter_node_os=bottlerocket -r rackName

Switch back to Amazon Linux 2023 at any time:

    $ convox rack params set karpenter_node_os=al2023 -r rackName

#### New Rack Parameters

| Parameter | Default | Description |
|-----------|---------|-------------|
| `karpenter_node_os` | `al2023` | Node OS for the Karpenter workload NodePool. Accepts `al2023` or `bottlerocket`. When `bottlerocket`, the workload nodes use the EKS-optimized Bottlerocket AMI with the two-volume disk layout. AWS only, applies when `karpenter_enabled=true`. |

---

### Does it have a breaking change?

**No breaking changes** are introduced with this feature.

The parameter defaults to `al2023`, so existing racks render the workload NodePool exactly as before. Opting in triggers a graceful node replacement managed by Karpenter, and setting the parameter back to `al2023` rolls nodes back the same way. Downgrading the rack to an earlier version simply reverts the workload nodes to the Amazon Linux 2023 default.

---

### Requirements

This feature requires version `3.24.10` or later for the rack.

**Update the Rack:** Run `convox rack update 3.24.10 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.23.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
