### PR TITLE
Propagate renewed cert secrets to app namespaces

### DIFF
--- a/provider/k8s/controller_secret.go
+++ b/provider/k8s/controller_secret.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/convox/convox/pkg/common"
@@ -59,7 +60,7 @@ func (c *SecretController) Informer() cache.SharedInformer {
 }
 
 func (c *SecretController) ListOptions(opts *am.ListOptions) {
-	opts.LabelSelector = "system=convox,type=state"
+	opts.LabelSelector = "system=convox,type in (state,letsencrypt-certificate)"
 }
 
 func (c *SecretController) Run() {
@@ -116,7 +117,8 @@ func (c *SecretController) Update(prev, cur interface{}) error {
 		}
 	}
 
-	if ss.Labels["system"] == "convox" && ss.Labels["type"] == "letsencrypt-certificate" {
+	// rack-namespace certs are the only ones with copies in app namespaces to keep in sync
+	if ss.Labels["system"] == "convox" && ss.Labels["type"] == "letsencrypt-certificate" && ss.Namespace == c.Provider.Namespace {
 		c.syncSecretCertData(ss)
 	}
 	return nil
@@ -136,11 +138,18 @@ func (c *SecretController) syncSecretCertData(certSecret *v1.Secret) {
 		})
 		if err != nil {
 			c.log.Errorf("failed to list secrets: %s", err)
+			return
 		}
 
 		for i := range sList.Items {
+			if sList.Items[i].Namespace == certSecret.Namespace {
+				continue
+			}
 			if sList.Items[i].Annotations[AnnotationSecretDataHash] != dataHash {
 				_, err := c.Provider.PatchSecret(context.TODO(), &sList.Items[i], func(s *v1.Secret) *v1.Secret {
+					if s.Annotations == nil {
+						s.Annotations = map[string]string{}
+					}
 					s.Annotations[AnnotationSecretDataHash] = dataHash
 					s.Data = certSecret.Data
 					return s
@@ -169,7 +178,12 @@ func assertSecret(v interface{}) (*ac.Secret, error) {
 
 func secretDataHash(s *v1.Secret) (string, error) {
 	h := sha1.New()
+	keys := make([]string, 0, len(s.Data))
 	for k := range s.Data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
 		_, err := h.Write(s.Data[k])
 		if err != nil {
 			return "", err

--- a/provider/k8s/controller_secret_test.go
+++ b/provider/k8s/controller_secret_test.go
@@ -1,0 +1,152 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/convox/logger"
+	"github.com/stretchr/testify/require"
+	ac "k8s.io/api/core/v1"
+	am "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+var certLabels = map[string]string{"system": "convox", "type": "letsencrypt-certificate"}
+
+func newTestSecretController(objs ...runtime.Object) (*SecretController, *fake.Clientset) {
+	c := fake.NewSimpleClientset(objs...)
+	sc := &SecretController{
+		Provider: &Provider{
+			Cluster:   c,
+			Namespace: "rack1",
+			ctx:       context.Background(),
+			logger:    logger.New("ns=secret-test"),
+		},
+		log: logger.New("ns=secret-test"),
+	}
+	return sc, c
+}
+
+func mkSecret(ns, name string, labels, ann map[string]string, data map[string][]byte) *ac.Secret {
+	return &ac.Secret{
+		ObjectMeta: am.ObjectMeta{Namespace: ns, Name: name, Labels: labels, Annotations: ann},
+		Data:       data,
+	}
+}
+
+func patchCount(c *fake.Clientset, ns, name string) int {
+	n := 0
+	for _, a := range c.Actions() {
+		pa, ok := a.(k8stesting.PatchAction)
+		if ok && a.GetVerb() == "patch" && a.GetResource().Resource == "secrets" && a.GetNamespace() == ns && pa.GetName() == name {
+			n++
+		}
+	}
+	return n
+}
+
+func TestSecretSyncCrossAppNoContamination(t *testing.T) {
+	app1 := mkSecret("app1", "cert-web", certLabels, map[string]string{}, map[string][]byte{"tls.crt": []byte("A"), "tls.key": []byte("A")})
+	app2 := mkSecret("app2", "cert-web", certLabels, map[string]string{AnnotationSecretDataHash: "stale"}, map[string][]byte{"tls.crt": []byte("B"), "tls.key": []byte("B")})
+	sc, c := newTestSecretController(app1, app2)
+	c.ClearActions()
+
+	require.NotPanics(t, func() { _ = sc.Update(app1, app1) })
+
+	got, err := c.CoreV1().Secrets("app2").Get(context.TODO(), "cert-web", am.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, []byte("B"), got.Data["tls.crt"])
+	require.Equal(t, 0, patchCount(c, "app2", "cert-web"))
+}
+
+func TestSecretSyncFlowAPropagation(t *testing.T) {
+	src := mkSecret("rack1", "cert-abc", certLabels, map[string]string{}, map[string][]byte{"tls.crt": []byte("NEW"), "tls.key": []byte("NEWKEY")})
+	cp := mkSecret("myapp", "cert-abc", nil, map[string]string{AnnotationSecretDataHash: "stale"}, map[string][]byte{"tls.crt": []byte("OLD"), "tls.key": []byte("OLDKEY")})
+	sc, c := newTestSecretController(src, cp)
+	c.ClearActions()
+
+	require.NoError(t, sc.Update(src, src))
+
+	got, err := c.CoreV1().Secrets("myapp").Get(context.TODO(), "cert-abc", am.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, []byte("NEW"), got.Data["tls.crt"])
+	require.Equal(t, []byte("NEWKEY"), got.Data["tls.key"])
+	want, err := secretDataHash(src)
+	require.NoError(t, err)
+	require.Equal(t, want, got.Annotations[AnnotationSecretDataHash])
+	require.Equal(t, 0, patchCount(c, "rack1", "cert-abc"))
+}
+
+func TestSecretSyncNoOpWhenHashMatches(t *testing.T) {
+	data := map[string][]byte{"tls.crt": []byte("SAME"), "tls.key": []byte("SAMEKEY")}
+	src := mkSecret("rack1", "cert-abc", certLabels, map[string]string{}, data)
+	h, err := secretDataHash(src)
+	require.NoError(t, err)
+	cp := mkSecret("myapp", "cert-abc", nil, map[string]string{AnnotationSecretDataHash: h}, data)
+	sc, c := newTestSecretController(src, cp)
+	c.ClearActions()
+
+	require.NoError(t, sc.Update(src, src))
+
+	require.Equal(t, 0, patchCount(c, "myapp", "cert-abc"))
+}
+
+func TestSecretDataHashDeterministic(t *testing.T) {
+	s := &ac.Secret{Data: map[string][]byte{
+		"tls.key": []byte("KEYDATA"),
+		"tls.crt": []byte("CRTDATA"),
+		"ca.crt":  []byte("CADATA"),
+	}}
+
+	first, err := secretDataHash(s)
+	require.NoError(t, err)
+	require.NotEmpty(t, first)
+
+	for i := 0; i < 200; i++ {
+		got, err := secretDataHash(s)
+		require.NoError(t, err)
+		require.Equal(t, first, got)
+	}
+
+	s2 := &ac.Secret{Data: map[string][]byte{
+		"ca.crt":  []byte("CADATA"),
+		"tls.crt": []byte("CRTDATA"),
+		"tls.key": []byte("KEYDATA"),
+	}}
+	got2, err := secretDataHash(s2)
+	require.NoError(t, err)
+	require.Equal(t, first, got2)
+}
+
+func TestSecretSyncNilAnnotationsTarget(t *testing.T) {
+	src := mkSecret("rack1", "cert-abc", certLabels, map[string]string{}, map[string][]byte{"tls.crt": []byte("NEW"), "tls.key": []byte("NEW")})
+	cp := mkSecret("myapp", "cert-abc", nil, nil, map[string][]byte{"tls.crt": []byte("OLD"), "tls.key": []byte("OLD")})
+	sc, c := newTestSecretController(src, cp)
+
+	require.NotPanics(t, func() { _ = sc.Update(src, src) })
+
+	got, err := c.CoreV1().Secrets("myapp").Get(context.TODO(), "cert-abc", am.GetOptions{})
+	require.NoError(t, err)
+	require.NotEmpty(t, got.Annotations[AnnotationSecretDataHash])
+}
+
+func TestSecretSyncListErrorNoPanic(t *testing.T) {
+	src := mkSecret("rack1", "cert-abc", certLabels, map[string]string{}, map[string][]byte{"tls.crt": []byte("X")})
+	sc, c := newTestSecretController(src)
+	c.PrependReactor("list", "secrets", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("boom")
+	})
+
+	require.NotPanics(t, func() { _ = sc.Update(src, src) })
+}
+
+func TestSecretListOptionsSelector(t *testing.T) {
+	sc, _ := newTestSecretController()
+	opts := &am.ListOptions{}
+	sc.ListOptions(opts)
+	require.Contains(t, opts.LabelSelector, "letsencrypt-certificate")
+	require.Contains(t, opts.LabelSelector, "state")
+}


### PR DESCRIPTION
### What is the feature/update/fix?

**Fix: Renewed Certificates Now Propagate Automatically to App Namespaces**

When a certificate created with `convox certs generate` is attached to a service through the `certificate:` option in convox.yml, the rack copies the certificate secret from the rack namespace into the app namespace at deploy time, and cert-manager renews the original in the rack namespace on its normal schedule. With this fix, the rack's secret controller now watches these certificate secrets and propagates each renewal from the rack namespace to the matching copies in app namespaces as soon as it is observed, so running services always serve the current certificate without requiring a new deploy.

The sync is precisely scoped. Only certificates in the rack namespace act as a propagation source, and each renewal updates only the app-namespace copies of that same certificate, so every app receives exactly its own renewed certificate. Certificates that cert-manager manages directly inside app namespaces are outside the sync and remain untouched. Change detection uses a deterministic content hash stored in the `convox.com/data-hash` annotation on each copy, so a copy is patched only when its recorded hash differs from the renewed source.

---

### Why is this important?

Let's Encrypt certificates are short-lived by design and renew automatically in the background. This fix makes renewal propagation an equally automatic behavior of the rack: whenever cert-manager renews a rack-level certificate, every service that references it picks up the renewed certificate promptly, with no deploy or manual step involved.

**Benefits:**

- **Hands-off certificate rotation.** Renewed certificates reach every app namespace that uses them as soon as the controller observes the renewal, keeping the served certificate current between deploys.
- **Correct per-app delivery.** Each renewal updates only the copies of that specific certificate, and per-service certificates managed in place by cert-manager are not part of the sync, so every app always holds its own certificate.
- **Minimal write traffic.** Deterministic content hashing means the controller patches a copy only when its recorded hash differs from the source, so steady-state sync cycles produce no unnecessary writes.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this fix.

This is a code-only change to the rack's secret controller with no new parameters, flags, or configuration. Secrets used for resource state (`type=state`) are handled exactly as before, and all providers share the same behavior. On the first sync cycle after updating, existing app-namespace certificate copies are reconciled once: any copy whose recorded hash differs from the current certificate data is refreshed and annotated with the new content hash. This requires no action.

---

### Requirements

This fix requires version `3.25.1` or later for the rack.

**Update the Rack:** Run `convox rack update 3.25.1 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
