### PR TITLE
GCP TPU node pools and google.com/tpu scheduling

### DIFF
--- a/docs/configuration/rack-parameters/gcp/additional_node_groups_config.md
+++ b/docs/configuration/rack-parameters/gcp/additional_node_groups_config.md
@@ -41,6 +41,7 @@ The `additional_node_groups_config` parameter takes a JSON array of node pool co
 | `zones` | No | Comma-separated list of GCP zones (e.g., `us-east1-b,us-east1-c`) | None (region default) |
 | `gpu_type` | No | NVIDIA accelerator type to attach (e.g., `nvidia-l4`, `nvidia-tesla-t4`). When set, GKE installs the NVIDIA driver and device plugin automatically and taints the pool with `nvidia.com/gpu:NoSchedule` | None |
 | `gpu_count` | No | Number of GPUs to attach per node (only applies when `gpu_type` is set) | 1 |
+| `tpu_topology` | No | TPU slice topology (e.g., `1x1`, `2x2`, `2x4`) for a Cloud TPU node pool. When set, the pool gets a `COMPACT` placement policy with this topology. Use a TPU machine type (e.g., `ct5lp-hightpu-8t`) as `type`. Single-host slices only | None |
 
 ## Setting Parameters
 To set the `additional_node_groups_config` parameter, there are several methods:
@@ -106,6 +107,47 @@ services:
 ```
 
 > **Zone availability**: A given accelerator type is only available in specific zones. If the pool's zones (the rack region's default zones, or the `zones` you specify) do not offer the requested `gpu_type`, GKE will fail to create the pool. Consult the [GCP GPU regions and zones documentation](https://cloud.google.com/compute/docs/gpus/gpu-regions-zones) and set `zones` accordingly.
+
+## TPU Node Pools
+
+To run Cloud TPU workloads, use a TPU machine type as `type` and set `tpu_topology`. The machine type implies the TPU generation (for example `ct5lp-hightpu-8t` for TPU v5e), so no `gpu_type` is needed. GKE installs the TPU device plugin automatically; no DaemonSet is required. GKE taints TPU node pools with `google.com/tpu:NoSchedule`; Convox automatically adds the matching toleration to services with `scale.gpu.vendor: google`, so no manual toleration is needed either way.
+
+Only single-host TPU slices are supported. Multi-host slices (which require JobSet or Kueue orchestration) are not supported.
+
+TPUs are only available in specific zones for each generation. Pin the pool to a zone that offers your TPU type with the `zones` field, or the pool will fail to create.
+
+The following example creates a scale-to-zero Spot pool of `ct5lp-hightpu-8t` machines (TPU v5e) with a single-host `2x4` topology, pinned to a v5e zone:
+
+```json
+[
+  {
+    "id": 300,
+    "type": "ct5lp-hightpu-8t",
+    "capacity_type": "SPOT",
+    "min_size": 0,
+    "max_size": 1,
+    "label": "tpu-workers",
+    "zones": "us-west4-a",
+    "tpu_topology": "2x4"
+  }
+]
+```
+
+A matching `convox.yml` service requests the TPU with `scale.gpu` (vendor `google`) and selects the TPU pool with `nodeSelectorLabels`. Unlike GPUs, TPU workloads must set the `cloud.google.com/gke-tpu-accelerator` and `cloud.google.com/gke-tpu-topology` node selectors so the scheduler places them on the right slice:
+
+```yaml
+services:
+  trainer:
+    scale:
+      gpu:
+        count: 8
+        vendor: google
+    nodeSelectorLabels:
+      cloud.google.com/gke-tpu-accelerator: tpu-v5-lite-podslice
+      cloud.google.com/gke-tpu-topology: 2x4
+```
+
+Convox maps `vendor: google` to the `google.com/tpu` resource request and limit, and `count` is the number of TPU chips requested per pod (8 for a `ct5lp-hightpu-8t` node). The accelerator label value depends on the TPU generation (`tpu-v5-lite-podslice` for v5e); consult the [GKE TPU documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/tpus) for the value that matches your machine type.
 
 ## Node Pool Identification
 

--- a/docs/configuration/rack-parameters/gcp/additional_node_groups_config.md
+++ b/docs/configuration/rack-parameters/gcp/additional_node_groups_config.md
@@ -32,16 +32,16 @@ The `additional_node_groups_config` parameter takes a JSON array of node pool co
 | `capacity_type` | No | Whether to use on-demand or spot VMs. Accepts `ON_DEMAND` or `SPOT` (`Regular` and `Spot` are also accepted, for configs shared with Azure) | `ON_DEMAND` |
 | `min_size` | No | Minimum number of nodes per zone. `0` is allowed for scale-to-zero pools | 1 |
 | `max_size` | No | Maximum number of nodes per zone | 100 |
-
-> **Counts are per zone, not totals.** GCP racks use regional GKE clusters, so `min_size` and `max_size` apply to each zone in the region. In a 3-zone region, `min_size: 1` runs 3 nodes and `max_size: 100` allows up to 300. This differs from AWS and Azure, where the same values are totals. For expensive pools (such as GPU pools), set `min_size: 0` or pin a single zone with `zones`.
 | `label` | No | Custom label value for the node pool. Applied as `convox.io/label: <label-value>` | None |
 | `id` | No | A unique integer identifier for the node pool that persists across updates | Auto-generated |
 | `tags` | No | Custom GCP resource labels specified as comma-separated key-value pairs (e.g., `environment=production,team=backend`) | None |
 | `dedicated` | No | When `true`, only services with matching node pool labels will be scheduled on these nodes (adds a `dedicated-node` NoSchedule taint) | `false` |
 | `zones` | No | Comma-separated list of GCP zones (e.g., `us-east1-b,us-east1-c`) | None (region default) |
-| `gpu_type` | No | NVIDIA accelerator type to attach (e.g., `nvidia-l4`, `nvidia-tesla-t4`). When set, GKE installs the NVIDIA driver and device plugin automatically and taints the pool with `nvidia.com/gpu:NoSchedule` | None |
+| `gpu_type` | No | NVIDIA accelerator type to attach (e.g., `nvidia-l4`, `nvidia-tesla-t4`). When set, GKE installs the NVIDIA driver and device plugin automatically and taints the pool with `nvidia.com/gpu=present:NoSchedule` | None |
 | `gpu_count` | No | Number of GPUs to attach per node (only applies when `gpu_type` is set) | 1 |
-| `tpu_topology` | No | TPU slice topology (e.g., `1x1`, `2x2`, `2x4`) for a Cloud TPU node pool. When set, the pool gets a `COMPACT` placement policy with this topology. Use a TPU machine type (e.g., `ct5lp-hightpu-8t`) as `type`. Single-host slices only | None |
+| `tpu_topology` | No | TPU slice topology for a Cloud TPU node pool, matched to the machine type (e.g., `2x4` for `ct5lp-hightpu-8t`). When set, the pool gets a `COMPACT` placement policy with this topology. Requires a TPU machine type as `type`. Single-host slices only | None |
+
+> **Counts are per zone, not totals.** GCP racks use regional GKE clusters, so `min_size` and `max_size` apply to each zone in the region. In a 3-zone region, `min_size: 1` runs 3 nodes and `max_size: 100` allows up to 300. This differs from AWS and Azure, where the same values are totals. For expensive pools (such as GPU pools), set `min_size: 0` or pin a single zone with `zones`.
 
 ## Setting Parameters
 To set the `additional_node_groups_config` parameter, there are several methods:
@@ -76,7 +76,7 @@ Updating parameters... OK
 
 ## GPU Node Pools
 
-To run GPU workloads, set `gpu_type` (and optionally `gpu_count`) on a node pool. GKE manages the NVIDIA driver and device plugin for you, and automatically applies the `nvidia.com/gpu:NoSchedule` taint. Convox services that request GPUs (via `scale.gpu.count` in `convox.yml`) get the matching resource request and toleration automatically, so they schedule onto these nodes.
+To run GPU workloads, set `gpu_type` (and optionally `gpu_count`) on a node pool. GKE manages the NVIDIA driver and device plugin for you, and automatically applies the `nvidia.com/gpu=present:NoSchedule` taint. Convox services that request GPUs (via `scale.gpu.count` in `convox.yml`) get the matching resource request and toleration automatically, so they schedule onto these nodes.
 
 Node pools use the rack's node service account. For workloads that call GCP APIs (including GPU workloads running third-party code), use [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity) rather than relying on node credentials.
 

--- a/docs/configuration/scaling/workload-placement.md
+++ b/docs/configuration/scaling/workload-placement.md
@@ -46,7 +46,7 @@ At the rack level, you can define custom node groups using provider-specific rac
 - [`additional_build_groups_config`](/configuration/rack-parameters/azure/additional_build_groups_config): Creates node pools specifically for build processes
 
 **GCP:**
-- [`additional_node_groups_config`](/configuration/rack-parameters/gcp/additional_node_groups_config): Creates general-purpose node pools, including GPU node pools via the `gpu_type` and `gpu_count` fields
+- [`additional_node_groups_config`](/configuration/rack-parameters/gcp/additional_node_groups_config): Creates general-purpose node pools, GPU node pools (via the `gpu_type` and `gpu_count` fields), and single-host Cloud TPU node pools (via a TPU machine type and the `tpu_topology` field)
 
 These parameters allow you to specify:
 - Instance types (EC2 instance types on AWS, VM sizes on Azure)

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -976,7 +976,7 @@ type NodeGroupConfigParam struct {
 	TpuTopology  *string `json:"tpu_topology,omitempty"`
 }
 
-var tpuTopologyPattern = regexp.MustCompile(`^[0-9]+x[0-9]+(x[0-9]+)?$`)
+var tpuTopologyPattern = regexp.MustCompile(`^[1-9][0-9]*x[1-9][0-9]*(x[1-9][0-9]*)?$`)
 
 func (n *NodeGroupConfigParam) Validate() error {
 	if n.Type == "" {

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -973,7 +973,10 @@ type NodeGroupConfigParam struct {
 	Zones        *string `json:"zones,omitempty"`
 	GpuType      *string `json:"gpu_type,omitempty"`
 	GpuCount     *int    `json:"gpu_count,omitempty"`
+	TpuTopology  *string `json:"tpu_topology,omitempty"`
 }
+
+var tpuTopologyPattern = regexp.MustCompile(`^[0-9]+x[0-9]+(x[0-9]+)?$`)
 
 func (n *NodeGroupConfigParam) Validate() error {
 	if n.Type == "" {
@@ -1008,6 +1011,18 @@ func (n *NodeGroupConfigParam) Validate() error {
 
 	if n.GpuCount != nil && n.GpuType == nil {
 		return fmt.Errorf("gpu_type is required when gpu_count is set")
+	}
+
+	if n.TpuTopology != nil {
+		if !tpuTopologyPattern.MatchString(*n.TpuTopology) {
+			return fmt.Errorf("invalid tpu_topology '%s', expected NxM or NxMxP (e.g. 2x4 or 2x2x2)", *n.TpuTopology)
+		}
+		if n.GpuType != nil {
+			return fmt.Errorf("gpu_type and tpu_topology cannot be combined on one node group")
+		}
+		if !strings.HasPrefix(n.Type, "ct") && !strings.HasPrefix(n.Type, "tpu") {
+			return fmt.Errorf("tpu_topology requires a TPU machine type (e.g. ct5lp-*, ct6e-*, tpu7x-*), found: '%s'", n.Type)
+		}
 	}
 
 	if n.Tags != nil {

--- a/pkg/cli/rack_validate_test.go
+++ b/pkg/cli/rack_validate_test.go
@@ -660,7 +660,7 @@ func TestValidateAndMutateParams_PrometheusUrl_SSRF(t *testing.T) {
 }
 
 func TestAdditionalNodeGroupsConfigFieldRoundTrip(t *testing.T) {
-	in := `[{"id":200,"type":"g2-standard-8","disk":100,"disk_type":"pd-ssd","capacity_type":"SPOT","min_size":0,"max_size":3,"label":"gpu-workers","zones":"us-east1-b,us-east1-c","gpu_type":"nvidia-l4","gpu_count":2}]`
+	in := `[{"id":200,"type":"g2-standard-8","disk":100,"disk_type":"pd-ssd","capacity_type":"SPOT","min_size":0,"max_size":3,"label":"gpu-workers","zones":"us-east1-b,us-east1-c","gpu_type":"nvidia-l4","gpu_count":2},{"id":300,"type":"ct5lp-hightpu-8t","min_size":0,"max_size":1,"zones":"us-west4-a","tpu_topology":"2x4"}]`
 
 	params := map[string]string{"additional_node_groups_config": in}
 	if err := validateAndMutateParams(params, "gcp", map[string]string{}, false); err != nil {
@@ -673,7 +673,7 @@ func TestAdditionalNodeGroupsConfigFieldRoundTrip(t *testing.T) {
 	}
 
 	// every provider-specific field must survive the validate/marshal round-trip
-	for _, field := range []string{`"disk_type":"pd-ssd"`, `"zones":"us-east1-b,us-east1-c"`, `"gpu_type":"nvidia-l4"`, `"gpu_count":2`, `"capacity_type":"SPOT"`, `"min_size":0`} {
+	for _, field := range []string{`"disk_type":"pd-ssd"`, `"zones":"us-east1-b,us-east1-c"`, `"gpu_type":"nvidia-l4"`, `"gpu_count":2`, `"tpu_topology":"2x4"`, `"capacity_type":"SPOT"`, `"min_size":0`} {
 		if !strings.Contains(string(decoded), field) {
 			t.Errorf("field %s stripped by param round-trip: %s", field, decoded)
 		}
@@ -690,6 +690,32 @@ func TestAdditionalNodeGroupsConfigGpuValidation(t *testing.T) {
 		{"zero gpu_count", `[{"id":1,"type":"g2-standard-8","gpu_type":"nvidia-l4","gpu_count":0}]`, "invalid gpu_count"},
 		{"negative gpu_count", `[{"id":1,"type":"g2-standard-8","gpu_type":"nvidia-l4","gpu_count":-1}]`, "invalid gpu_count"},
 		{"valid gpu pool", `[{"id":1,"type":"g2-standard-8","gpu_type":"nvidia-l4","gpu_count":1}]`, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := map[string]string{"additional_node_groups_config": tt.config}
+			err := validateAndMutateParams(params, "gcp", map[string]string{}, false)
+			if tt.wantErr == "" && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantErr != "" && (err == nil || !strings.Contains(err.Error(), tt.wantErr)) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestAdditionalNodeGroupsConfigTpuValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  string
+		wantErr string
+	}{
+		{"bad topology format", `[{"id":1,"type":"ct5lp-hightpu-8t","tpu_topology":"2*4"}]`, "invalid tpu_topology"},
+		{"topology with gpu_type", `[{"id":1,"type":"ct5lp-hightpu-8t","gpu_type":"nvidia-l4","tpu_topology":"2x4"}]`, "cannot be combined"},
+		{"topology on non-tpu machine", `[{"id":1,"type":"g2-standard-8","tpu_topology":"2x4"}]`, "requires a TPU machine type"},
+		{"valid 2d topology", `[{"id":1,"type":"ct5lp-hightpu-8t","tpu_topology":"2x4"}]`, ""},
+		{"valid 3d topology", `[{"id":1,"type":"ct5p-hightpu-4t","tpu_topology":"2x2x2"}]`, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cli/rack_validate_test.go
+++ b/pkg/cli/rack_validate_test.go
@@ -712,6 +712,7 @@ func TestAdditionalNodeGroupsConfigTpuValidation(t *testing.T) {
 		wantErr string
 	}{
 		{"bad topology format", `[{"id":1,"type":"ct5lp-hightpu-8t","tpu_topology":"2*4"}]`, "invalid tpu_topology"},
+		{"zero topology dimension", `[{"id":1,"type":"ct5lp-hightpu-8t","tpu_topology":"0x0"}]`, "invalid tpu_topology"},
 		{"topology with gpu_type", `[{"id":1,"type":"ct5lp-hightpu-8t","gpu_type":"nvidia-l4","tpu_topology":"2x4"}]`, "cannot be combined"},
 		{"topology on non-tpu machine", `[{"id":1,"type":"g2-standard-8","tpu_topology":"2x4"}]`, "requires a TPU machine type"},
 		{"valid 2d topology", `[{"id":1,"type":"ct5lp-hightpu-8t","tpu_topology":"2x4"}]`, ""},

--- a/provider/k8s/helpers.go
+++ b/provider/k8s/helpers.go
@@ -431,6 +431,8 @@ func gpuResourceKey(vendor string) string {
 		return "nvidia.com/gpu"
 	case "amd", "amd.com":
 		return "amd.com/gpu"
+	case "google", "google.com", "tpu":
+		return "google.com/tpu"
 	default:
 		return "nvidia.com/gpu"
 	}
@@ -444,6 +446,7 @@ func gpuResourceKey(vendor string) string {
 var gpuKeyToVendor = map[string]string{
 	"nvidia.com/gpu": "nvidia",
 	"amd.com/gpu":    "amd",
+	"google.com/tpu": "google",
 }
 
 func resourceSubstitutionId(app, rType, rName string) string {

--- a/provider/k8s/template_test.go
+++ b/provider/k8s/template_test.go
@@ -619,6 +619,9 @@ func TestGpuResourceKey(t *testing.T) {
 		{"nvidia.com", "nvidia.com/gpu"},
 		{"amd", "amd.com/gpu"},
 		{"amd.com", "amd.com/gpu"},
+		{"google", "google.com/tpu"},
+		{"google.com", "google.com/tpu"},
+		{"tpu", "google.com/tpu"},
 		{"bogus", "nvidia.com/gpu"},
 		{"neuron", "nvidia.com/gpu"},
 	}

--- a/terraform/cluster/gcp/node_pools.tf
+++ b/terraform/cluster/gcp/node_pools.tf
@@ -16,6 +16,7 @@ locals {
       zones        = compact(split(",", lookup(ng, "zones", "")))
       gpu_type     = lookup(ng, "gpu_type", null)
       gpu_count    = tonumber(lookup(ng, "gpu_count", 1))
+      tpu_topology = lookup(ng, "tpu_topology", null)
       resource_labels = {
         for pair in compact(split(",", lookup(ng, "tags", ""))) :
         trimspace(split("=", pair)[0]) => trimspace(try(split("=", pair)[1], "novalue"))
@@ -83,6 +84,14 @@ resource "google_container_node_pool" "additional" {
           gpu_driver_version = "DEFAULT"
         }
       }
+    }
+  }
+
+  dynamic "placement_policy" {
+    for_each = each.value.tpu_topology != null ? [1] : []
+    content {
+      type         = "COMPACT"
+      tpu_topology = each.value.tpu_topology
     }
   }
 


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: Cloud TPU Node Pools for GCP Racks**

GCP racks can now run Google Cloud TPU workloads. The `additional_node_groups_config` rack parameter gains a `tpu_topology` field, and setting it on a node group with a TPU machine type creates a GKE node pool with a `COMPACT` placement policy at that topology. The machine type implies the TPU generation (`ct5lp-*`, `ct6e-*`, `ct5p-*`, `tpu7x-*`), and GKE provisions the TPU runtime for the pool, so no driver DaemonSet or Helm chart is involved.

The CLI validates the configuration when the parameter is set: `tpu_topology` must be in `NxM` or `NxMxP` form, it requires a TPU machine type, and `gpu_type` and `tpu_topology` cannot be combined on one node group.

Scheduling uses the fields already in `convox.yml`. A service that declares `scale.gpu` with `count: 8` and `vendor: google` produces `google.com/tpu` resource requests and limits, along with the toleration GKE requires for a TPU node pool. Workloads target a specific slice with the existing per-service `nodeSelectorLabels`, using `cloud.google.com/gke-tpu-accelerator` and `cloud.google.com/gke-tpu-topology`.

This release covers single-host TPU slices. Multi-host slices, which require atomic scaling and JobSet or Kueue orchestration, are not covered, and TPU pricing is not part of the rack cost tables.

---

### Why is this important?

TPU capacity is now available through the same rack parameter and the same `convox.yml` scaling fields that already describe CPU and GPU pools, so a training or inference service reaches a TPU slice with a node group entry and a scale block rather than a separate provisioning path.

**Benefits:**

- **One configuration surface for all accelerator pools.** TPU pools are declared in `additional_node_groups_config` alongside general-purpose and GPU pools, with the same `id`, `zones`, `capacity_type`, `min_size`, and `max_size` semantics.
- **Managed TPU runtime.** The machine type carries the TPU generation and GKE provisions the runtime for the pool, so there is nothing to install or maintain in the cluster.
- **Scheduling handled by the rack.** `scale.gpu` with `vendor: google` generates the `google.com/tpu` requests, limits, and toleration, and slice targeting uses the `nodeSelectorLabels` field services already have.
- **Configuration checked at set time.** Topology format, the TPU machine type requirement, and the accelerator field combination are validated by the CLI, so the response arrives from `convox rack params set` rather than from the cloud API.
- **Cost control on expensive capacity.** TPU pools support `min_size: 0` and `capacity_type: SPOT`, so a pool scales to zero between jobs.

---

### How to use it?

Create a Spot TPU v5e pool with a single-host `2x4` topology, scaled to zero when idle and pinned to a zone that offers the machine type:

    $ convox rack params set 'additional_node_groups_config=[{"id":300,"type":"ct5lp-hightpu-8t","capacity_type":"SPOT","min_size":0,"max_size":1,"label":"tpu-workers","zones":"us-west4-a","tpu_topology":"2x4"}]' -r rackName

TPU machine types are offered in specific zones per generation, so set `zones` to a zone that offers the type you request.

Then request the TPU chips and select the slice in `convox.yml`:

```yaml
services:
  trainer:
    scale:
      gpu:
        count: 8
        vendor: google
    nodeSelectorLabels:
      cloud.google.com/gke-tpu-accelerator: tpu-v5-lite-podslice
      cloud.google.com/gke-tpu-topology: 2x4
```

`count` is the number of TPU chips requested per pod, which is 8 for a `ct5lp-hightpu-8t` node. The accelerator label value follows the TPU generation, for example `tpu-v5-lite-podslice` for v5e.

#### New `additional_node_groups_config` Field (GCP)

| Field | Type | Default | Effect |
|-------|------|---------|--------|
| `tpu_topology` | string | none | TPU slice topology for the node pool, in `NxM` or `NxMxP` form and matched to the machine type (for example `2x4` for `ct5lp-hightpu-8t`). Requires a TPU machine type as `type`, and applies a `COMPACT` placement policy at that topology. Single-host slices only |

---

### Does it have a breaking change?

**No breaking changes** are introduced with this feature.

`tpu_topology` is a new optional field on `additional_node_groups_config`. Existing node group configurations parse and apply exactly as before, and a rack that does not set the field sees identical behavior. GPU pools declared with `gpu_type` and `gpu_count` are unchanged, as is every non-accelerator pool.

Additional node groups are new to GCP racks in this release. Downgrading a GCP rack below `3.25.3` removes them, and services pinned to those pools stay Pending until the rack is upgraded again. A Console-managed rack restores the pools from its stored parameters on re-upgrade with no action required; on a self-managed rack, set `additional_node_groups_config` again after upgrading.

---

### Requirements

This feature requires version `3.25.3` or later for the rack.

**Update the Rack:** Run `convox rack update 3.25.3 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
