### PR TITLE
create-before-destroy for additional node groups

### DIFF
--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -967,10 +967,11 @@ type NodeGroupConfigParam struct {
 	Label        *string `json:"label,omitempty"`
 	AmiID        *string `json:"ami_id,omitempty"`
 	Dedicated    *bool   `json:"dedicated,omitempty"`
+	Zones        *string `json:"zones,omitempty"`
 	Tags         *string `json:"tags,omitempty"`
 }
 
-func (n *NodeGroupConfigParam) Validate() error {
+func (n *NodeGroupConfigParam) Validate(provider string) error {
 	if n.Type == "" {
 		return fmt.Errorf("node type is required: '%s'", n.Type)
 	}
@@ -986,8 +987,19 @@ func (n *NodeGroupConfigParam) Validate() error {
 	if n.MinSize != nil && n.MaxSize != nil && *n.MinSize > *n.MaxSize {
 		return fmt.Errorf("invalid min size: '%d' must be less or equal to max size", *n.MinSize)
 	}
-	if n.CapacityType != nil && (*n.CapacityType != "ON_DEMAND" && *n.CapacityType != "SPOT" && *n.CapacityType != "Regular" && *n.CapacityType != "Spot") {
-		return fmt.Errorf("allowed capacity type: ON_DEMAND, SPOT, Regular, or Spot, found: '%s'", *n.CapacityType)
+	if n.CapacityType != nil {
+		var allowed []string
+		switch provider {
+		case "aws":
+			allowed = []string{"ON_DEMAND", "SPOT"}
+		case "azure":
+			allowed = []string{"ON_DEMAND", "SPOT", "Regular", "Spot"}
+		default:
+			allowed = []string{"ON_DEMAND", "SPOT", "Regular", "Spot"}
+		}
+		if !common.ContainsInStringSlice(allowed, *n.CapacityType) {
+			return fmt.Errorf("allowed capacity type for %s: %s, found: '%s'", provider, strings.Join(allowed, ", "), *n.CapacityType)
+		}
 	}
 	if n.Label != nil && !manifest.NameValidator.MatchString(*n.Label) {
 		return fmt.Errorf("label value '%s' invalid, %s", *n.Label, manifest.ValidNameDescription)
@@ -1263,11 +1275,11 @@ func (ko KarpenterNodeOverlays) Validate() error {
 
 type AdditionalNodeGroups []NodeGroupConfigParam
 
-func (an AdditionalNodeGroups) Validate() error {
+func (an AdditionalNodeGroups) Validate(provider string) error {
 	idCnt := 0
 	idMap := map[int]bool{}
 	for i := range an {
-		if err := an[i].Validate(); err != nil {
+		if err := an[i].Validate(provider); err != nil {
 			return err
 		}
 		if an[i].Id != nil {
@@ -1275,6 +1287,7 @@ func (an AdditionalNodeGroups) Validate() error {
 			if idMap[*an[i].Id] {
 				return fmt.Errorf("duplicate node group id is found: %d", *an[i].Id)
 			}
+			idMap[*an[i].Id] = true
 		}
 	}
 
@@ -1948,7 +1961,7 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 				}
 			}
 
-			if err := nCfgs.Validate(); err != nil {
+			if err := nCfgs.Validate(provider); err != nil {
 				return err
 			}
 

--- a/pkg/cli/rack_karpenter_test.go
+++ b/pkg/cli/rack_karpenter_test.go
@@ -2065,7 +2065,7 @@ func TestAdditionalNodeGroups_Validate_AutoAssignIdsFromZero(t *testing.T) {
 		{Type: "m5.large"},
 		{Type: "c5.xlarge"},
 	}
-	if err := ngs.Validate(); err != nil {
+	if err := ngs.Validate("aws"); err != nil {
 		t.Fatal(err)
 	}
 	if ngs[0].Id == nil || *ngs[0].Id != 0 {
@@ -2145,6 +2145,84 @@ func TestValidateAndMutateParams_PreserveExistingNodeGroupIds(t *testing.T) {
 				t.Errorf("expected id=%d, got id=%d", tt.wantId, *result[0].Id)
 			}
 		})
+	}
+}
+
+func TestAdditionalNodeGroups_ZonesRoundTrip(t *testing.T) {
+	t.Run("zones survives re-marshal", func(t *testing.T) {
+		params := map[string]string{
+			"additional_node_groups_config": `[{"type":"Standard_D2s_v3","zones":"1,2"}]`,
+		}
+		if err := validateAndMutateParams(params, "azure", map[string]string{}, false); err != nil {
+			t.Fatal(err)
+		}
+		decoded, err := base64.StdEncoding.DecodeString(params["additional_node_groups_config"])
+		if err != nil {
+			t.Fatal(err)
+		}
+		var result AdditionalNodeGroups
+		if err := json.Unmarshal(decoded, &result); err != nil {
+			t.Fatal(err)
+		}
+		if result[0].Zones == nil || *result[0].Zones != "1,2" {
+			t.Errorf("expected zones=1,2 to survive, got %v", result[0].Zones)
+		}
+	})
+
+	t.Run("no zones emits no zones key", func(t *testing.T) {
+		params := map[string]string{
+			"additional_node_groups_config": `[{"type":"m5.large"}]`,
+		}
+		if err := validateAndMutateParams(params, "aws", map[string]string{}, false); err != nil {
+			t.Fatal(err)
+		}
+		decoded, err := base64.StdEncoding.DecodeString(params["additional_node_groups_config"])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(decoded), "zones") {
+			t.Errorf("expected no zones key, got %s", decoded)
+		}
+	})
+}
+
+func TestAdditionalNodeGroups_CapacityTypePerProvider(t *testing.T) {
+	tests := []struct {
+		name         string
+		provider     string
+		capacityType string
+		wantErr      bool
+	}{
+		{"aws rejects Regular", "aws", "Regular", true},
+		{"aws rejects Spot", "aws", "Spot", true},
+		{"aws accepts SPOT", "aws", "SPOT", false},
+		{"aws accepts ON_DEMAND", "aws", "ON_DEMAND", false},
+		{"azure accepts Regular", "azure", "Regular", false},
+		{"azure accepts SPOT", "azure", "SPOT", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := map[string]string{
+				"additional_node_groups_config": `[{"type":"m5.large","capacity_type":"` + tt.capacityType + `"}]`,
+			}
+			err := validateAndMutateParams(params, tt.provider, map[string]string{}, false)
+			if tt.wantErr && err == nil {
+				t.Errorf("expected rejection of capacity_type=%s on %s", tt.capacityType, tt.provider)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error for capacity_type=%s on %s: %v", tt.capacityType, tt.provider, err)
+			}
+		})
+	}
+}
+
+func TestAdditionalNodeGroups_DuplicateIdRejected(t *testing.T) {
+	params := map[string]string{
+		"additional_node_groups_config": `[{"id":1,"type":"m5.large"},{"id":1,"type":"c5.large"}]`,
+	}
+	err := validateAndMutateParams(params, "aws", map[string]string{}, false)
+	if err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Errorf("expected duplicate id rejection, got %v", err)
 	}
 }
 

--- a/terraform/cluster/aws/node_groups.tf
+++ b/terraform/cluster/aws/node_groups.tf
@@ -65,6 +65,10 @@ resource "random_id" "additional_node_groups" {
     role_arn            = replace(aws_iam_role.nodes.arn, "role/convox/", "role/") # eks barfs on roles with paths
     tags                = try(jsonencode(each.value.tags), "")
   }
+
+  lifecycle {
+    ignore_changes = [keepers["tags"]]
+  }
 }
 
 data "aws_ec2_instance_type" "additional_node_type" {
@@ -119,7 +123,8 @@ resource "aws_eks_node_group" "cluster_additional" {
   }
 
   lifecycle {
-    ignore_changes = [scaling_config[0].desired_size]
+    create_before_destroy = true
+    ignore_changes        = [scaling_config[0].desired_size]
   }
 
   labels = {
@@ -218,6 +223,10 @@ resource "random_id" "build_node_additional" {
     role_arn            = local.build_minimal_role_enabled ? replace(aws_iam_role.karpenter_build_nodes[0].arn, "role/convox/", "role/") : replace(aws_iam_role.nodes.arn, "role/convox/", "role/") # eks barfs on roles with paths
     tags                = try(jsonencode(each.value.tags), "")
   }
+
+  lifecycle {
+    ignore_changes = [keepers["tags"]]
+  }
 }
 
 data "aws_ec2_instance_type" "build_node_type" {
@@ -281,6 +290,9 @@ resource "aws_eks_node_group" "build_additional" {
     create = "1h"
   }
 
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_launch_template" "build_additional" {


### PR DESCRIPTION
### What is the feature/update/fix?

**Fix: Additional Node Groups Create Replacement Capacity Before Removing Old Nodes**

On AWS racks, edits to `additional_node_groups_config` that require a new EKS node group now create the replacement group and wait for it to become active before the previous group is removed. This applies to `type`, `disk`, `capacity_type`, `ami_id`, and, on additional node groups, a flip of the rack `private` parameter. The same create-first ordering covers additional build node groups configured through `additional_build_groups_config`. A pool carrying `dedicated: true` keeps schedulable capacity for its pinned services across the whole change.

Editing a node group's `tags` now updates the group in place. Tags continue to reach the node group object, the launch template `tag_specifications`, and the Auto Scaling group, and the nodes roll gracefully through a launch template version bump instead of the group being replaced.

**Node group edits:**

| Edit | Previously | Now |
|------|------------|-----|
| `tags` | replaced the node group | updates in place, nodes roll gracefully through a launch template version bump |
| `type`, `disk`, `capacity_type`, `ami_id`, rack `private` flip | replacement created after the previous group was removed | replacement created and active before the previous group is removed |
| `min_size`, `max_size`, `label`, `dedicated` flip, Kubernetes version bump | applied in place or as a rolling update | unchanged |
| adding or removing a node group | create only, or remove only | unchanged |

This release also makes two improvements to how the CLI handles `additional_node_groups_config`.

**Configuration handling:**

| Check | Behavior |
|-------|----------|
| `capacity_type` | validated per provider: AWS accepts `ON_DEMAND` and `SPOT`, Azure accepts those plus `Regular` and `Spot` |
| node group `id` | a duplicate `id` is reported with a clear message |

Validation runs only against the values supplied in the current `convox rack params set` call, never against stored configuration, so an existing rack is unaffected until it next sets the parameter. On AWS the value of `capacity_type` passes straight through to the EKS node group, which accepts `ON_DEMAND` and `SPOT`, so the CLI names the accepted values for the provider directly.

---

### Why is this important?

Additional node groups often carry dedicated workloads, GPU pools, or build capacity that a subset of services depends on exclusively. Ordering the replacement so that new capacity exists first keeps those services schedulable while the change rolls through, and treating a tag edit as an in-place update keeps routine metadata changes off the replacement path entirely.

**Benefits:**

- **Continuous capacity through a replacement.** Instance type, disk, capacity type, AMI, and `private` changes bring up the new node group and wait for it to become active before the previous group is removed, so a `dedicated: true` pool keeps nodes available for its pinned services throughout.
- **Tag edits stay in place.** Adding or changing tags on an additional node group updates the group and its launch template and rolls the nodes gracefully, so cost allocation and inventory tagging are ordinary configuration changes.
- **Configuration feedback in the CLI.** Provider-accurate `capacity_type` values and duplicate `id` detection are reported by the CLI at the point the parameter is set.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this fix.

There is no new rack parameter and no change to the shape of stored configuration. An existing rack with additional node groups sees an empty plan for untouched groups on the first apply, so nothing rolls or is replaced by the fix itself. The `capacity_type` values accepted on AWS now match what EKS itself accepts, and because validation applies only to values supplied in the current call, a rack with stored configuration is never rejected on that basis.

If a rack is later downgraded below `3.25.3`, the earlier version applies the prior replacement ordering to any subsequent node group edit. The lifecycle configuration carries no Terraform variable, so a rack whose additional node group `tags` are unchanged since the upgrade sees no plan diff from the downgrade itself.

---

### Requirements

This fix requires version `3.25.3` or later for the rack.

**Update the Rack:** Run `convox rack update 3.25.3 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
