### PR TITLE
Release/3.24.11

### DIFF
--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -1482,6 +1482,7 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 		fmt.Fprintf(os.Stderr, "WARNING: pod_security_mode=enforce rejects non-conforming app pods at admission.\n")
 		fmt.Fprintf(os.Stderr, "Any service that sets a violating securityContext will fail to deploy.\n")
 		fmt.Fprintf(os.Stderr, "restricted with enforce also rejects default convox pods. Roll out warn, then audit, then enforce.\n")
+		fmt.Fprintf(os.Stderr, "After leaving enforce, each app namespace keeps enforcing until its next promote. Builds route around this automatically.\n")
 	}
 
 	if v, has := params["access_log_retention_in_days"]; has && v != "" {

--- a/provider/k8s/app.go
+++ b/provider/k8s/app.go
@@ -379,13 +379,21 @@ func (p *Provider) buildNamespace(app string) string {
 	return strings.TrimRight(prefix, "-") + "-" + hex.EncodeToString(sum[:])[:8]
 }
 
-// processBuildNamespace returns where the build pod runs. Under PSA enforce the
-// app namespace's label would reject the build pod, so the build runs in a
-// dedicated unlabeled namespace; otherwise it runs in the app namespace as before.
+// processBuildNamespace returns where the build pod runs. Params enforce or an
+// app namespace still carrying an enforce label (it persists until the next
+// promote after leaving enforce) routes to the dedicated unlabeled namespace.
 func (p *Provider) processBuildNamespace(app string) string {
 	if p.PodSecurityStandard != "" && p.PodSecurityMode == "enforce" {
 		return p.buildNamespace(app)
 	}
+
+	ns, err := p.Cluster.CoreV1().Namespaces().Get(context.TODO(), p.AppNamespace(app), am.GetOptions{})
+	if err == nil {
+		if _, ok := ns.Labels["pod-security.kubernetes.io/enforce"]; ok {
+			return p.buildNamespace(app)
+		}
+	}
+
 	return p.AppNamespace(app)
 }
 

--- a/provider/k8s/app_psa_test.go
+++ b/provider/k8s/app_psa_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	ac "k8s.io/api/core/v1"
 	am "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -77,6 +78,85 @@ func TestProcessBuildNamespace(t *testing.T) {
 				p.PodSecurityStandard = tc.standard
 				p.PodSecurityMode = tc.mode
 				assert.Equal(t, tc.want, p.ProcessBuildNamespaceForTest("app1"))
+			})
+		})
+	}
+}
+
+func TestProcessBuildNamespaceEnforceTransition(t *testing.T) {
+	enforceLabel := map[string]string{"pod-security.kubernetes.io/enforce": "baseline"}
+
+	cases := []struct {
+		name     string
+		standard string
+		mode     string
+		labels   map[string]string
+		noNs     bool
+		want     string
+	}{
+		{name: "label-persists-after-enforce", standard: "baseline", mode: "warn", labels: enforceLabel, want: "rack1-build-app1"},
+		{name: "label-persists-standard-cleared", standard: "", mode: "warn", labels: enforceLabel, want: "rack1-build-app1"},
+		{name: "unlabeled-warn", standard: "baseline", mode: "warn", want: "rack1-app1"},
+		{name: "warn-label-only", standard: "baseline", mode: "warn", labels: map[string]string{"pod-security.kubernetes.io/warn": "baseline"}, want: "rack1-app1"},
+		{name: "params-enforce-skips-read", standard: "baseline", mode: "enforce", noNs: true, want: "rack1-build-app1"},
+		{name: "read-error-falls-back", standard: "baseline", mode: "warn", noNs: true, want: "rack1-app1"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			testProvider(t, func(p *k8s.Provider) {
+				p.PodSecurityStandard = tc.standard
+				p.PodSecurityMode = tc.mode
+
+				if !tc.noNs {
+					kk, _ := p.Cluster.(*fake.Clientset)
+					_, err := kk.CoreV1().Namespaces().Create(context.TODO(), &ac.Namespace{
+						ObjectMeta: am.ObjectMeta{Name: "rack1-app1", Labels: tc.labels},
+					}, am.CreateOptions{})
+					require.NoError(t, err)
+				}
+
+				assert.Equal(t, tc.want, p.ProcessBuildNamespaceForTest("app1"))
+			})
+		})
+	}
+}
+
+func TestBuildLogsNamespaceFollowsPod(t *testing.T) {
+	enforceLabel := map[string]string{"pod-security.kubernetes.io/enforce": "baseline"}
+
+	cases := []struct {
+		name     string
+		nsLabels map[string]string
+		podNs    string
+		want     string
+	}{
+		{name: "pod-in-build-ns-label-gone", nsLabels: nil, podNs: "rack1-build-app1", want: "rack1-build-app1"},
+		{name: "pod-in-app-ns-label-present", nsLabels: enforceLabel, podNs: "rack1-app1", want: "rack1-app1"},
+		{name: "pod-matches-routing", nsLabels: enforceLabel, podNs: "rack1-build-app1", want: "rack1-build-app1"},
+		{name: "pod-missing-falls-back-to-routing", nsLabels: nil, podNs: "", want: "rack1-app1"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			testProvider(t, func(p *k8s.Provider) {
+				p.PodSecurityStandard = "baseline"
+				p.PodSecurityMode = "warn"
+
+				kk, _ := p.Cluster.(*fake.Clientset)
+				_, err := kk.CoreV1().Namespaces().Create(context.TODO(), &ac.Namespace{
+					ObjectMeta: am.ObjectMeta{Name: "rack1-app1", Labels: tc.nsLabels},
+				}, am.CreateOptions{})
+				require.NoError(t, err)
+
+				if tc.podNs != "" {
+					_, err := kk.CoreV1().Pods(tc.podNs).Create(context.TODO(), &ac.Pod{
+						ObjectMeta: am.ObjectMeta{Name: "build-xxxxx"},
+					}, am.CreateOptions{})
+					require.NoError(t, err)
+				}
+
+				assert.Equal(t, tc.want, p.BuildLogsNamespaceForTest("app1", "build-xxxxx"))
 			})
 		})
 	}

--- a/provider/k8s/build.go
+++ b/provider/k8s/build.go
@@ -725,6 +725,25 @@ func (p *Provider) BuildImport(app string, r io.Reader) (*structs.Build, error) 
 	return target, nil
 }
 
+// buildLogsNamespace anchors log streaming to wherever the build pod actually
+// runs; label-aware routing can change between pod creation and stream attach.
+func (p *Provider) buildLogsNamespace(app, process string) string {
+	ns := p.processBuildNamespace(app)
+	if _, err := p.Cluster.CoreV1().Pods(ns).Get(context.TODO(), process, am.GetOptions{}); err == nil {
+		return ns
+	}
+
+	alt := p.buildNamespace(app)
+	if alt == ns {
+		alt = p.AppNamespace(app)
+	}
+	if _, err := p.Cluster.CoreV1().Pods(alt).Get(context.TODO(), process, am.GetOptions{}); err == nil {
+		return alt
+	}
+
+	return ns
+}
+
 func (p *Provider) BuildLogs(app, id string, opts structs.LogsOptions) (io.ReadCloser, error) {
 	b, err := p.BuildGet(app, id)
 	if err != nil {
@@ -738,7 +757,7 @@ func (p *Provider) BuildLogs(app, id string, opts structs.LogsOptions) (io.ReadC
 		if b.Process == "" {
 			return nil, fmt.Errorf("build %s has running status but no process ID", id)
 		}
-		return p.processLogsNamespace(p.processBuildNamespace(app), b.Process, opts)
+		return p.processLogsNamespace(p.buildLogsNamespace(app, b.Process), b.Process, opts)
 	case "created":
 		return p.buildLogsStreamFromCreated(app, id, opts)
 	default:
@@ -800,7 +819,7 @@ func (p *Provider) streamBuildLogsFromCreated(w io.WriteCloser, app, id string, 
 				}
 				tick.Stop()
 				heartbeat.Stop()
-				p.streamProcessLogs(w, p.processBuildNamespace(app), b.Process, opts)
+				p.streamProcessLogs(w, p.buildLogsNamespace(app, b.Process), b.Process, opts)
 				return
 			case "failed", "complete":
 				p.writeStoredBuildLogs(w, app, id, b)

--- a/provider/k8s/export_test.go
+++ b/provider/k8s/export_test.go
@@ -693,3 +693,9 @@ func (p *Provider) ProcessBuildNamespaceForTest(app string) string {
 func (p *Provider) EnsureBuildNamespaceForTest(app string) error {
 	return p.ensureBuildNamespace(app)
 }
+
+// BuildLogsNamespaceForTest exposes buildLogsNamespace so external tests can
+// assert log streaming follows the build pod's actual namespace.
+func (p *Provider) BuildLogsNamespaceForTest(app, process string) string {
+	return p.buildLogsNamespace(app, process)
+}

--- a/provider/k8s/process.go
+++ b/provider/k8s/process.go
@@ -402,8 +402,8 @@ func (p *Provider) ProcessRun(app, service string, opts structs.ProcessRunOption
 		}
 	}
 
-	// Build pods run in a dedicated namespace under PSA enforce so the app
-	// namespace's enforce label does not reject them. Ensure it before
+	// Build pods run in a dedicated namespace while PSA enforcement applies so
+	// the app namespace's enforce label does not reject them. Ensure it before
 	// podSpecFromRunOptions, which writes the pull secret into this namespace.
 	createNs := p.AppNamespace(app)
 	if opts.IsBuild {
@@ -415,7 +415,7 @@ func (p *Provider) ProcessRun(app, service string, opts structs.ProcessRunOption
 		}
 	}
 
-	s, err := p.podSpecFromRunOptions(app, service, opts)
+	s, err := p.podSpecFromRunOptions(app, service, createNs, opts)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -772,7 +772,7 @@ func (p *Provider) podSpecFromService(app, service, release string, isBuild bool
 	return ps, nil
 }
 
-func (p *Provider) podSpecFromRunOptions(app, service string, opts structs.ProcessRunOptions) (*ac.PodSpec, error) {
+func (p *Provider) podSpecFromRunOptions(app, service, ns string, opts structs.ProcessRunOptions) (*ac.PodSpec, error) { //nolint:gocritic // by-value opts matches ProcessRun and sibling helpers
 	s, err := p.podSpecFromService(app, service, common.DefaultString(opts.Release, ""), opts.IsBuild)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -894,11 +894,7 @@ func (p *Provider) podSpecFromRunOptions(app, service string, opts structs.Proce
 	}
 
 	if p.hasDockerHubAuth() {
-		secretNs := p.AppNamespace(app)
-		if opts.IsBuild {
-			secretNs = p.processBuildNamespace(app)
-		}
-		if err := p.ensureDockerHubSecret(secretNs); err != nil {
+		if err := p.ensureDockerHubSecret(ns); err != nil {
 			return nil, errors.WithStack(err)
 		}
 


### PR DESCRIPTION
### What is the feature/update/fix?

**Update: Build routing for Pod Security Admission transitions**

Builds now run in the dedicated per-app build namespace whenever an app namespace carries a Pod Security Admission `enforce` label. This extends the routing introduced in 3.24.10, which keyed only on the current rack parameters, to also cover the transition window after leaving `enforce` mode: the namespace label persists until the app's next promote, and builds detect it and route around it automatically.

Build log streaming now follows the build pod to whichever namespace it actually runs in, so `convox build` and `convox deploy` output is unaffected by the routing.

The CLI also prints an additional line when setting `pod_security_mode=enforce`, noting that each app namespace keeps enforcing until its next promote after leaving `enforce` and that builds route around this automatically.

---

### Why is this important?

Builds keep working through every phase of a Pod Security Admission rollout, including tightening to `enforce` and stepping back down, with no manual intervention and no redeploy required first.

**Benefits:**

- **Uninterrupted builds.** `convox build` and `convox deploy` work throughout PSA transitions, not only while `enforce` is the active setting.
- **Consistent log streaming.** Build logs attach to the namespace the build pod runs in, wherever the routing places it.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this update.

The routing activates only when an app namespace carries a Pod Security Admission `enforce` label. Racks that do not use `pod_security_standard` are unaffected, and no parameters change.

---

### Requirements

This update requires version `3.24.11` or later for the rack.

**Update the Rack:** Run `convox rack update 3.24.11 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.23.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
