### PR TITLE
env drop guard warns by default

### DIFF
--- a/pkg/cli/builds.go
+++ b/pkg/cli/builds.go
@@ -158,9 +158,9 @@ func Build(rack sdk.Interface, c *stdcli.Context) error {
 	return nil
 }
 
-// checkPendingEnvDrop stops a build whose newest release drops env vars still
-// set in the running release (the env-unset-without-promote trap that surfaces
-// as a confusing "required env" failure). Fail-open; --force overrides.
+// checkPendingEnvDrop warns when the newest release drops env vars still set
+// in the running release (the env-unset-without-promote trap). Fail-open;
+// CONVOX_ENV_DROP_GUARD=strict blocks instead; --force shortens the warning.
 func checkPendingEnvDrop(rack sdk.Interface, c *stdcli.Context, appName string) error {
 	a, _ := rack.AppGet(appName)
 	if a == nil || a.Release == "" {
@@ -204,12 +204,23 @@ func checkPendingEnvDrop(rack sdk.Interface, c *stdcli.Context, appName string) 
 	sort.Strings(dropped)
 
 	if !c.Bool("force") {
-		return fmt.Errorf("this build will drop env var(s) that are set in your running release %s: %s\n\n"+
+		if os.Getenv("CONVOX_ENV_DROP_GUARD") == "strict" {
+			return fmt.Errorf("this build will drop env var(s) that are set in your running release %s: %s\n\n"+
+				"These vars are present in the running release (%s) but missing from the latest release (%s), which is what a new build inherits from. This usually happens after `convox env set` or `convox env unset` without --promote.\n\n"+
+				"To keep them, set them again with --promote before deploying, for example:\n"+
+				"    convox env set %s=... --promote\n\n"+
+				"If you meant to drop these vars, or you believe this is a false alarm, re-run with --force",
+				a.Release, strings.Join(dropped, ", "), a.Release, newest.Id, dropped[0])
+		}
+
+		fmt.Fprintf(c.Writer().Stderr, "WARNING: this build will drop env var(s) that are set in your running release %s: %s\n\n"+
 			"These vars are present in the running release (%s) but missing from the latest release (%s), which is what a new build inherits from. This usually happens after `convox env set` or `convox env unset` without --promote.\n\n"+
 			"To keep them, set them again with --promote before deploying, for example:\n"+
 			"    convox env set %s=... --promote\n\n"+
-			"If you meant to drop these vars, or you believe this is a false alarm, re-run with --force",
+			"If this drop is intentional, pass --force to reduce this to a one-line notice. To make this check blocking, set CONVOX_ENV_DROP_GUARD=strict.\n",
 			a.Release, strings.Join(dropped, ", "), a.Release, newest.Id, dropped[0])
+
+		return nil
 	}
 
 	fmt.Fprintf(c.Writer().Stderr, "WARNING: proceeding with --force; this build drops env var(s) set in the running release: %s\n", strings.Join(dropped, ", "))

--- a/pkg/cli/builds_test.go
+++ b/pkg/cli/builds_test.go
@@ -131,7 +131,33 @@ func TestBuildClassic(t *testing.T) {
 	})
 }
 
-func TestBuildEnvDropBlocked(t *testing.T) {
+func TestBuildEnvDropWarns(t *testing.T) {
+	t.Setenv("CONVOX_ENV_DROP_GUARD", "")
+	testClientWait(t, 50*time.Millisecond, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("AppGet", "app1").Return(&structs.App{Name: "app1", Release: "release1", Status: "running", Generation: "2"}, nil)
+		i.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{{Id: "release2", App: "app1", Env: "FOO=bar", Created: fxStarted.Add(time.Hour)}}, nil)
+		i.On("ReleaseGet", "app1", "release1").Return(&structs.Release{Id: "release1", App: "app1", Env: "SECRET_KEY=abc\nFOO=bar", Created: fxStarted}, nil)
+		i.On("SystemGet").Return(fxSystem(), nil)
+		i.On("ObjectStore", "app1", mock.AnythingOfType("string"), mock.Anything, structs.ObjectStoreOptions{}).Return(&fxObject, nil)
+		i.On("BuildCreate", "app1", "object://test", structs.BuildCreateOptions{Description: options.String("foo")}).Return(fxBuild(), nil)
+		i.On("BuildLogs", "app1", "build1", structs.LogsOptions{}).Return(testLogs(fxLogs()), nil)
+		i.On("BuildGet", "app1", "build1").Return(fxBuildRunning(), nil).Once()
+		i.On("BuildGet", "app1", "build1").Return(fxBuild(), nil)
+		i.On("BuildGet", "app1", "build4").Return(fxBuild(), nil)
+
+		res, err := testExecute(e, "build ./testdata/httpd -a app1 -d foo", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		require.Contains(t, res.Stderr, "WARNING: this build will drop env var(s) that are set in your running release release1: SECRET_KEY")
+		require.Contains(t, res.Stderr, "missing from the latest release (release2)")
+		require.Contains(t, res.Stderr, "pass --force")
+		require.Contains(t, res.Stderr, "CONVOX_ENV_DROP_GUARD=strict")
+		require.NotContains(t, res.Stderr, "proceeding with --force")
+	})
+}
+
+func TestBuildEnvDropStrictBlocked(t *testing.T) {
+	t.Setenv("CONVOX_ENV_DROP_GUARD", "strict")
 	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
 		i.On("AppGet", "app1").Return(&structs.App{Name: "app1", Release: "release1", Status: "running", Generation: "2"}, nil)
 		i.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{{Id: "release2", App: "app1", Env: "FOO=bar", Created: fxStarted.Add(time.Hour)}}, nil)
@@ -141,8 +167,52 @@ func TestBuildEnvDropBlocked(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, res.Code)
 		require.Contains(t, res.Stderr, "this build will drop env var(s) that are set in your running release release1: SECRET_KEY")
+		require.Contains(t, res.Stderr, "missing from the latest release (release2)")
 		require.Contains(t, res.Stderr, "re-run with --force")
 		i.AssertNotCalled(t, "BuildCreate", mock.Anything, mock.Anything, mock.Anything)
+	})
+}
+
+func TestBuildEnvDropStrictForce(t *testing.T) {
+	t.Setenv("CONVOX_ENV_DROP_GUARD", "strict")
+	testClientWait(t, 50*time.Millisecond, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("AppGet", "app1").Return(&structs.App{Name: "app1", Release: "release1", Status: "running", Generation: "2"}, nil)
+		i.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{{Id: "release2", App: "app1", Env: "FOO=bar", Created: fxStarted.Add(time.Hour)}}, nil)
+		i.On("ReleaseGet", "app1", "release1").Return(&structs.Release{Id: "release1", App: "app1", Env: "SECRET_KEY=abc\nFOO=bar", Created: fxStarted}, nil)
+		i.On("SystemGet").Return(fxSystem(), nil)
+		i.On("ObjectStore", "app1", mock.AnythingOfType("string"), mock.Anything, structs.ObjectStoreOptions{}).Return(&fxObject, nil)
+		i.On("BuildCreate", "app1", "object://test", structs.BuildCreateOptions{Description: options.String("foo")}).Return(fxBuild(), nil)
+		i.On("BuildLogs", "app1", "build1", structs.LogsOptions{}).Return(testLogs(fxLogs()), nil)
+		i.On("BuildGet", "app1", "build1").Return(fxBuildRunning(), nil).Once()
+		i.On("BuildGet", "app1", "build1").Return(fxBuild(), nil)
+		i.On("BuildGet", "app1", "build4").Return(fxBuild(), nil)
+
+		res, err := testExecute(e, "build ./testdata/httpd -a app1 -d foo --force", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		require.Contains(t, res.Stderr, "WARNING: proceeding with --force; this build drops env var(s) set in the running release: SECRET_KEY")
+	})
+}
+
+func TestBuildEnvDropGuardUnrecognizedValue(t *testing.T) {
+	t.Setenv("CONVOX_ENV_DROP_GUARD", "true")
+	testClientWait(t, 50*time.Millisecond, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("AppGet", "app1").Return(&structs.App{Name: "app1", Release: "release1", Status: "running", Generation: "2"}, nil)
+		i.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{{Id: "release2", App: "app1", Env: "FOO=bar", Created: fxStarted.Add(time.Hour)}}, nil)
+		i.On("ReleaseGet", "app1", "release1").Return(&structs.Release{Id: "release1", App: "app1", Env: "SECRET_KEY=abc\nFOO=bar", Created: fxStarted}, nil)
+		i.On("SystemGet").Return(fxSystem(), nil)
+		i.On("ObjectStore", "app1", mock.AnythingOfType("string"), mock.Anything, structs.ObjectStoreOptions{}).Return(&fxObject, nil)
+		i.On("BuildCreate", "app1", "object://test", structs.BuildCreateOptions{Description: options.String("foo")}).Return(fxBuild(), nil)
+		i.On("BuildLogs", "app1", "build1", structs.LogsOptions{}).Return(testLogs(fxLogs()), nil)
+		i.On("BuildGet", "app1", "build1").Return(fxBuildRunning(), nil).Once()
+		i.On("BuildGet", "app1", "build1").Return(fxBuild(), nil)
+		i.On("BuildGet", "app1", "build4").Return(fxBuild(), nil)
+
+		res, err := testExecute(e, "build ./testdata/httpd -a app1 -d foo", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		require.Contains(t, res.Stderr, "WARNING: this build will drop env var(s) that are set in your running release release1: SECRET_KEY")
+		require.Contains(t, res.Stderr, "CONVOX_ENV_DROP_GUARD=strict")
 	})
 }
 


### PR DESCRIPTION
### What is the feature/update/fix?

**Update: Env-Drop Build Check Now Warns by Default, with Opt-In Strict Mode**

The pre-build environment check introduced in 3.25.1 (#1059) now warns instead of stopping. When `convox build`, `convox deploy`, or `convox test` detects that the newest release drops environment variables still set in the running release, the CLI prints the full diagnosis as a warning to stderr and proceeds with the build. Setting the `CONVOX_ENV_DROP_GUARD=strict` environment variable makes the check blocking, with the same error text as 3.25.1.

The warning carries the complete diagnosis: the dropped variable names, both release ids being compared, the exact `convox env set KEY=... --promote` command to keep the variables, and both ways to change the check's behavior:

    WARNING: this build will drop env var(s) that are set in your running release RABC123: SECRET_KEY

    These vars are present in the running release (RABC123) but missing from the latest release (RDEF456), which is what a new build inherits from. This usually happens after `convox env set` or `convox env unset` without --promote.

    To keep them, set them again with --promote before deploying, for example:
        convox env set SECRET_KEY=... --promote

    If this drop is intentional, pass --force to reduce this to a one-line notice. To make this check blocking, set CONVOX_ENV_DROP_GUARD=strict.

**Behavior:**

| State at build time | Behavior |
|---------------------|----------|
| Drops detected, no `--force`, `CONVOX_ENV_DROP_GUARD` unset or any value other than `strict` | Warning to stderr, build proceeds |
| Drops detected, no `--force`, `CONVOX_ENV_DROP_GUARD=strict` | Error, build stops |
| Drops detected, `--force` | One-line notice, build proceeds (unchanged) |
| No drops detected, or a release lookup fails | Silent, build proceeds (unchanged) |

The trigger condition, the environment comparison, the fail-open paths, and the `--force` flag on all three commands are unchanged from 3.25.1.

---

### Why is this important?

A pending environment drop is worth surfacing every time, but not every workflow wants a hard stop. Interactive users see the warning immediately and can restore the variables with `--promote` before promoting the new release. Automated pipelines that remove variables deliberately proceed without any modification, with the full diagnosis preserved in the build log. Teams that prefer enforcement can turn the check back into a blocker with one environment variable.

**Benefits:**

- **Automation-friendly default.** CI/CD pipelines, including workflows that install the latest CLI on every run, are never stopped by the check; the diagnosis lands in the build log instead.
- **Nothing is lost from the diagnosis.** The warning names the variables, identifies both releases being compared, and shows the exact remediation command, the same content as the blocking error.
- **Enforcement stays available.** `CONVOX_ENV_DROP_GUARD=strict` restores the blocking behavior for teams that want builds to stop on a pending drop.
- **Same coverage, same safety.** `convox build`, `convox deploy`, and `convox test` all share the check, and it remains fail-open, so it never blocks a build because of its own lookup problems.

---

### How to use it?

No action is needed. The check runs automatically and warns by default.

To make the check blocking, set the environment variable in your shell or pipeline:

    $ export CONVOX_ENV_DROP_GUARD=strict
    $ convox deploy -a my-app

**Environment Variable:**

| Variable | Value | Effect |
|----------|-------|--------|
| `CONVOX_ENV_DROP_GUARD` | `strict` | Makes the env-drop check blocking. Any other value, or unset, warns and proceeds. |

`--force` behaves as before on all three commands: the check is reduced to a one-line notice and the build proceeds.

    $ convox deploy --force -a my-app

---

### Does it have a breaking change?

**No breaking changes** are introduced with this update. The change is CLI-only and affects only the unforced default when a pending drop is detected: the CLI now warns and proceeds where 3.25.1 stopped. Workflows that want the blocking behavior can restore it exactly with `CONVOX_ENV_DROP_GUARD=strict`. No API endpoints, SDK methods, response structs, or rack-side behavior are modified.

---

### Requirements

This update requires version `3.25.2` or later for the rack.

**Update the Rack:** Run `convox rack update 3.25.2 -r rackName` to update to this version.

The check runs in the Convox CLI, so updating your CLI to `3.25.2` applies the new default for apps on any rack version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
