### PR TITLE
multi-arch app image builds for karpenter racks

### DIFF
--- a/pkg/build/build_buildkit_test.go
+++ b/pkg/build/build_buildkit_test.go
@@ -71,7 +71,9 @@ func TestBuild(t *testing.T) {
 			"--import-cache", "type=registry,ref=registry.test.com:web.buildcache",
 			"--opt", "build-arg:FOO=bar",
 		).Return(nil).Run(func(args mock.Arguments) {
-			fmt.Fprintf(args.Get(0).(io.Writer), "build1\nbuild2\n")
+			w, ok := args.Get(0).(io.Writer)
+			require.True(t, ok)
+			fmt.Fprintf(w, "build1\nbuild2\n")
 		})
 
 		e.On(
@@ -83,7 +85,9 @@ func TestBuild(t *testing.T) {
 		).Return(fxSkopeoInspect(), nil)
 
 		p.On("ObjectStore", "app1", "build/build1/logs", mock.Anything, structs.ObjectStoreOptions{}).Return(fxObject(), nil).Run(func(args mock.Arguments) {
-			_, err := io.ReadAll(args.Get(2).(io.Reader))
+			r, ok := args.Get(2).(io.Reader)
+			require.True(t, ok)
+			_, err := io.ReadAll(r)
 			require.NoError(t, err)
 		})
 		p.On("ReleaseCreate", "app1", structs.ReleaseCreateOptions{Build: options.String("build1")}).Return(fxRelease2(), nil)
@@ -145,7 +149,9 @@ func TestBuildDevelopment(t *testing.T) {
 			"--import-cache", "type=registry,ref=registry.test.com:web.buildcache",
 			"--opt", "target=development",
 		).Return(nil).Run(func(args mock.Arguments) {
-			fmt.Fprintf(args.Get(0).(io.Writer), "build1\nbuild2\n")
+			w, ok := args.Get(0).(io.Writer)
+			require.True(t, ok)
+			fmt.Fprintf(w, "build1\nbuild2\n")
 		})
 
 		e.On(
@@ -157,7 +163,250 @@ func TestBuildDevelopment(t *testing.T) {
 		).Return(fxSkopeoInspect(), nil)
 
 		p.On("ObjectStore", "app1", "build/build1/logs", mock.Anything, structs.ObjectStoreOptions{}).Return(fxObject(), nil).Run(func(args mock.Arguments) {
-			_, err := io.ReadAll(args.Get(2).(io.Reader))
+			r, ok := args.Get(2).(io.Reader)
+			require.True(t, ok)
+			_, err := io.ReadAll(r)
+			require.NoError(t, err)
+		})
+		p.On("ReleaseCreate", "app1", structs.ReleaseCreateOptions{Build: options.String("build1")}).Return(fxRelease2(), nil)
+		p.On("EventSend", "build:create", structs.EventSendOptions{Data: map[string]string{"app": "app1", "id": "build1", "release_id": "release2"}}).Return(nil)
+
+		err = b.Execute()
+		require.NoError(t, err)
+	})
+}
+
+func TestBuildMultiArch(t *testing.T) {
+	opts := build.Options{
+		App:      "app1",
+		Auth:     "{}",
+		Cache:    true,
+		Id:       "build1",
+		Rack:     "rack1",
+		Source:   "object://app1/object.tgz",
+		Push:     "registry.test.com",
+		Manifest: "convox2.yml",
+	}
+
+	t.Setenv("PROVIDER", "do")
+	t.Setenv("BUILD_ARCHS", "arm64,amd64")
+	testBuild(t, opts, bkEngine, func(b *build.Build, p *structs.MockProvider, e *exec.MockInterface, out *bytes.Buffer) {
+		p.On("BuildGet", "app1", "build1").Return(fxBuildStarted(), nil).Once()
+
+		bdata, err := os.ReadFile("testdata/httpd.tgz")
+		require.NoError(t, err)
+		p.On("ObjectFetch", "app1", "/object.tgz").Return(io.NopCloser(bytes.NewReader(bdata)), nil)
+
+		p.On("BuildUpdate", "app1", "build1", mock.Anything).Return(fxBuildStarted(), nil)
+
+		p.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{*fxRelease()}, nil)
+		p.On("ReleaseGet", "app1", "release1").Return(fxRelease(), nil)
+
+		e.On(
+			"Run",
+			mock.Anything,
+			"buildctl", "build", "--frontend", "dockerfile.v0", "--local", mock.MatchedBy(matchContext), "--local", mock.MatchedBy(matchDockerfile),
+			"--opt", mock.MatchedBy(matchFilename), "--output", mock.MatchedBy(matchTag), "--opt", "platform=linux/amd64,linux/arm64",
+			"--export-cache", "mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true,type=registry,ref=registry.test.com:web.buildcache",
+			"--import-cache", "type=registry,ref=registry.test.com:web.buildcache",
+			"--opt", "build-arg:FOO=bar",
+		).Return(nil).Run(func(args mock.Arguments) {
+			w, ok := args.Get(0).(io.Writer)
+			require.True(t, ok)
+			fmt.Fprintf(w, "build1\nbuild2\n")
+		})
+
+		e.On(
+			"Execute",
+			"skopeo",
+			"inspect",
+			"--config",
+			"docker://registry.test.com:web.build1",
+		).Return(fxSkopeoInspect(), nil)
+
+		p.On("ObjectStore", "app1", "build/build1/logs", mock.Anything, structs.ObjectStoreOptions{}).Return(fxObject(), nil).Run(func(args mock.Arguments) {
+			r, ok := args.Get(2).(io.Reader)
+			require.True(t, ok)
+			_, err := io.ReadAll(r)
+			require.NoError(t, err)
+		})
+		p.On("ReleaseCreate", "app1", structs.ReleaseCreateOptions{Build: options.String("build1")}).Return(fxRelease2(), nil)
+		p.On("EventSend", "build:create", structs.EventSendOptions{Data: map[string]string{"app": "app1", "id": "build1", "release_id": "release2"}}).Return(nil)
+
+		err = b.Execute()
+		require.NoError(t, err)
+	})
+}
+
+func TestBuildSingleArchPin(t *testing.T) {
+	opts := build.Options{
+		App:      "app1",
+		Auth:     "{}",
+		Cache:    true,
+		Id:       "build1",
+		Rack:     "rack1",
+		Source:   "object://app1/object.tgz",
+		Push:     "registry.test.com",
+		Manifest: "convox2.yml",
+	}
+
+	t.Setenv("PROVIDER", "do")
+	t.Setenv("BUILD_ARCHS", "arm64")
+	testBuild(t, opts, bkEngine, func(b *build.Build, p *structs.MockProvider, e *exec.MockInterface, out *bytes.Buffer) {
+		p.On("BuildGet", "app1", "build1").Return(fxBuildStarted(), nil).Once()
+
+		bdata, err := os.ReadFile("testdata/httpd.tgz")
+		require.NoError(t, err)
+		p.On("ObjectFetch", "app1", "/object.tgz").Return(io.NopCloser(bytes.NewReader(bdata)), nil)
+
+		p.On("BuildUpdate", "app1", "build1", mock.Anything).Return(fxBuildStarted(), nil)
+
+		p.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{*fxRelease()}, nil)
+		p.On("ReleaseGet", "app1", "release1").Return(fxRelease(), nil)
+
+		e.On(
+			"Run",
+			mock.Anything,
+			"buildctl", "build", "--frontend", "dockerfile.v0", "--local", mock.MatchedBy(matchContext), "--local", mock.MatchedBy(matchDockerfile),
+			"--opt", mock.MatchedBy(matchFilename), "--output", mock.MatchedBy(matchTag), "--opt", "platform=linux/arm64",
+			"--export-cache", "mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true,type=registry,ref=registry.test.com:web.buildcache",
+			"--import-cache", "type=registry,ref=registry.test.com:web.buildcache",
+			"--opt", "build-arg:FOO=bar",
+		).Return(nil).Run(func(args mock.Arguments) {
+			w, ok := args.Get(0).(io.Writer)
+			require.True(t, ok)
+			fmt.Fprintf(w, "build1\nbuild2\n")
+		})
+
+		e.On(
+			"Execute",
+			"skopeo",
+			"inspect",
+			"--config",
+			"docker://registry.test.com:web.build1",
+		).Return(fxSkopeoInspect(), nil)
+
+		p.On("ObjectStore", "app1", "build/build1/logs", mock.Anything, structs.ObjectStoreOptions{}).Return(fxObject(), nil).Run(func(args mock.Arguments) {
+			r, ok := args.Get(2).(io.Reader)
+			require.True(t, ok)
+			_, err := io.ReadAll(r)
+			require.NoError(t, err)
+		})
+		p.On("ReleaseCreate", "app1", structs.ReleaseCreateOptions{Build: options.String("build1")}).Return(fxRelease2(), nil)
+		p.On("EventSend", "build:create", structs.EventSendOptions{Data: map[string]string{"app": "app1", "id": "build1", "release_id": "release2"}}).Return(nil)
+
+		err = b.Execute()
+		require.NoError(t, err)
+	})
+}
+
+func TestBuildMultiArchNoMatchError(t *testing.T) {
+	opts := build.Options{
+		App:      "app1",
+		Auth:     "{}",
+		Cache:    true,
+		Id:       "build1",
+		Rack:     "rack1",
+		Source:   "object://app1/object.tgz",
+		Push:     "registry.test.com",
+		Manifest: "convox2.yml",
+	}
+
+	t.Setenv("PROVIDER", "do")
+	t.Setenv("BUILD_ARCHS", "amd64,arm64")
+	testBuild(t, opts, bkEngine, func(b *build.Build, p *structs.MockProvider, e *exec.MockInterface, out *bytes.Buffer) {
+		p.On("BuildGet", "app1", "build1").Return(fxBuildStarted(), nil).Once()
+
+		bdata, err := os.ReadFile("testdata/httpd.tgz")
+		require.NoError(t, err)
+		p.On("ObjectFetch", "app1", "/object.tgz").Return(io.NopCloser(bytes.NewReader(bdata)), nil)
+
+		p.On("BuildUpdate", "app1", "build1", mock.Anything).Return(fxBuildStarted(), nil)
+
+		p.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{*fxRelease()}, nil)
+		p.On("ReleaseGet", "app1", "release1").Return(fxRelease(), nil)
+
+		e.On(
+			"Run",
+			mock.Anything,
+			"buildctl", "build", "--frontend", "dockerfile.v0", "--local", mock.MatchedBy(matchContext), "--local", mock.MatchedBy(matchDockerfile),
+			"--opt", mock.MatchedBy(matchFilename), "--output", mock.MatchedBy(matchTag), "--opt", "platform=linux/amd64,linux/arm64",
+			"--export-cache", "mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true,type=registry,ref=registry.test.com:web.buildcache",
+			"--import-cache", "type=registry,ref=registry.test.com:web.buildcache",
+			"--opt", "build-arg:FOO=bar",
+		).Return(fmt.Errorf("exit status 1")).Run(func(args mock.Arguments) {
+			w, ok := args.Get(0).(io.Writer)
+			require.True(t, ok)
+			fmt.Fprintf(w, "error: failed to solve: httpd: no match for platform in manifest: not found\n")
+		})
+
+		p.On("ObjectStore", "app1", "build/build1/logs", mock.Anything, structs.ObjectStoreOptions{}).Return(fxObject(), nil).Run(func(args mock.Arguments) {
+			r, ok := args.Get(2).(io.Reader)
+			require.True(t, ok)
+			_, err := io.ReadAll(r)
+			require.NoError(t, err)
+		})
+		p.On("EventSend", "build:create", mock.Anything).Return(nil)
+
+		err = b.Execute()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not published for the requested build architectures (amd64,arm64)")
+		require.Contains(t, err.Error(), "BuildArch")
+	})
+}
+
+func TestBuildMultiArchDevelopment(t *testing.T) {
+	opts := build.Options{
+		App:         "app1",
+		Auth:        "{}",
+		Cache:       true,
+		Development: true,
+		Id:          "build1",
+		Rack:        "rack1",
+		Source:      "object://app1/object.tgz",
+		Push:        "registry.test.com",
+	}
+
+	t.Setenv("PROVIDER", "do")
+	t.Setenv("BUILD_ARCHS", "amd64,arm64")
+	testBuild(t, opts, bkEngine, func(b *build.Build, p *structs.MockProvider, e *exec.MockInterface, out *bytes.Buffer) {
+		p.On("BuildGet", "app1", "build1").Return(fxBuildStarted(), nil).Once()
+
+		bdata, err := os.ReadFile("testdata/httpd-dev.tgz")
+		require.NoError(t, err)
+		p.On("ObjectFetch", "app1", "/object.tgz").Return(io.NopCloser(bytes.NewReader(bdata)), nil)
+
+		p.On("BuildUpdate", "app1", "build1", mock.Anything).Return(fxBuildStarted(), nil)
+
+		p.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{*fxRelease()}, nil)
+		p.On("ReleaseGet", "app1", "release1").Return(fxRelease(), nil)
+
+		e.On(
+			"Run",
+			mock.Anything,
+			"buildctl", "build", "--frontend", "dockerfile.v0", "--local", mock.MatchedBy(matchContext), "--local", mock.MatchedBy(matchDockerfile),
+			"--opt", mock.MatchedBy(matchFilename), "--output", mock.MatchedBy(matchTag),
+			"--export-cache", "mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true,type=registry,ref=registry.test.com:web.buildcache",
+			"--import-cache", "type=registry,ref=registry.test.com:web.buildcache",
+			"--opt", "target=development",
+		).Return(nil).Run(func(args mock.Arguments) {
+			w, ok := args.Get(0).(io.Writer)
+			require.True(t, ok)
+			fmt.Fprintf(w, "build1\nbuild2\n")
+		})
+
+		e.On(
+			"Execute",
+			"skopeo",
+			"inspect",
+			"--config",
+			"docker://registry.test.com:web.build1",
+		).Return(fxSkopeoInspect(), nil)
+
+		p.On("ObjectStore", "app1", "build/build1/logs", mock.Anything, structs.ObjectStoreOptions{}).Return(fxObject(), nil).Run(func(args mock.Arguments) {
+			r, ok := args.Get(2).(io.Reader)
+			require.True(t, ok)
+			_, err := io.ReadAll(r)
 			require.NoError(t, err)
 		})
 		p.On("ReleaseCreate", "app1", structs.ReleaseCreateOptions{Build: options.String("build1")}).Return(fxRelease2(), nil)
@@ -219,7 +468,9 @@ func TestBuildOptions(t *testing.T) {
 			"--import-cache", "type=registry,ref=registry.test.com:web.buildcache",
 			"--opt", "build-arg:FOO=bar",
 		).Return(nil).Run(func(args mock.Arguments) {
-			fmt.Fprintf(args.Get(0).(io.Writer), "build1\nbuild2\n")
+			w, ok := args.Get(0).(io.Writer)
+			require.True(t, ok)
+			fmt.Fprintf(w, "build1\nbuild2\n")
 		})
 
 		e.On(
@@ -231,7 +482,9 @@ func TestBuildOptions(t *testing.T) {
 		).Return([]byte("''"), nil)
 
 		p.On("ObjectStore", "app1", "build/build1/logs", mock.Anything, structs.ObjectStoreOptions{}).Return(fxObject(), nil).Run(func(args mock.Arguments) {
-			_, err := io.ReadAll(args.Get(2).(io.Reader))
+			r, ok := args.Get(2).(io.Reader)
+			require.True(t, ok)
+			_, err := io.ReadAll(r)
 			require.NoError(t, err)
 		})
 		p.On("ReleaseCreate", "app1", structs.ReleaseCreateOptions{Build: options.String("build1")}).Return(fxRelease2(), nil)

--- a/pkg/build/buildkit.go
+++ b/pkg/build/buildkit.go
@@ -208,15 +208,28 @@ func (bk *BuildKit) build(bb *Build, path, dockerfile, tag string, env map[strin
 	}
 
 	args := []string{"build"}
-	args = append(args, "--frontend", "dockerfile.v0")                                // skipcq
-	args = append(args, "--local", fmt.Sprintf("context=%s", path))                   // skipcq
-	args = append(args, "--local", fmt.Sprintf("dockerfile=%s", path))                // skipcq
-	args = append(args, "--opt", fmt.Sprintf("filename=%s", dockerfile))              // skipcq
+	args = append(args,
+		"--frontend", "dockerfile.v0",
+		"--local", fmt.Sprintf("context=%s", path),
+		"--local", fmt.Sprintf("dockerfile=%s", path),
+		"--opt", fmt.Sprintf("filename=%s", dockerfile),
+	) // skipcq
 	outputOpt := fmt.Sprintf("type=image,name=%s,push=true", tag)
 	if os.Getenv("PROVIDER") == "local" {
 		outputOpt = fmt.Sprintf("type=image,name=%s,push=true,registry.insecure=true", tag)
 	}
 	args = append(args, "--output", outputOpt) // skipcq
+
+	archs := common.BuildArchs(os.Getenv("BUILD_ARCHS"))
+	platformed := len(archs) > 0 && !bb.Development
+
+	if platformed {
+		platforms := make([]string, len(archs))
+		for i, a := range archs {
+			platforms[i] = "linux/" + a
+		}
+		args = append(args, "--opt", fmt.Sprintf("platform=%s", strings.Join(platforms, ","))) // skipcq
+	}
 
 	localCacheAdded := false
 
@@ -273,6 +286,9 @@ func (bk *BuildKit) build(bb *Build, path, dockerfile, tag string, env map[strin
 		}
 	} else {
 		if err := bb.Exec.Run(bb.writer, "buildctl", args...); err != nil {
+			if platformed && strings.Contains(bb.logs.String(), "no match for platform") {
+				return fmt.Errorf("an image in this build is not published for the requested build architectures (%s): set the BuildArch app parameter to an architecture the image supports (convox apps params set BuildArch=amd64 -a %s) or use multi-arch images", strings.Join(archs, ","), bb.App)
+			}
 			return err
 		}
 	}

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -1336,6 +1336,97 @@ func suggestParam(key string, known map[string]bool) string {
 	return best
 }
 
+var instanceFamilyRe = regexp.MustCompile(`^([a-z]+)([0-9]+)([a-z]*)$`)
+
+// familyArch classifies an EC2 instance family as amd64, arm64, or "" when
+// the naming convention cannot determine it (Graviton families carry a "g"
+// after the generation digit, e.g. c6g, t4g, im4gn, g5g).
+func familyArch(family string) string {
+	family = strings.ToLower(strings.TrimSpace(family))
+	if family == "a1" {
+		return "arm64"
+	}
+	m := instanceFamilyRe.FindStringSubmatch(family)
+	if m == nil {
+		return ""
+	}
+	if strings.Contains(m[3], "g") {
+		return "arm64"
+	}
+	return "amd64"
+}
+
+func instanceArch(instanceType string) string {
+	if instanceType == "" {
+		return ""
+	}
+	first := strings.Split(instanceType, ",")[0]
+	return familyArch(strings.Split(first, ".")[0])
+}
+
+func checkArchFamilies(param, families string, archs []string, archSource string) error {
+	if families == "" || len(archs) == 0 {
+		return nil
+	}
+	for _, f := range strings.Split(families, ",") {
+		cls := familyArch(f)
+		if cls == "" {
+			return nil
+		}
+		for _, a := range archs {
+			if a == cls {
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("%s (%s) has no family matching the %s architecture (%s); Karpenter could not provision any matching node", param, families, archSource, strings.Join(archs, ","))
+}
+
+// validateKarpenterArchFamilies rejects arch/instance-family combinations that
+// make a Karpenter node pool unsatisfiable. Values not in the call fall back
+// to currentParams so stale combinations are caught when karpenter is enabled.
+func validateKarpenterArchFamilies(params, currentParams map[string]string) error {
+	effective := func(key string) string {
+		if v, ok := params[key]; ok {
+			return v
+		}
+		return currentParams[key]
+	}
+
+	relevant := false
+	for _, k := range []string{"karpenter_enabled", "karpenter_arch", "karpenter_instance_families", "karpenter_build_instance_families", "node_type", "build_node_type"} {
+		if _, ok := params[k]; ok {
+			relevant = true
+			break
+		}
+	}
+	if !relevant || effective("karpenter_enabled") != "true" {
+		return nil
+	}
+
+	workloadArchs := []string{}
+	if v := effective("karpenter_arch"); v != "" {
+		for _, a := range strings.Split(v, ",") {
+			workloadArchs = append(workloadArchs, strings.TrimSpace(a))
+		}
+	} else if a := instanceArch(effective("node_type")); a != "" {
+		workloadArchs = append(workloadArchs, a)
+	}
+	if err := checkArchFamilies("karpenter_instance_families", effective("karpenter_instance_families"), workloadArchs, "karpenter_arch"); err != nil {
+		return err
+	}
+
+	buildType := effective("build_node_type")
+	if buildType == "" {
+		buildType = effective("node_type")
+	}
+	buildArchs := []string{}
+	if a := instanceArch(buildType); a != "" {
+		buildArchs = append(buildArchs, a)
+	}
+	return checkArchFamilies("karpenter_build_instance_families", effective("karpenter_build_instance_families"), buildArchs, "build_node_type")
+}
+
 func validateAndMutateParams(params map[string]string, provider string, currentParams map[string]string, force bool) error {
 	// Install-only params — these define infrastructure that cannot be changed
 	// after rack creation without catastrophic consequences (network recreation,
@@ -1732,6 +1823,10 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 				return fmt.Errorf("invalid karpenter architecture: %s (must be amd64 or arm64)", arch)
 			}
 		}
+	}
+
+	if err := validateKarpenterArchFamilies(params, currentParams); err != nil {
+		return err
 	}
 
 	for k, v := range params {

--- a/pkg/cli/rack_arch_family_test.go
+++ b/pkg/cli/rack_arch_family_test.go
@@ -1,0 +1,171 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFamilyArch(t *testing.T) {
+	cases := []struct {
+		family string
+		want   string
+	}{
+		{"c6g", "arm64"},
+		{"c6gd", "arm64"},
+		{"c7gn", "arm64"},
+		{"t4g", "arm64"},
+		{"m8g", "arm64"},
+		{"x2gd", "arm64"},
+		{"im4gn", "arm64"},
+		{"is4gen", "arm64"},
+		{"g5g", "arm64"},
+		{"hpc7g", "arm64"},
+		{"a1", "arm64"},
+		{"c5", "amd64"},
+		{"m7i", "amd64"},
+		{"t3a", "amd64"},
+		{"g4dn", "amd64"},
+		{"g5", "amd64"},
+		{"x2idn", "amd64"},
+		{"inf2", "amd64"},
+		{"C6G", "arm64"},
+		{" c6g ", "arm64"},
+		{"mac2-m2", ""},
+		{"u-6tb1", ""},
+		{"", ""},
+	}
+
+	for _, c := range cases {
+		if got := familyArch(c.family); got != c.want {
+			t.Errorf("familyArch(%q) = %q, want %q", c.family, got, c.want)
+		}
+	}
+}
+
+func TestInstanceArch(t *testing.T) {
+	cases := []struct {
+		instanceType string
+		want         string
+	}{
+		{"t4g.large", "arm64"},
+		{"m5.xlarge", "amd64"},
+		{"t3.medium,t3.large", "amd64"},
+		{"t4g.medium,m5.large", "arm64"},
+		{"", ""},
+		{"weird", ""},
+	}
+
+	for _, c := range cases {
+		if got := instanceArch(c.instanceType); got != c.want {
+			t.Errorf("instanceArch(%q) = %q, want %q", c.instanceType, got, c.want)
+		}
+	}
+}
+
+func TestValidateKarpenterArchFamilies(t *testing.T) {
+	cases := []struct {
+		name    string
+		params  map[string]string
+		current map[string]string
+		wantErr bool
+	}{
+		{
+			name:    "workload conflict",
+			params:  map[string]string{"karpenter_enabled": "true", "karpenter_arch": "amd64", "karpenter_instance_families": "c6g"},
+			wantErr: true,
+		},
+		{
+			name:    "workload conflict arm",
+			params:  map[string]string{"karpenter_enabled": "true", "karpenter_arch": "arm64", "karpenter_instance_families": "c5,m5"},
+			wantErr: true,
+		},
+		{
+			name:   "workload multi arch matches",
+			params: map[string]string{"karpenter_enabled": "true", "karpenter_arch": "amd64,arm64", "karpenter_instance_families": "c6g"},
+		},
+		{
+			name:   "workload one family matches",
+			params: map[string]string{"karpenter_enabled": "true", "karpenter_arch": "amd64", "karpenter_instance_families": "c6g,c5"},
+		},
+		{
+			name:   "unknown family skipped",
+			params: map[string]string{"karpenter_enabled": "true", "karpenter_arch": "amd64", "karpenter_instance_families": "mac2-m2"},
+		},
+		{
+			name:    "build conflict via build_node_type",
+			params:  map[string]string{"karpenter_enabled": "true", "build_node_type": "m5.large", "karpenter_build_instance_families": "c6g"},
+			wantErr: true,
+		},
+		{
+			name:    "build conflict via node_type fallback",
+			params:  map[string]string{"karpenter_enabled": "true", "node_type": "t4g.large", "karpenter_build_instance_families": "c5"},
+			wantErr: true,
+		},
+		{
+			name:   "build arch underivable skipped",
+			params: map[string]string{"karpenter_enabled": "true", "karpenter_build_instance_families": "c6g"},
+		},
+		{
+			name:   "build family matches",
+			params: map[string]string{"karpenter_enabled": "true", "build_node_type": "t4g.large", "karpenter_build_instance_families": "c6g,c7g"},
+		},
+		{
+			name:    "karpenter disabled skips",
+			params:  map[string]string{"karpenter_arch": "amd64", "karpenter_instance_families": "c6g"},
+			current: map[string]string{"karpenter_enabled": "false"},
+		},
+		{
+			name:    "stale conflict caught on enable",
+			params:  map[string]string{"karpenter_enabled": "true"},
+			current: map[string]string{"karpenter_arch": "amd64", "karpenter_instance_families": "c6g"},
+			wantErr: true,
+		},
+		{
+			name:    "conflict on already-enabled rack",
+			params:  map[string]string{"karpenter_instance_families": "c6g"},
+			current: map[string]string{"karpenter_enabled": "true", "karpenter_arch": "amd64"},
+			wantErr: true,
+		},
+		{
+			name:    "workload arch derived from node_type",
+			params:  map[string]string{"karpenter_enabled": "true", "karpenter_instance_families": "c6g"},
+			current: map[string]string{"node_type": "m5.large"},
+			wantErr: true,
+		},
+		{
+			name:    "no relevant keys in call",
+			params:  map[string]string{"karpenter_cpu_limit": "50"},
+			current: map[string]string{"karpenter_enabled": "true", "karpenter_arch": "amd64", "karpenter_instance_families": "c6g"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateKarpenterArchFamilies(c.params, c.current)
+			if c.wantErr && err == nil {
+				t.Errorf("expected error, got nil")
+			}
+			if !c.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateAndMutateParamsArchFamilyConflict(t *testing.T) {
+	params := map[string]string{"karpenter_enabled": "true", "karpenter_auth_mode": "true", "karpenter_arch": "amd64", "karpenter_build_instance_families": "c6g"}
+	current := map[string]string{"build_node_type": "m5.large"}
+	err := validateAndMutateParams(params, "aws", current, false)
+	if err == nil {
+		t.Fatalf("expected arch/family conflict error, got nil")
+	}
+	if !strings.Contains(err.Error(), "karpenter_build_instance_families") {
+		t.Errorf("expected arch/family conflict error, got: %v", err)
+	}
+
+	params = map[string]string{"karpenter_enabled": "true", "karpenter_auth_mode": "true", "karpenter_arch": "amd64,arm64", "karpenter_build_instance_families": "c6g"}
+	current = map[string]string{"build_node_type": "c6g.large"}
+	if err := validateAndMutateParams(params, "aws", current, false); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/pkg/common/arch.go
+++ b/pkg/common/arch.go
@@ -1,0 +1,24 @@
+package common
+
+import (
+	"sort"
+	"strings"
+)
+
+// BuildArchs parses a comma-separated architecture list into a sorted, deduplicated set containing only amd64 and arm64.
+func BuildArchs(s string) []string {
+	seen := map[string]bool{}
+	archs := []string{}
+
+	for _, a := range strings.Split(s, ",") {
+		a = strings.TrimSpace(a)
+		if (a == "amd64" || a == "arm64") && !seen[a] {
+			seen[a] = true
+			archs = append(archs, a)
+		}
+	}
+
+	sort.Strings(archs)
+
+	return archs
+}

--- a/pkg/common/arch_test.go
+++ b/pkg/common/arch_test.go
@@ -1,0 +1,30 @@
+package common
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBuildArchs(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"", []string{}},
+		{"amd64", []string{"amd64"}},
+		{"arm64", []string{"arm64"}},
+		{"amd64,arm64", []string{"amd64", "arm64"}},
+		{"arm64,amd64", []string{"amd64", "arm64"}},
+		{" arm64 , amd64 ", []string{"amd64", "arm64"}},
+		{"amd64,amd64", []string{"amd64"}},
+		{"amd64,,arm64", []string{"amd64", "arm64"}},
+		{"bogus", []string{}},
+		{"amd64,bogus,arm64", []string{"amd64", "arm64"}},
+	}
+
+	for _, c := range cases {
+		if got := BuildArchs(c.in); !reflect.DeepEqual(got, c.want) {
+			t.Errorf("BuildArchs(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}

--- a/pkg/mock/engine.go
+++ b/pkg/mock/engine.go
@@ -16,7 +16,7 @@ func (*TestEngine) AppIdles(_ string) (bool, error) {
 }
 
 func (*TestEngine) AppParameters() map[string]string {
-	return map[string]string{"Test": "foo"}
+	return map[string]string{"BuildArch": "", "Test": "foo"}
 }
 
 func (*TestEngine) Heartbeat() (map[string]interface{}, error) {

--- a/provider/k8s/app.go
+++ b/provider/k8s/app.go
@@ -450,6 +450,7 @@ func (p *Provider) NamespaceApp(namespace string) (string, error) {
 
 func (p *Provider) AppParameters() map[string]string {
 	return map[string]string{
+		structs.AppParamBuildArch:   "",
 		structs.AppParamBuildCpu:    "",
 		structs.AppParamBuildMem:    "",
 		structs.AppParamBuildLabels: "",

--- a/provider/k8s/build.go
+++ b/provider/k8s/build.go
@@ -90,6 +90,7 @@ func (p *Provider) BuildCreate(app, url string, opts structs.BuildCreateOptions)
 		"PROVIDER":                        os.Getenv("PROVIDER"),
 		"DISABLE_IMAGE_MANIFEST_CACHE":    os.Getenv("DISABLE_IMAGE_MANIFEST_CACHE"),
 		"BUILDKIT_HOST_PATH_CACHE_ENABLE": os.Getenv("BUILDKIT_HOST_PATH_CACHE_ENABLE"),
+		"BUILD_ARCHS":                     os.Getenv("BUILD_ARCHS"),
 		"RACK_URL":                        fmt.Sprintf("https://convox:%s@api.%s.svc.cluster.local:5443", p.Password, p.Namespace),
 		"CONVOX_TID":                      p.ContextTID(),
 		// Propagate audit actor so build pod callbacks don't use the rack password as actor.
@@ -128,6 +129,7 @@ func (p *Provider) BuildCreate(app, url string, opts structs.BuildCreateOptions)
 			return nil, fmt.Errorf("invalid BuildArch: %s, must be amd64 or arm64", arch)
 		}
 		psOpts.BuildArch = options.String(arch)
+		env["BUILD_ARCHS"] = arch
 	}
 
 	if cpu := appObj.Parameters[structs.AppParamBuildCpu]; cpu != "" {
@@ -253,7 +255,7 @@ func (p *Provider) BuildExport(app, id string, w io.Writer) error {
 		from := fmt.Sprintf("docker://%s:%s.%s", repo, service, build.Id)
 		to := fmt.Sprintf("oci-archive:%s/%s.%s.tar", tmp, service, build.Id)
 
-		if err := exec.Command("skopeo", "copy", "--src-creds", fmt.Sprintf("%s:%s", user, pass), from, to).Run(); err != nil {
+		if err := exec.Command("skopeo", "copy", "--all", "--src-creds", fmt.Sprintf("%s:%s", user, pass), from, to).Run(); err != nil { //nolint:gosec // fixed argv; refs derive from rack build records
 			return errors.WithStack(err)
 		}
 	}
@@ -591,13 +593,11 @@ func (p *Provider) buildImportImageRun(app string, b *structs.Build, m *manifest
 		}
 		dst := fmt.Sprintf("%s:%s.%s", repo, svc.Name, b.Id)
 
-		args := []string{
-			"copy",
-			"--authfile", authPath,
-			"--",
-			fmt.Sprintf("docker://%s", src),
-			fmt.Sprintf("docker://%s", dst),
+		args := []string{"copy", "--authfile", authPath}
+		if len(common.BuildArchs(os.Getenv("BUILD_ARCHS"))) > 1 {
+			args = append(args, "--all")
 		}
+		args = append(args, "--", fmt.Sprintf("docker://%s", src), fmt.Sprintf("docker://%s", dst))
 
 		ctx, cancel := context.WithTimeout(context.Background(), skopeoCopyTimeout)
 		out, runErr := skopeoExec(ctx, args...)
@@ -695,9 +695,9 @@ func (p *Provider) BuildImport(app string, r io.Reader) (*structs.Build, error) 
 	for svc, img := range imgBySvc {
 		dst := fmt.Sprintf("%s:%s.%s", repo, svc, target.Id)
 
-		b, err := exec.Command("skopeo", "copy", "--dest-creds", fmt.Sprintf("%s:%s", user, pass), fmt.Sprintf("oci-archive:%s", img), fmt.Sprintf("docker://%s", dst)).CombinedOutput()
+		b, err := exec.Command("skopeo", "copy", "--all", "--dest-creds", fmt.Sprintf("%s:%s", user, pass), fmt.Sprintf("oci-archive:%s", img), fmt.Sprintf("docker://%s", dst)).CombinedOutput() //nolint:gosec // fixed argv; refs derive from rack build records
 		if err != nil {
-			errors.Errorf("failed to push image - %s\n%s", err.Error(), string(b))
+			return nil, errors.Errorf("failed to push image - %s\n%s", err.Error(), string(b))
 		}
 	}
 

--- a/provider/k8s/build_test.go
+++ b/provider/k8s/build_test.go
@@ -264,6 +264,49 @@ func TestBuildCreate(t *testing.T) {
 	})
 }
 
+func TestBuildCreateBuildArch(t *testing.T) {
+	testProvider(t, func(p *k8s.Provider) {
+		kk, ok := p.Cluster.(*fake.Clientset)
+		require.True(t, ok)
+		aa, ok := p.Atom.(*atom.MockInterface)
+		require.True(t, ok)
+		aa.On("Status", "rack1-app1", "app").Return("Creating", "R1234567", nil)
+
+		require.NoError(t, appCreateWithAnnotation(kk, "rack1", "app1", map[string]string{
+			"convox.com/params": `{"BuildArch":"arm64"}`,
+		}))
+
+		_, err := p.BuildCreate("app1", "object://app1/object.tgz", structs.BuildCreateOptions{})
+		require.NoError(t, err)
+
+		pods, err := kk.CoreV1().Pods("rack1-app1").List(context.TODO(), am.ListOptions{})
+		require.NoError(t, err)
+		require.Len(t, pods.Items, 1)
+
+		envs := map[string]string{}
+		for _, e := range pods.Items[0].Spec.Containers[0].Env {
+			envs[e.Name] = e.Value
+		}
+		assert.Equal(t, "arm64", envs["BUILD_ARCHS"])
+	})
+
+	testProvider(t, func(p *k8s.Provider) {
+		kk, ok := p.Cluster.(*fake.Clientset)
+		require.True(t, ok)
+		aa, ok := p.Atom.(*atom.MockInterface)
+		require.True(t, ok)
+		aa.On("Status", "rack1-app2", "app").Return("Creating", "R1234567", nil)
+
+		require.NoError(t, appCreateWithAnnotation(kk, "rack1", "app2", map[string]string{
+			"convox.com/params": `{"BuildArch":"bogus"}`,
+		}))
+
+		_, err := p.BuildCreate("app2", "object://app2/object.tgz", structs.BuildCreateOptions{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid BuildArch")
+	})
+}
+
 func buildCreate(kc cv.Interface, ns, id, fixture string) error {
 	spec, err := buildFixture(fixture)
 	if err != nil {
@@ -410,6 +453,52 @@ func TestBuildImportImage(t *testing.T) {
 			require.NotEmpty(t, authContents, "authfile must exist during skopeo invocation")
 			assert.Contains(t, authContents, "repo1", "authfile must scope to destination host")
 			assert.Contains(t, authContents, "dW4xOnB3MQ==", "authfile must carry base64(un1:pw1) for dest")
+		})
+	})
+
+	t.Run("MultiArchRackRelaysAllPlatforms", func(t *testing.T) {
+		t.Setenv("BUILD_ARCHS", "amd64,arm64")
+		testProvider(t, func(p *k8s.Provider) {
+			kk, ok := p.Cluster.(*fake.Clientset)
+			require.True(t, ok)
+			require.NoError(t, appCreate(kk, "rack1", "app1"))
+			require.NoError(t, buildCreate(p.Convox, "rack1-app1", "build8", "basic"))
+
+			var capturedArgs []string
+			*k8s.SkopeoExecForTest = func(ctx context.Context, args ...string) ([]byte, error) {
+				capturedArgs = append([]string(nil), args...)
+				return []byte("ok"), nil
+			}
+
+			err := p.BuildImportImage("app1", "build8", "vllm/vllm-openai:v0.6.3", structs.BuildImportImageOptions{})
+			require.NoError(t, err)
+
+			waitForBuildStatus(t, p, "app1", "build8", "complete")
+			assertArgsShape(t, capturedArgs)
+			assert.Contains(t, capturedArgs, "--all")
+		})
+	})
+
+	t.Run("SingleArchRackRelayUnchanged", func(t *testing.T) {
+		t.Setenv("BUILD_ARCHS", "")
+		testProvider(t, func(p *k8s.Provider) {
+			kk, ok := p.Cluster.(*fake.Clientset)
+			require.True(t, ok)
+			require.NoError(t, appCreate(kk, "rack1", "app1"))
+			require.NoError(t, buildCreate(p.Convox, "rack1-app1", "build9", "basic"))
+
+			var capturedArgs []string
+			*k8s.SkopeoExecForTest = func(ctx context.Context, args ...string) ([]byte, error) {
+				capturedArgs = append([]string(nil), args...)
+				return []byte("ok"), nil
+			}
+
+			err := p.BuildImportImage("app1", "build9", "vllm/vllm-openai:v0.6.3", structs.BuildImportImageOptions{})
+			require.NoError(t, err)
+
+			waitForBuildStatus(t, p, "app1", "build9", "complete")
+			assertArgsShape(t, capturedArgs)
+			assert.NotContains(t, capturedArgs, "--all")
 		})
 	})
 

--- a/terraform/api/aws/main.tf
+++ b/terraform/api/aws/main.tf
@@ -57,6 +57,7 @@ module "k8s" {
     CERT_MANAGER                              = "true"
     CERT_MANAGER_ROLE_ARN                     = aws_iam_role.cert-manager.arn
     EFS_FILE_SYSTEM_ID                        = var.efs_file_system_id
+    BUILD_ARCHS                               = var.build_archs
     BUILD_DISABLE_CONVOX_RESOLVER             = var.build_disable_convox_resolver
     PDB_DEFAULT_MIN_AVAILABLE_PERCENTAGE      = var.pdb_default_min_available_percentage
     PROVIDER                                  = "aws"

--- a/terraform/api/aws/variables.tf
+++ b/terraform/api/aws/variables.tf
@@ -7,6 +7,11 @@ variable "buildkit_enabled" {
   default = false
 }
 
+variable "build_archs" {
+  type    = string
+  default = ""
+}
+
 variable "build_disable_convox_resolver" {
   default = false
 }

--- a/terraform/rack/aws/main.tf
+++ b/terraform/rack/aws/main.tf
@@ -26,6 +26,7 @@ module "api" {
   }
 
   buildkit_enabled                          = var.buildkit_enabled
+  build_archs                               = var.build_archs
   build_disable_convox_resolver             = var.build_disable_convox_resolver
   build_node_enabled                        = var.build_node_enabled
   buildkit_host_path_cache_enable           = var.buildkit_host_path_cache_enable

--- a/terraform/rack/aws/variables.tf
+++ b/terraform/rack/aws/variables.tf
@@ -7,6 +7,11 @@ variable "buildkit_enabled" {
   default = false
 }
 
+variable "build_archs" {
+  type    = string
+  default = ""
+}
+
 variable "build_disable_convox_resolver" {
   default = false
 }

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -96,6 +96,13 @@ locals {
   additional_karpenter_nodepools = try(jsondecode(var.additional_karpenter_nodepools_config), jsondecode(base64decode(var.additional_karpenter_nodepools_config)), [])
   karpenter_node_overlays        = try(jsondecode(var.karpenter_node_overlays_config), jsondecode(base64decode(var.karpenter_node_overlays_config)), [])
 
+  karpenter_arch_effective = var.karpenter_arch != "" ? var.karpenter_arch : (local.arm_type ? "arm64" : "amd64")
+  karpenter_arch_all = distinct(compact([for a in flatten([
+    split(",", local.karpenter_arch_effective),
+    [for np in local.additional_karpenter_nodepools : split(",", lookup(np, "arch", "amd64"))],
+  ]) : trimspace(a)]))
+  build_archs = var.karpenter_enabled == "true" && length(local.karpenter_arch_all) > 1 ? join(",", sort(local.karpenter_arch_all)) : ""
+
   public_access_cidrs  = var.eks_api_server_public_access_cidrs == "" ? ["0.0.0.0/0"] : split(",", var.eks_api_server_public_access_cidrs)
   private_access_cidrs = var.eks_api_server_private_access_cidrs == "" ? [] : split(",", var.eks_api_server_private_access_cidrs)
   eks_log_types        = var.eks_log_types == "" ? [] : split(",", var.eks_log_types)
@@ -150,7 +157,7 @@ module "cluster" {
   karpenter_instance_families         = var.karpenter_instance_families
   karpenter_instance_sizes            = var.karpenter_instance_sizes
   karpenter_capacity_types            = var.karpenter_capacity_types
-  karpenter_arch                      = var.karpenter_arch != "" ? var.karpenter_arch : (local.arm_type ? "arm64" : "amd64")
+  karpenter_arch                      = local.karpenter_arch_effective
   karpenter_cpu_limit                 = var.karpenter_cpu_limit
   karpenter_memory_limit_gb           = var.karpenter_memory_limit_gb
   karpenter_consolidation_enabled     = var.karpenter_consolidation_enabled
@@ -271,6 +278,7 @@ module "rack" {
   seccomp_default_enabled                   = var.seccomp_default_enabled
   karpenter_enabled                         = var.karpenter_enabled == "true"
   system_readonly_rootfs_enabled            = var.system_readonly_rootfs_enabled
+  build_archs                               = local.build_archs
   build_node_enabled                        = var.build_node_enabled
   buildkit_host_path_cache_enable           = var.buildkit_host_path_cache_enable
   cluster                                   = module.cluster.id


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: Multi-Arch App Image Builds for Mixed-Architecture Karpenter Racks**

On a rack running Karpenter with more than one architecture configured, either through `karpenter_arch=amd64,arm64` or through additional Karpenter node pools of differing `arch`, Convox-built app images are now multi-arch manifest lists. An image the rack builds runs on any node the rack provisions, whichever architecture Karpenter selects for it. There are no new rack parameters and nothing to configure; the rack derives its architecture set from configuration it already has.

The build adds both platforms to the single existing buildctl invocation, and the BuildKit builder image the rack uses (v0.28.0) bundles the emulators, so both architectures are produced in place with no additional nodes or images provisioned. The push produces one manifest list per service tag, with per-architecture manifests pushed by digest, so it is compatible with immutable-tag ECR repositories. A rack configured with fewer than two architectures produces byte-identical build behavior to today, and non-AWS providers are unchanged. Development builds through `convox start` stay single-arch native to keep the dev loop fast.

The `BuildArch` app parameter pins an individual app to a single architecture.

**App parameter:**

| Parameter | Type | Default | Effect |
|-----------|------|---------|--------|
| `BuildArch` | string (`amd64` or `arm64`) | unset | Unset, the app follows the rack and needs no configuration. Set, the app builds exactly that architecture. |

`BuildArch` is intended for apps that depend on images published for only one architecture. On racks with dedicated build nodes, the build pod is also pinned to a node of the matching architecture for native build speed. Runtime placement for a pinned app uses the existing per-service `nodeSelectorLabels`, for example `kubernetes.io/arch: amd64`.

Also in this release, `convox rack params set` rejects Karpenter architecture and instance-family combinations that could provision no nodes, for example `karpenter_build_instance_families=c6g` on an amd64 build pool, for both the workload pool and the build pool.

**Scope:**

- Releases built before this change stay single-arch until they are rebuilt and promoted.
- If an image in the build is published for only one architecture, the build reports that directly and points at `BuildArch`, at build time rather than at runtime.
- The emulated architecture builds more slowly, commonly 2x to 10x on compile-heavy steps, and applies only to racks that opt into multiple architectures. The `BuildCpu` and `BuildMem` app parameters can be raised for heavy builds.
- `import-image` of a large public image on a multi-arch rack copies every platform the source publishes, which increases registry storage for those tags.
- Architecture overrides supplied through `karpenter_config` requirements are not part of the architecture set the rack derives, so a rack that widens pool architecture that way should set `karpenter_arch` to match.

---

### Why is this important?

Karpenter picks the most cost-effective instance it can find for each workload, and on a rack that allows both amd64 and arm64 that choice can land on either architecture. Multi-arch images make that freedom usable directly: one build, one tag, and the node resolves the right image for itself.

**Benefits:**

- **Images run on any node the rack provisions.** A single service tag carries both architectures, so Karpenter is free to place and consolidate workloads across the full instance selection the rack allows.
- **No extra build infrastructure.** Both platforms come out of the same build pod and the same buildctl invocation, with the emulators already bundled in BuildKit, so nothing additional is provisioned or maintained.
- **Registry-compatible push.** One manifest list per service tag, with per-architecture manifests pushed by digest, works with immutable-tag ECR repositories.
- **Per-app control.** `BuildArch` pins an app that depends on single-architecture images, and the rest of the rack continues to build multi-arch.
- **Configuration checked up front.** Karpenter architecture and instance-family combinations that could provision no nodes are rejected by the CLI at `rack params set` time.
- **Unchanged for single-architecture racks.** A rack with one architecture builds exactly as it does today, and so does every non-AWS provider.

---

### How to use it?

Configure the rack for more than one architecture:

    $ convox rack params set karpenter_arch=amd64,arm64 -r rackName

Subsequent builds produce multi-arch images automatically. No app configuration is required.

Pin a single app to one architecture:

    $ convox apps params set BuildArch=amd64 -a my-app

Place that app's services on matching nodes with the existing per-service `nodeSelectorLabels` in `convox.yml`:

```yaml
services:
  web:
    build: .
    nodeSelectorLabels:
      kubernetes.io/arch: amd64
```

---

### Does it have a breaking change?

**No breaking changes** are introduced with this feature.

Multi-arch builds engage only when a Karpenter rack is configured with more than one architecture. A rack with a single architecture, and every non-AWS provider, produces the same build arguments and the same image as before. `BuildArch` is unset by default, so an app follows the rack until it is explicitly pinned. Opting out is per app with `BuildArch`, or rack-wide by setting `karpenter_arch` to a single architecture.

Under a downgrade, images already published as manifest lists keep running, since a manifest list resolves per node architecture regardless of rack version, and new builds return to single-arch. The `BuildArch` parameter simply stops being applied.

---

### Requirements

This feature requires version `3.25.3` or later for the rack.

**Update the Rack:** Run `convox rack update 3.25.3 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
