### PR TITLE
Spread service pods across availability zones

### DIFF
--- a/docs/reference/primitives/app/service.md
+++ b/docs/reference/primitives/app/service.md
@@ -140,7 +140,6 @@ services:
 | **configMounts** | list |     | Mount configuration files into the container filesystem. See [Config Mounts](/configuration/config-mounts) |
 | **nodeAffinityLabels** | map |  | Node affinity rules for workload placement. See [Workload Placement](/configuration/scaling/workload-placement) |
 | **nodeSelectorLabels** | map |  | Node selector labels for workload placement. See [Workload Placement](/configuration/scaling/workload-placement) |
-| `spreadAcrossZones` | boolean | false | Ask Kubernetes to spread this Service's pods across availability zones |
 | **port**        | string     |                     | The port that the default Rack balancer will use to [route incoming traffic](/configuration/load-balancers). For grpc service specify the scheme: `grpc:5051`|
 | **ports**       | list       |                     | A list of ports available for internal [service discovery](/configuration/service-discovery) or custom [Balancers](/reference/primitives/app/balancer). Supports TCP (default) and UDP protocols |
 | **privileged**  | boolean    | false               | Set to **true** to allow [Processes](/reference/primitives/app/process) of this Service to run as root inside their container. Use with caution as this grants elevated permissions |
@@ -148,6 +147,7 @@ services:
 | **scale**       | map        | 1                   | Define scaling parameters (see below)                                                                                                      |
 | **securityContext** | map   |                     | Container security settings including capabilities, read-only filesystem, and seccomp profiles (see below)                               |
 | **singleton**   | boolean    | false               | Set to **true** to prevent extra [Processes](/reference/primitives/app/process) of this Service from being started during deployments                               |
+| **spreadAcrossZones** | boolean | false            | Set to **true** to spread this Service's pods across availability zones (see [spreadAcrossZones](#spreadacrosszones) below) |
 | **sticky**      | boolean    | false               | Set to **true** to enable sticky sessions                                                                                                    |
 | **termination** | map        |                     | Termination related configuration                                                                                                          |
 | **test**        | string     |                     | A command to run to test this Service when running **convox test**                                                                           |
@@ -160,25 +160,6 @@ services:
 > Environment variables declared on `convox.yml` will be populated for a Service.
 
 > The `drain` attribute is deprecated. Use `termination.grace` instead.
-
-### spreadAcrossZones
-
-Set `spreadAcrossZones: true` to ask Kubernetes to keep this Service's pods evenly spread across availability zones:
-
-```yaml
-services:
-  web:
-    image: example/web
-    spreadAcrossZones: true
-    scale:
-      count: 3
-```
-
-Convox uses the standard `topology.kubernetes.io/zone` node label and allows a maximum difference of one pod between eligible zones. The scheduler favours an even spread but still schedules a pod when it cannot meet that spread.
-
-The Rack must have eligible nodes in at least 2 zones, and the Service must run at least 2 replicas. This setting does not create zones or nodes. Node selectors, node affinity and zonal storage can reduce the eligible zones.
-
-Agent services do not support `spreadAcrossZones` because they run one pod on each eligible node as a DaemonSet.
 
 ### annotations
 You can use annotations to attach arbitrary non-identifying metadata to objects. Clients such as tools and libraries can retrieve this metadata. On Convox, annotations will reflect in pods and service accounts.
@@ -591,6 +572,27 @@ services:
         add:
           - NET_BIND_SERVICE
 ```
+
+&nbsp;
+
+### spreadAcrossZones
+
+Set `spreadAcrossZones: true` to ask Kubernetes to keep this Service's pods evenly spread across availability zones:
+
+```yaml
+services:
+  web:
+    image: example/web
+    spreadAcrossZones: true
+    scale:
+      count: 3
+```
+
+Convox uses the standard `topology.kubernetes.io/zone` node label and allows a maximum difference of one pod between eligible zones. It also asks the scheduler to keep the pods spread across nodes, with the same tolerance Kubernetes applies by default. The scheduler favors an even spread but still schedules a pod when it cannot meet that spread.
+
+The zone spread only has an effect when the Rack has eligible nodes in at least 2 zones and the Service runs at least 2 replicas. The setting does not create zones. Node selectors, node affinity and zonal storage can reduce the eligible zones. On Racks running [Karpenter](/configuration/scaling/karpenter), Karpenter may launch extra nodes to satisfy the spread and may keep them running instead of consolidating them away.
+
+Agent services do not support `spreadAcrossZones` because they run one pod on each eligible node as a DaemonSet.
 
 &nbsp;
 

--- a/docs/reference/primitives/app/service.md
+++ b/docs/reference/primitives/app/service.md
@@ -140,6 +140,7 @@ services:
 | **configMounts** | list |     | Mount configuration files into the container filesystem. See [Config Mounts](/configuration/config-mounts) |
 | **nodeAffinityLabels** | map |  | Node affinity rules for workload placement. See [Workload Placement](/configuration/scaling/workload-placement) |
 | **nodeSelectorLabels** | map |  | Node selector labels for workload placement. See [Workload Placement](/configuration/scaling/workload-placement) |
+| `spreadAcrossZones` | boolean | false | Ask Kubernetes to spread this Service's pods across availability zones |
 | **port**        | string     |                     | The port that the default Rack balancer will use to [route incoming traffic](/configuration/load-balancers). For grpc service specify the scheme: `grpc:5051`|
 | **ports**       | list       |                     | A list of ports available for internal [service discovery](/configuration/service-discovery) or custom [Balancers](/reference/primitives/app/balancer). Supports TCP (default) and UDP protocols |
 | **privileged**  | boolean    | false               | Set to **true** to allow [Processes](/reference/primitives/app/process) of this Service to run as root inside their container. Use with caution as this grants elevated permissions |
@@ -159,6 +160,25 @@ services:
 > Environment variables declared on `convox.yml` will be populated for a Service.
 
 > The `drain` attribute is deprecated. Use `termination.grace` instead.
+
+### spreadAcrossZones
+
+Set `spreadAcrossZones: true` to ask Kubernetes to keep this Service's pods evenly spread across availability zones:
+
+```yaml
+services:
+  web:
+    image: example/web
+    spreadAcrossZones: true
+    scale:
+      count: 3
+```
+
+Convox uses the standard `topology.kubernetes.io/zone` node label and allows a maximum difference of one pod between eligible zones. The scheduler favours an even spread but still schedules a pod when it cannot meet that spread.
+
+The Rack must have eligible nodes in at least 2 zones, and the Service must run at least 2 replicas. This setting does not create zones or nodes. Node selectors, node affinity and zonal storage can reduce the eligible zones.
+
+Agent services do not support `spreadAcrossZones` because they run one pod on each eligible node as a DaemonSet.
 
 ### annotations
 You can use annotations to attach arbitrary non-identifying metadata to objects. Clients such as tools and libraries can retrieve this metadata. On Convox, annotations will reflect in pods and service accounts.

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -53,6 +53,7 @@ type Service struct {
 	Labels             Labels                   `yaml:"labels,omitempty"`
 	NodeAffinityLabels Affinities               `yaml:"nodeAffinityLabels,omitempty"`
 	NodeSelectorLabels Labels                   `yaml:"nodeSelectorLabels,omitempty"`
+	SpreadAcrossZones  bool                     `yaml:"spreadAcrossZones,omitempty"`
 	Lifecycle          ServiceLifecycle         `yaml:"lifecycle,omitempty"`
 	Port               ServicePortScheme        `yaml:"port,omitempty"`
 	Ports              []ServicePortProtocol    `yaml:"ports,omitempty"`

--- a/pkg/manifest/service_test.go
+++ b/pkg/manifest/service_test.go
@@ -404,3 +404,14 @@ func TestAnnotationsMapReadsAnnotations(t *testing.T) {
 	require.NotContains(t, got, "ingress-key",
 		"AnnotationsMap must not return ingress annotations")
 }
+
+func TestManifestValidateSpreadAcrossZonesRejectsAgent(t *testing.T) {
+	m, err := manifest.Load([]byte(`services:
+  worker:
+    agent: true
+    image: example/worker
+    spreadAcrossZones: true
+`), nil)
+	require.NoError(t, err)
+	require.EqualError(t, m.Validate(), "validation errors:\nservice worker can not set spreadAcrossZones when agent is enabled")
+}

--- a/pkg/manifest/validate.go
+++ b/pkg/manifest/validate.go
@@ -136,6 +136,10 @@ func (m *Manifest) validateServices() []error {
 			errs = append(errs, fmt.Errorf("service %s can not have both internal and internalRouter set as true", s.Name))
 		}
 
+		if s.Agent.Enabled && s.SpreadAcrossZones {
+			errs = append(errs, fmt.Errorf("service %s can not set spreadAcrossZones when agent is enabled", s.Name))
+		}
+
 		for _, r := range s.ResourcesName() {
 			if _, err := m.Resource(r); err != nil {
 				if strings.HasPrefix(err.Error(), "no such resource") {

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -97,6 +97,16 @@ spec:
             app: {{.App.Name}}
             service: {{.Service.Name}}
             type: service
+      - maxSkew: 3
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            system: convox
+            rack: {{.Rack}}
+            app: {{.App.Name}}
+            service: {{.Service.Name}}
+            type: service
       {{ end }}
       {{ if or (.Service.NodeSelectorLabels) (.Service.NodeAffinityLabels) }}
       affinity:

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -85,6 +85,19 @@ spec:
         {{.Key}}: "{{.Value}}"
         {{ end }}
     spec:
+      {{ if .Service.SpreadAcrossZones }}
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            system: convox
+            rack: {{.Rack}}
+            app: {{.App.Name}}
+            service: {{.Service.Name}}
+            type: service
+      {{ end }}
       {{ if or (.Service.NodeSelectorLabels) (.Service.NodeAffinityLabels) }}
       affinity:
         nodeAffinity:

--- a/provider/k8s/template_test.go
+++ b/provider/k8s/template_test.go
@@ -868,3 +868,53 @@ func TestRenderTemplateServiceHealthPort(t *testing.T) {
 		assertNotContains("startupProbe does not use liveness port", startupBlock, "port: 9091")
 	})
 }
+
+func TestRenderTemplateServiceSpreadAcrossZones(t *testing.T) {
+	m, err := manifest.Load([]byte(`services:
+  web:
+    image: example/web
+    spreadAcrossZones: true
+`), nil)
+	require.NoError(t, err)
+
+	svc, err := m.Service("web")
+	require.NoError(t, err)
+	require.True(t, svc.SpreadAcrossZones)
+
+	p := Provider{Engine: &mock.TestEngine{}}
+	p.templater = templater.New(template.TemplatesFS)
+	params := map[string]interface{}{
+		"Annotations":    svc.AnnotationsMap(),
+		"App":            &structs.App{Name: "test-app"},
+		"Environment":    map[string]string{},
+		"MaxSurge":       100,
+		"MaxUnavailable": 100,
+		"Namespace":      "ns",
+		"Password":       "pass",
+		"Rack":           "rack",
+		"Release":        &structs.Release{Id: "r1"},
+		"Replicas":       3,
+		"Resources":      svc.ResourceMap(),
+		"Service":        *svc,
+	}
+
+	data, err := p.RenderTemplate("app/service", params)
+	require.NoError(t, err)
+	rendered := string(data)
+	require.Contains(t, rendered, "topologySpreadConstraints:")
+	require.Contains(t, rendered, "maxSkew: 1")
+	require.Contains(t, rendered, "topologyKey: topology.kubernetes.io/zone")
+	require.Contains(t, rendered, "whenUnsatisfiable: ScheduleAnyway")
+	require.Contains(t, rendered, `matchLabels:
+            app: test-app
+            rack: rack
+            service: web
+            system: convox
+            type: service`)
+
+	svc.SpreadAcrossZones = false
+	params["Service"] = *svc
+	data, err = p.RenderTemplate("app/service", params)
+	require.NoError(t, err)
+	require.NotContains(t, string(data), "topologySpreadConstraints:")
+}

--- a/provider/k8s/template_test.go
+++ b/provider/k8s/template_test.go
@@ -902,9 +902,12 @@ func TestRenderTemplateServiceSpreadAcrossZones(t *testing.T) {
 	require.NoError(t, err)
 	rendered := string(data)
 	require.Contains(t, rendered, "topologySpreadConstraints:")
-	require.Contains(t, rendered, "maxSkew: 1")
-	require.Contains(t, rendered, "topologyKey: topology.kubernetes.io/zone")
-	require.Contains(t, rendered, "whenUnsatisfiable: ScheduleAnyway")
+	require.Contains(t, rendered, `maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway`)
+	require.Contains(t, rendered, `maxSkew: 3
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway`)
 	require.Contains(t, rendered, `matchLabels:
             app: test-app
             rack: rack


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: `spreadAcrossZones` Service Attribute**

Services in `convox.yml` gain a new boolean attribute, `spreadAcrossZones`. When it is set to `true`, Convox renders Kubernetes topology spread constraints into the service's pod template so the scheduler places that service's pods evenly across availability zones and across nodes. The default is `false`, and nothing is rendered unless the attribute is set to `true`.

**New Service Attribute:**

| Attribute | Type | Default | Effect |
|-----------|------|---------|--------|
| `spreadAcrossZones` | boolean | `false` | When `true`, the service's pod template carries topology spread constraints for zone and node placement. |

Two constraints are rendered together. Kubernetes replaces its entire default constraint set as soon as a pod declares constraints of its own, so the node constraint is emitted alongside the zone one and carries the same tolerance Kubernetes applies by default:

| Topology key | maxSkew | whenUnsatisfiable |
|--------------|---------|-------------------|
| `topology.kubernetes.io/zone` | `1` | `ScheduleAnyway` |
| `kubernetes.io/hostname` | `3` | `ScheduleAnyway` |

Both constraints are soft. `ScheduleAnyway` means the scheduler prefers an even spread and still places the pod when the spread cannot be met, so a service never goes unscheduled because zones or nodes are unavailable. Both use the same label selector (`system`, `rack`, `app`, `service`, and `type: service`), so the skew count covers only that service's own pods in that app on that rack, including pods from an outgoing release during a rolling deploy. Timer pods and one-off process pods from `convox run` and builds carry a different `type` label, so they neither receive the constraints nor count toward the skew. The attribute applies to standard services and to `stateful: true` services, which share the same pod template. Agent services are rejected at validation with `service <name> can not set spreadAcrossZones when agent is enabled`, since a DaemonSet already places one pod per eligible node. The attribute is available on all providers (AWS, GCP, Azure, DigitalOcean, Metal, and Local) because the workload template is shared, and the zone constraint takes effect on clusters whose nodes carry the standard `topology.kubernetes.io/zone` label.

---

### Why is this important?

A service that wants its replicas distributed across availability zones can now ask for that in `convox.yml`, without node selectors, node affinity rules, or any change to how the rack is provisioned.

**Benefits:**

- **Zone distribution as a service attribute.** One boolean on the service describes the placement goal, and Convox renders the matching Kubernetes constraints on every deploy.
- **Node spread preserved.** The node constraint ships with the zone constraint at Kubernetes' own default tolerance, so opting into zone spread keeps the per-node distribution the scheduler would apply otherwise.
- **A preference, not a requirement.** Both constraints use `ScheduleAnyway`, so a rack with nodes in a single zone, or a scale count of one, simply schedules as it did before.
- **Scoped counting.** The label selector limits the count to the service's own pods, so timers, `convox run` processes, and other services in the same app do not influence placement.
- **Unchanged by default.** The attribute defaults to `false`, and services that do not set it render exactly as they do today.

---

### How to use it?

Set the attribute on any non-agent service in `convox.yml`:

```yaml
services:
  web:
    image: example/web
    spreadAcrossZones: true
    scale:
      count: 3
```

Deploy the app to apply it:

    $ convox deploy -a my-app -r rackName

The zone spread only has an effect when the rack has eligible nodes in at least two zones and the service runs at least two replicas. It does not create zones, and node selectors, node affinity, and zonal storage all reduce the set of eligible zones. On racks running Karpenter, Karpenter may launch additional nodes to satisfy the spread and keep them running rather than consolidating them away.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this feature.

The attribute is purely additive and defaults to `false`. Services that do not set it render byte-identical workloads and keep the scheduling behavior they have today. Turning it on changes the rendered pod template, which rolls the service on the next deploy the same way any other pod spec change does. Setting it on an agent service is reported as a validation error at build time, so the condition surfaces before anything is deployed. On a rack older than `3.25.4` the attribute is ignored during manifest parsing, so a manifest that carries it still deploys after a downgrade, with the service returning to the cluster's default spread behavior.

---

### Requirements

This feature requires version `3.25.4` or later for the rack.

**Update the Rack:** Run `convox rack update 3.25.4 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
