### PR TITLE
raise node group desired before apply

### DIFF
--- a/pkg/rack/terraform.go
+++ b/pkg/rack/terraform.go
@@ -1,6 +1,7 @@
 package rack
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,7 +15,12 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/aws/aws-sdk-go/service/eks/eksiface"
 	"github.com/convox/convox/pkg/common"
 	"github.com/convox/convox/sdk"
 	"github.com/convox/stdcli"
@@ -394,6 +400,10 @@ func (t Terraform) UpdateParams(params map[string]string) error {
 		return err
 	}
 
+	if err := t.reconcileAdditionalNodeGroupDesired(vars); err != nil {
+		return err
+	}
+
 	if err := t.apply(); err != nil {
 		return err
 	}
@@ -437,6 +447,10 @@ func (t Terraform) UpdateVersion(version string, force bool) error {
 	}
 
 	if err := t.reconcileVarsWithModule(version); err != nil {
+		return err
+	}
+
+	if err := t.reconcileAdditionalNodeGroupDesired(vars); err != nil {
 		return err
 	}
 
@@ -561,6 +575,156 @@ func (t Terraform) reconcileVarsWithModule(release string) error {
 	}
 
 	return t.update(release, vars)
+}
+
+type nodeGroupDesired struct {
+	Id      *int `json:"id"`
+	MinSize *int `json:"min_size"`
+	MaxSize *int `json:"max_size"`
+}
+
+// reconcileAdditionalNodeGroupDesired raises each additional node group's EKS
+// desiredSize to its new min_size before apply. AWS only, best-effort.
+func (t Terraform) reconcileAdditionalNodeGroupDesired(vars map[string]string) error {
+	if t.provider != "aws" {
+		return nil
+	}
+
+	raw := vars["additional_node_groups_config"]
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+
+	data := []byte(raw)
+	if decoded, err := base64.StdEncoding.DecodeString(raw); err == nil {
+		data = decoded
+	}
+
+	var groups []nodeGroupDesired
+	if err := json.Unmarshal(data, &groups); err != nil || len(groups) == 0 {
+		return nil //nolint:nilerr // best-effort: malformed or empty config is a no-op, not an apply blocker
+	}
+
+	region := common.CoalesceString(vars["region"], os.Getenv("AWS_REGION"), os.Getenv("AWS_DEFAULT_REGION"))
+
+	s, err := session.NewSession(aws.NewConfig().WithRegion(region))
+	if err != nil {
+		nodeGroupDebugf("build aws session: %v", err)
+		return nil
+	}
+
+	return reconcileNodeGroupDesired(eks.New(s), common.CoalesceString(vars["name"], t.name), groups)
+}
+
+func reconcileNodeGroupDesired(api eksiface.EKSAPI, cluster string, groups []nodeGroupDesired) error {
+	listed, err := api.ListNodegroups(&eks.ListNodegroupsInput{ClusterName: aws.String(cluster)})
+	if err != nil {
+		nodeGroupDebugf("list node groups for %s: %v", cluster, err)
+		return nil
+	}
+
+	type pendingUpdate struct {
+		nodegroup string
+		id        string
+	}
+	var pending []pendingUpdate
+
+	for i, g := range groups {
+		if g.MinSize == nil {
+			continue
+		}
+
+		key := i
+		if g.Id != nil {
+			key = *g.Id
+		}
+		prefix := fmt.Sprintf("%s-additional-%d-", cluster, key)
+
+		name := ""
+		for _, n := range listed.Nodegroups {
+			if strings.HasPrefix(aws.StringValue(n), prefix) {
+				name = aws.StringValue(n)
+				break
+			}
+		}
+		if name == "" {
+			continue
+		}
+
+		desc, err := api.DescribeNodegroup(&eks.DescribeNodegroupInput{
+			ClusterName:   aws.String(cluster),
+			NodegroupName: aws.String(name),
+		})
+		if err != nil || desc.Nodegroup == nil || desc.Nodegroup.ScalingConfig == nil {
+			nodeGroupDebugf("describe node group %s: %v", name, err)
+			continue
+		}
+
+		newMin := int64(*g.MinSize)
+		currentDesired := aws.Int64Value(desc.Nodegroup.ScalingConfig.DesiredSize)
+		currentMax := aws.Int64Value(desc.Nodegroup.ScalingConfig.MaxSize)
+
+		if newMin <= currentDesired {
+			continue
+		}
+
+		// widen max too: EKS validates desired <= max against the pre-apply live max.
+		scaling := &eks.NodegroupScalingConfig{DesiredSize: aws.Int64(newMin)}
+		if newMin > currentMax {
+			scaling.MaxSize = aws.Int64(newMin)
+		}
+
+		out, err := api.UpdateNodegroupConfig(&eks.UpdateNodegroupConfigInput{
+			ClusterName:   aws.String(cluster),
+			NodegroupName: aws.String(name),
+			ScalingConfig: scaling,
+		})
+		if err != nil {
+			nodeGroupDebugf("raise desired on %s: %v", name, err)
+			continue
+		}
+
+		fmt.Fprintf(os.Stderr, "NOTICE: raising node group %s desired size to %d before apply\n", name, newMin)
+
+		if out.Update != nil {
+			pending = append(pending, pendingUpdate{nodegroup: name, id: aws.StringValue(out.Update.Id)})
+		}
+	}
+
+	for _, p := range pending {
+		waitForNodeGroupUpdate(api, cluster, p.nodegroup, p.id)
+	}
+
+	return nil
+}
+
+func waitForNodeGroupUpdate(api eksiface.EKSAPI, cluster, nodegroup, id string) {
+	if id == "" {
+		return
+	}
+
+	// 80 polls x 30s ~ 40min, matching the SDK nodegroup-active waiter.
+	for i := 0; i < 80; i++ {
+		out, err := api.DescribeUpdate(&eks.DescribeUpdateInput{
+			Name:          aws.String(cluster),
+			NodegroupName: aws.String(nodegroup),
+			UpdateId:      aws.String(id),
+		})
+		if err != nil {
+			nodeGroupDebugf("describe update %s/%s: %v", nodegroup, id, err)
+			return
+		}
+		if out.Update == nil || aws.StringValue(out.Update.Status) != eks.UpdateStatusInProgress {
+			return
+		}
+		time.Sleep(30 * time.Second)
+	}
+}
+
+func nodeGroupDebugf(format string, args ...interface{}) {
+	if os.Getenv("CONVOX_DEBUG") == "true" {
+		fmt.Fprintf(os.Stderr, "DEBUG: node group desired reconcile: "+format+"\n", args...)
+	}
 }
 
 func (t Terraform) create(release string, vars map[string]string, state []byte) error {

--- a/pkg/rack/terraform_nodegroup_desired_test.go
+++ b/pkg/rack/terraform_nodegroup_desired_test.go
@@ -1,0 +1,179 @@
+package rack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/aws/aws-sdk-go/service/eks/eksiface"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeEKS struct {
+	eksiface.EKSAPI
+	nodegroups []string
+	scaling    map[string]*eks.NodegroupScalingConfig
+	updates    []*eks.UpdateNodegroupConfigInput
+	listErr    error
+}
+
+func (f *fakeEKS) ListNodegroups(*eks.ListNodegroupsInput) (*eks.ListNodegroupsOutput, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	out := &eks.ListNodegroupsOutput{}
+	for _, n := range f.nodegroups {
+		out.Nodegroups = append(out.Nodegroups, aws.String(n))
+	}
+	return out, nil
+}
+
+func (f *fakeEKS) DescribeNodegroup(in *eks.DescribeNodegroupInput) (*eks.DescribeNodegroupOutput, error) {
+	sc, ok := f.scaling[aws.StringValue(in.NodegroupName)]
+	if !ok {
+		return nil, fmt.Errorf("no such node group")
+	}
+	return &eks.DescribeNodegroupOutput{Nodegroup: &eks.Nodegroup{ScalingConfig: sc}}, nil
+}
+
+func (f *fakeEKS) UpdateNodegroupConfig(in *eks.UpdateNodegroupConfigInput) (*eks.UpdateNodegroupConfigOutput, error) {
+	f.updates = append(f.updates, in)
+	return &eks.UpdateNodegroupConfigOutput{Update: &eks.Update{Id: aws.String("u-1"), Status: aws.String(eks.UpdateStatusSuccessful)}}, nil
+}
+
+func (f *fakeEKS) DescribeUpdate(in *eks.DescribeUpdateInput) (*eks.DescribeUpdateOutput, error) {
+	return &eks.DescribeUpdateOutput{Update: &eks.Update{Id: in.UpdateId, Status: aws.String(eks.UpdateStatusSuccessful)}}, nil
+}
+
+func intp(i int) *int { return &i }
+
+func scaling(desired, min, max int64) *eks.NodegroupScalingConfig {
+	return &eks.NodegroupScalingConfig{
+		DesiredSize: aws.Int64(desired),
+		MinSize:     aws.Int64(min),
+		MaxSize:     aws.Int64(max),
+	}
+}
+
+func TestReconcileNodeGroupDesired(t *testing.T) {
+	cases := []struct {
+		name        string
+		nodegroups  []string
+		scaling     map[string]*eks.NodegroupScalingConfig
+		groups      []nodeGroupDesired
+		listErr     error
+		wantNames   []string
+		wantDesired int64
+		wantMaxSet  bool
+		wantMax     int64
+	}{
+		{
+			name:       "no min set is a no-op",
+			nodegroups: []string{"rack-additional-0-abcd"},
+			scaling:    map[string]*eks.NodegroupScalingConfig{"rack-additional-0-abcd": scaling(1, 1, 5)},
+			groups:     []nodeGroupDesired{{Id: intp(0), MaxSize: intp(9)}},
+		},
+		{
+			name:       "group absent is a no-op",
+			nodegroups: []string{"rack-additional-7-abcd"},
+			scaling:    map[string]*eks.NodegroupScalingConfig{"rack-additional-7-abcd": scaling(1, 1, 5)},
+			groups:     []nodeGroupDesired{{Id: intp(0), MinSize: intp(3)}},
+		},
+		{
+			name:       "new min at or below desired is a no-op",
+			nodegroups: []string{"rack-additional-0-abcd"},
+			scaling:    map[string]*eks.NodegroupScalingConfig{"rack-additional-0-abcd": scaling(3, 1, 5)},
+			groups:     []nodeGroupDesired{{Id: intp(0), MinSize: intp(3)}},
+		},
+		{
+			name:        "raise desired within existing max",
+			nodegroups:  []string{"rack-additional-101-abcd"},
+			scaling:     map[string]*eks.NodegroupScalingConfig{"rack-additional-101-abcd": scaling(1, 1, 5)},
+			groups:      []nodeGroupDesired{{Id: intp(101), MinSize: intp(3), MaxSize: intp(9)}},
+			wantNames:   []string{"rack-additional-101-abcd"},
+			wantDesired: 3,
+		},
+		{
+			name:        "raise desired above existing max also widens max",
+			nodegroups:  []string{"rack-additional-0-abcd"},
+			scaling:     map[string]*eks.NodegroupScalingConfig{"rack-additional-0-abcd": scaling(1, 1, 2)},
+			groups:      []nodeGroupDesired{{Id: intp(0), MinSize: intp(8), MaxSize: intp(20)}},
+			wantNames:   []string{"rack-additional-0-abcd"},
+			wantDesired: 8,
+			wantMaxSet:  true,
+			wantMax:     8,
+		},
+		{
+			name:        "nil id falls back to slice index",
+			nodegroups:  []string{"rack-additional-0-abcd"},
+			scaling:     map[string]*eks.NodegroupScalingConfig{"rack-additional-0-abcd": scaling(1, 1, 5)},
+			groups:      []nodeGroupDesired{{MinSize: intp(3), MaxSize: intp(9)}},
+			wantNames:   []string{"rack-additional-0-abcd"},
+			wantDesired: 3,
+		},
+		{
+			name:        "id prefix does not collide with a longer id listed first",
+			nodegroups:  []string{"rack-additional-11-bbbb", "rack-additional-1-aaaa"},
+			scaling:     map[string]*eks.NodegroupScalingConfig{"rack-additional-11-bbbb": scaling(1, 1, 5), "rack-additional-1-aaaa": scaling(1, 1, 5)},
+			groups:      []nodeGroupDesired{{Id: intp(1), MinSize: intp(3), MaxSize: intp(9)}},
+			wantNames:   []string{"rack-additional-1-aaaa"},
+			wantDesired: 3,
+		},
+		{
+			name:       "id does not match a longer id when its own group is absent",
+			nodegroups: []string{"rack-additional-11-bbbb"},
+			scaling:    map[string]*eks.NodegroupScalingConfig{"rack-additional-11-bbbb": scaling(1, 1, 5)},
+			groups:     []nodeGroupDesired{{Id: intp(1), MinSize: intp(3)}},
+		},
+		{
+			name:        "describe error on one group still reconciles the others",
+			nodegroups:  []string{"rack-additional-0-xxxx", "rack-additional-1-yyyy"},
+			scaling:     map[string]*eks.NodegroupScalingConfig{"rack-additional-1-yyyy": scaling(1, 1, 5)},
+			groups:      []nodeGroupDesired{{Id: intp(0), MinSize: intp(3)}, {Id: intp(1), MinSize: intp(3), MaxSize: intp(9)}},
+			wantNames:   []string{"rack-additional-1-yyyy"},
+			wantDesired: 3,
+		},
+		{
+			name:        "multiple groups each get raised",
+			nodegroups:  []string{"rack-additional-0-xxxx", "rack-additional-1-yyyy"},
+			scaling:     map[string]*eks.NodegroupScalingConfig{"rack-additional-0-xxxx": scaling(1, 1, 5), "rack-additional-1-yyyy": scaling(1, 1, 5)},
+			groups:      []nodeGroupDesired{{Id: intp(0), MinSize: intp(3), MaxSize: intp(9)}, {Id: intp(1), MinSize: intp(3), MaxSize: intp(9)}},
+			wantNames:   []string{"rack-additional-0-xxxx", "rack-additional-1-yyyy"},
+			wantDesired: 3,
+		},
+		{
+			name:    "list error is best-effort no-op",
+			listErr: fmt.Errorf("throttled"),
+			groups:  []nodeGroupDesired{{Id: intp(0), MinSize: intp(3)}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &fakeEKS{nodegroups: tc.nodegroups, scaling: tc.scaling, listErr: tc.listErr}
+
+			err := reconcileNodeGroupDesired(f, "rack", tc.groups)
+			assert.NoError(t, err)
+			assert.Len(t, f.updates, len(tc.wantNames))
+
+			var gotNames []string
+			for _, u := range f.updates {
+				gotNames = append(gotNames, aws.StringValue(u.NodegroupName))
+				assert.Nil(t, u.ScalingConfig.MinSize)
+				if tc.wantDesired > 0 {
+					assert.Equal(t, tc.wantDesired, aws.Int64Value(u.ScalingConfig.DesiredSize))
+				}
+			}
+			assert.Equal(t, tc.wantNames, gotNames)
+
+			if tc.wantMaxSet {
+				assert.Equal(t, tc.wantMax, aws.Int64Value(f.updates[0].ScalingConfig.MaxSize))
+			} else {
+				for _, u := range f.updates {
+					assert.Nil(t, u.ScalingConfig.MaxSize)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What is the feature/update/fix?

**Fix: Additional Node Group Minimum Size Increases Apply in One Parameter Change on AWS Racks**

Raising the `min_size` of an existing entry in `additional_node_groups_config` on an AWS rack applies in a single `convox rack params set` call. Before Terraform runs, the rack brings each affected node group's desired size up to the new minimum so the group's live scaling configuration already satisfies the new floor by the time the apply reaches it. When the new minimum is also above the group's current maximum, the maximum is widened in the same operation. The rack waits for each change to settle before the apply begins.

The reconcile only ever raises values. Desired size is never lowered and maximum size is never narrowed, so scale-in decisions stay with the cluster autoscaler exactly as they do today. It runs on the parameter-set, version-update, and install paths, and it covers every node group that belongs to a pool, so a pool in the middle of a replacement is brought to its configured minimum along with the rest. A `NOTICE` names each group whose desired size is raised, and the step is best effort, so if it cannot run the apply proceeds exactly as it does today.

This applies to AWS racks and is a code-only change. There are no new rack parameters, no new Terraform variables, and no change to the rack module.

---

### Why is this important?

`min_size` is how a user guarantees a floor of capacity on a dedicated or workload-specific node pool. Raising that floor is now a one-step parameter change: the new minimum reaches the live node group and the apply carries it through, with the autoscaler still free to run the pool above the floor as demand dictates.

**Benefits:**

- **One-step minimum increases.** A single `convox rack params set` carries a higher `min_size` all the way to the live node group, with no preparatory step against the pool.
- **Autoscaler ownership preserved.** The rack only raises desired size and only widens maximum size, so the cluster autoscaler continues to own every scaling decision above the configured floor.
- **Complete pool coverage.** Every node group belonging to a pool is brought to the configured minimum, including a pool that is mid-replacement, so the floor is honored in every state a pool can be in.
- **Transparent and non-intrusive.** A `NOTICE` names each group whose desired size is raised, groups already at or above the new minimum are left untouched, and the step never blocks an apply.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this fix.

This is a code-only change with no new parameters, flags, or configuration. Node groups whose desired size already meets the configured minimum are left untouched, so a rack that does not change `additional_node_groups_config` behaves identically. Providers other than AWS are unaffected.

---

### Requirements

This fix requires version `3.25.3` or later for the rack.

**Update the Rack:** Run `convox rack update 3.25.3 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._

This improvement is delivered through the Convox CLI rather than the rack Terraform module, so a Console-managed rack receives it once Console is updated, and a self-managed rack receives it with the CLI.
