### PR TITLE
add karpenter build disruption budget param

### DIFF
--- a/assets/provider/aws/params.yaml
+++ b/assets/provider/aws/params.yaml
@@ -583,7 +583,7 @@ Groups:
       - name: karpenter_disruption_budget_nodes
         default: "10%"
         type: string
-        regex: ^\d+%?$
+        regex: ^((100|[0-9]{1,2})%|[0-9]+)$
         description: Maximum nodes that can be disrupted simultaneously. &l &i e.g. &i 10%, 3 &l
       - name: karpenter_node_disk
         default: "0"
@@ -680,6 +680,11 @@ Groups:
         type: string
         regex: ^\d+[smh]$
         description: Time before empty build nodes are removed.
+      - name: karpenter_build_disruption_budget_nodes
+        default: "100%"
+        type: string
+        regex: ^((100|[0-9]{1,2})%|[0-9]+)$
+        description: Maximum empty build nodes reclaimed simultaneously. &l &i e.g. &i 100%, 1 &l
       - name: karpenter_build_imds_tokens
         default: ""
         sideNote: Empty inherits the cluster IMDS setting

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -74,7 +74,8 @@ var awsKnownParams = map[string]bool{
 	"karpenter_arch": true, "karpenter_auth_mode": true,
 	"karpenter_build_capacity_types": true, "karpenter_build_consolidate_after": true,
 	"karpenter_build_cpu_limit": true, "karpenter_build_instance_families": true,
-	"karpenter_build_instance_sizes": true, "karpenter_build_memory_limit_gb": true,
+	"karpenter_build_disruption_budget_nodes": true,
+	"karpenter_build_instance_sizes":          true, "karpenter_build_memory_limit_gb": true,
 	"karpenter_build_imds_tokens": true, "karpenter_build_imds_hop_limit": true,
 	"karpenter_build_node_labels": true, "karpenter_capacity_types": true,
 	"karpenter_config": true, "karpenter_consolidate_after": true,
@@ -254,34 +255,35 @@ var paramGroups = map[string]map[string]bool{
 		"tags":                            true,
 	},
 	"karpenter": {
-		"additional_karpenter_nodepools_config": true,
-		"karpenter_arch":                        true,
-		"karpenter_auth_mode":                   true,
-		"karpenter_build_capacity_types":        true,
-		"karpenter_build_consolidate_after":     true,
-		"karpenter_build_cpu_limit":             true,
-		"karpenter_build_instance_families":     true,
-		"karpenter_build_instance_sizes":        true,
-		"karpenter_build_memory_limit_gb":       true,
-		"karpenter_build_node_labels":           true,
-		"karpenter_capacity_types":              true,
-		"karpenter_config":                      true,
-		"karpenter_consolidate_after":           true,
-		"karpenter_consolidation_enabled":       true,
-		"karpenter_cpu_limit":                   true,
-		"karpenter_disruption_budget_nodes":     true,
-		"karpenter_enabled":                     true,
-		"karpenter_instance_families":           true,
-		"karpenter_instance_sizes":              true,
-		"karpenter_memory_limit_gb":             true,
-		"karpenter_node_disk":                   true,
-		"karpenter_node_expiry":                 true,
-		"karpenter_node_labels":                 true,
-		"karpenter_node_os":                     true,
-		"karpenter_node_overlays_config":        true,
-		"karpenter_node_taints":                 true,
-		"karpenter_node_volume_type":            true,
-		"keda_enable":                           true,
+		"additional_karpenter_nodepools_config":   true,
+		"karpenter_arch":                          true,
+		"karpenter_auth_mode":                     true,
+		"karpenter_build_capacity_types":          true,
+		"karpenter_build_consolidate_after":       true,
+		"karpenter_build_cpu_limit":               true,
+		"karpenter_build_disruption_budget_nodes": true,
+		"karpenter_build_instance_families":       true,
+		"karpenter_build_instance_sizes":          true,
+		"karpenter_build_memory_limit_gb":         true,
+		"karpenter_build_node_labels":             true,
+		"karpenter_capacity_types":                true,
+		"karpenter_config":                        true,
+		"karpenter_consolidate_after":             true,
+		"karpenter_consolidation_enabled":         true,
+		"karpenter_cpu_limit":                     true,
+		"karpenter_disruption_budget_nodes":       true,
+		"karpenter_enabled":                       true,
+		"karpenter_instance_families":             true,
+		"karpenter_instance_sizes":                true,
+		"karpenter_memory_limit_gb":               true,
+		"karpenter_node_disk":                     true,
+		"karpenter_node_expiry":                   true,
+		"karpenter_node_labels":                   true,
+		"karpenter_node_os":                       true,
+		"karpenter_node_overlays_config":          true,
+		"karpenter_node_taints":                   true,
+		"karpenter_node_volume_type":              true,
+		"keda_enable":                             true,
 	},
 	"gpu": {
 		"additional_karpenter_nodepools_config": true, // dual-listed in karpenter
@@ -399,19 +401,20 @@ var paramGroups = map[string]map[string]bool{
 	},
 	"scaling": {
 		// v3 native (snake_case)
-		"build_node_min_count":                 true,
-		"high_availability":                    true,
-		"karpenter_disruption_budget_nodes":    true,
-		"karpenter_enabled":                    true,
-		"keda_enable":                          true,
-		"max_on_demand_count":                  true,
-		"min_on_demand_count":                  true,
-		"node_max_unavailable_percentage":      true,
-		"pdb_default_min_available_percentage": true,
-		"schedule_rack_scale_down":             true,
-		"schedule_rack_scale_up":               true,
-		"terraform_update_timeout":             true,
-		"vpa_enable":                           true,
+		"build_node_min_count":                    true,
+		"high_availability":                       true,
+		"karpenter_build_disruption_budget_nodes": true, // dual-listed in build
+		"karpenter_disruption_budget_nodes":       true,
+		"karpenter_enabled":                       true,
+		"keda_enable":                             true,
+		"max_on_demand_count":                     true,
+		"min_on_demand_count":                     true,
+		"node_max_unavailable_percentage":         true,
+		"pdb_default_min_available_percentage":    true,
+		"schedule_rack_scale_down":                true,
+		"schedule_rack_scale_up":                  true,
+		"terraform_update_timeout":                true,
+		"vpa_enable":                              true,
 		// v2 PascalCase (no-op on v3 racks; surfaced on v2 racks)
 		"Autoscale":                      true,
 		"AutoscaleExtra":                 true,
@@ -480,23 +483,24 @@ var paramGroups = map[string]map[string]bool{
 	},
 	"build": {
 		// v3 native (snake_case)
-		"additional_build_groups_config":    true,
-		"build_disable_convox_resolver":     true,
-		"build_node_enabled":                true,
-		"build_node_min_count":              true,
-		"build_node_minimal_role_enabled":   true, // dual-listed in security
-		"build_node_type":                   true,
-		"buildkit_enabled":                  true,
-		"buildkit_host_path_cache_enable":   true,
-		"karpenter_build_capacity_types":    true,
-		"karpenter_build_consolidate_after": true,
-		"karpenter_build_cpu_limit":         true,
-		"karpenter_build_imds_hop_limit":    true, // dual-listed in security
-		"karpenter_build_imds_tokens":       true, // dual-listed in security
-		"karpenter_build_instance_families": true,
-		"karpenter_build_instance_sizes":    true,
-		"karpenter_build_memory_limit_gb":   true,
-		"karpenter_build_node_labels":       true,
+		"additional_build_groups_config":          true,
+		"build_disable_convox_resolver":           true,
+		"build_node_enabled":                      true,
+		"build_node_min_count":                    true,
+		"build_node_minimal_role_enabled":         true, // dual-listed in security
+		"build_node_type":                         true,
+		"buildkit_enabled":                        true,
+		"buildkit_host_path_cache_enable":         true,
+		"karpenter_build_capacity_types":          true,
+		"karpenter_build_consolidate_after":       true,
+		"karpenter_build_cpu_limit":               true,
+		"karpenter_build_disruption_budget_nodes": true, // dual-listed in scaling
+		"karpenter_build_imds_hop_limit":          true, // dual-listed in security
+		"karpenter_build_imds_tokens":             true, // dual-listed in security
+		"karpenter_build_instance_families":       true,
+		"karpenter_build_instance_sizes":          true,
+		"karpenter_build_memory_limit_gb":         true,
+		"karpenter_build_node_labels":             true,
 		// v2 PascalCase (no-op on v3 racks; surfaced on v2 racks)
 		"BuildCpu":                    true,
 		"BuildImage":                  true,
@@ -1086,9 +1090,9 @@ func (np *KarpenterNodePoolConfigParam) Validate() error {
 	}
 
 	if np.DisruptionBudgetNodes != nil {
-		budgetRe := regexp.MustCompile(`^\d+%?$`)
+		budgetRe := regexp.MustCompile(`^((100|[0-9]{1,2})%|[0-9]+)$`)
 		if !budgetRe.MatchString(*np.DisruptionBudgetNodes) {
-			return fmt.Errorf("karpenter nodepool '%s': disruption_budget_nodes must be a number or percentage", np.Name)
+			return fmt.Errorf("karpenter nodepool '%s': disruption_budget_nodes must be a node count or a percentage from 0%% to 100%%", np.Name)
 		}
 	}
 
@@ -1711,6 +1715,7 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 			"karpenter_capacity_types", "karpenter_cpu_limit", "karpenter_memory_limit_gb",
 			"karpenter_consolidate_after", "karpenter_build_consolidate_after",
 			"karpenter_node_expiry", "karpenter_disruption_budget_nodes",
+			"karpenter_build_disruption_budget_nodes",
 			"karpenter_build_capacity_types", "karpenter_build_cpu_limit",
 			"karpenter_build_memory_limit_gb", "karpenter_node_taints",
 			"karpenter_node_labels", "karpenter_build_node_labels",
@@ -1785,10 +1790,14 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 		}
 	}
 
-	if v, ok := params["karpenter_disruption_budget_nodes"]; ok && v != "" {
-		budgetRe := regexp.MustCompile(`^\d+%?$`)
-		if !budgetRe.MatchString(v) {
-			return fmt.Errorf("karpenter_disruption_budget_nodes must be a number or percentage (e.g. 10%%)")
+	// Pattern matches the Karpenter NodePool CRD validation for disruption budgets,
+	// so an out-of-range percentage fails here instead of at terraform apply.
+	budgetRe := regexp.MustCompile(`^((100|[0-9]{1,2})%|[0-9]+)$`)
+	for _, bk := range []string{"karpenter_disruption_budget_nodes", "karpenter_build_disruption_budget_nodes"} {
+		if v, ok := params[bk]; ok && v != "" {
+			if !budgetRe.MatchString(v) {
+				return fmt.Errorf("%s must be a node count or a percentage from 0%% to 100%% (e.g. 100%%)", bk)
+			}
 		}
 	}
 

--- a/pkg/cli/rack_karpenter_test.go
+++ b/pkg/cli/rack_karpenter_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestValidateAndMutateParams_BudgetRegex(t *testing.T) {
-	tests := []struct {
+	cases := []struct {
 		name    string
 		value   string
 		wantErr bool
@@ -16,25 +16,30 @@ func TestValidateAndMutateParams_BudgetRegex(t *testing.T) {
 		{"plain number", "3", false},
 		{"percentage", "10%", false},
 		{"zero", "0", false},
+		{"zero percent", "0%", false},
 		{"hundred percent", "100%", false},
 		{"double percent", "10%%", true},
 		{"text", "abc", true},
 		{"empty", "", true}, // empty is now rejected (clearableParams guard)
 		{"negative", "-1", true},
 		{"decimal", "1.5", true},
+		{"over hundred percent", "101%", true},
+		{"way over hundred percent", "200%", true},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			params := map[string]string{
-				"karpenter_enabled":                 "true",
-				"karpenter_disruption_budget_nodes": tt.value,
-			}
-			err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"}, false)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("budget=%q: got err=%v, wantErr=%v", tt.value, err, tt.wantErr)
-			}
-		})
+	for _, param := range []string{"karpenter_disruption_budget_nodes", "karpenter_build_disruption_budget_nodes"} {
+		for _, tt := range cases {
+			t.Run(param+"/"+tt.name, func(t *testing.T) {
+				params := map[string]string{
+					"karpenter_enabled": "true",
+					param:               tt.value,
+				}
+				err := validateAndMutateParams(params, "aws", map[string]string{"karpenter_auth_mode": "true"}, false)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("%s=%q: got err=%v, wantErr=%v", param, tt.value, err, tt.wantErr)
+				}
+			})
+		}
 	}
 }
 
@@ -513,6 +518,11 @@ func TestKarpenterNodePoolConfigParam_Validate(t *testing.T) {
 		{
 			"invalid budget double percent",
 			KarpenterNodePoolConfigParam{Name: "test", DisruptionBudgetNodes: strPtr("10%%")},
+			true, "disruption_budget_nodes",
+		},
+		{
+			"invalid budget over one hundred percent",
+			KarpenterNodePoolConfigParam{Name: "test", DisruptionBudgetNodes: strPtr("200%")},
 			true, "disruption_budget_nodes",
 		},
 	}
@@ -1952,6 +1962,13 @@ func TestValidateAndMutateParams_KarpenterReenableValidation(t *testing.T) {
 			"must be 'optional' or 'required'",
 		},
 		{
+			"stale invalid build_disruption_budget_nodes in currentParams caught on re-enable",
+			map[string]string{"karpenter_enabled": "true", "karpenter_auth_mode": "true"},
+			map[string]string{"karpenter_auth_mode": "true", "karpenter_build_disruption_budget_nodes": "200%"},
+			true,
+			"karpenter_build_disruption_budget_nodes must be a node count or a percentage",
+		},
+		{
 			"valid currentParams pass re-enable validation",
 			map[string]string{"karpenter_enabled": "true", "karpenter_auth_mode": "true"},
 			map[string]string{"karpenter_auth_mode": "true", "karpenter_capacity_types": "on-demand"},
@@ -2284,6 +2301,7 @@ func TestValidateAndMutateParams_EmptyParamRejection(t *testing.T) {
 		{"empty karpenter_build_consolidate_after", "karpenter_build_consolidate_after", "", true, "requires an explicit value"},
 		{"empty karpenter_node_expiry", "karpenter_node_expiry", "", true, "requires an explicit value"},
 		{"empty karpenter_disruption_budget_nodes", "karpenter_disruption_budget_nodes", "", true, "requires an explicit value"},
+		{"empty karpenter_build_disruption_budget_nodes", "karpenter_build_disruption_budget_nodes", "", true, "requires an explicit value"},
 		{"empty karpenter_auth_mode", "karpenter_auth_mode", "", true, "requires an explicit value"},
 		{"empty karpenter_enabled", "karpenter_enabled", "", true, "requires an explicit value"},
 		// Non-karpenter params also rejected when empty

--- a/terraform/cluster/aws/karpenter_nodepool.tf
+++ b/terraform/cluster/aws/karpenter_nodepool.tf
@@ -295,6 +295,7 @@ resource "kubectl_manifest" "karpenter_nodepool_build" {
     karpenter_build_cpu_limit         = var.karpenter_build_cpu_limit
     karpenter_build_memory_limit_gb   = var.karpenter_build_memory_limit_gb
     karpenter_build_consolidate_after = var.karpenter_build_consolidate_after
+    karpenter_build_disruption_budget_nodes = var.karpenter_build_disruption_budget_nodes
     karpenter_build_arch              = var.build_arm_type ? "arm64" : "amd64"
     extra_labels                      = local.karpenter_build_extra_labels
   })

--- a/terraform/cluster/aws/templates/karpenter-nodepool-build.yaml.tpl
+++ b/terraform/cluster/aws/templates/karpenter-nodepool-build.yaml.tpl
@@ -44,3 +44,8 @@ spec:
   disruption:
     consolidationPolicy: WhenEmpty
     consolidateAfter: ${karpenter_build_consolidate_after}
+    budgets:
+      - nodes: "${karpenter_build_disruption_budget_nodes}"
+        reasons: ["Empty"]
+      - nodes: "10%"
+        reasons: ["Drifted", "Underutilized"]

--- a/terraform/cluster/aws/variables.tf
+++ b/terraform/cluster/aws/variables.tf
@@ -249,6 +249,11 @@ variable "karpenter_build_consolidate_after" {
   default = "60s"
 }
 
+variable "karpenter_build_disruption_budget_nodes" {
+  type    = string
+  default = "100%"
+}
+
 variable "karpenter_build_node_labels" {
   type    = string
   default = ""

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -169,6 +169,7 @@ module "cluster" {
   karpenter_build_cpu_limit           = var.karpenter_build_cpu_limit
   karpenter_build_memory_limit_gb     = var.karpenter_build_memory_limit_gb
   karpenter_build_consolidate_after   = var.karpenter_build_consolidate_after
+  karpenter_build_disruption_budget_nodes = var.karpenter_build_disruption_budget_nodes
   karpenter_build_node_labels         = var.karpenter_build_node_labels
   karpenter_build_imds_tokens         = var.karpenter_build_imds_tokens
   karpenter_build_imds_hop_limit      = var.karpenter_build_imds_hop_limit

--- a/terraform/system/aws/telemetry.tf
+++ b/terraform/system/aws/telemetry.tf
@@ -74,6 +74,7 @@ locals {
     karpenter_build_capacity_types            = var.karpenter_build_capacity_types
     karpenter_build_consolidate_after         = var.karpenter_build_consolidate_after
     karpenter_build_cpu_limit                 = var.karpenter_build_cpu_limit
+    karpenter_build_disruption_budget_nodes   = var.karpenter_build_disruption_budget_nodes
     karpenter_build_imds_hop_limit            = var.karpenter_build_imds_hop_limit
     karpenter_build_imds_tokens               = var.karpenter_build_imds_tokens
     karpenter_build_instance_families         = var.karpenter_build_instance_families
@@ -227,6 +228,7 @@ locals {
     karpenter_build_capacity_types            = "on-demand"
     karpenter_build_consolidate_after         = "60s"
     karpenter_build_cpu_limit                 = "32"
+    karpenter_build_disruption_budget_nodes   = "100%"
     karpenter_build_imds_hop_limit            = "0"
     karpenter_build_imds_tokens               = ""
     karpenter_build_instance_families         = ""

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -383,6 +383,11 @@ variable "karpenter_build_consolidate_after" {
   default = "60s"
 }
 
+variable "karpenter_build_disruption_budget_nodes" {
+  type    = string
+  default = "100%"
+}
+
 variable "karpenter_build_node_labels" {
   type    = string
   default = ""


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: Configurable Disruption Budget for Karpenter Build Nodes**

`karpenter_build_disruption_budget_nodes` is a new AWS rack parameter that sets how many empty Karpenter build nodes may be reclaimed in a single disruption pass, so build capacity scales back toward zero promptly once builds finish. It accepts a node count (`1`, `5`) or a percentage (`50%`, `100%`) and defaults to `100%`. It applies to racks running Karpenter with dedicated build nodes enabled.

| Parameter | Type | Default | Effect |
|-----------|------|---------|--------|
| `karpenter_build_disruption_budget_nodes` | string | `100%` | Maximum empty Karpenter build nodes reclaimed in one disruption pass. Accepts a node count (`1`, `5`) or a percentage (`50%`, `100%`). `0` freezes empty-node reclamation on the build pool. |

The budget governs empty-node reclamation only. Every other disruption reason keeps its current `10%` ceiling, so drift and underutilization behavior is unchanged. The build pool uses `consolidationPolicy: WhenEmpty`, so only nodes with no reschedulable pods are ever considered, and a high budget cannot interrupt a running build. Adding the field is an in-place manifest update that does not churn existing nodes.

Disruption budget values are also now validated against the Karpenter NodePool CRD pattern `^((100|[0-9]{1,2})%|[0-9]+)$` in all three places that feed that field: `karpenter_disruption_budget_nodes` for the workload pool, the new `karpenter_build_disruption_budget_nodes` for the build pool, and `disruption_budget_nodes` inside `additional_karpenter_nodepools_config` for each additional pool. An out-of-range value is reported by the CLI as the parameter is set, rather than during the rack apply. `0` and `0%` remain valid, since a zero budget is the Karpenter idiom for pausing voluntary disruption on a pool. Validation covers the values supplied in the current call and does not reject a value the rack already has stored.

---

### Why is this important?

Build nodes are disposable capacity that should exist only while builds are running. This parameter puts the rate at which idle build nodes are reclaimed under direct control, with a default that returns the build pool to zero quickly after a burst of builds, and a full range of narrower settings for racks that prefer to release build capacity more gradually.

**Benefits:**

- **Build capacity returns to zero promptly.** At the `100%` default, every empty build node in the pool is eligible for reclamation in the same disruption pass, so the pool tracks actual build demand.
- **Direct control over the reclamation rate.** A node count or percentage sets exactly how much of the build pool may be reclaimed at once, and `0` holds the current build nodes in place.
- **Running builds are unaffected.** Empty-node consolidation considers only nodes with no reschedulable pods, so raising the budget never shortens a build in flight.
- **Unchanged behavior everywhere else.** Drift and underutilization on the build pool stay at their current `10%` ceiling, and the workload pool and additional Karpenter node pools keep their existing budgets.
- **Budget values checked at the CLI.** All three disruption budget settings are validated against the same pattern Karpenter enforces, so a value outside the accepted range is reported as the parameter is set.

---

### How to use it?

Set the budget on a Karpenter rack with build nodes enabled:

    $ convox rack params set karpenter_build_disruption_budget_nodes=100% -r rackName

Use a fixed node count to release build capacity more gradually:

    $ convox rack params set karpenter_build_disruption_budget_nodes=2 -r rackName

Hold the current build nodes in place:

    $ convox rack params set karpenter_build_disruption_budget_nodes=0 -r rackName

---

### Does it have a breaking change?

**No breaking changes** are introduced with this feature.

On upgrade, the build pool's empty-node disruption budget moves from the implicit `10%` CRD default to `100%`. This behavior change is confined to the disposable build pool and has no effect on workload or app capacity, and the parameter can be set to a node count or a lower percentage at any time for a narrower budget. Applying the change is an in-place manifest update, so existing nodes are not churned.

Downgrade is clean. The parameter is removed from the rack configuration when an earlier version is applied, and the build pool returns to the CRD default budget.

---

### Requirements

This feature requires version `3.25.3` or later for the rack.

**Update the Rack:** Run `convox rack update 3.25.3 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
