### PR TITLE
Fix metal install terraform validate failure

### DIFF
--- a/terraform/router/local/versions.tf
+++ b/terraform/router/local/versions.tf
@@ -12,10 +12,6 @@ terraform {
       source  = "hashicorp/null"
       version = "~> 3.2"
     }
-    tls = {
-      source  = "hashicorp/tls"
-      version = "~> 3.1"
-    }
   }
   required_version = ">= 0.12"
 }

--- a/terraform/router/metal/ca.tf
+++ b/terraform/router/metal/ca.tf
@@ -3,7 +3,6 @@ resource "tls_private_key" "ca-private" {
 }
 
 resource "tls_self_signed_cert" "ca" {
-  key_algorithm   = tls_private_key.ca-private.algorithm
   private_key_pem = tls_private_key.ca-private.private_key_pem
 
   dns_names             = ["ca.${var.name}"]

--- a/terraform/router/metal/versions.tf
+++ b/terraform/router/metal/versions.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.35.1"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
   }
   required_version = ">= 0.12"
 }


### PR DESCRIPTION
### What is the feature/update/fix?

**Fix: Metal Router CA Aligned With the Current hashicorp/tls Provider**

The Metal router module generates a self-signed CA with the `hashicorp/tls` provider, and its `tls_self_signed_cert` resource no longer sets the `key_algorithm` attribute, which the provider made read-only in v4.0.0 and now infers from the private key. A fresh `convox rack install metal` validates, plans, and applies against the current provider release. The generated CA certificate is unchanged: the same RSA key, subject, allowed uses, and ten year validity period as before.

The Metal router module also declares a `hashicorp/tls` requirement pinned to `~> 4.0`, matching the `~>` constraints already used for its other providers, so the provider major stays bounded on every `terraform init`. An unused `hashicorp/tls` requirement was removed from the local router module, which declares no TLS resources.

This change is scoped to Metal. No other provider or module declares TLS resources, and no rack parameters are involved.

---

### Why is this important?

Metal racks are installed directly against a user-supplied Kubernetes cluster, and the router module's self-signed CA is created as part of that first install. Keeping the module's provider requirements explicit and its resource configuration aligned with the current provider schema means a Metal install runs to completion on the current provider release, and stays predictable as new provider versions are published.

**Benefits:**

- **Aligned with the current provider release.** `convox rack install metal` validates, plans, and applies against the current `hashicorp/tls` provider release.
- **Identical CA output.** The algorithm is inferred from the RSA private key, so the certificate the module produces is the same as before.
- **Bounded provider resolution.** Pinning `hashicorp/tls` to `~> 4.0` keeps the Metal router module on a known provider major across future initializations.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this fix.

This is a Terraform-only change confined to the Metal router module and an unused provider requirement in the local router module. The CA certificate the module generates is unchanged, and there are no new or changed parameters, flags, or outputs. AWS, GCP, Azure, and DigitalOcean racks are untouched.

---

### Requirements

This fix requires version `3.25.3` or later for the rack.

**Update the Rack:** Run `convox rack update 3.25.3 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
