### PR TITLE
Add cloudwatch_disable rack param

### DIFF
--- a/assets/provider/aws/params.yaml
+++ b/assets/provider/aws/params.yaml
@@ -485,6 +485,10 @@ Groups:
         default: "false"
         type: boolean
         description: "Stops shipping your logs to CloudWatch. &l Enable this if you use another logging service. &l"
+      - name: cloudwatch_disable
+        default: "false"
+        type: boolean
+        description: "Stops Convox from creating, writing, or reading its own CloudWatch log groups (/convox/<rack>/<app>). &l Turn this on together with fluentd_disable if you route logs elsewhere; on its own it only hides the rack-side CloudWatch view. &l Note: convox logs and convox rack logs return empty while this is on. &l"
       - name: fluentd_memory
         default: 200Mi
         type: string

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -41,7 +41,7 @@ var awsKnownParams = map[string]bool{
 	"aws_ebs_csi_driver_version": true, "build_disable_convox_resolver": true,
 	"build_node_enabled": true, "build_node_minimal_role_enabled": true, "build_node_min_count": true,
 	"build_node_type": true, "buildkit_host_path_cache_enable": true,
-	"cert_duration": true, "cidr": true,
+	"cert_duration": true, "cidr": true, "cloudwatch_disable": true,
 	"convox_domain_tls_cert_disable": true, "convox_rack_domain": true,
 	"coredns_version": true, "cost_tracking_enable": true, "custom_provided_bucket": true,
 	"deploy_extra_nlb": true, "disable_convox_resolver": true,
@@ -186,6 +186,7 @@ var boolParams = map[string]bool{
 	"build_node_enabled":              true,
 	"build_node_minimal_role_enabled": true,
 	"buildkit_host_path_cache_enable": true,
+	"cloudwatch_disable":              true,
 	"convox_domain_tls_cert_disable":  true,
 	"cost_tracking_enable":            true,
 	"deploy_extra_nlb":                true,
@@ -528,6 +529,7 @@ var paramGroups = map[string]map[string]bool{
 	"logging": {
 		// v3 native (snake_case)
 		"access_log_retention_in_days":    true,
+		"cloudwatch_disable":              true,
 		"cost_tracking_enable":            true,
 		"eks_log_types":                   true,
 		"fluentd_disable":                 true,
@@ -1744,6 +1746,23 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 		}
 		// Canonicalize to "true"/"false" for consistent vars.json storage.
 		params[k] = strconv.FormatBool(b)
+	}
+
+	if provider == "aws" {
+		effectiveFluentd := params["fluentd_disable"]
+		if effectiveFluentd == "" {
+			effectiveFluentd = currentParams["fluentd_disable"]
+		}
+		effectiveCloudwatch := params["cloudwatch_disable"]
+		if effectiveCloudwatch == "" {
+			effectiveCloudwatch = currentParams["cloudwatch_disable"]
+		}
+		if params["cloudwatch_disable"] == "true" && effectiveFluentd != "true" {
+			fmt.Fprintf(os.Stderr, "WARNING: cloudwatch_disable stops Convox rack-side CloudWatch writes and makes 'convox logs' return empty, but fluentd is still enabled and will keep shipping application logs to CloudWatch and creating /convox/<rack>/<app> groups. To stop CloudWatch entirely, also set fluentd_disable=true.\n")
+		}
+		if params["fluentd_disable"] == "true" && effectiveCloudwatch != "true" {
+			fmt.Fprintf(os.Stderr, "WARNING: disabling fluentd stops application logs, but the rack still creates an empty CloudWatch log group per app (/convox/<rack>/<app>). Set cloudwatch_disable=true to prevent them.\n")
+		}
 	}
 
 	if v, ok := params["karpenter_capacity_types"]; ok && v != "" {

--- a/pkg/cli/rack_validate_test.go
+++ b/pkg/cli/rack_validate_test.go
@@ -1,9 +1,31 @@
 package cli
 
 import (
+	"io"
+	"os"
 	"strings"
 	"testing"
 )
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	fn()
+
+	w.Close()
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	return string(out)
+}
 
 func TestLevenshtein(t *testing.T) {
 	tests := []struct {
@@ -655,5 +677,101 @@ func TestValidateAndMutateParams_PrometheusUrl_SSRF(t *testing.T) {
 				t.Errorf("error %q should contain %q", err.Error(), tt.errMsg)
 			}
 		})
+	}
+}
+
+func TestValidateAndMutateParams_CloudwatchDisableWarnings(t *testing.T) {
+	const warnA = "cloudwatch_disable stops Convox"
+	const warnB = "disabling fluentd stops application logs"
+
+	cases := []struct {
+		name         string
+		params       map[string]string
+		current      map[string]string
+		provider     string
+		wantContains []string
+		wantAbsent   []string
+	}{
+		{
+			name:         "A fires: cloudwatch_disable=true, fluentd enabled",
+			params:       map[string]string{"cloudwatch_disable": "true"},
+			wantContains: []string{warnA},
+			wantAbsent:   []string{warnB},
+		},
+		{
+			name:         "A fires for non-canonical bool form",
+			params:       map[string]string{"cloudwatch_disable": "1"},
+			wantContains: []string{warnA},
+		},
+		{
+			name:         "B fires: fluentd_disable=true, cloudwatch enabled",
+			params:       map[string]string{"fluentd_disable": "true"},
+			wantContains: []string{warnB},
+			wantAbsent:   []string{warnA},
+		},
+		{
+			name:         "B fires for non-canonical bool form",
+			params:       map[string]string{"fluentd_disable": "1"},
+			wantContains: []string{warnB},
+		},
+		{
+			name:       "both set in one call fires neither",
+			params:     map[string]string{"fluentd_disable": "true", "cloudwatch_disable": "true"},
+			wantAbsent: []string{warnA, warnB},
+		},
+		{
+			name:       "A suppressed when fluentd already disabled",
+			params:     map[string]string{"cloudwatch_disable": "true"},
+			current:    map[string]string{"fluentd_disable": "true"},
+			wantAbsent: []string{warnA, warnB},
+		},
+		{
+			name:       "B suppressed when cloudwatch already disabled",
+			params:     map[string]string{"fluentd_disable": "true"},
+			current:    map[string]string{"cloudwatch_disable": "true"},
+			wantAbsent: []string{warnA, warnB},
+		},
+		{
+			name:       "no warning on unrelated param set",
+			params:     map[string]string{"cost_tracking_enable": "true"},
+			wantAbsent: []string{warnA, warnB},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			current := tc.current
+			if current == nil {
+				current = map[string]string{}
+			}
+			out := captureStderr(t, func() {
+				if err := validateAndMutateParams(tc.params, "aws", current, false); err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			})
+			for _, s := range tc.wantContains {
+				if !strings.Contains(out, s) {
+					t.Errorf("expected stderr to contain %q, got %q", s, out)
+				}
+			}
+			for _, s := range tc.wantAbsent {
+				if strings.Contains(out, s) {
+					t.Errorf("expected stderr NOT to contain %q, got %q", s, out)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateAndMutateParams_CloudwatchDisableBoolValidation(t *testing.T) {
+	captureStderr(t, func() {
+		for _, v := range []string{"true", "false", "1", "0", "t", "F"} {
+			if err := validateAndMutateParams(map[string]string{"cloudwatch_disable": v}, "aws", map[string]string{}, false); err != nil {
+				t.Errorf("cloudwatch_disable=%q: unexpected error: %v", v, err)
+			}
+		}
+	})
+	if err := validateAndMutateParams(map[string]string{"cloudwatch_disable": "maybe"}, "aws", map[string]string{}, false); err == nil {
+		t.Error("cloudwatch_disable=maybe: expected error, got nil")
 	}
 }

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -37,6 +37,7 @@ type Provider struct {
 
 	EcrScanOnPushEnable     bool
 	EcrImmutableTagsEnabled bool
+	CloudwatchDisable       bool
 
 	Ec2 *ec2.EC2
 
@@ -72,6 +73,7 @@ func FromEnv() (*Provider, error) {
 		Region:                  os.Getenv("AWS_REGION"),
 		EcrScanOnPushEnable:     ecrScanOnPushEnable,
 		EcrImmutableTagsEnabled: ecrImmutableTagsEnabled,
+		CloudwatchDisable:       os.Getenv("CLOUDWATCH_DISABLE") == "true",
 	}
 
 	k.Engine = p

--- a/provider/aws/log.go
+++ b/provider/aws/log.go
@@ -23,6 +23,10 @@ var (
 )
 
 func (p *Provider) Log(name, stream string, ts time.Time, message string) error {
+	if p.CloudwatchDisable {
+		return nil
+	}
+
 	group := p.appLogGroup(name)
 
 	req := &cloudwatchlogs.PutLogEventsInput{
@@ -74,6 +78,9 @@ func (p *Provider) Log(name, stream string, ts time.Time, message string) error 
 }
 
 func (p *Provider) AppLogs(name string, opts structs.LogsOptions) (io.ReadCloser, error) {
+	if p.CloudwatchDisable {
+		return io.NopCloser(strings.NewReader("")), nil
+	}
 	if p.ContextTID() != "" {
 		name = fmt.Sprintf("%s-%s", p.ContextTID(), name)
 	}
@@ -81,6 +88,9 @@ func (p *Provider) AppLogs(name string, opts structs.LogsOptions) (io.ReadCloser
 }
 
 func (p *Provider) SystemLogs(opts structs.LogsOptions) (io.ReadCloser, error) {
+	if p.CloudwatchDisable {
+		return io.NopCloser(strings.NewReader("")), nil
+	}
 	return p.subscribeLogs(p.Context(), p.appLogGroup("system"), "", opts)
 }
 
@@ -113,6 +123,9 @@ func (p *Provider) createLogGroup(app string) error {
 }
 
 func (p *Provider) UpdateOrDisableLogGroupRetention(app string, retentionDays int, disableRetention bool) error {
+	if p.CloudwatchDisable {
+		return nil
+	}
 
 	// disable retention policy
 	if disableRetention {

--- a/provider/aws/log_internal_test.go
+++ b/provider/aws/log_internal_test.go
@@ -66,6 +66,60 @@ func TestStreamLogsStopsOnMissingLogGroup(t *testing.T) {
 	m.AssertNumberOfCalls(t, "FilterLogEvents", 3)
 }
 
+// With cloudwatch_disable=true, Log short-circuits before any CloudWatch call,
+// so no log group is created or written. A mock with no expectations panics if
+// the guard is bypassed.
+func TestLogCloudwatchDisableShortCircuits(t *testing.T) {
+	m := &mocks.CloudWatchLogsAPI{}
+	p := &Provider{CloudWatchLogs: m, CloudwatchDisable: true}
+
+	if err := p.Log("app", "stream", time.Now(), "msg"); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	m.AssertNumberOfCalls(t, "PutLogEvents", 0)
+	m.AssertNumberOfCalls(t, "CreateLogGroup", 0)
+}
+
+func TestAppAndSystemLogsCloudwatchDisableReturnEmpty(t *testing.T) {
+	m := &mocks.CloudWatchLogsAPI{}
+	p := &Provider{CloudWatchLogs: m, CloudwatchDisable: true}
+
+	for _, tc := range []struct {
+		name string
+		open func() (io.ReadCloser, error)
+	}{
+		{"AppLogs", func() (io.ReadCloser, error) { return p.AppLogs("app", structs.LogsOptions{}) }},
+		{"SystemLogs", func() (io.ReadCloser, error) { return p.SystemLogs(structs.LogsOptions{}) }},
+	} {
+		r, err := tc.open()
+		if err != nil {
+			t.Fatalf("%s: expected nil error, got %v", tc.name, err)
+		}
+		b, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatalf("%s: read: %v", tc.name, err)
+		}
+		if len(b) != 0 {
+			t.Fatalf("%s: expected empty reader, got %q", tc.name, b)
+		}
+	}
+	m.AssertNumberOfCalls(t, "FilterLogEvents", 0)
+}
+
+func TestUpdateOrDisableLogGroupRetentionCloudwatchDisable(t *testing.T) {
+	m := &mocks.CloudWatchLogsAPI{}
+	p := &Provider{CloudWatchLogs: m, CloudwatchDisable: true}
+
+	if err := p.UpdateOrDisableLogGroupRetention("app", 30, false); err != nil {
+		t.Fatalf("set retention: expected nil, got %v", err)
+	}
+	if err := p.UpdateOrDisableLogGroupRetention("app", 0, true); err != nil {
+		t.Fatalf("disable retention: expected nil, got %v", err)
+	}
+	m.AssertNumberOfCalls(t, "PutRetentionPolicy", 0)
+	m.AssertNumberOfCalls(t, "DeleteRetentionPolicy", 0)
+}
+
 // A successful FilterLogEvents must reset the consecutive-miss counter, so an
 // eventual-consistency blip while a group is being created never kills a tail.
 func TestStreamLogsResourceNotFoundResetsOnSuccess(t *testing.T) {

--- a/terraform/api/aws/main.tf
+++ b/terraform/api/aws/main.tf
@@ -65,6 +65,7 @@ module "k8s" {
     SOCKET                                    = "/var/run/docker.sock"
     ECR_IMMUTABLE_TAGS_ENABLED                = var.ecr_immutable_tags_enabled
     ECR_SCAN_ON_PUSH_ENABLE                   = var.ecr_scan_on_push_enable
+    CLOUDWATCH_DISABLE                        = var.cloudwatch_disable
     SUBNET_IDS                                = join(",", var.subnets)
     VPC_ID                                    = var.vpc_id
     RELEASES_TO_RETAIN_AFTER_ACTIVE           = var.releases_to_retain_after_active

--- a/terraform/api/aws/variables.tf
+++ b/terraform/api/aws/variables.tf
@@ -93,6 +93,11 @@ variable "ecr_scan_on_push_enable" {
   default = false
 }
 
+variable "cloudwatch_disable" {
+  type    = bool
+  default = false
+}
+
 variable "efs_file_system_id" {
   type = string
 }

--- a/terraform/rack/aws/main.tf
+++ b/terraform/rack/aws/main.tf
@@ -41,6 +41,7 @@ module "api" {
   ecr_full_access                           = var.ecr_full_access
   ecr_immutable_tags_enabled                = var.ecr_immutable_tags_enabled
   ecr_scan_on_push_enable                   = var.ecr_scan_on_push_enable
+  cloudwatch_disable                        = var.cloudwatch_disable
   ecr_docker_hub_cache_prefix               = var.ecr_docker_hub_cache_prefix
   efs_csi_driver_enable                     = var.efs_csi_driver_enable
   efs_file_system_id                        = var.efs_file_system_id

--- a/terraform/rack/aws/variables.tf
+++ b/terraform/rack/aws/variables.tf
@@ -83,6 +83,11 @@ variable "ecr_scan_on_push_enable" {
   default = false
 }
 
+variable "cloudwatch_disable" {
+  type    = bool
+  default = false
+}
+
 variable "ecr_docker_hub_cache_prefix" {
   type    = string
   default = ""

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -321,6 +321,7 @@ module "rack" {
   ecr_full_access                           = var.ecr_full_access
   ecr_immutable_tags_enabled                = var.ecr_immutable_tags_enabled
   ecr_scan_on_push_enable                   = var.ecr_scan_on_push_enable
+  cloudwatch_disable                        = var.cloudwatch_disable
   ecr_docker_hub_cache_prefix               = module.cluster.ecr_docker_hub_cache_prefix
   vpc_id                                    = module.cluster.vpc
   vpa_enable                                = var.vpa_enable

--- a/terraform/system/aws/telemetry.tf
+++ b/terraform/system/aws/telemetry.tf
@@ -18,6 +18,7 @@ locals {
     buildkit_host_path_cache_enable           = var.buildkit_host_path_cache_enable
     cert_duration                             = var.cert_duration
     cidr                                      = var.cidr
+    cloudwatch_disable                        = var.cloudwatch_disable
     contour_cpu_request                       = var.contour_cpu_request
     contour_internal_tls                      = var.contour_internal_tls
     contour_memory_request                    = var.contour_memory_request
@@ -171,6 +172,7 @@ locals {
     buildkit_host_path_cache_enable           = "false"
     cert_duration                             = "2160h"
     cidr                                      = "10.1.0.0/16"
+    cloudwatch_disable                        = "false"
     contour_cpu_request                       = "100m"
     contour_internal_tls                      = "true"
     contour_memory_request                    = "128Mi"

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -112,6 +112,11 @@ variable "ecr_docker_hub_cache" {
   default = false
 }
 
+variable "cloudwatch_disable" {
+  type    = bool
+  default = false
+}
+
 variable "fluentd_disable" {
   type    = bool
   default = false


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: `cloudwatch_disable` Rack Parameter for AWS Racks**

AWS racks gain a new parameter, `cloudwatch_disable`, that turns off the rack's own CloudWatch activity. When it is set to `true`, the rack does not create, write to, or read from its Convox CloudWatch log groups (`/convox/<rack>/<app>`). It is intended for racks that route logs to another destination and want CloudWatch out of the picture on the Convox side. The default is `false`, so behavior is unchanged unless the parameter is explicitly set.

**New Rack Parameter:**

| Parameter | Type | Default | Effect |
|-----------|------|---------|--------|
| `cloudwatch_disable` | bool | `false` | When `true`, the AWS rack does not create, write, or read its Convox CloudWatch log groups. Default `false` preserves current behavior exactly. |

With `cloudwatch_disable=true`, `convox logs -a my-app` and `convox rack logs` return empty. That is the intended effect of the parameter: both of those views read from CloudWatch, and the parameter turns that reading off. `convox logs -a my-app -s web` is unaffected, because per-service logs are read from the pods directly. The `appSettings.awsLogs` retention settings in `convox.yml` are also not applied while the parameter is on, since the rack is no longer managing those log groups.

`cloudwatch_disable` is the sibling of `fluentd_disable`. On its own it stops only the rack's own CloudWatch activity; application logs continue to flow to CloudWatch through fluentd. Pair the two to route logs entirely elsewhere. Because a two-step rollout is a legitimate way to get there, the CLI prints a non-blocking warning when one of the pair is enabled while the other is still off, and setting both in a single call prints neither.

---

### Why is this important?

Racks that send their logs to a third-party logging service now have a single parameter that takes Convox out of CloudWatch entirely, so the rack's log destination matches how the team actually reads logs.

**Benefits:**

- **A complete opt-out from CloudWatch.** Combined with `fluentd_disable`, the rack neither ships application logs to CloudWatch nor creates or reads its own log groups, so a rack that reads logs elsewhere keeps its CloudWatch footprint at zero.
- **Independent control of the two halves.** `fluentd_disable` governs application log shipping and `cloudwatch_disable` governs the rack's own CloudWatch groups, so each can be turned off on its own schedule, with a CLI warning as a reminder when only one of the two is set.
- **Predictable log surfaces.** The effect on `convox logs` and `convox rack logs` is explicit and documented, and per-service logs through `convox logs -s` continue to work unchanged.
- **Unchanged by default.** The parameter defaults to `false` on every rack and applies only to AWS, so existing racks see no difference until they opt in.

---

### How to use it?

Turn off CloudWatch for the rack and for application log shipping in a single call:

    $ convox rack params set cloudwatch_disable=true fluentd_disable=true -r rackName

Set only the rack's own CloudWatch activity, leaving fluentd shipping application logs:

    $ convox rack params set cloudwatch_disable=true -r rackName

The parameter appears in `convox rack params -r rackName` once it has been set.

Setting the parameter back to `false` restores the previous behavior, and log groups are recreated as the rack writes to them again.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this feature.

The parameter is purely additive and defaults to `false`, which is exactly the current behavior on every rack version. It applies to AWS only; GCP, Azure, DigitalOcean, Metal, and Local racks are unaffected. Downgrading a rack below `3.25.3` removes the parameter, and the rack returns to creating, writing, and reading its CloudWatch log groups as before.

---

### Requirements

This feature requires version `3.25.3` or later for the rack.

**Update the Rack:** Run `convox rack update 3.25.3 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
