### PR TITLE
expand convox run flags with termination grace

### DIFF
--- a/pkg/structs/process.go
+++ b/pkg/structs/process.go
@@ -72,8 +72,16 @@ type ProcessRunOptions struct {
 	Privileged       *bool             `header:"Privileged"`
 	NodeLabels       *string           `flag:"node-labels" header:"Node-Labels"`
 	SystemCritical   *bool             `flag:"system-critical" header:"System-Critical"`
-	IsBuild          bool
-	BuildArch        *string
+
+	TerminationGrace    *int    `flag:"termination-grace" header:"Termination-Grace"`
+	Annotations         *string `flag:"annotations" header:"Run-Annotations"`
+	Labels              *string `flag:"labels" header:"Run-Labels"`
+	UseServiceLifecycle *bool   `flag:"use-service-lifecycle" header:"Use-Service-Lifecycle"`
+	NodeAffinity        *string `flag:"node-affinity" header:"Node-Affinity"`
+	Tolerations         *string `flag:"tolerations" header:"Run-Tolerations"`
+
+	IsBuild   bool
+	BuildArch *string
 }
 
 func (p *Process) sortKey() string {

--- a/provider/k8s/process.go
+++ b/provider/k8s/process.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math/rand"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/pkg/errors"
 	ac "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/api/validate/content"
 	am "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
@@ -500,25 +502,66 @@ func (p *Provider) ProcessRun(app, service string, opts structs.ProcessRunOption
 		s.PriorityClassName = "system-node-critical"
 	}
 
+	labels := map[string]string{
+		"app":     app,
+		"rack":    p.Name,
+		"release": release,
+		"service": service,
+		"system":  "convox",
+		"type":    "process",
+		"name":    service,
+	}
+
+	if opts.IsBuild {
+		labels["service-type"] = "build"
+	}
+
+	if opts.Annotations != nil {
+		kv, err := parseRunKV(*opts.Annotations)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range kv {
+			if msgs := content.IsLabelKey(k); len(msgs) > 0 {
+				return nil, structs.ErrBadRequest("invalid annotation key %q: %s", k, strings.Join(msgs, "; "))
+			}
+			if _, ok := ans[k]; ok {
+				continue
+			}
+			ans[k] = v
+		}
+	}
+
+	if opts.Labels != nil {
+		reserved := map[string]bool{
+			"app": true, "rack": true, "service": true, "system": true,
+			"type": true, "name": true, "release": true, "service-type": true,
+		}
+		kv, err := parseRunKV(*opts.Labels)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range kv {
+			if reserved[k] {
+				return nil, structs.ErrBadRequest("label key %q is reserved by convox", k)
+			}
+			if msgs := content.IsLabelKey(k); len(msgs) > 0 {
+				return nil, structs.ErrBadRequest("invalid label key %q: %s", k, strings.Join(msgs, "; "))
+			}
+			if msgs := content.IsLabelValue(v); len(msgs) > 0 {
+				return nil, structs.ErrBadRequest("invalid label value %q: %s", v, strings.Join(msgs, "; "))
+			}
+			labels[k] = v
+		}
+	}
+
 	pod := &ac.Pod{
 		ObjectMeta: am.ObjectMeta{
 			Annotations:  ans,
 			GenerateName: fmt.Sprintf("%s-", service),
-			Labels: map[string]string{
-				"app":     app,
-				"rack":    p.Name,
-				"release": release,
-				"service": service,
-				"system":  "convox",
-				"type":    "process",
-				"name":    service,
-			},
+			Labels:       labels,
 		},
 		Spec: *s,
-	}
-
-	if opts.IsBuild {
-		pod.ObjectMeta.Labels["service-type"] = "build"
 	}
 
 	pd, err := p.Cluster.CoreV1().Pods(createNs).Create(
@@ -608,6 +651,7 @@ func (p *Provider) podSpecFromService(app, service, release string, isBuild bool
 
 	serviceAccountName := ""
 	var nodeSelectorLabels map[string]string
+	var graceSecs *int64
 	if !isBuild && release != "" {
 		m, r, err := common.ReleaseManifest(p, app, release)
 		if err != nil {
@@ -679,6 +723,9 @@ func (p *Provider) podSpecFromService(app, service, release string, isBuild bool
 
 			nodeSelectorLabels = s.NodeSelectorLabels
 
+			g := int64(s.Termination.Grace)
+			graceSecs = &g
+
 			if sc := serviceSecurityContext(s); sc != nil {
 				c.SecurityContext = sc
 			}
@@ -694,6 +741,10 @@ func (p *Provider) podSpecFromService(app, service, release string, isBuild bool
 		Containers:            []ac.Container{c},
 		ShareProcessNamespace: options.Bool(true),
 		Volumes:               vs,
+	}
+
+	if graceSecs != nil {
+		ps.TerminationGracePeriodSeconds = graceSecs
 	}
 
 	if len(nodeSelectorLabels) > 0 {
@@ -770,6 +821,109 @@ func (p *Provider) podSpecFromService(app, service, release string, isBuild bool
 	}
 
 	return ps, nil
+}
+
+func parseRunKV(csv string) (map[string]string, error) {
+	out := map[string]string{}
+	for _, seg := range strings.Split(csv, ",") {
+		seg = strings.TrimSpace(seg)
+		if seg == "" {
+			continue
+		}
+		parts := strings.SplitN(seg, "=", 2)
+		if len(parts) != 2 || parts[0] == "" {
+			return nil, structs.ErrBadRequest("invalid entry %q, use format key=value", seg)
+		}
+		out[parts[0]] = parts[1]
+	}
+	return out, nil
+}
+
+func parseRunNodeAffinity(csv string) ([]ac.PreferredSchedulingTerm, error) {
+	var terms []ac.PreferredSchedulingTerm
+	for _, seg := range strings.Split(csv, ",") {
+		seg = strings.TrimSpace(seg)
+		if seg == "" {
+			continue
+		}
+		weight := 100
+		kv := seg
+		if i := strings.Index(seg, ":"); i >= 0 {
+			kv = seg[:i]
+			w, err := strconv.Atoi(seg[i+1:])
+			if err != nil || w < 1 || w > 100 {
+				return nil, structs.ErrBadRequest("invalid node-affinity weight in %q, must be an integer 1-100", seg)
+			}
+			weight = w
+		}
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return nil, structs.ErrBadRequest("invalid node-affinity entry %q, use format key=value[:weight]", seg)
+		}
+		key, value := parts[0], parts[1]
+		if msgs := content.IsLabelKey(key); len(msgs) > 0 {
+			return nil, structs.ErrBadRequest("invalid node-affinity key %q: %s", key, strings.Join(msgs, "; "))
+		}
+		if msgs := content.IsLabelValue(value); len(msgs) > 0 {
+			return nil, structs.ErrBadRequest("invalid node-affinity value %q: %s", value, strings.Join(msgs, "; "))
+		}
+		terms = append(terms, ac.PreferredSchedulingTerm{
+			Weight: int32(weight), //nolint:gosec // weight range-checked to [1,100]
+			Preference: ac.NodeSelectorTerm{
+				MatchExpressions: []ac.NodeSelectorRequirement{
+					{Key: key, Operator: ac.NodeSelectorOpIn, Values: []string{value}},
+				},
+			},
+		})
+	}
+	return terms, nil
+}
+
+func parseRunTolerations(csv string) ([]ac.Toleration, error) {
+	validEffects := map[string]bool{"NoSchedule": true, "PreferNoSchedule": true, "NoExecute": true}
+	var tols []ac.Toleration
+	for _, seg := range strings.Split(csv, ",") {
+		seg = strings.TrimSpace(seg)
+		if seg == "" {
+			continue
+		}
+		left := seg
+		effect := ""
+		if colon := strings.SplitN(seg, ":", 2); len(colon) == 2 {
+			left = colon[0]
+			effect = colon[1]
+		}
+		if effect != "" && !validEffects[effect] {
+			return nil, structs.ErrBadRequest("invalid toleration effect %q (must be NoSchedule, PreferNoSchedule, or NoExecute)", effect)
+		}
+		key := left
+		value := ""
+		hasValue := false
+		if eq := strings.SplitN(left, "=", 2); len(eq) == 2 {
+			key, value, hasValue = eq[0], eq[1], true
+		}
+		if key == "" {
+			return nil, structs.ErrBadRequest("invalid toleration entry %q, key must not be empty", seg)
+		}
+		if hasValue && value == "" {
+			return nil, structs.ErrBadRequest("invalid toleration entry %q, value must not be empty after '='", seg)
+		}
+		if msgs := content.IsLabelKey(key); len(msgs) > 0 {
+			return nil, structs.ErrBadRequest("invalid toleration key %q: %s", key, strings.Join(msgs, "; "))
+		}
+		t := ac.Toleration{Key: key, Effect: ac.TaintEffect(effect)}
+		if hasValue {
+			if msgs := content.IsLabelValue(value); len(msgs) > 0 {
+				return nil, structs.ErrBadRequest("invalid toleration value %q: %s", value, strings.Join(msgs, "; "))
+			}
+			t.Operator = ac.TolerationOpEqual
+			t.Value = value
+		} else {
+			t.Operator = ac.TolerationOpExists
+		}
+		tols = append(tols, t)
+	}
+	return tols, nil
 }
 
 func (p *Provider) podSpecFromRunOptions(app, service, ns string, opts structs.ProcessRunOptions) (*ac.PodSpec, error) { //nolint:gocritic // by-value opts matches ProcessRun and sibling helpers
@@ -891,6 +1045,80 @@ func (p *Provider) podSpecFromRunOptions(app, service, ns string, opts structs.P
 				Effect:   ac.TaintEffectNoSchedule,
 			})
 		}
+	}
+
+	if opts.NodeAffinity != nil {
+		terms, err := parseRunNodeAffinity(*opts.NodeAffinity)
+		if err != nil {
+			return nil, err
+		}
+		if len(terms) > 0 {
+			if s.Affinity == nil {
+				s.Affinity = &ac.Affinity{}
+			}
+			if s.Affinity.NodeAffinity == nil {
+				s.Affinity.NodeAffinity = &ac.NodeAffinity{}
+			}
+			s.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(
+				s.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution, terms...)
+		}
+	}
+
+	if opts.Tolerations != nil {
+		tols, err := parseRunTolerations(*opts.Tolerations)
+		if err != nil {
+			return nil, err
+		}
+		s.Tolerations = append(s.Tolerations, tols...)
+	}
+
+	if opts.UseServiceLifecycle != nil && *opts.UseServiceLifecycle {
+		release := common.DefaultString(opts.Release, "")
+		if release == "" {
+			a, err := p.AppGet(app)
+			if err != nil {
+				return nil, errors.WithStack(err)
+			}
+			release = a.Release
+		}
+
+		m, _, err := common.ReleaseManifest(p, app, release)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+
+		svc, err := m.Service(service)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+
+		if svc.Lifecycle.PostStart != "" || svc.Lifecycle.PreStop != "" {
+			s.Containers[0].Lifecycle = &ac.Lifecycle{}
+
+			if svc.Lifecycle.PostStart != "" {
+				cmd, err := shellquote.Split(svc.Lifecycle.PostStart)
+				if err != nil {
+					return nil, errors.WithStack(err)
+				}
+				s.Containers[0].Lifecycle.PostStart = &ac.LifecycleHandler{Exec: &ac.ExecAction{Command: cmd}}
+			}
+
+			if svc.Lifecycle.PreStop != "" {
+				cmd, err := shellquote.Split(svc.Lifecycle.PreStop)
+				if err != nil {
+					return nil, errors.WithStack(err)
+				}
+				s.Containers[0].Lifecycle.PreStop = &ac.LifecycleHandler{Exec: &ac.ExecAction{Command: cmd}}
+			}
+		}
+	}
+
+	if opts.TerminationGrace != nil {
+		if *opts.TerminationGrace < 0 {
+			return nil, structs.ErrBadRequest("termination-grace must be a non-negative integer")
+		}
+		g := int64(*opts.TerminationGrace)
+		s.TerminationGracePeriodSeconds = &g
 	}
 
 	if p.hasDockerHubAuth() {

--- a/provider/k8s/process_run_flags_test.go
+++ b/provider/k8s/process_run_flags_test.go
@@ -1,0 +1,371 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	"github.com/convox/convox/pkg/options"
+	"github.com/convox/convox/pkg/structs"
+	"github.com/stretchr/testify/require"
+	ac "k8s.io/api/core/v1"
+	am "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const manifestRunFlags = `services:
+  web:
+    build: .
+    termination:
+      grace: 300
+  plain:
+    build: .
+  hooks:
+    build: .
+    lifecycle:
+      postStart: /bin/poststart.sh arg
+      preStop: /bin/prestop.sh
+  onehook:
+    build: .
+    lifecycle:
+      postStart: echo hi
+  sel:
+    build: .
+    nodeSelectorLabels:
+      team: ml
+`
+
+func runFlagsProvider(t *testing.T) (*Provider, *fake.Clientset) {
+	t.Helper()
+	p, kk, kc := minimalProvider(t)
+	createAppNamespace(t, kk, "rack1", "app1")
+	createBuild(t, kc, "rack1-app1", "build1")
+	createRelease(t, kc, "rack1-app1", "rel1", manifestRunFlags)
+	return p, kk
+}
+
+func runAndGetPod(t *testing.T, p *Provider, kk *fake.Clientset, app, service string, opts structs.ProcessRunOptions) *ac.Pod { //nolint:gocritic // hugeParam: mirrors runAndGetPodSpec and ProcessRun by-value opts
+	t.Helper()
+	ps, err := p.ProcessRun(app, service, opts)
+	require.NoError(t, err)
+	require.NotNil(t, ps)
+
+	pod, err := kk.CoreV1().Pods(p.AppNamespace(app)).Get(context.TODO(), ps.Id, am.GetOptions{})
+	require.NoError(t, err)
+	return pod
+}
+
+func TestProcessRun_GraceCarryover(t *testing.T) {
+	p, kk := runFlagsProvider(t)
+	spec := runAndGetPod(t, p, kk, "app1", "web", structs.ProcessRunOptions{Release: options.String("rel1")}).Spec
+	require.NotNil(t, spec.TerminationGracePeriodSeconds)
+	require.Equal(t, int64(300), *spec.TerminationGracePeriodSeconds)
+}
+
+func TestProcessRun_GraceDefaultThirty(t *testing.T) {
+	p, kk := runFlagsProvider(t)
+	spec := runAndGetPod(t, p, kk, "app1", "plain", structs.ProcessRunOptions{Release: options.String("rel1")}).Spec
+	require.NotNil(t, spec.TerminationGracePeriodSeconds)
+	require.Equal(t, int64(30), *spec.TerminationGracePeriodSeconds)
+}
+
+func TestProcessRun_GraceOverrideBeatsManifest(t *testing.T) {
+	p, kk := runFlagsProvider(t)
+	spec := runAndGetPod(t, p, kk, "app1", "web", structs.ProcessRunOptions{
+		Release:          options.String("rel1"),
+		TerminationGrace: options.Int(900),
+	}).Spec
+	require.NotNil(t, spec.TerminationGracePeriodSeconds)
+	require.Equal(t, int64(900), *spec.TerminationGracePeriodSeconds)
+}
+
+func TestProcessRun_GraceZeroOverride(t *testing.T) {
+	p, kk := runFlagsProvider(t)
+	spec := runAndGetPod(t, p, kk, "app1", "web", structs.ProcessRunOptions{
+		Release:          options.String("rel1"),
+		TerminationGrace: options.Int(0),
+	}).Spec
+	require.NotNil(t, spec.TerminationGracePeriodSeconds)
+	require.Equal(t, int64(0), *spec.TerminationGracePeriodSeconds)
+}
+
+func TestProcessRun_GraceNegativeRejected(t *testing.T) {
+	p, _ := runFlagsProvider(t)
+	_, err := p.ProcessRun("app1", "web", structs.ProcessRunOptions{
+		Release:          options.String("rel1"),
+		TerminationGrace: options.Int(-1),
+	})
+	require.Error(t, err)
+}
+
+func TestProcessRun_BuildPodGraceNil(t *testing.T) {
+	p, kk := runFlagsProvider(t)
+	spec := runAndGetPod(t, p, kk, "app1", "web", structs.ProcessRunOptions{
+		Release: options.String("rel1"),
+		IsBuild: true,
+	}).Spec
+	require.Nil(t, spec.TerminationGracePeriodSeconds, "build pods must keep the k8s default (nil), never be force-set to 0")
+}
+
+func TestProcessRun_Annotations(t *testing.T) {
+	p, kk := runFlagsProvider(t)
+	pod := runAndGetPod(t, p, kk, "app1", "plain", structs.ProcessRunOptions{
+		Release:     options.String("rel1"),
+		Annotations: options.String("team=infra,karpenter.sh/do-not-disrupt=true"),
+	})
+	require.Equal(t, "infra", pod.Annotations["team"])
+	require.Equal(t, "true", pod.Annotations["karpenter.sh/do-not-disrupt"])
+}
+
+func TestProcessRun_AnnotationsMalformedKeyRejected(t *testing.T) {
+	p, _ := runFlagsProvider(t)
+	_, err := p.ProcessRun("app1", "plain", structs.ProcessRunOptions{
+		Release:     options.String("rel1"),
+		Annotations: options.String("bad key=v"),
+	})
+	require.Error(t, err)
+}
+
+func TestProcessRun_AnnotationsNoEqualsRejected(t *testing.T) {
+	p, _ := runFlagsProvider(t)
+	_, err := p.ProcessRun("app1", "plain", structs.ProcessRunOptions{
+		Release:     options.String("rel1"),
+		Annotations: options.String("novalue"),
+	})
+	require.Error(t, err)
+}
+
+func TestProcessRun_AnnotationsEmptyNoOp(t *testing.T) {
+	p, kk := runFlagsProvider(t)
+	pod := runAndGetPod(t, p, kk, "app1", "plain", structs.ProcessRunOptions{
+		Release:     options.String("rel1"),
+		Annotations: options.String(""),
+	})
+	_, hasTeam := pod.Annotations["team"]
+	require.False(t, hasTeam)
+}
+
+func TestProcessRun_AnnotationsTrailingComma(t *testing.T) {
+	p, kk := runFlagsProvider(t)
+	pod := runAndGetPod(t, p, kk, "app1", "plain", structs.ProcessRunOptions{
+		Release:     options.String("rel1"),
+		Annotations: options.String("a=b,"),
+	})
+	require.Equal(t, "b", pod.Annotations["a"])
+}
+
+func TestProcessRun_AnnotationValueNotLabelValidated(t *testing.T) {
+	p, kk := runFlagsProvider(t)
+	pod := runAndGetPod(t, p, kk, "app1", "plain", structs.ProcessRunOptions{
+		Release:     options.String("rel1"),
+		Annotations: options.String("team=infra/prod team"),
+	})
+	require.Equal(t, "infra/prod team", pod.Annotations["team"])
+}
+
+func TestProcessRun_Labels(t *testing.T) {
+	p, kk := runFlagsProvider(t)
+	pod := runAndGetPod(t, p, kk, "app1", "plain", structs.ProcessRunOptions{
+		Release: options.String("rel1"),
+		Labels:  options.String("purpose=batch"),
+	})
+	require.Equal(t, "batch", pod.Labels["purpose"])
+	require.Equal(t, "app1", pod.Labels["app"])
+}
+
+func TestProcessRun_LabelsReservedRejected(t *testing.T) {
+	p, _ := runFlagsProvider(t)
+	for _, k := range []string{"app", "rack", "service", "system", "type", "name", "release", "service-type"} {
+		_, err := p.ProcessRun("app1", "plain", structs.ProcessRunOptions{
+			Release: options.String("rel1"),
+			Labels:  options.String(k + "=evil"),
+		})
+		require.Error(t, err, "reserved label %q must be rejected", k)
+	}
+}
+
+func TestProcessRun_LabelsInvalidValueRejected(t *testing.T) {
+	p, _ := runFlagsProvider(t)
+	_, err := p.ProcessRun("app1", "plain", structs.ProcessRunOptions{
+		Release: options.String("rel1"),
+		Labels:  options.String("purpose=has space"),
+	})
+	require.Error(t, err)
+}
+
+func TestProcessRun_LifecycleBothHooks(t *testing.T) {
+	p, kk := runFlagsProvider(t)
+	c := runAndGetPod(t, p, kk, "app1", "hooks", structs.ProcessRunOptions{
+		Release:             options.String("rel1"),
+		UseServiceLifecycle: options.Bool(true),
+	}).Spec.Containers[0]
+	require.NotNil(t, c.Lifecycle)
+	require.NotNil(t, c.Lifecycle.PostStart)
+	require.Equal(t, []string{"/bin/poststart.sh", "arg"}, c.Lifecycle.PostStart.Exec.Command)
+	require.NotNil(t, c.Lifecycle.PreStop)
+	require.Equal(t, []string{"/bin/prestop.sh"}, c.Lifecycle.PreStop.Exec.Command)
+}
+
+func TestProcessRun_LifecycleOneHook(t *testing.T) {
+	p, kk := runFlagsProvider(t)
+	c := runAndGetPod(t, p, kk, "app1", "onehook", structs.ProcessRunOptions{
+		Release:             options.String("rel1"),
+		UseServiceLifecycle: options.Bool(true),
+	}).Spec.Containers[0]
+	require.NotNil(t, c.Lifecycle)
+	require.NotNil(t, c.Lifecycle.PostStart)
+	require.Nil(t, c.Lifecycle.PreStop)
+}
+
+func TestProcessRun_LifecycleNoHooksNoOp(t *testing.T) {
+	p, kk := runFlagsProvider(t)
+	c := runAndGetPod(t, p, kk, "app1", "plain", structs.ProcessRunOptions{
+		Release:             options.String("rel1"),
+		UseServiceLifecycle: options.Bool(true),
+	}).Spec.Containers[0]
+	require.Nil(t, c.Lifecycle)
+}
+
+func TestProcessRun_LifecycleWithoutReleasePinsCurrent(t *testing.T) {
+	p, kk := runFlagsProvider(t)
+	c := runAndGetPod(t, p, kk, "app1", "hooks", structs.ProcessRunOptions{
+		UseServiceLifecycle: options.Bool(true),
+	}).Spec.Containers[0]
+	require.NotNil(t, c.Lifecycle)
+	require.NotNil(t, c.Lifecycle.PostStart)
+}
+
+func TestProcessRun_NodeAffinity(t *testing.T) {
+	p, kk := runFlagsProvider(t)
+	spec := runAndGetPod(t, p, kk, "app1", "plain", structs.ProcessRunOptions{
+		Release:      options.String("rel1"),
+		NodeAffinity: options.String("gpu=v:80"),
+	}).Spec
+	require.NotNil(t, spec.Affinity)
+	require.NotNil(t, spec.Affinity.NodeAffinity)
+	pref := spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	require.Len(t, pref, 1)
+	require.Equal(t, int32(80), pref[0].Weight)
+	require.Equal(t, "gpu", pref[0].Preference.MatchExpressions[0].Key)
+	require.Equal(t, ac.NodeSelectorOpIn, pref[0].Preference.MatchExpressions[0].Operator)
+	require.Equal(t, []string{"v"}, pref[0].Preference.MatchExpressions[0].Values)
+}
+
+func TestProcessRun_NodeAffinityDefaultWeight(t *testing.T) {
+	p, kk := runFlagsProvider(t)
+	spec := runAndGetPod(t, p, kk, "app1", "plain", structs.ProcessRunOptions{
+		Release:      options.String("rel1"),
+		NodeAffinity: options.String("gpu=v"),
+	}).Spec
+	pref := spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	require.Len(t, pref, 1)
+	require.Equal(t, int32(100), pref[0].Weight)
+}
+
+func TestProcessRun_NodeAffinitySameKeyTwoTerms(t *testing.T) {
+	p, kk := runFlagsProvider(t)
+	spec := runAndGetPod(t, p, kk, "app1", "plain", structs.ProcessRunOptions{
+		Release:      options.String("rel1"),
+		NodeAffinity: options.String("zone=east:80,zone=west:50"),
+	}).Spec
+	pref := spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+	require.Len(t, pref, 2)
+}
+
+func TestProcessRun_NodeAffinityRejects(t *testing.T) {
+	p, _ := runFlagsProvider(t)
+	for _, bad := range []string{"gpu:80", "gpu=", "gpu=v:0", "gpu=v:101", "gpu=v:abc", "gpu=v:80:90", "bad key=v"} {
+		_, err := p.ProcessRun("app1", "plain", structs.ProcessRunOptions{
+			Release:      options.String("rel1"),
+			NodeAffinity: options.String(bad),
+		})
+		require.Error(t, err, "node-affinity %q must be rejected", bad)
+	}
+}
+
+func TestProcessRun_NodeAffinityAppendsToInheritedRequired(t *testing.T) {
+	p, kk := runFlagsProvider(t)
+	spec := runAndGetPod(t, p, kk, "app1", "sel", structs.ProcessRunOptions{
+		Release:      options.String("rel1"),
+		NodeAffinity: options.String("gpu=v:80"),
+	}).Spec
+	require.NotNil(t, spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
+	require.Len(t, spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution, 1)
+}
+
+func TestProcessRun_Tolerations(t *testing.T) {
+	p, kk := runFlagsProvider(t)
+	spec := runAndGetPod(t, p, kk, "app1", "plain", structs.ProcessRunOptions{
+		Release:     options.String("rel1"),
+		Tolerations: options.String("k1=v:NoSchedule,k2:NoExecute,k3"),
+	}).Spec
+	require.Len(t, spec.Tolerations, 3)
+
+	require.Equal(t, "k1", spec.Tolerations[0].Key)
+	require.Equal(t, ac.TolerationOpEqual, spec.Tolerations[0].Operator)
+	require.Equal(t, "v", spec.Tolerations[0].Value)
+	require.Equal(t, ac.TaintEffectNoSchedule, spec.Tolerations[0].Effect)
+
+	require.Equal(t, "k2", spec.Tolerations[1].Key)
+	require.Equal(t, ac.TolerationOpExists, spec.Tolerations[1].Operator)
+	require.Equal(t, "", spec.Tolerations[1].Value)
+	require.Equal(t, ac.TaintEffectNoExecute, spec.Tolerations[1].Effect)
+
+	require.Equal(t, "k3", spec.Tolerations[2].Key)
+	require.Equal(t, ac.TolerationOpExists, spec.Tolerations[2].Operator)
+	require.Equal(t, ac.TaintEffect(""), spec.Tolerations[2].Effect)
+}
+
+func TestProcessRun_TolerationsMultiSameKey(t *testing.T) {
+	p, kk := runFlagsProvider(t)
+	spec := runAndGetPod(t, p, kk, "app1", "plain", structs.ProcessRunOptions{
+		Release:     options.String("rel1"),
+		Tolerations: options.String("k:NoSchedule,k:NoExecute"),
+	}).Spec
+	require.Len(t, spec.Tolerations, 2)
+	require.Equal(t, ac.TaintEffectNoSchedule, spec.Tolerations[0].Effect)
+	require.Equal(t, ac.TaintEffectNoExecute, spec.Tolerations[1].Effect)
+}
+
+func TestProcessRun_TolerationsEmptySegmentNoWildcard(t *testing.T) {
+	p, kk := runFlagsProvider(t)
+	spec := runAndGetPod(t, p, kk, "app1", "plain", structs.ProcessRunOptions{
+		Release:     options.String("rel1"),
+		Tolerations: options.String("k:NoSchedule,"),
+	}).Spec
+	require.Len(t, spec.Tolerations, 1)
+	require.Equal(t, "k", spec.Tolerations[0].Key)
+}
+
+func TestProcessRun_TolerationsRejects(t *testing.T) {
+	p, _ := runFlagsProvider(t)
+	for _, bad := range []string{"k=:NoSchedule", "=v:NoSchedule", "k:BadEffect", "bad key:NoSchedule"} {
+		_, err := p.ProcessRun("app1", "plain", structs.ProcessRunOptions{
+			Release:     options.String("rel1"),
+			Tolerations: options.String(bad),
+		})
+		require.Error(t, err, "toleration %q must be rejected", bad)
+	}
+}
+
+func TestProcessRun_OrderingWithNodeLabels(t *testing.T) {
+	p, kk := runFlagsProvider(t)
+	spec := runAndGetPod(t, p, kk, "app1", "sel", structs.ProcessRunOptions{
+		Release:      options.String("rel1"),
+		NodeLabels:   options.String("custom-pool=debug"),
+		NodeAffinity: options.String("gpu=v:80"),
+		Tolerations:  options.String("t=1:NoSchedule"),
+	}).Spec
+
+	require.Equal(t, map[string]string{"custom-pool": "debug"}, spec.NodeSelector)
+
+	require.NotNil(t, spec.Affinity, "node-affinity must survive the --node-labels reset")
+	require.Len(t, spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution, 1)
+
+	var found bool
+	for _, tol := range spec.Tolerations {
+		if tol.Key == "t" {
+			found = true
+		}
+	}
+	require.True(t, found, "user toleration must survive the --node-labels reset")
+}

--- a/provider/k8s/template/app/timer.yml.tmpl
+++ b/provider/k8s/template/app/timer.yml.tmpl
@@ -136,6 +136,7 @@ spec:
           - name: {{ . }}
           {{ end }}
           {{ end }}
+          terminationGracePeriodSeconds: {{$.Service.Termination.Grace}}
           restartPolicy: Never
           shareProcessNamespace: {{.Service.Init}}
           serviceAccountName: timer-{{.Timer.Name}}

--- a/provider/k8s/template_test.go
+++ b/provider/k8s/template_test.go
@@ -515,6 +515,38 @@ timers:
 	}
 }
 
+func TestRenderTimerTerminationGrace(t *testing.T) {
+	set := `services:
+  worker:
+    build: .
+    termination:
+      grace: 300
+timers:
+  nightly:
+    schedule: "0 0 * * ? *"
+    command: "echo hi"
+    service: worker
+`
+	p, params := gpuTemplateFixture(t, set)
+	data, err := p.RenderTemplate("app/timer", params)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "terminationGracePeriodSeconds: 300")
+
+	unset := `services:
+  worker:
+    build: .
+timers:
+  nightly:
+    schedule: "0 0 * * ? *"
+    command: "echo hi"
+    service: worker
+`
+	p, params = gpuTemplateFixture(t, unset)
+	data, err = p.RenderTemplate("app/timer", params)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "terminationGracePeriodSeconds: 30")
+}
+
 func TestRenderServiceEmptyDirSizeLimit(t *testing.T) {
 	src := `services:
   web:


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: New `convox run` Flags with Termination Grace Support**

`convox run` now supports six new optional flags that customize the one-off process pod for a single invocation: a termination grace override, custom pod annotations and labels, reuse of the service's lifecycle hooks, preferred node affinity, and tolerations. All six are opt-in, and runs that do not pass them behave exactly as before.

In addition, run pods and timer pods now honor the service's `termination.grace` setting from `convox.yml`, matching the behavior that regular service deployments already have. A service that does not set `termination.grace` is unchanged, since the manifest default of `30` seconds equals the Kubernetes default. Build pods are unaffected.

---

### Why is this important?

One-off processes such as migrations, backfills, and maintenance jobs often need different pod settings than the service they are based on. These flags provide that control per invocation, with no changes to `convox.yml` and no effect on the deployed service.

**Benefits:**

- **Per-run pod customization.** Annotations, labels, and scheduling preferences can be applied to a single run without modifying the app manifest or redeploying.
- **Consistent graceful teardown.** Services that set `termination.grace` now get that grace period on run and timer pods as well as deployments, and `--termination-grace` adjusts it for a single run when a job needs more (or less) time to finish cleanup.
- **Node placement control.** `--node-affinity` and `--tolerations` let a run prefer specific node pools or schedule onto tainted nodes, which is useful for batch jobs on dedicated capacity.
- **Interruption protection on Karpenter racks.** Passing `--annotations karpenter.sh/do-not-disrupt=true` keeps the run pod's node from being voluntarily consolidated until the process finishes.
- **Lifecycle hook parity.** `--use-service-lifecycle` copies the service's `lifecycle.postStart` and `preStop` hooks onto the run container so one-off processes can perform the same setup and teardown as their parent service.

---

### How to use it?

Give a long-running migration extra teardown time and protect it from node consolidation:

    $ convox run -a my-app -r my-rack --termination-grace 900 --annotations karpenter.sh/do-not-disrupt=true web bin/migrate

Run a batch job that prefers a dedicated node pool and tolerates its taint, with a label for later identification:

    $ convox run -a my-app -r my-rack --node-affinity workload=batch:80 --tolerations dedicated=batch:NoSchedule --labels purpose=batch web bin/backfill

Run a one-off process with the service's lifecycle hooks applied:

    $ convox run -a my-app -r my-rack --use-service-lifecycle web bin/task

To set a default grace period for a service (applied to its deployment, timer pods, and run pods), use the `termination.grace` field in `convox.yml`:

    services:
      web:
        build: .
        termination:
          grace: 300

#### New `convox run` Flags

| Flag | Default | Description |
|------|---------|-------------|
| `--termination-grace` | Service `termination.grace` (`30` if unset) | Sets the pod's `terminationGracePeriodSeconds` for this run. Must be `0` or greater. |
| `--annotations` | None | Adds pod annotations as comma-separated `key=value` pairs. Annotation keys already set by Convox are left unchanged. |
| `--labels` | None | Adds pod labels as comma-separated `key=value` pairs. Convox-reserved keys (`app`, `rack`, `service`, `system`, `type`, `name`, `release`, `service-type`) are rejected. |
| `--use-service-lifecycle` | `false` | Copies the service's `lifecycle.postStart` and `preStop` hooks from `convox.yml` onto the run container. |
| `--node-affinity` | None | Adds preferred node affinity terms as comma-separated `key=value:weight` entries. Weight is optional, must be between `1` and `100`, and defaults to `100`. |
| `--tolerations` | None | Adds pod tolerations as comma-separated entries in `key=value:Effect`, `key:Effect`, or bare `key` form. Valid effects are `NoSchedule`, `PreferNoSchedule`, and `NoExecute`. |

Input is validated on the rack, and malformed entries return a clear error before any pod is created. When `--node-labels` is also passed, it continues to reset service-inherited affinity and tolerations first, and entries from `--node-affinity` and `--tolerations` are applied after that reset.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this feature.

All six flags are optional additions to the existing `convox run` command, and existing flags, defaults, and output are unchanged. Runs that do not pass the new flags produce the same pods as before. The `termination.grace` carry-over only affects services that explicitly set the field, since the default of `30` seconds matches the Kubernetes default that run and timer pods were already receiving. Behavior is uniform across all providers.

---

### Requirements

This feature requires version `3.25.1` or later for the rack. When the new flags are used against a rack on an older version, they are ignored, so make sure the rack is updated before relying on them.

**Update the Rack:** Run `convox rack update 3.25.1 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
