### PR TITLE
guard builds against dropping running-release env

### DIFF
--- a/pkg/cli/builds.go
+++ b/pkg/cli/builds.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -77,7 +78,7 @@ func resolveSrcCredsPass(c *stdcli.Context) (*string, error) {
 
 func init() {
 	register("build", "create a build", Build, stdcli.CommandOptions{
-		Flags:    append(stdcli.OptionFlags(structs.BuildCreateOptions{}), flagRack, flagApp, flagId),
+		Flags:    append(stdcli.OptionFlags(structs.BuildCreateOptions{}), flagRack, flagApp, flagId, flagForce),
 		Usage:    "[dir]",
 		Validate: stdcli.ArgsMax(1),
 	}, WithCloud())
@@ -157,7 +158,70 @@ func Build(rack sdk.Interface, c *stdcli.Context) error {
 	return nil
 }
 
+// checkPendingEnvDrop stops a build whose newest release drops env vars still
+// set in the running release (the env-unset-without-promote trap that surfaces
+// as a confusing "required env" failure). Fail-open; --force overrides.
+func checkPendingEnvDrop(rack sdk.Interface, c *stdcli.Context, appName string) error {
+	a, _ := rack.AppGet(appName)
+	if a == nil || a.Release == "" {
+		return nil
+	}
+
+	rs, _ := rack.ReleaseList(appName, structs.ReleaseListOptions{Limit: options.Int(1)})
+	if len(rs) == 0 {
+		return nil
+	}
+
+	newest := rs[0]
+	if newest.Id == a.Release {
+		return nil
+	}
+
+	// A running release newer than the listed newest means the release cache
+	// is lagging; skip rather than compare against stale data.
+	runningRel, _ := rack.ReleaseGet(appName, a.Release)
+	if runningRel == nil || runningRel.Created.After(newest.Created) {
+		return nil
+	}
+
+	runningEnv := structs.Environment{}
+	_ = runningEnv.Load([]byte(runningRel.Env))
+
+	newestEnv := structs.Environment{}
+	if err := newestEnv.Load([]byte(newest.Env)); err != nil {
+		return nil //nolint:nilerr // fail-open: an unparseable newest env must not block the build
+	}
+
+	dropped := []string{}
+	for k := range runningEnv {
+		if _, ok := newestEnv[k]; !ok {
+			dropped = append(dropped, k)
+		}
+	}
+	if len(dropped) == 0 {
+		return nil
+	}
+	sort.Strings(dropped)
+
+	if !c.Bool("force") {
+		return fmt.Errorf("this build will drop env var(s) that are set in your running release %s: %s\n\n"+
+			"These vars are present in the running release (%s) but missing from the latest release (%s), which is what a new build inherits from. This usually happens after `convox env set` or `convox env unset` without --promote.\n\n"+
+			"To keep them, set them again with --promote before deploying, for example:\n"+
+			"    convox env set %s=... --promote\n\n"+
+			"If you meant to drop these vars, or you believe this is a false alarm, re-run with --force",
+			a.Release, strings.Join(dropped, ", "), a.Release, newest.Id, dropped[0])
+	}
+
+	fmt.Fprintf(c.Writer().Stderr, "WARNING: proceeding with --force; this build drops env var(s) set in the running release: %s\n", strings.Join(dropped, ", "))
+
+	return nil
+}
+
 func build(rack sdk.Interface, c *stdcli.Context, development bool) (*structs.Build, error) {
+	if err := checkPendingEnvDrop(rack, c, app(c)); err != nil {
+		return nil, err
+	}
+
 	var opts structs.BuildCreateOptions
 
 	if development {

--- a/pkg/cli/builds_test.go
+++ b/pkg/cli/builds_test.go
@@ -19,6 +19,8 @@ import (
 
 func TestBuild(t *testing.T) {
 	testClientWait(t, 50*time.Millisecond, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("AppGet", "app1").Return(fxApp(), nil).Once()
+		i.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{*fxRelease()}, nil).Once()
 		i.On("SystemGet").Return(fxSystem(), nil)
 		i.On("ObjectStore", "app1", mock.AnythingOfType("string"), mock.Anything, structs.ObjectStoreOptions{}).Return(&fxObject, nil).Run(func(args mock.Arguments) {
 			require.Regexp(t, `tmp/[0-9a-f]{30}\.tgz`, args.Get(1).(string))
@@ -49,6 +51,8 @@ func TestBuild(t *testing.T) {
 func TestBuildFinalizeLogs(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
 		// i.On("ClientType").Return("standard")
+		i.On("AppGet", "app1").Return(fxApp(), nil).Once()
+		i.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{*fxRelease()}, nil).Once()
 		i.On("SystemGet").Return(fxSystem(), nil)
 		i.On("ObjectStore", "app1", mock.AnythingOfType("string"), mock.Anything, structs.ObjectStoreOptions{}).Return(&fxObject, nil).Run(func(args mock.Arguments) {
 			require.Regexp(t, `tmp/[0-9a-f]{30}\.tgz`, args.Get(1).(string))
@@ -80,6 +84,8 @@ func TestBuildFinalizeLogs(t *testing.T) {
 func TestBuildError(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
 		// i.On("ClientType").Return("standard")
+		i.On("AppGet", "app1").Return(fxApp(), nil).Once()
+		i.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{*fxRelease()}, nil).Once()
 		i.On("SystemGet").Return(fxSystem(), nil)
 		i.On("ObjectStore", "app1", mock.AnythingOfType("string"), mock.Anything, structs.ObjectStoreOptions{}).Return(&fxObject, nil).Run(func(args mock.Arguments) {
 			require.Regexp(t, `tmp/[0-9a-f]{30}\.tgz`, args.Get(1).(string))
@@ -101,6 +107,8 @@ func TestBuildError(t *testing.T) {
 func TestBuildClassic(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
 		// i.On("ClientType").Return("standard")
+		i.On("AppGet", "app1").Return(fxApp(), nil).Once()
+		i.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{*fxRelease()}, nil).Once()
 		i.On("SystemGet").Return(fxSystemClassic(), nil)
 		i.On("BuildCreateUpload", "app1", mock.Anything, structs.BuildCreateOptions{Description: options.String("foo")}).Return(fxBuild(), nil)
 		i.On("BuildLogs", "app1", "build1", structs.LogsOptions{}).Return(testLogs(fxLogs()), nil)
@@ -120,6 +128,104 @@ func TestBuildClassic(t *testing.T) {
 			"Build:   build1",
 			"Release: release1",
 		})
+	})
+}
+
+func TestBuildEnvDropBlocked(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("AppGet", "app1").Return(&structs.App{Name: "app1", Release: "release1", Status: "running", Generation: "2"}, nil)
+		i.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{{Id: "release2", App: "app1", Env: "FOO=bar", Created: fxStarted.Add(time.Hour)}}, nil)
+		i.On("ReleaseGet", "app1", "release1").Return(&structs.Release{Id: "release1", App: "app1", Env: "SECRET_KEY=abc\nFOO=bar", Created: fxStarted}, nil)
+
+		res, err := testExecute(e, "build ./testdata/httpd -a app1 -d foo", nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, res.Code)
+		require.Contains(t, res.Stderr, "this build will drop env var(s) that are set in your running release release1: SECRET_KEY")
+		require.Contains(t, res.Stderr, "re-run with --force")
+		i.AssertNotCalled(t, "BuildCreate", mock.Anything, mock.Anything, mock.Anything)
+	})
+}
+
+func TestBuildEnvDropForce(t *testing.T) {
+	testClientWait(t, 50*time.Millisecond, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("AppGet", "app1").Return(&structs.App{Name: "app1", Release: "release1", Status: "running", Generation: "2"}, nil)
+		i.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{{Id: "release2", App: "app1", Env: "FOO=bar", Created: fxStarted.Add(time.Hour)}}, nil)
+		i.On("ReleaseGet", "app1", "release1").Return(&structs.Release{Id: "release1", App: "app1", Env: "SECRET_KEY=abc\nFOO=bar", Created: fxStarted}, nil)
+		i.On("SystemGet").Return(fxSystem(), nil)
+		i.On("ObjectStore", "app1", mock.AnythingOfType("string"), mock.Anything, structs.ObjectStoreOptions{}).Return(&fxObject, nil)
+		i.On("BuildCreate", "app1", "object://test", structs.BuildCreateOptions{Description: options.String("foo")}).Return(fxBuild(), nil)
+		i.On("BuildLogs", "app1", "build1", structs.LogsOptions{}).Return(testLogs(fxLogs()), nil)
+		i.On("BuildGet", "app1", "build1").Return(fxBuildRunning(), nil).Once()
+		i.On("BuildGet", "app1", "build1").Return(fxBuild(), nil)
+		i.On("BuildGet", "app1", "build4").Return(fxBuild(), nil)
+
+		res, err := testExecute(e, "build ./testdata/httpd -a app1 -d foo --force", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		require.Contains(t, res.Stderr, "WARNING: proceeding with --force; this build drops env var(s) set in the running release: SECRET_KEY")
+	})
+}
+
+// diverged newest that only adds/changes vars (drops none) must proceed silently
+func TestBuildEnvDivergeNoDrop(t *testing.T) {
+	testClientWait(t, 50*time.Millisecond, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("AppGet", "app1").Return(&structs.App{Name: "app1", Release: "release1", Status: "running", Generation: "2"}, nil)
+		i.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{{Id: "release2", App: "app1", Env: "FOO=changed\nKEEP=1\nNEW=x", Created: fxStarted.Add(time.Hour)}}, nil)
+		i.On("ReleaseGet", "app1", "release1").Return(&structs.Release{Id: "release1", App: "app1", Env: "FOO=bar\nKEEP=1", Created: fxStarted}, nil)
+		i.On("SystemGet").Return(fxSystem(), nil)
+		i.On("ObjectStore", "app1", mock.AnythingOfType("string"), mock.Anything, structs.ObjectStoreOptions{}).Return(&fxObject, nil)
+		i.On("BuildCreate", "app1", "object://test", structs.BuildCreateOptions{Description: options.String("foo")}).Return(fxBuild(), nil)
+		i.On("BuildLogs", "app1", "build1", structs.LogsOptions{}).Return(testLogs(fxLogs()), nil)
+		i.On("BuildGet", "app1", "build1").Return(fxBuildRunning(), nil).Once()
+		i.On("BuildGet", "app1", "build1").Return(fxBuild(), nil)
+		i.On("BuildGet", "app1", "build4").Return(fxBuild(), nil)
+
+		res, err := testExecute(e, "build ./testdata/httpd -a app1 -d foo", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		require.NotContains(t, res.Stderr, "will drop env var")
+	})
+}
+
+// running release newer than the listed newest (stale release cache) must skip the guard
+func TestBuildEnvStaleListSkips(t *testing.T) {
+	testClientWait(t, 50*time.Millisecond, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("AppGet", "app1").Return(&structs.App{Name: "app1", Release: "release2", Status: "running", Generation: "2"}, nil)
+		i.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{{Id: "release1", App: "app1", Env: "FOO=bar", Created: fxStarted}}, nil)
+		i.On("ReleaseGet", "app1", "release2").Return(&structs.Release{Id: "release2", App: "app1", Env: "FOO=bar\nSECRET_KEY=abc", Created: fxStarted.Add(time.Hour)}, nil)
+		i.On("SystemGet").Return(fxSystem(), nil)
+		i.On("ObjectStore", "app1", mock.AnythingOfType("string"), mock.Anything, structs.ObjectStoreOptions{}).Return(&fxObject, nil)
+		i.On("BuildCreate", "app1", "object://test", structs.BuildCreateOptions{Description: options.String("foo")}).Return(fxBuild(), nil)
+		i.On("BuildLogs", "app1", "build1", structs.LogsOptions{}).Return(testLogs(fxLogs()), nil)
+		i.On("BuildGet", "app1", "build1").Return(fxBuildRunning(), nil).Once()
+		i.On("BuildGet", "app1", "build1").Return(fxBuild(), nil)
+		i.On("BuildGet", "app1", "build4").Return(fxBuild(), nil)
+
+		res, err := testExecute(e, "build ./testdata/httpd -a app1 -d foo", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		require.NotContains(t, res.Stderr, "will drop env var")
+	})
+}
+
+// running-release fetch failure must fail open (proceed), never block
+func TestBuildEnvDropFailOpen(t *testing.T) {
+	testClientWait(t, 50*time.Millisecond, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("AppGet", "app1").Return(&structs.App{Name: "app1", Release: "release1", Status: "running", Generation: "2"}, nil)
+		i.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{{Id: "release2", App: "app1", Env: "FOO=bar", Created: fxStarted.Add(time.Hour)}}, nil)
+		i.On("ReleaseGet", "app1", "release1").Return(nil, fmt.Errorf("boom"))
+		i.On("SystemGet").Return(fxSystem(), nil)
+		i.On("ObjectStore", "app1", mock.AnythingOfType("string"), mock.Anything, structs.ObjectStoreOptions{}).Return(&fxObject, nil)
+		i.On("BuildCreate", "app1", "object://test", structs.BuildCreateOptions{Description: options.String("foo")}).Return(fxBuild(), nil)
+		i.On("BuildLogs", "app1", "build1", structs.LogsOptions{}).Return(testLogs(fxLogs()), nil)
+		i.On("BuildGet", "app1", "build1").Return(fxBuildRunning(), nil).Once()
+		i.On("BuildGet", "app1", "build1").Return(fxBuild(), nil)
+		i.On("BuildGet", "app1", "build4").Return(fxBuild(), nil)
+
+		res, err := testExecute(e, "build ./testdata/httpd -a app1 -d foo", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		require.NotContains(t, res.Stderr, "will drop env var")
 	})
 }
 

--- a/pkg/cli/deploy_test.go
+++ b/pkg/cli/deploy_test.go
@@ -16,6 +16,8 @@ import (
 func TestDeploy(t *testing.T) {
 	testClientWait(t, 100*time.Millisecond, func(e *cli.Engine, i *mocksdk.Interface) {
 		// i.On("ClientType").Return("standard")
+		i.On("AppGet", "app1").Return(fxApp(), nil).Once()
+		i.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{*fxRelease()}, nil).Once()
 		i.On("SystemGet").Return(fxSystem(), nil)
 		i.On("ObjectStore", "app1", mock.AnythingOfType("string"), mock.Anything, structs.ObjectStoreOptions{}).Return(&fxObject, nil).Run(func(args mock.Arguments) {
 			require.Regexp(t, `tmp/[0-9a-f]{30}\.tgz`, args.Get(1).(string))
@@ -55,6 +57,8 @@ func TestDeploy(t *testing.T) {
 func TestDeployError(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
 		// i.On("ClientType").Return("standard")
+		i.On("AppGet", "app1").Return(fxApp(), nil).Once()
+		i.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{*fxRelease()}, nil).Once()
 		i.On("SystemGet").Return(fxSystem(), nil)
 		i.On("ObjectStore", "app1", mock.AnythingOfType("string"), mock.Anything, structs.ObjectStoreOptions{}).Return(&fxObject, nil).Run(func(args mock.Arguments) {
 			require.Regexp(t, `tmp/[0-9a-f]{30}\.tgz`, args.Get(1).(string))

--- a/pkg/cli/test.go
+++ b/pkg/cli/test.go
@@ -16,6 +16,7 @@ func init() {
 		Flags: []stdcli.Flag{
 			flagApp,
 			flagRack,
+			flagForce,
 			stdcli.StringFlag("description", "d", "description"),
 			stdcli.StringFlag("release", "", "use existing release to run tests"),
 			stdcli.IntFlag("timeout", "t", "timeout"),

--- a/pkg/cli/test_test.go
+++ b/pkg/cli/test_test.go
@@ -15,6 +15,8 @@ import (
 
 func TestTest(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("AppGet", "app1").Return(fxApp(), nil).Once()
+		i.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{*fxRelease()}, nil).Once()
 		i.On("SystemGet").Return(fxSystem(), nil)
 		i.On("ObjectStore", "app1", mock.AnythingOfType("string"), mock.Anything, structs.ObjectStoreOptions{}).Return(&fxObject, nil).Run(func(args mock.Arguments) {
 			require.Regexp(t, `tmp/[0-9a-f]{30}\.tgz`, args.Get(1).(string))
@@ -55,6 +57,8 @@ func TestTest(t *testing.T) {
 
 func TestTestFail(t *testing.T) {
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("AppGet", "app1").Return(fxApp(), nil).Once()
+		i.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{*fxRelease()}, nil).Once()
 		i.On("SystemGet").Return(fxSystem(), nil)
 		i.On("ObjectStore", "app1", mock.AnythingOfType("string"), mock.Anything, structs.ObjectStoreOptions{}).Return(&fxObject, nil).Run(func(args mock.Arguments) {
 			require.Regexp(t, `tmp/[0-9a-f]{30}\.tgz`, args.Get(1).(string))


### PR DESCRIPTION
### What is the feature/update/fix?

**Update: Build Guard Against Dropping Running-Release Environment Variables**

The CLI now runs a preflight check when you create a build with `convox build`, `convox deploy`, or `convox test`. New builds inherit their environment from the app's newest release, which can differ from the currently running release when environment changes are staged with `convox env set` or `convox env unset` without `--promote`. If the release a build is about to inherit from is missing environment variables that are set in the running release, the CLI now stops before building and explains exactly which variables would be dropped and how to keep them.

The safeguard lives in the shared build path, so it protects `convox build`, `convox deploy`, and `convox test` from a single place, including external builds. When it triggers, the output looks like this:

    ERROR: this build will drop env var(s) that are set in your running release RABC123: SECRET_KEY

    These vars are present in the running release (RABC123) but missing from the latest release (RDEF456), which is what a new build inherits from. This usually happens after `convox env set` or `convox env unset` without --promote.

    To keep them, set them again with --promote before deploying, for example:
        convox env set SECRET_KEY=... --promote

    If you meant to drop these vars, or you believe this is a false alarm, re-run with --force

The check is precise and conservative. It only triggers when the newest release differs from the running release and one or more keys set in the running release are absent from the newest release. Adding new variables or changing values never triggers it, so `convox env set NEW=value` followed by `convox deploy`, and stage-then-deploy workflows, behave exactly as before. The check is also fail-open: if the app has no promoted release, a lookup fails, or the release list is momentarily stale, the build proceeds normally. The safeguard never blocks a build because of its own lookup problems.

---

### Why is this important?

Environment variables are part of your app's running configuration, and changes to them should be visible and deliberate. This guard makes any pending environment drop visible at the moment it matters, before a new release is built and promoted, so the variables can be restored with `--promote` before anything changes.

**Benefits:**

- **Protects running apps during deploys.** The CLI surfaces any pending environment drop up front, with the exact variable names, before a new release is built and promoted.
- **Actionable guidance.** The message names the affected variables, identifies both releases being compared, and shows the exact `convox env set KEY=... --promote` command to keep them.
- **Consistent coverage.** One check covers `convox build`, `convox deploy`, and `convox test`, so every path that creates a build gets the same protection.
- **Never gets in the way of normal workflows.** Additions and value changes pass through untouched, lookup failures fail open, and `--force` remains available as an escape hatch if the guard misfires or the drop is intentional.
- **Works everywhere.** The safeguard is implemented entirely in the CLI using read-only API calls, so it works with apps on every rack version and every provider, with no rack-side or API changes.

---

### How to use it?

No action is needed for normal workflows. The check runs automatically on every `convox build`, `convox deploy`, and `convox test`.

If the safeguard triggers and you want to keep the variables, set them again with `--promote` before deploying:

    $ convox env set SECRET_KEY=value --promote -a my-app

If the drop is intentional, or you believe the guard is wrong, `--force` bypasses it for that command:

    $ convox deploy --force -a my-app

    $ convox build --force -a my-app

With `--force`, the build proceeds and the CLI prints a warning noting which variables are being dropped:

    WARNING: proceeding with --force; this build drops env var(s) set in the running release: SECRET_KEY

#### New CLI Flags

| Command | Flag | Effect |
|---------|------|--------|
| `convox build` | `--force` | Escape hatch: proceed even when the guard detects a pending environment drop |
| `convox test` | `--force` | Same as `convox build` |

`convox deploy` already accepts `--force`. On deploy, the flag now also bypasses this safeguard in addition to its existing meaning of forcing the promote without waiting for readiness.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this update, though there is one intentional behavior change to be aware of. A `convox build`, `convox deploy`, or `convox test` that would produce a release missing environment variables set in the running release now stops and reports the pending drop, including cases where the variables are optional and the build would otherwise have completed. This is deliberate: a pending configuration change to a running app should be confirmed, not applied silently. The guard can be bypassed per command with `--force`, and workflows that only add variables or change values are completely unaffected.

The change is CLI-only and additive. No API endpoints, SDK methods, response structs, or rack-side behavior are modified, and all existing flags and output formats are preserved.

---

### Requirements

This update requires version `3.25.1` or later for the rack.

**Update the Rack:** Run `convox rack update 3.25.1 -r rackName` to update to this version.

The safeguard itself runs in the Convox CLI, so updating your CLI to `3.25.1` enables it for apps on any rack version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
