### PR TITLE
clear stuck helm releases before rack apply

### DIFF
--- a/pkg/rack/helm.go
+++ b/pkg/rack/helm.go
@@ -1,0 +1,219 @@
+package rack
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const helmReleaseType = "helm.sh/release.v1"
+
+// Only clear releases pending longer than a live helm op could be: the system
+// releases pin timeout=600, so a fresh pending secret may be an in-flight apply.
+const helmStuckMinAge = 15 * time.Minute
+
+var helmPendingStatuses = map[string]bool{
+	"pending-install":  true,
+	"pending-upgrade":  true,
+	"pending-rollback": true,
+}
+
+func convoxHelmReleases(rack string) map[string]string {
+	system := strings.ToLower(rack) + "-system"
+	return map[string]string{
+		"aws-lbc":              "kube-system",
+		"karpenter":            "kube-system",
+		"karpenter-crd":        "kube-system",
+		"keda":                 "keda",
+		"vpa":                  "vpa",
+		"dcgm-exporter":        "kube-system",
+		"nvidia-device-plugin": "kube-system",
+		"contour":              system,
+		"contour-internal":     system,
+	}
+}
+
+type helmReleaseSecret struct {
+	secretName string
+	release    string
+	namespace  string
+	status     string
+	version    string
+	created    time.Time
+}
+
+// stuckHelmSecrets returns the allowlisted release secrets stuck pending-* past
+// minAge. Helm blocks new ops while pending, so no max-revision math is needed.
+func stuckHelmSecrets(found []helmReleaseSecret, allow map[string]string, now time.Time, minAge time.Duration) []helmReleaseSecret {
+	var out []helmReleaseSecret
+	for _, s := range found {
+		if ns, ok := allow[s.release]; !ok || ns != s.namespace {
+			continue
+		}
+		if !helmPendingStatuses[s.status] {
+			continue
+		}
+		if now.Sub(s.created) < minAge {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// reconcileStuckHelmReleases clears convox-owned Helm releases stranded in
+// pending-* by an interrupted apply. Best-effort: failures log under CONVOX_DEBUG.
+func (t Terraform) reconcileStuckHelmReleases() {
+	if t.provider != "aws" {
+		return
+	}
+
+	vars, err := t.vars()
+	if err != nil {
+		return
+	}
+	if vars["private_eks_host"] != "" {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cluster := strings.ToLower(t.name)
+
+	client, err := eksClient(ctx, cluster, vars["region"])
+	if err != nil {
+		helmReconcileDebug("build eks client for %s: %v", cluster, err)
+		return
+	}
+
+	list, err := client.CoreV1().Secrets(metav1.NamespaceAll).List(ctx, metav1.ListOptions{LabelSelector: "owner=helm"})
+	if err != nil {
+		helmReconcileDebug("list helm secrets: %v", err)
+		return
+	}
+
+	var found []helmReleaseSecret
+	for i := range list.Items {
+		s := &list.Items[i]
+		if string(s.Type) != helmReleaseType {
+			continue
+		}
+		found = append(found, helmReleaseSecret{
+			secretName: s.Name,
+			release:    s.Labels["name"],
+			namespace:  s.Namespace,
+			status:     s.Labels["status"],
+			version:    s.Labels["version"],
+			created:    s.CreationTimestamp.Time,
+		})
+	}
+
+	for _, s := range stuckHelmSecrets(found, convoxHelmReleases(t.name), time.Now(), helmStuckMinAge) {
+		fmt.Fprintf(os.Stderr, "NOTICE: clearing stuck Helm release %s (%s, revision %s) before apply\n", s.release, s.status, s.version)
+		if err := client.CoreV1().Secrets(s.namespace).Delete(ctx, s.secretName, metav1.DeleteOptions{}); err != nil {
+			helmReconcileDebug("delete %s/%s: %v", s.namespace, s.secretName, err)
+		}
+	}
+}
+
+func eksClient(ctx context.Context, cluster, region string) (*kubernetes.Clientset, error) {
+	endpoint, ca, err := eksClusterEndpoint(ctx, cluster, region)
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := eksToken(ctx, cluster, region)
+	if err != nil {
+		return nil, err
+	}
+
+	return kubernetes.NewForConfig(&rest.Config{
+		Host:            endpoint,
+		BearerToken:     token,
+		TLSClientConfig: rest.TLSClientConfig{CAData: ca},
+		Timeout:         20 * time.Second,
+	})
+}
+
+func eksClusterEndpoint(ctx context.Context, cluster, region string) (string, []byte, error) {
+	out, err := awsEKS(ctx, region, "describe-cluster", "--name", cluster, "--output", "json")
+	if err != nil {
+		return "", nil, err
+	}
+
+	var resp struct {
+		Cluster struct {
+			Endpoint             string `json:"endpoint"`
+			CertificateAuthority struct {
+				Data string `json:"data"`
+			} `json:"certificateAuthority"`
+		} `json:"cluster"`
+	}
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return "", nil, err
+	}
+
+	ca, err := base64.StdEncoding.DecodeString(resp.Cluster.CertificateAuthority.Data)
+	if err != nil {
+		return "", nil, err
+	}
+	if resp.Cluster.Endpoint == "" || len(ca) == 0 {
+		return "", nil, fmt.Errorf("empty cluster endpoint or ca")
+	}
+
+	return resp.Cluster.Endpoint, ca, nil
+}
+
+func eksToken(ctx context.Context, cluster, region string) (string, error) {
+	out, err := awsEKS(ctx, region, "get-token", "--cluster-name", cluster, "--output", "json")
+	if err != nil {
+		return "", err
+	}
+
+	var resp struct {
+		Status struct {
+			Token string `json:"token"`
+		} `json:"status"`
+	}
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return "", err
+	}
+	if resp.Status.Token == "" {
+		return "", fmt.Errorf("empty eks token")
+	}
+
+	return resp.Status.Token, nil
+}
+
+func awsEKS(ctx context.Context, region string, args ...string) ([]byte, error) {
+	full := append([]string{"eks"}, args...)
+	if region != "" {
+		full = append(full, "--region", region)
+	}
+
+	out, err := exec.CommandContext(ctx, "aws", full...).Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("%v: %s", err, strings.TrimSpace(string(ee.Stderr)))
+		}
+		return nil, err
+	}
+
+	return out, nil
+}
+
+func helmReconcileDebug(format string, args ...interface{}) {
+	if os.Getenv("CONVOX_DEBUG") == "true" {
+		fmt.Fprintf(os.Stderr, "debug: helm reconcile: "+format+"\n", args...)
+	}
+}

--- a/pkg/rack/helm_test.go
+++ b/pkg/rack/helm_test.go
@@ -1,0 +1,51 @@
+package rack
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStuckHelmSecrets(t *testing.T) {
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	allow := convoxHelmReleases("myrack")
+
+	stale := now.Add(-1 * time.Hour)
+	fresh := now.Add(-2 * time.Minute)
+
+	secret := func(name, release, ns, status string, created time.Time) helmReleaseSecret {
+		return helmReleaseSecret{secretName: name, release: release, namespace: ns, status: status, version: "1", created: created}
+	}
+
+	found := []helmReleaseSecret{
+		secret("sh.helm.release.v1.aws-lbc.v3", "aws-lbc", "kube-system", "pending-upgrade", stale),
+		secret("sh.helm.release.v1.karpenter.v2", "karpenter", "kube-system", "pending-install", stale),
+		secret("sh.helm.release.v1.contour.v5", "contour", "myrack-system", "pending-upgrade", stale),
+		secret("sh.helm.release.v1.keda.v1", "keda", "keda", "deployed", stale),
+		secret("sh.helm.release.v1.vpa.v4", "vpa", "vpa", "superseded", stale),
+		secret("sh.helm.release.v1.aws-lbc.v2", "aws-lbc", "kube-system", "failed", stale),
+		secret("sh.helm.release.v1.dcgm.v1", "dcgm-exporter", "kube-system", "pending-upgrade", fresh),
+		secret("sh.helm.release.v1.keda.v9", "keda", "default", "pending-upgrade", stale),
+		secret("sh.helm.release.v1.datadog.v1", "datadog", "monitoring", "pending-upgrade", stale),
+		secret("sh.helm.release.v1.contour.v1", "contour", "kube-system", "pending-upgrade", stale),
+	}
+
+	got := stuckHelmSecrets(found, allow, now, helmStuckMinAge)
+
+	var names []string
+	for _, s := range got {
+		names = append(names, s.secretName)
+	}
+
+	assert.ElementsMatch(t, []string{
+		"sh.helm.release.v1.aws-lbc.v3",
+		"sh.helm.release.v1.karpenter.v2",
+		"sh.helm.release.v1.contour.v5",
+	}, names)
+}
+
+func TestStuckHelmSecretsEmpty(t *testing.T) {
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	assert.Empty(t, stuckHelmSecrets(nil, convoxHelmReleases("myrack"), now, helmStuckMinAge))
+}

--- a/pkg/rack/terraform.go
+++ b/pkg/rack/terraform.go
@@ -453,6 +453,8 @@ func (t Terraform) apply() error {
 		return err
 	}
 
+	t.reconcileStuckHelmReleases()
+
 	if err := terraform(t.ctx, dir, "apply", "-auto-approve", "-no-color"); err != nil {
 		return err
 	}


### PR DESCRIPTION
### What is the feature/update/fix?

**Fix: Rack Applies Reconcile Helm Release State Before Running**

Rack applies now reconcile Helm release state before they begin. Where a previous apply was interrupted partway through a Helm operation and left a revision recorded as still mid-operation, the rack clears that revision at the start of the next apply, so re-running the rack update proceeds on its own.

The reconcile runs at the start of every AWS rack apply, which covers install, parameter updates, and version updates on both self-managed and Console-managed racks. It considers only the Helm releases Convox owns (`aws-lbc`, `karpenter`, `karpenter-crd`, `keda`, `vpa`, `dcgm-exporter`, `nvidia-device-plugin`, `contour`, and `contour-internal`), each in the namespace the rack installs it into. Releases a user installs themselves are never considered, and a `deployed`, `superseded`, or `failed` revision is never touched.

Timing keeps the check clear of live work. A revision is only ever cleared once it has been recorded mid-operation for longer than 15 minutes, which is longer than the operation timeout of any system chart, so an operation that is still running is left alone. When the rack does clear a revision it prints a `NOTICE` naming the release before the apply starts. The check is best effort: if it cannot reach the cluster or cannot complete, the apply runs exactly as it does today.

---

### Why is this important?

Rack updates are routinely retried, and a retry should be able to finish on its own. This fix makes recovery from an interrupted apply part of the normal rack update path, so the next `convox rack update` or `convox rack params set` completes without any direct action against the cluster.

**Benefits:**

- **Retries complete on their own.** Re-running the rack update after an interrupted apply is all that is required, with no direct step against the cluster in between.
- **Narrow, predictable scope.** Only the Convox-owned releases listed above, in the namespaces the rack installs them into, are ever considered. Anything a user installs is left untouched.
- **Live operations are protected.** The 15 minute minimum age sits beyond every system chart's operation timeout, so an operation that is still in flight is never affected.
- **No change to the apply path when it is not needed.** The check is best effort, so a rack that has nothing to reconcile behaves exactly as it does today.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this fix.

This is a code-only change with no new rack parameters, no Terraform changes, and no API or CLI surface changes. The rack reads Helm release state at the start of an apply and acts only on the specific case described above, so a rack with nothing to reconcile sees the same apply behavior as before.

---

### Requirements

This fix requires version `3.25.3` or later for the rack.

**Update the Rack:** Run `convox rack update 3.25.3 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._

This improvement is delivered through the Convox CLI rather than the rack Terraform module, so a Console-managed rack receives it once Console is updated, and a self-managed rack receives it with the CLI.
