### PR TITLE
cloud aws resource state and rds curation updates

### DIFF
--- a/pkg/manifest/resource.go
+++ b/pkg/manifest/resource.go
@@ -8,6 +8,9 @@ import (
 
 const (
 	DEFAULT_RESOURCE_ENV_NAME = "URL"
+
+	ResourceProviderAws       = "aws"
+	ResourceProviderContainer = "container"
 )
 
 var (
@@ -24,10 +27,11 @@ var (
 )
 
 type Resource struct {
-	Name    string            `yaml:"-"`
-	Type    string            `yaml:"type"`
-	Image   string            `yaml:"image,omitempty"`
-	Options map[string]string `yaml:"options"`
+	Name     string            `yaml:"-"`
+	Type     string            `yaml:"type"`
+	Provider string            `yaml:"provider,omitempty"`
+	Image    string            `yaml:"image,omitempty"`
+	Options  map[string]string `yaml:"options"`
 }
 
 type Resources []Resource
@@ -53,10 +57,18 @@ func (r Resource) mountEnv(envVar string) string {
 }
 
 func (r Resource) IsCustomManagedResource() bool {
-	return r.IsRds() || r.IsElastiCache()
+	return r.IsRds() || r.IsElastiCache() || r.IsAwsProvider()
+}
+
+func (r Resource) IsAwsProvider() bool {
+	return r.Provider == ResourceProviderAws
 }
 
 func (r Resource) IsRds() bool {
+	switch r.Type {
+	case "postgres", "mysql", "mariadb":
+		return r.IsAwsProvider()
+	}
 	return strings.HasPrefix(r.Type, "rds-")
 }
 
@@ -71,6 +83,10 @@ func (r Resource) RdsNameValidate() error {
 }
 
 func (r Resource) IsElastiCache() bool {
+	switch r.Type {
+	case "redis", "memcached":
+		return r.IsAwsProvider()
+	}
 	return strings.HasPrefix(r.Type, "elasticache-")
 }
 
@@ -87,7 +103,7 @@ func (r Resource) ElastiCacheNameValidate() error {
 func (r Resource) IsContainerizedResource() bool {
 	switch r.Type {
 	case "postgres", "mysql", "mariadb", "redis", "memcached", "postgis":
-		return true
+		return r.Provider == "" || r.Provider == ResourceProviderContainer
 	default:
 		return false
 	}

--- a/pkg/manifest/resource_test.go
+++ b/pkg/manifest/resource_test.go
@@ -1,0 +1,69 @@
+package manifest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceProviderClassification(t *testing.T) {
+	for _, tc := range []struct {
+		rType         string
+		provider      string
+		rds           bool
+		elasticache   bool
+		containerized bool
+		custom        bool
+	}{
+		{rType: "postgres", containerized: true},
+		{rType: "postgres", provider: "container", containerized: true},
+		{rType: "postgres", provider: "aws", rds: true, custom: true},
+		{rType: "mysql", provider: "aws", rds: true, custom: true},
+		{rType: "mariadb", provider: "aws", rds: true, custom: true},
+		{rType: "redis", containerized: true},
+		{rType: "redis", provider: "aws", elasticache: true, custom: true},
+		{rType: "memcached", provider: "aws", elasticache: true, custom: true},
+		{rType: "postgis", containerized: true},
+		{rType: "postgis", provider: "aws", custom: true},
+		{rType: "rds-postgres", rds: true, custom: true},
+		{rType: "rds-postgres", provider: "aws", rds: true, custom: true},
+		{rType: "elasticache-redis", elasticache: true, custom: true},
+		{rType: "elasticache-redis", provider: "aws", elasticache: true, custom: true},
+		{rType: "webhook"},
+	} {
+		r := Resource{Name: "res1", Type: tc.rType, Provider: tc.provider}
+
+		require.Equal(t, tc.rds, r.IsRds(), "IsRds for %s/%s", tc.rType, tc.provider)
+		require.Equal(t, tc.elasticache, r.IsElastiCache(), "IsElastiCache for %s/%s", tc.rType, tc.provider)
+		require.Equal(t, tc.containerized, r.IsContainerizedResource(), "IsContainerizedResource for %s/%s", tc.rType, tc.provider)
+		require.Equal(t, tc.custom, r.IsCustomManagedResource(), "IsCustomManagedResource for %s/%s", tc.rType, tc.provider)
+	}
+}
+
+func TestResourceProviderParse(t *testing.T) {
+	m, err := Load([]byte("resources:\n  db:\n    type: postgres\n    provider: aws\n  cache:\n    type: redis\n"), nil)
+	require.NoError(t, err)
+	require.Len(t, m.Resources, 2)
+
+	db, err := m.Resource("db")
+	require.NoError(t, err)
+	require.Equal(t, "aws", db.Provider)
+	require.True(t, db.IsRds())
+
+	cache, err := m.Resource("cache")
+	require.NoError(t, err)
+	require.Equal(t, "", cache.Provider)
+	require.True(t, cache.IsContainerizedResource())
+}
+
+func TestValidateResourceProvider(t *testing.T) {
+	for _, provider := range []string{"", "aws", "container"} {
+		m := &Manifest{Resources: Resources{{Name: "db", Type: "postgres", Provider: provider}}}
+		require.Empty(t, m.validateResources(), "provider %q", provider)
+	}
+
+	m := &Manifest{Resources: Resources{{Name: "db", Type: "postgres", Provider: "gcp"}}}
+	errs := m.validateResources()
+	require.Len(t, errs, 1)
+	require.EqualError(t, errs[0], `resource "db" has unknown provider "gcp"`)
+}

--- a/pkg/manifest/validate.go
+++ b/pkg/manifest/validate.go
@@ -98,6 +98,12 @@ func (m *Manifest) validateResources() []error {
 		if strings.TrimSpace(r.Type) == "" {
 			errs = append(errs, fmt.Errorf("resource %q has blank type", r.Name))
 		}
+
+		switch r.Provider {
+		case "", ResourceProviderAws, ResourceProviderContainer:
+		default:
+			errs = append(errs, fmt.Errorf("resource %q has unknown provider %q", r.Name, r.Provider))
+		}
 	}
 
 	return errs

--- a/pkg/options/feature_gates.go
+++ b/pkg/options/feature_gates.go
@@ -6,15 +6,17 @@ import (
 )
 
 const (
-	FeatureGateRdsDisable                   = "rds-disable"
-	FeatureGateElasticacheDisable           = "elasticache-disable"
-	FeatureGateSystemEnvDisable             = "system-env-disable"
-	FeatureGateBalancerDisable              = "balancer-disable"
-	FeatureGateTid                          = "tid"
-	FeatureGateAppLimitRequired             = "app-limit-required"
-	FeatureGateExternalDnsResolver          = "external-dns-resolver"           // will use 1.1.1.1 as the default resolver if enabled
-	FeatureGateResourceInternalDomainSuffix = "resource-internal-domain-suffix" // will use svc.cluster.local as the default internal resource domain suffix
-	FeatureGateDisableHostUsersAsDefault    = "disable-host-users"              // will disable setting the host user in the container if enabled
+	FeatureGateRdsDisable                    = "rds-disable"
+	FeatureGateElasticacheDisable            = "elasticache-disable"
+	FeatureGateSystemEnvDisable              = "system-env-disable"
+	FeatureGateBalancerDisable               = "balancer-disable"
+	FeatureGateTid                           = "tid"
+	FeatureGateAppLimitRequired              = "app-limit-required"
+	FeatureGateExternalDnsResolver           = "external-dns-resolver"             // will use 1.1.1.1 as the default resolver if enabled
+	FeatureGateResourceInternalDomainSuffix  = "resource-internal-domain-suffix"   // will use svc.cluster.local as the default internal resource domain suffix
+	FeatureGateDisableHostUsersAsDefault     = "disable-host-users"                // will disable setting the host user in the container if enabled
+	FeatureGatePrefixBasedAwsResourceDisable = "aws-resource-prefix-based-disable" // will reject resources named with the rds- and elasticache- prefixes
+	FeatureGateRDSTemplateConfig             = "rds-template-config"               // names a config map that limits rds options to a curated set
 )
 
 func GetFeatureGates() map[string]bool {

--- a/provider/aws/provisioner/elasticache/provisioner.go
+++ b/provider/aws/provisioner/elasticache/provisioner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -40,11 +41,16 @@ func NewProvisioner(s provisioner.Storage) *Provisioner {
 	}
 }
 
-func (p *Provisioner) Provision(id string, options map[string]string) error {
+type ProvisionExtraOpts struct {
+	Tags map[string]string
+	Meta map[string]string
+}
+
+func (p *Provisioner) Provision(id string, options map[string]string, extraOpts ProvisionExtraOpts) error {
 	if options[ParamEngine] == "redis" {
 		if v, ok := options[ParamImport]; ok {
 			p.logger.Logf("Start redis replication group import")
-			if err := p.ImportReplicatonGroup(id, v, options); err != nil {
+			if err := p.ImportReplicatonGroup(id, v, options, extraOpts); err != nil {
 				return fmt.Errorf("failed to import redis replication group: %s", err)
 			}
 			return nil
@@ -55,7 +61,7 @@ func (p *Provisioner) Provision(id string, options map[string]string) error {
 			if provisioner.IsNotFoundError(err) {
 
 				p.logger.Logf("Start provisioning for redis replication group")
-				if err := p.InstallReplicationGroup(id, options); err != nil {
+				if err := p.InstallReplicationGroup(id, options, extraOpts); err != nil {
 					return fmt.Errorf("failed to install redis replication group: %s", err)
 				}
 				return nil
@@ -64,14 +70,14 @@ func (p *Provisioner) Provision(id string, options map[string]string) error {
 		}
 
 		p.logger.Logf("Start redis replication group update")
-		if err := p.UpdateReplicationGroup(id, options); err != nil {
+		if err := p.UpdateReplicationGroup(id, options, extraOpts); err != nil {
 			return fmt.Errorf("failed to update redis replication group: %s", err)
 		}
 		return nil
 	} else if options[ParamEngine] == "memcached" {
 		if v, ok := options[ParamImport]; ok {
 			p.logger.Logf("Start memcached cache cluster import")
-			if err := p.ImportCacheCluster(id, v, options); err != nil {
+			if err := p.ImportCacheCluster(id, v, options, extraOpts); err != nil {
 				return fmt.Errorf("failed to import memcached cache cluster: %s", err)
 			}
 			return nil
@@ -82,7 +88,7 @@ func (p *Provisioner) Provision(id string, options map[string]string) error {
 			if provisioner.IsNotFoundError(err) {
 
 				p.logger.Logf("Start provisioning for memcached cache cluster")
-				if err := p.InstallCacheCluster(id, options); err != nil {
+				if err := p.InstallCacheCluster(id, options, extraOpts); err != nil {
 					return fmt.Errorf("failed to install memcache cache cluster: %s", err)
 				}
 				return nil
@@ -91,7 +97,7 @@ func (p *Provisioner) Provision(id string, options map[string]string) error {
 		}
 
 		p.logger.Logf("Start memcached cache cluster update")
-		if err := p.UpdateCacheCluster(id, options); err != nil {
+		if err := p.UpdateCacheCluster(id, options, extraOpts); err != nil {
 			return fmt.Errorf("failed to update memcached cache cluster: %s", err)
 		}
 		return nil
@@ -100,7 +106,7 @@ func (p *Provisioner) Provision(id string, options map[string]string) error {
 	return fmt.Errorf("%s not supported", options[ParamEngine])
 }
 
-func (p *Provisioner) InstallReplicationGroup(id string, options map[string]string) error {
+func (p *Provisioner) InstallReplicationGroup(id string, options map[string]string, extraOpts ProvisionExtraOpts) error {
 	_, err := p.storage.GetState(id)
 	if err != nil && !provisioner.IsNotFoundError(err) {
 		return err
@@ -140,6 +146,7 @@ func (p *Provisioner) InstallReplicationGroup(id string, options map[string]stri
 
 	p.logger.Logf("Generating the state data for id: %s", id)
 	stateData := NewState(id, StateProvisioning, params)
+	stateData.SetMeta(extraOpts.Meta)
 
 	if err := p.createSecurityGroupIfNotProvided(stateData); err != nil {
 		return fmt.Errorf("failed to create security group: %s", err)
@@ -160,6 +167,7 @@ func (p *Provisioner) InstallReplicationGroup(id string, options map[string]stri
 			Value: aws.String(stateData.Id),
 		},
 	}
+	createOptions.Tags = append(createOptions.Tags, extraTags(extraOpts.Tags)...)
 
 	p.logger.Logf("Installing redis replication group: %s", id)
 	_, err = p.elasticacheClient.CreateReplicationGroup(context.TODO(), createOptions)
@@ -181,7 +189,7 @@ func (p *Provisioner) InstallReplicationGroup(id string, options map[string]stri
 	return nil
 }
 
-func (p *Provisioner) InstallCacheCluster(id string, options map[string]string) error {
+func (p *Provisioner) InstallCacheCluster(id string, options map[string]string, extraOpts ProvisionExtraOpts) error {
 	_, err := p.storage.GetState(id)
 	if err != nil && !provisioner.IsNotFoundError(err) {
 		return err
@@ -221,6 +229,7 @@ func (p *Provisioner) InstallCacheCluster(id string, options map[string]string) 
 
 	p.logger.Logf("Generating the state data for id: %s", id)
 	stateData := NewState(id, StateProvisioning, params)
+	stateData.SetMeta(extraOpts.Meta)
 
 	if err := p.createSecurityGroupIfNotProvided(stateData); err != nil {
 		return fmt.Errorf("failed to create security group: %s", err)
@@ -241,6 +250,7 @@ func (p *Provisioner) InstallCacheCluster(id string, options map[string]string) 
 			Value: aws.String(stateData.Id),
 		},
 	}
+	createOptions.Tags = append(createOptions.Tags, extraTags(extraOpts.Tags)...)
 
 	p.logger.Logf("Installing memcached cache cluster: %s", id)
 	_, err = p.elasticacheClient.CreateCacheCluster(context.TODO(), createOptions)
@@ -262,7 +272,7 @@ func (p *Provisioner) InstallCacheCluster(id string, options map[string]string) 
 	return nil
 }
 
-func (p *Provisioner) UpdateReplicationGroup(id string, optoins map[string]string) error {
+func (p *Provisioner) UpdateReplicationGroup(id string, options map[string]string, extraOpts ProvisionExtraOpts) error {
 	stateBytes, err := p.storage.GetState(id)
 	if err != nil {
 		return err
@@ -273,10 +283,14 @@ func (p *Provisioner) UpdateReplicationGroup(id string, optoins map[string]strin
 		return err
 	}
 
+	if extraOpts.Meta != nil {
+		stateData.SetMeta(extraOpts.Meta)
+	}
+
 	updateMetadata := GetParametersMetaDataForReplicationGroupUpdate()
 
 	changedParams := []string{}
-	for k, v := range optoins {
+	for k, v := range options {
 		changed, err := stateData.UpdateParameterValueForCacheUpdate(k, v, updateMetadata)
 		if err != nil {
 			return fmt.Errorf("failed to update parameter value: %s", err)
@@ -371,7 +385,7 @@ func (p *Provisioner) UpdateReplicationGroup(id string, optoins map[string]strin
 	return nil
 }
 
-func (p *Provisioner) UpdateCacheCluster(id string, optoins map[string]string) error {
+func (p *Provisioner) UpdateCacheCluster(id string, options map[string]string, extraOpts ProvisionExtraOpts) error {
 	stateBytes, err := p.storage.GetState(id)
 	if err != nil {
 		return err
@@ -382,10 +396,14 @@ func (p *Provisioner) UpdateCacheCluster(id string, optoins map[string]string) e
 		return err
 	}
 
+	if extraOpts.Meta != nil {
+		stateData.SetMeta(extraOpts.Meta)
+	}
+
 	updateMetadata := GetParametersMetaDataForCacheClusterUpdate()
 
 	changedParams := []string{}
-	for k, v := range optoins {
+	for k, v := range options {
 		changed, err := stateData.UpdateParameterValueForCacheUpdate(k, v, updateMetadata)
 		if err != nil {
 			return fmt.Errorf("failed to update parameter value: %s", err)
@@ -436,13 +454,14 @@ func (p *Provisioner) UpdateCacheCluster(id string, optoins map[string]string) e
 	return nil
 }
 
-func (p *Provisioner) ImportReplicatonGroup(id string, repGrpId string, options map[string]string) error {
+func (p *Provisioner) ImportReplicatonGroup(id string, repGrpId string, options map[string]string, extraOpts ProvisionExtraOpts) error {
 	_, err := p.storage.GetState(id)
 	if err != nil && !provisioner.IsNotFoundError(err) {
 		return err
 	}
 
 	state := NewStateForImport(id)
+	state.SetMeta(extraOpts.Meta)
 
 	p.logger.Logf("Fetching redis replication group details: %s", repGrpId)
 
@@ -469,13 +488,14 @@ func (p *Provisioner) ImportReplicatonGroup(id string, repGrpId string, options 
 	return nil
 }
 
-func (p *Provisioner) ImportCacheCluster(id string, clusterId string, options map[string]string) error {
+func (p *Provisioner) ImportCacheCluster(id string, clusterId string, options map[string]string, extraOpts ProvisionExtraOpts) error {
 	_, err := p.storage.GetState(id)
 	if err != nil && !provisioner.IsNotFoundError(err) {
 		return err
 	}
 
 	state := NewStateForImport(id)
+	state.SetMeta(extraOpts.Meta)
 
 	p.logger.Logf("Fetching memcached cache cluster details: %s", clusterId)
 
@@ -611,7 +631,7 @@ func (p *Provisioner) SaveState(id string, stateData *StateData) error {
 		return err
 	}
 
-	if err := p.storage.SaveState(id, stateBytes, ProvisionerName); err != nil {
+	if err := p.storage.SaveState(id, stateBytes, ProvisionerName, stateData.Meta); err != nil {
 		p.logger.Errorf("Failed to save state: %s", err)
 		return err
 	}
@@ -1163,4 +1183,21 @@ func (p *Provisioner) deleteCacheSubnetGroupIfManaged(state *StateData) error {
 	p.logger.Logf("Deleting cache subnet group: %s", *sbg.CacheSubnetGroupName)
 	p.DeleteCacheSubnetGroup(*sbg.CacheSubnetGroupName)
 	return nil
+}
+
+func extraTags(tags map[string]string) []elasticachetypes.Tag {
+	keys := make([]string, 0, len(tags))
+	for k := range tags {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	out := make([]elasticachetypes.Tag, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, elasticachetypes.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(tags[k]),
+		})
+	}
+	return out
 }

--- a/provider/aws/provisioner/elasticache/states.go
+++ b/provider/aws/provisioner/elasticache/states.go
@@ -33,6 +33,8 @@ type StateData struct {
 
 	Host string `json:"host"`
 
+	Meta map[string]string `json:"meta,omitempty"`
+
 	Paramters map[string]Parameter `json:"parameters"`
 }
 
@@ -72,6 +74,10 @@ func (s *StateData) GetStatus() string {
 
 func (s *StateData) SetStatus(state StatusType) {
 	s.Status = state
+}
+
+func (s *StateData) SetMeta(meta map[string]string) {
+	s.Meta = meta
 }
 
 func (s *StateData) AddParameter(p Parameter) error {

--- a/provider/aws/provisioner/provisioner.go
+++ b/provider/aws/provisioner/provisioner.go
@@ -1,7 +1,7 @@
 package provisioner
 
 type Storage interface {
-	SaveState(id string, data []byte, provisioner string) error
+	SaveState(id string, data []byte, provisioner string, meta map[string]string) error
 	GetState(id string) ([]byte, error)
 	SendStateLog(id, message string) error
 }

--- a/provider/aws/provisioner/rds/provisioner.go
+++ b/provider/aws/provisioner/rds/provisioner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -40,14 +41,19 @@ func NewProvisioner(s provisioner.Storage) *Provisioner {
 	}
 }
 
-func (p *Provisioner) Provision(id string, options map[string]string) error {
+type ProvisionExtraOpts struct {
+	Tags map[string]string
+	Meta map[string]string
+}
+
+func (p *Provisioner) Provision(id string, options map[string]string, extraOpts ProvisionExtraOpts) error {
 	if v, ok := options[ParamImport]; ok {
 		pass := options[ParamMasterUserPassword]
 		if pass == "" {
 			return fmt.Errorf("imported db password is required for import")
 		}
 		p.logger.Logf("Start db instance import")
-		if err := p.Import(id, v, &pass); err != nil {
+		if err := p.Import(id, v, &pass, extraOpts); err != nil {
 			return fmt.Errorf("failed to import db instance: %s", err)
 		}
 		return nil
@@ -58,16 +64,16 @@ func (p *Provisioner) Provision(id string, options map[string]string) error {
 		if provisioner.IsNotFoundError(err) {
 			if options[ParamSourceDBInstanceIdentifier] != "" {
 				p.logger.Logf("Start provision for db replica")
-				return p.InstallReplica(id, options)
+				return p.InstallReplica(id, options, extraOpts)
 			}
 
 			if options[ParamDBSnapshotIdentifier] != "" {
 				p.logger.Logf("Start provision for db instance from snapshot")
-				return p.RestoreFromSnapshot(id, options)
+				return p.RestoreFromSnapshot(id, options, extraOpts)
 			}
 
 			p.logger.Logf("Start provision for db instance")
-			if err := p.Install(id, options); err != nil {
+			if err := p.Install(id, options, extraOpts); err != nil {
 				return fmt.Errorf("failed to install db instance: %s", err)
 			}
 			return nil
@@ -76,13 +82,13 @@ func (p *Provisioner) Provision(id string, options map[string]string) error {
 	}
 
 	p.logger.Logf("Start db instance update")
-	if err := p.Update(id, options); err != nil {
+	if err := p.Update(id, options, extraOpts); err != nil {
 		return fmt.Errorf("failed to update db instance: %s", err)
 	}
 	return nil
 }
 
-func (p *Provisioner) Install(id string, options map[string]string) error {
+func (p *Provisioner) Install(id string, options map[string]string, extraOpts ProvisionExtraOpts) error {
 	_, err := p.storage.GetState(id)
 	if err != nil && !provisioner.IsNotFoundError(err) {
 		return err
@@ -122,6 +128,7 @@ func (p *Provisioner) Install(id string, options map[string]string) error {
 
 	p.logger.Logf("Generating the state data for id: %s", id)
 	stateData := NewState(id, StateProvisioning, params)
+	stateData.SetMeta(extraOpts.Meta)
 
 	if err := p.createSecurityGroupIfNotProvided(stateData); err != nil {
 		return fmt.Errorf("failed to create security group: %s", err)
@@ -142,6 +149,7 @@ func (p *Provisioner) Install(id string, options map[string]string) error {
 			Value: aws.String(stateData.Id),
 		},
 	}
+	createOptions.Tags = append(createOptions.Tags, extraTags(extraOpts.Tags)...)
 
 	p.logger.Logf("Installing db instance: %s", id)
 	dbCreateResp, err := p.rdsClient.CreateDBInstance(context.TODO(), createOptions)
@@ -168,7 +176,7 @@ func (p *Provisioner) Install(id string, options map[string]string) error {
 	return nil
 }
 
-func (p *Provisioner) InstallReplica(id string, options map[string]string) error {
+func (p *Provisioner) InstallReplica(id string, options map[string]string, extraOpts ProvisionExtraOpts) error {
 	_, err := p.storage.GetState(id)
 	if err != nil && !provisioner.IsNotFoundError(err) {
 		return err
@@ -215,6 +223,7 @@ func (p *Provisioner) InstallReplica(id string, options map[string]string) error
 
 	p.logger.Logf("Generating the state data for id: %s", id)
 	stateData := NewState(id, StateProvisioning, params)
+	stateData.SetMeta(extraOpts.Meta)
 
 	createOptions, err := stateData.GenerateCreateDBInstanceReadReplicaInput()
 	if err != nil {
@@ -227,6 +236,7 @@ func (p *Provisioner) InstallReplica(id string, options map[string]string) error
 			Value: aws.String(stateData.Id),
 		},
 	}
+	createOptions.Tags = append(createOptions.Tags, extraTags(extraOpts.Tags)...)
 
 	p.logger.Logf("Installing db instance read replica: %s", id)
 	dbCreateResp, err := p.rdsClient.CreateDBInstanceReadReplica(context.TODO(), createOptions)
@@ -253,7 +263,7 @@ func (p *Provisioner) InstallReplica(id string, options map[string]string) error
 	return nil
 }
 
-func (p *Provisioner) Update(id string, optoins map[string]string) error {
+func (p *Provisioner) Update(id string, options map[string]string, extraOpts ProvisionExtraOpts) error {
 	stateBytes, err := p.storage.GetState(id)
 	if err != nil {
 		return err
@@ -264,8 +274,12 @@ func (p *Provisioner) Update(id string, optoins map[string]string) error {
 		return err
 	}
 
+	if extraOpts.Meta != nil {
+		stateData.SetMeta(extraOpts.Meta)
+	}
+
 	changedParams := []string{}
-	for k, v := range optoins {
+	for k, v := range options {
 		changed, err := stateData.UpdateParameterValueForDbUpdate(k, v)
 		if err != nil {
 			return fmt.Errorf("failed to update parameter value: %s", err)
@@ -277,7 +291,7 @@ func (p *Provisioner) Update(id string, optoins map[string]string) error {
 
 	isPromoted := false
 	sourceDBParam := stateData.GetParameter(ParamSourceDBInstanceIdentifier)
-	if _, has := optoins[ParamSourceDBInstanceIdentifier]; !has && sourceDBParam != nil && !sourceDBParam.IsValueEmpty() {
+	if _, has := options[ParamSourceDBInstanceIdentifier]; !has && sourceDBParam != nil && !sourceDBParam.IsValueEmpty() {
 		dbIdentifier, err := stateData.GetParameterValue(ParamDBInstanceIdentifier)
 		if err != nil {
 			return err
@@ -329,13 +343,14 @@ func (p *Provisioner) Update(id string, optoins map[string]string) error {
 	return nil
 }
 
-func (p *Provisioner) Import(id string, dbIdentifier string, pass *string) error {
+func (p *Provisioner) Import(id string, dbIdentifier string, pass *string, extraOpts ProvisionExtraOpts) error {
 	_, err := p.storage.GetState(id)
 	if err != nil && !provisioner.IsNotFoundError(err) {
 		return err
 	}
 
 	state := NewStateForImport(id)
+	state.SetMeta(extraOpts.Meta)
 
 	p.logger.Logf("Fetching db instance details: %s", dbIdentifier)
 
@@ -357,7 +372,7 @@ func (p *Provisioner) Import(id string, dbIdentifier string, pass *string) error
 	return nil
 }
 
-func (p *Provisioner) RestoreFromSnapshot(id string, options map[string]string) error {
+func (p *Provisioner) RestoreFromSnapshot(id string, options map[string]string, extraOpts ProvisionExtraOpts) error {
 	_, err := p.storage.GetState(id)
 	if err != nil && !provisioner.IsNotFoundError(err) {
 		return err
@@ -391,6 +406,7 @@ func (p *Provisioner) RestoreFromSnapshot(id string, options map[string]string) 
 
 	p.logger.Logf("Generating the state data for id: %s", id)
 	stateData := NewState(id, StateProvisioning, params)
+	stateData.SetMeta(extraOpts.Meta)
 
 	if err := p.createSecurityGroupIfNotProvided(stateData); err != nil {
 		return fmt.Errorf("failed to create security group: %s", err)
@@ -411,6 +427,7 @@ func (p *Provisioner) RestoreFromSnapshot(id string, options map[string]string) 
 			Value: aws.String(stateData.Id),
 		},
 	}
+	createOptions.Tags = append(createOptions.Tags, extraTags(extraOpts.Tags)...)
 
 	p.logger.Logf("Restoring db instance: %s from snapshot", id)
 	dbCreateResp, err := p.rdsClient.RestoreDBInstanceFromDBSnapshot(context.TODO(), createOptions)
@@ -480,7 +497,7 @@ func (p *Provisioner) SaveState(id string, stateData *StateData) error {
 		return err
 	}
 
-	if err := p.storage.SaveState(id, stateBytes, ProvisionerName); err != nil {
+	if err := p.storage.SaveState(id, stateBytes, ProvisionerName, stateData.Meta); err != nil {
 		p.logger.Errorf("Failed to save state: %s", err)
 		return err
 	}
@@ -853,4 +870,21 @@ func (p *Provisioner) deleteDBSubnetGroupIfManaged(state *StateData) error {
 	p.logger.Logf("Deleting db subnet group: %s", *dbSbg.DBSubnetGroupName)
 	p.DeleteDBSubnetGroup(*dbSbg.DBSubnetGroupName)
 	return nil
+}
+
+func extraTags(tags map[string]string) []rdstypes.Tag {
+	keys := make([]string, 0, len(tags))
+	for k := range tags {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	out := make([]rdstypes.Tag, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, rdstypes.Tag{
+			Key:   aws.String(k),
+			Value: aws.String(tags[k]),
+		})
+	}
+	return out
 }

--- a/provider/aws/provisioner/rds/states.go
+++ b/provider/aws/provisioner/rds/states.go
@@ -32,6 +32,8 @@ type StateData struct {
 
 	Host string `json:"host"`
 
+	Meta map[string]string `json:"meta,omitempty"`
+
 	Paramters map[string]Parameter `json:"parameters"`
 }
 
@@ -71,6 +73,10 @@ func (s *StateData) GetStatus() string {
 
 func (s *StateData) SetStatus(state StatusType) {
 	s.Status = state
+}
+
+func (s *StateData) SetMeta(meta map[string]string) {
+	s.Meta = meta
 }
 
 func (s *StateData) AddParameter(p Parameter) error {

--- a/provider/k8s/app.go
+++ b/provider/k8s/app.go
@@ -354,10 +354,16 @@ func (p *Provider) AppNamespace(app string) string {
 		return p.Namespace
 	default:
 		if p.ContextTID() != "" {
-			return fmt.Sprintf("%s-%s-%s", p.Name, p.ContextTID(), app)
+			return p.tidNamespace(p.ContextTID(), app)
 		}
 		return fmt.Sprintf("%s-%s", p.Name, app)
 	}
+}
+
+// tidNamespace is AppNamespace for callers that carry the tenant explicitly
+// because they run outside a tenant request context.
+func (p *Provider) tidNamespace(tid, app string) string {
+	return fmt.Sprintf("%s-%s-%s", p.Name, tid, app)
 }
 
 // buildNamespace returns a deterministic, length-safe namespace dedicated to an

--- a/provider/k8s/aws_resources.go
+++ b/provider/k8s/aws_resources.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/convox/convox/pkg/common"
+	"github.com/convox/convox/pkg/manifest"
+	"github.com/convox/convox/pkg/options"
 	"github.com/convox/convox/pkg/structs"
 	"github.com/convox/convox/provider/aws/provisioner/elasticache"
 	"github.com/convox/convox/provider/aws/provisioner/rds"
@@ -22,6 +25,14 @@ import (
 const (
 	StateFinalizer = "convox.com/rds-provisioner"
 	StateDataKey   = "state"
+
+	AnnotationUninstalledAt = "convox.com/uninstalled-at"
+
+	MetaAppKey      = "convox-x-app"
+	MetaRackKey     = "convox-x-rack"
+	MetaResourceKey = "convox-x-resource"
+	MetaRdsTypeKey  = "convox-x-rds-type"
+	MetaTidKey      = "convox-x-tid"
 )
 
 var (
@@ -30,10 +41,152 @@ var (
 		s:         map[string][]string{},
 		threshold: 50,
 	}
+
+	awsResourceMetaOptions = []string{"class", "durable", "instance", "nodes", "storage", "version"}
 )
 
-func (p *Provider) CreateAwsResourceStateId(app string, resourceName string) string {
-	return fmt.Sprintf("%s-r%sr-%s", resourceName, p.Name, app)
+func generateResourceStateId(rack, tid, app, resourceName string) string {
+	if tid != "" {
+		return fmt.Sprintf("%s-%s-%s", resourceName, tid, app)
+	}
+	return fmt.Sprintf("%s-r%sr-%s", resourceName, rack, app)
+}
+
+// CreateAwsResourceStateId returns the state id for a resource. A tenant id is not
+// parseable, so it also gets a labeled secret the state lookups read it back from.
+func (p *Provider) CreateAwsResourceStateId(tid, app, resourceName string) (string, error) {
+	id := generateResourceStateId(p.Name, tid, app, resourceName)
+	if tid == "" {
+		return id, nil
+	}
+
+	ns := p.tidNamespace(tid, app)
+
+	cur, err := p.Cluster.CoreV1().Secrets(ns).Get(p.ctx, id, metav1.GetOptions{})
+	if err == nil {
+		if cur.DeletionTimestamp != nil {
+			return "", structs.ErrBadRequest("resource %s is still being deleted, promote again once it is gone", resourceName)
+		}
+		return id, nil
+	}
+	if !kerr.IsNotFound(err) {
+		return "", err
+	}
+
+	_, err = p.Cluster.CoreV1().Secrets(ns).Create(p.ctx, &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: id,
+			Labels: map[string]string{
+				"rack":     p.RackName,
+				"system":   "convox",
+				"app":      app,
+				"resource": resourceName,
+				"tid":      tid,
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil && !kerr.IsAlreadyExists(err) {
+		return "", fmt.Errorf("failed to create state secret for resource %s: %s", resourceName, err)
+	}
+
+	return id, nil
+}
+
+type AwsStateIdInfo struct {
+	App          string
+	ResourceName string
+	Tid          string
+}
+
+func (p *Provider) GetInfoFromAwsResourceStateId(id string) (*AwsStateIdInfo, error) {
+	if parts := strings.Split(id, fmt.Sprintf("-r%sr-", p.Name)); len(parts) == 2 {
+		return &AwsStateIdInfo{App: parts[1], ResourceName: parts[0]}, nil
+	}
+
+	s, err := p.awsResourceStateSecret(id)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AwsStateIdInfo{
+		App:          s.Labels["app"],
+		ResourceName: s.Labels["resource"],
+		Tid:          s.Labels["tid"],
+	}, nil
+}
+
+// The provisioner storage callbacks run on the base provider, with no tenant
+// context, so a tenant id can only be resolved by name across namespaces.
+func (p *Provider) awsResourceStateSecret(id string) (*corev1.Secret, error) {
+	if app, err := p.ParseAppNameFromAwsResourceStateId(id); err == nil {
+		s, err := p.Cluster.CoreV1().Secrets(p.AppNamespace(app)).Get(p.ctx, id, metav1.GetOptions{})
+		if err != nil {
+			if kerr.IsNotFound(err) {
+				return nil, structs.ErrNotFound("state not found")
+			}
+			return nil, err
+		}
+		return s, nil
+	}
+
+	sList, err := p.Cluster.CoreV1().Secrets(corev1.NamespaceAll).List(p.ctx, metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("metadata.name=%s", id),
+		LabelSelector: "system=convox",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range sList.Items {
+		if sList.Items[i].Name == id {
+			return &sList.Items[i], nil
+		}
+	}
+
+	return nil, structs.ErrNotFound("state not found")
+}
+
+func (p *Provider) AwsResourceTags(tid, app, resourceName string) map[string]string {
+	tags := map[string]string{
+		"rack":     p.RackName,
+		"system":   "convox",
+		"app":      app,
+		"resource": resourceName,
+	}
+	if tid != "" {
+		tags["tid"] = tid
+	}
+	return tags
+}
+
+// awsResourceMeta records what a resource was asked for next to its state. With no
+// option template to say which options exist, only the descriptive ones are taken:
+// the rest of the manifest options may be credentials.
+func (p *Provider) awsResourceMeta(tid, app string, r manifest.Resource, requested map[string]string) map[string]string {
+	meta := map[string]string{}
+
+	if requested != nil {
+		for k, v := range requested {
+			meta[k] = v
+		}
+	} else {
+		for _, k := range awsResourceMetaOptions {
+			if v := r.Options[k]; v != "" {
+				meta[k] = v
+			}
+		}
+	}
+
+	meta[MetaAppKey] = app
+	meta[MetaRackKey] = p.RackName
+	meta[MetaResourceKey] = r.Name
+	meta[MetaTidKey] = tid
+
+	return meta
 }
 
 func (p *Provider) ParseAppNameFromAwsResourceStateId(id string) (string, error) {
@@ -52,15 +205,25 @@ func (p *Provider) ParseResourceNameFromAwsResourceStateId(id string) (string, e
 	return parts[0], nil
 }
 
-func (p *Provider) SaveState(id string, data []byte, provisioner string) error {
-	app, err := p.ParseAppNameFromAwsResourceStateId(id)
-	if err != nil {
-		return err
+func (p *Provider) SaveState(id string, data []byte, provisioner string, meta map[string]string) error {
+	app, resourceName, tid := meta[MetaAppKey], meta[MetaResourceKey], meta[MetaTidKey]
+
+	if app == "" {
+		info, err := p.GetInfoFromAwsResourceStateId(id)
+		if err != nil {
+			return err
+		}
+		app, resourceName, tid = info.App, info.ResourceName, info.Tid
 	}
 
-	_, err = p.CreateOrPatchSecret(p.ctx, metav1.ObjectMeta{
+	ns := p.AppNamespace(app)
+	if tid != "" {
+		ns = p.tidNamespace(tid, app)
+	}
+
+	_, err := p.CreateOrPatchSecret(p.ctx, metav1.ObjectMeta{
 		Name:      id,
-		Namespace: p.AppNamespace(app),
+		Namespace: ns,
 	}, func(s *corev1.Secret) *corev1.Secret {
 		if !hasStateFinalizer(s.Finalizers) {
 			s.Finalizers = append(s.Finalizers, StateFinalizer)
@@ -71,6 +234,9 @@ func (p *Provider) SaveState(id string, data []byte, provisioner string) error {
 			"system":      "convox",
 			"provisioner": provisioner,
 			"type":        "state",
+			"app":         app,
+			"resource":    resourceName,
+			"tid":         tid,
 		}
 		s.Data = map[string][]byte{
 			StateDataKey: data,
@@ -84,16 +250,8 @@ func (p *Provider) SaveState(id string, data []byte, provisioner string) error {
 }
 
 func (p *Provider) GetState(id string) ([]byte, error) {
-	app, err := p.ParseAppNameFromAwsResourceStateId(id)
+	s, err := p.awsResourceStateSecret(id)
 	if err != nil {
-		return nil, err
-	}
-
-	s, err := p.Cluster.CoreV1().Secrets(p.AppNamespace(app)).Get(p.ctx, id, metav1.GetOptions{})
-	if err != nil {
-		if kerr.IsNotFound(err) {
-			return nil, structs.ErrNotFound("state not found")
-		}
 		return nil, err
 	}
 
@@ -102,29 +260,24 @@ func (p *Provider) GetState(id string) ([]byte, error) {
 		return nil, structs.ErrNotFound("state not found")
 	}
 
-	return data, err
+	return data, nil
 }
 
 func (p *Provider) SendStateLog(id, message string) error {
-	app, err := p.ParseAppNameFromAwsResourceStateId(id)
+	info, err := p.GetInfoFromAwsResourceStateId(id)
 	if err != nil {
 		return err
 	}
 
-	resourceName, err := p.ParseResourceNameFromAwsResourceStateId(id)
-	if err != nil {
-		return err
-	}
-
-	tempRdsEventLogStore.Add(app, fmt.Sprintf("resource %s: %s", resourceName, message))
+	tempRdsEventLogStore.Add(info.Tid, info.App, fmt.Sprintf("resource %s: %s", info.ResourceName, message))
 	return nil
 }
 
-func (p *Provider) FlushStateLog(app string) {
-	logList := tempRdsEventLogStore.Get(app)
-	tempRdsEventLogStore.Reset(app)
+func (p *Provider) FlushStateLog(tid, app string) {
+	logList := tempRdsEventLogStore.Get(tid, app)
+	tempRdsEventLogStore.Reset(tid, app)
 	for _, msg := range logList {
-		p.systemLog("", app, "state", time.Now(), msg)
+		_ = p.systemLog(tid, app, "state", time.Now(), msg)
 	}
 }
 
@@ -207,6 +360,16 @@ func (p *Provider) PatchSecretObject(ctx context.Context, cur, mod *corev1.Secre
 	return p.Cluster.CoreV1().Secrets(cur.Namespace).Patch(ctx, cur.Name, types.StrategicMergePatchType, patch, opts)
 }
 
+// MapToRdsParameterAndMeta maps only the options the rack's template allows.
+func (p *Provider) MapToRdsParameterAndMeta(tid, rdsType, app string, r manifest.Resource) (map[string]string, map[string]string, error) {
+	allowed, requested, err := p.filterRdsOptionsForTemplate(strings.TrimPrefix(rdsType, "rds-"), r.Options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return p.MapToRdsParameter(rdsType, app, allowed), p.awsResourceMeta(tid, app, r, requested), nil
+}
+
 func (p *Provider) MapToRdsParameter(rdsType, app string, params map[string]string) map[string]string {
 	out := map[string]string{
 		rds.ParamEngine:    strings.TrimPrefix(rdsType, "rds-"),
@@ -247,7 +410,7 @@ func (p *Provider) MapToRdsParameter(rdsType, app string, params map[string]stri
 
 	if strings.HasPrefix(out[rds.ParamSourceDBInstanceIdentifier], "#convox.resources.") {
 		rName := strings.TrimPrefix(out[rds.ParamSourceDBInstanceIdentifier], "#convox.resources.")
-		out[rds.ParamSourceDBInstanceIdentifier] = p.CreateAwsResourceStateId(app, rName)
+		out[rds.ParamSourceDBInstanceIdentifier] = generateResourceStateId(p.Name, p.ContextTID(), app, rName)
 	}
 
 	allowedParamList := map[string]struct{}{}
@@ -328,6 +491,11 @@ func (p *Provider) uninstallRdsAssociatedWithStateSecret(stateSecret *corev1.Sec
 				}
 			}
 			s.Finalizers = newFinalizers
+
+			if s.Annotations == nil {
+				s.Annotations = map[string]string{}
+			}
+			s.Annotations[AnnotationUninstalledAt] = time.Now().UTC().Format(time.RFC3339)
 		}
 		return s
 	}, metav1.PatchOptions{})
@@ -349,6 +517,11 @@ func (p *Provider) uninstallElaticacheAssociatedWithStateSecret(stateSecret *cor
 				}
 			}
 			s.Finalizers = newFinalizers
+
+			if s.Annotations == nil {
+				s.Annotations = map[string]string{}
+			}
+			s.Annotations[AnnotationUninstalledAt] = time.Now().UTC().Format(time.RFC3339)
 		}
 		return s
 	}, metav1.PatchOptions{})
@@ -363,4 +536,121 @@ func hasStateFinalizer(finalizers []string) bool {
 		}
 	}
 	return false
+}
+
+// The resource template and the atom dependency both key off the prefixed type,
+// so a provider alias has to carry it even though the manifest did not.
+func awsResourceType(prefix, rType string) string {
+	if strings.HasPrefix(rType, prefix) {
+		return rType
+	}
+	return prefix + rType
+}
+
+func (p *Provider) validateAwsProviderResource(r manifest.Resource) error {
+	if !r.IsAwsProvider() {
+		return nil
+	}
+
+	if !p.FeatureGates[options.FeatureGateRDSTemplateConfig] {
+		return structs.ErrBadRequest("resource %s: provider %s is not supported on this rack", r.Name, r.Provider)
+	}
+
+	if !r.IsRds() && !r.IsElastiCache() {
+		return structs.ErrBadRequest("resource %s: provider %s is not supported for type %s", r.Name, r.Provider, r.Type)
+	}
+
+	return nil
+}
+
+type rdsOption struct {
+	ParamName            string
+	AllowedValues        []string
+	AllowedMaximum       *int
+	AllowedMinimum       *int
+	Default              *string
+	MapAllowedToOriginal map[string]string
+}
+
+func (ro *rdsOption) ValidateAndMapValue(val string) (string, error) {
+	if len(ro.AllowedValues) > 0 && !common.ContainsInStringSlice(ro.AllowedValues, val) {
+		return "", fmt.Errorf("value '%s' is not allowed", val)
+	}
+
+	if ro.AllowedMinimum != nil || ro.AllowedMaximum != nil {
+		intVal, err := strconv.Atoi(val)
+		if err != nil {
+			return "", fmt.Errorf("value '%s' is not a valid integer", val)
+		}
+		if ro.AllowedMinimum != nil && intVal < *ro.AllowedMinimum {
+			return "", fmt.Errorf("value '%s' is below the allowed minimum %d", val, *ro.AllowedMinimum)
+		}
+		if ro.AllowedMaximum != nil && intVal > *ro.AllowedMaximum {
+			return "", fmt.Errorf("value '%s' is above the allowed maximum %d", val, *ro.AllowedMaximum)
+		}
+	}
+
+	if orig, has := ro.MapAllowedToOriginal[val]; has {
+		return orig, nil
+	}
+
+	return val, nil
+}
+
+func (p *Provider) filterRdsOptionsForTemplate(rdsEngine string, opts map[string]string) (map[string]string, map[string]string, error) {
+	cmName := options.GetFeatureGateValue(options.FeatureGateRDSTemplateConfig)
+
+	cm, err := p.Cluster.CoreV1().ConfigMaps(p.Namespace).Get(p.ctx, cmName, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to load db option template %s: %s", cmName, err)
+	}
+
+	data, has := cm.Data["config"]
+	if !has {
+		return nil, nil, fmt.Errorf("db option template %s has no config", cmName)
+	}
+
+	template := map[string][]rdsOption{}
+	if err := json.Unmarshal([]byte(data), &template); err != nil {
+		return nil, nil, fmt.Errorf("failed to parse db option template %s: %s", cmName, err)
+	}
+
+	engineOptions, has := template[rdsEngine]
+	if !has {
+		return nil, nil, structs.ErrBadRequest("db type '%s' is not supported", rdsEngine)
+	}
+
+	requested := map[string]string{}
+
+	for _, o := range engineOptions {
+		if v := opts[o.ParamName]; v != "" {
+			requested[o.ParamName] = v
+		} else if o.Default != nil {
+			requested[o.ParamName] = *o.Default
+		}
+	}
+
+	// storage follows the class rather than being chosen separately
+	requested["class"] = strings.ToLower(requested["class"])
+	requested["storage"] = requested["class"]
+
+	// vpc and subnets are deliberately absent: a curated resource goes where the
+	// rack says, not where the manifest asks
+	out := map[string]string{}
+
+	// declared order so the option a release is rejected for is deterministic
+	for _, o := range engineOptions {
+		v, has := requested[o.ParamName]
+		if !has {
+			continue
+		}
+
+		mapped, err := o.ValidateAndMapValue(v)
+		if err != nil {
+			return nil, nil, structs.ErrBadRequest("db options %s: %s", o.ParamName, err)
+		}
+		out[o.ParamName] = mapped
+	}
+
+	return out, requested, nil
 }

--- a/provider/k8s/aws_resources_test.go
+++ b/provider/k8s/aws_resources_test.go
@@ -1,0 +1,321 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	"github.com/convox/convox/pkg/manifest"
+	"github.com/convox/convox/pkg/options"
+	"github.com/convox/convox/pkg/structs"
+	"github.com/convox/logger"
+	"github.com/stretchr/testify/require"
+	ac "k8s.io/api/core/v1"
+	am "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const rdsOptionTemplate = `{
+	"postgres": [
+		{"ParamName": "class", "AllowedValues": ["small", "medium"], "MapAllowedToOriginal": {"small": "db.t4g.small", "medium": "db.t4g.medium"}},
+		{"ParamName": "storage", "AllowedValues": ["small", "medium"], "MapAllowedToOriginal": {"small": "20", "medium": "50"}},
+		{"ParamName": "version", "AllowedValues": ["16", "17"], "Default": "16"},
+		{"ParamName": "encrypted", "AllowedValues": ["false"], "Default": "false"},
+		{"ParamName": "backupRetentionPeriod", "AllowedMinimum": 1, "AllowedMaximum": 7}
+	]
+}`
+
+func newTestAwsProvider(objs ...runtime.Object) *Provider {
+	return &Provider{
+		Cluster:      fake.NewSimpleClientset(objs...),
+		FeatureGates: map[string]bool{},
+		Name:         "rack1",
+		RackName:     "rack1",
+		Namespace:    "rack1",
+		ctx:          context.Background(),
+		logger:       logger.New("ns=aws-resources-test"),
+	}
+}
+
+func tidContext(tid string) context.Context {
+	return context.WithValue(context.Background(), structs.ConvoxTIDCtxKey, tid)
+}
+
+func mkStateSecret(ns, name string, labels map[string]string, data map[string][]byte) *ac.Secret {
+	return &ac.Secret{
+		ObjectMeta: am.ObjectMeta{Namespace: ns, Name: name, Labels: labels},
+		Data:       data,
+	}
+}
+
+func TestGenerateResourceStateId(t *testing.T) {
+	require.Equal(t, "pg-rrack1r-app1", generateResourceStateId("rack1", "", "app1", "pg"))
+	require.Equal(t, "pg-ab12-app1", generateResourceStateId("rack1", "ab12", "app1", "pg"))
+}
+
+func TestCreateAwsResourceStateId(t *testing.T) {
+	p := newTestAwsProvider()
+
+	id, err := p.CreateAwsResourceStateId("", "app1", "pg")
+	require.NoError(t, err)
+	require.Equal(t, "pg-rrack1r-app1", id)
+
+	all, err := p.Cluster.CoreV1().Secrets(ac.NamespaceAll).List(context.TODO(), am.ListOptions{})
+	require.NoError(t, err)
+	require.Empty(t, all.Items, "a rack keyed id must not create a secret in any namespace")
+
+	id, err = p.CreateAwsResourceStateId("ab12", "app1", "pg")
+	require.NoError(t, err)
+	require.Equal(t, "pg-ab12-app1", id)
+
+	s, err := p.Cluster.CoreV1().Secrets("rack1-ab12-app1").Get(context.TODO(), id, am.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{
+		"rack":     "rack1",
+		"system":   "convox",
+		"app":      "app1",
+		"resource": "pg",
+		"tid":      "ab12",
+	}, s.Labels)
+
+	_, err = p.CreateAwsResourceStateId("ab12", "app1", "pg")
+	require.NoError(t, err, "creating the same id twice must be idempotent")
+
+	now := am.Now()
+	s.DeletionTimestamp = &now
+	_, err = p.Cluster.CoreV1().Secrets("rack1-ab12-app1").Update(context.TODO(), s, am.UpdateOptions{})
+	require.NoError(t, err)
+
+	_, err = p.CreateAwsResourceStateId("ab12", "app1", "pg")
+	require.EqualError(t, err, "resource pg is still being deleted, promote again once it is gone")
+}
+
+// The provisioner storage callbacks run on the base provider, so SaveState has no
+// tenant context: it must still land in the tenant namespace.
+func TestSaveStateWithoutTenantContext(t *testing.T) {
+	p := newTestAwsProvider(mkStateSecret("rack1-ab12-app1", "pg-ab12-app1", map[string]string{
+		"rack": "rack1", "system": "convox", "app": "app1", "resource": "pg", "tid": "ab12",
+	}, nil))
+
+	require.Equal(t, "", p.ContextTID())
+
+	meta := map[string]string{MetaAppKey: "app1", MetaResourceKey: "pg", MetaTidKey: "ab12"}
+	require.NoError(t, p.SaveState("pg-ab12-app1", []byte(`{"id":"pg"}`), "convox-rds", meta))
+
+	s, err := p.Cluster.CoreV1().Secrets("rack1-ab12-app1").Get(context.TODO(), "pg-ab12-app1", am.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, []byte(`{"id":"pg"}`), s.Data[StateDataKey])
+	require.Equal(t, "state", s.Labels["type"])
+	require.Equal(t, "ab12", s.Labels["tid"])
+	require.Equal(t, "app1", s.Labels["app"])
+	require.Equal(t, "pg", s.Labels["resource"])
+	require.Contains(t, s.Finalizers, StateFinalizer)
+
+	_, err = p.Cluster.CoreV1().Secrets("rack1-app1").Get(context.TODO(), "pg-ab12-app1", am.GetOptions{})
+	require.Error(t, err, "no state may be written to the non tenant namespace")
+}
+
+func TestSaveStateRackKeyed(t *testing.T) {
+	p := newTestAwsProvider()
+
+	require.NoError(t, p.SaveState("pg-rrack1r-app1", []byte(`{"id":"pg"}`), "convox-rds", nil))
+
+	s, err := p.Cluster.CoreV1().Secrets("rack1-app1").Get(context.TODO(), "pg-rrack1r-app1", am.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, []byte(`{"id":"pg"}`), s.Data[StateDataKey])
+	require.Equal(t, "app1", s.Labels["app"])
+	require.Equal(t, "pg", s.Labels["resource"])
+	require.Equal(t, "", s.Labels["tid"])
+}
+
+func TestGetStateAndInfo(t *testing.T) {
+	p := newTestAwsProvider(
+		mkStateSecret("rack1-ab12-app1", "pg-ab12-app1", map[string]string{
+			"rack": "rack1", "system": "convox", "type": "state", "app": "app1", "resource": "pg", "tid": "ab12",
+		}, map[string][]byte{StateDataKey: []byte("tenant")}),
+		mkStateSecret("rack1-app2", "pg-rrack1r-app2", map[string]string{
+			"rack": "rack1", "system": "convox", "type": "state",
+		}, map[string][]byte{StateDataKey: []byte("rack")}),
+	)
+
+	data, err := p.GetState("pg-ab12-app1")
+	require.NoError(t, err)
+	require.Equal(t, []byte("tenant"), data)
+
+	info, err := p.GetInfoFromAwsResourceStateId("pg-ab12-app1")
+	require.NoError(t, err)
+	require.Equal(t, &AwsStateIdInfo{App: "app1", ResourceName: "pg", Tid: "ab12"}, info)
+
+	data, err = p.GetState("pg-rrack1r-app2")
+	require.NoError(t, err)
+	require.Equal(t, []byte("rack"), data)
+
+	info, err = p.GetInfoFromAwsResourceStateId("pg-rrack1r-app2")
+	require.NoError(t, err)
+	require.Equal(t, &AwsStateIdInfo{App: "app2", ResourceName: "pg"}, info)
+
+	_, err = p.GetState("no-such-state")
+	require.EqualError(t, err, "state not found")
+
+	_, err = p.GetInfoFromAwsResourceStateId("no-such-state")
+	require.EqualError(t, err, "state not found")
+}
+
+func TestMapToRdsParameterUngated(t *testing.T) {
+	p := newTestAwsProvider()
+	p.VpcID = "vpc-rack"
+
+	out := p.MapToRdsParameter("rds-postgres", "app1", map[string]string{
+		"class":   "db.t4g.small",
+		"storage": "20",
+		"vpc":     "vpc-manifest",
+	})
+
+	require.Equal(t, "postgres", out["Engine"])
+	require.Equal(t, "db.t4g.small", out["DBInstanceClass"])
+	require.Equal(t, "20", out["AllocatedStorage"])
+	require.Equal(t, "vpc-manifest", out["VPC"], "the uncurated path still honors a manifest vpc")
+}
+
+func TestMapToRdsParameterAndMeta(t *testing.T) {
+	p := newTestAwsProvider(&ac.ConfigMap{
+		ObjectMeta: am.ObjectMeta{Namespace: "rack1", Name: "rds-template"},
+		Data:       map[string]string{"config": rdsOptionTemplate},
+	})
+	p.ctx = tidContext("ab12")
+	p.VpcID = "vpc-rack"
+	p.SubnetIDs = "subnet-rack"
+	t.Setenv("FEATURE_GATES", "rds-template-config=rds-template")
+
+	r := manifest.Resource{Name: "pg", Type: "rds-postgres", Options: map[string]string{
+		"class":    "Small",
+		"iops":     "3000",
+		"vpc":      "vpc-tenant",
+		"subnets":  "subnet-tenant",
+		MetaTidKey: "forged",
+	}}
+
+	out, meta, err := p.MapToRdsParameterAndMeta("ab12", "rds-postgres", "app1", r)
+	require.NoError(t, err)
+
+	require.Equal(t, "db.t4g.small", out["DBInstanceClass"], "friendly class maps to the real instance class")
+	require.Equal(t, "20", out["AllocatedStorage"], "storage is pinned to the class")
+	require.Equal(t, "16", out["EngineVersion"], "template default is applied")
+	require.Equal(t, "false", out["StorageEncrypted"])
+	require.Equal(t, "vpc-rack", out["VPC"], "a curated resource goes in the rack's vpc, not the manifest's")
+	require.Equal(t, "subnet-rack", out["SubnetIds"])
+	require.NotContains(t, out, "Iops", "an option the template does not declare is dropped")
+
+	require.Equal(t, "small", meta["class"], "meta records the requested tier, not the mapped instance class")
+	require.Equal(t, "small", meta["storage"])
+	require.NotContains(t, meta, "iops", "an option the template does not declare is not recorded either")
+	require.Equal(t, "app1", meta[MetaAppKey])
+	require.Equal(t, "pg", meta[MetaResourceKey])
+	require.Equal(t, "rack1", meta[MetaRackKey])
+	require.Equal(t, "ab12", meta[MetaTidKey], "a manifest option cannot forge the tenant")
+
+	r.Options["class"] = "xlarge"
+	_, _, err = p.MapToRdsParameterAndMeta("ab12", "rds-postgres", "app1", r)
+	require.EqualError(t, err, "db options class: value 'xlarge' is not allowed")
+
+	r.Options["class"] = "small"
+	r.Options["backupRetentionPeriod"] = "30"
+	_, _, err = p.MapToRdsParameterAndMeta("ab12", "rds-postgres", "app1", r)
+	require.EqualError(t, err, "db options backupRetentionPeriod: value '30' is above the allowed maximum 7")
+
+	r.Options["backupRetentionPeriod"] = "0"
+	_, _, err = p.MapToRdsParameterAndMeta("ab12", "rds-postgres", "app1", r)
+	require.EqualError(t, err, "db options backupRetentionPeriod: value '0' is below the allowed minimum 1")
+
+	r.Options["backupRetentionPeriod"] = "not-a-number"
+	_, _, err = p.MapToRdsParameterAndMeta("ab12", "rds-postgres", "app1", r)
+	require.EqualError(t, err, "db options backupRetentionPeriod: value 'not-a-number' is not a valid integer")
+
+	delete(r.Options, "backupRetentionPeriod")
+	_, _, err = p.MapToRdsParameterAndMeta("ab12", "rds-mysql", "app1", r)
+	require.EqualError(t, err, "db type 'mysql' is not supported")
+}
+
+func TestAwsResourceMetaUngated(t *testing.T) {
+	p := newTestAwsProvider()
+
+	r := manifest.Resource{Name: "pg", Type: "rds-postgres", Options: map[string]string{
+		"class":              "db.t4g.small",
+		"durable":            "true",
+		"masterUserPassword": "hunter2",
+		"password":           "hunter2",
+		MetaTidKey:           "forged",
+		MetaAppKey:           "forged",
+	}}
+
+	meta := p.awsResourceMeta("ab12", "app1", r, nil)
+
+	require.Equal(t, "db.t4g.small", meta["class"])
+	require.Equal(t, "true", meta["durable"])
+	require.Equal(t, "app1", meta[MetaAppKey], "a manifest option cannot forge the app")
+	require.Equal(t, "ab12", meta[MetaTidKey], "a manifest option cannot forge the tenant")
+	require.NotContains(t, meta, "masterUserPassword", "credential options are not recorded")
+	require.NotContains(t, meta, "password", "credential options are not recorded")
+}
+
+func TestValidateAwsProviderResource(t *testing.T) {
+	p := newTestAwsProvider()
+
+	require.NoError(t, p.validateAwsProviderResource(manifest.Resource{Name: "pg", Type: "rds-postgres"}))
+	require.NoError(t, p.validateAwsProviderResource(manifest.Resource{Name: "pg", Type: "postgres"}))
+
+	err := p.validateAwsProviderResource(manifest.Resource{Name: "pg", Type: "postgres", Provider: "aws"})
+	require.EqualError(t, err, "resource pg: provider aws is not supported on this rack")
+
+	p.FeatureGates[options.FeatureGateRDSTemplateConfig] = true
+
+	require.NoError(t, p.validateAwsProviderResource(manifest.Resource{Name: "pg", Type: "postgres", Provider: "aws"}))
+	require.NoError(t, p.validateAwsProviderResource(manifest.Resource{Name: "cache", Type: "redis", Provider: "aws"}))
+
+	err = p.validateAwsProviderResource(manifest.Resource{Name: "gis", Type: "postgis", Provider: "aws"})
+	require.EqualError(t, err, "resource gis: provider aws is not supported for type postgis")
+}
+
+func TestAwsResourceType(t *testing.T) {
+	require.Equal(t, "rds-postgres", awsResourceType("rds-", "postgres"))
+	require.Equal(t, "rds-postgres", awsResourceType("rds-", "rds-postgres"))
+	require.Equal(t, "elasticache-redis", awsResourceType("elasticache-", "redis"))
+	require.Equal(t, "elasticache-redis", awsResourceType("elasticache-", "elasticache-redis"))
+}
+
+func TestResourceSubstitutionId(t *testing.T) {
+	rs := &resourceSubstitution{App: "app1", RType: "rds-postgres", RName: "pg", StateId: "pg-ab12-app1", Tid: "ab12"}
+
+	id := resourceSubstitutionId(rs)
+	require.Equal(t, "##|app:app1|type:rds-postgres|resource:pg|stateId:pg-ab12-app1|tid:ab12|##", id)
+	require.Equal(t, rs, parseResourceSubstitutionId(id))
+
+	p := newTestAwsProvider()
+	require.Equal(t, "pg-ab12-app1", p.resourceSubstitutionStateId(rs))
+
+	legacy := parseResourceSubstitutionId("##|app:app1|type:rds-postgres|resource:pg|##")
+	require.Equal(t, &resourceSubstitution{App: "app1", RType: "rds-postgres", RName: "pg"}, legacy)
+	require.Equal(t, "pg-rrack1r-app1", p.resourceSubstitutionStateId(legacy))
+}
+
+// State logs are buffered per tenant and app: a shared key would flush one
+// tenant's resource logs into another tenant's stream.
+func TestStateLogStorageTenantScoping(t *testing.T) {
+	s := &tempStateLogStorage{s: map[string][]string{}, threshold: 50}
+
+	s.Add("ab12", "web", "one")
+	s.Add("cd34", "web", "two")
+	s.Add("", "web", "three")
+
+	require.Equal(t, []string{"one"}, s.Get("ab12", "web"))
+	require.Equal(t, []string{"two"}, s.Get("cd34", "web"))
+	require.Equal(t, []string{"three"}, s.Get("", "web"))
+
+	s.Reset("ab12", "web")
+	require.Empty(t, s.Get("ab12", "web"))
+	require.Equal(t, []string{"two"}, s.Get("cd34", "web"), "resetting one tenant must not clear another")
+
+	// a bare tid+app concatenation would collide these two
+	s.Add("ab", "12web", "collide")
+	require.Empty(t, s.Get("ab12", "web"))
+}

--- a/provider/k8s/controller_atom.go
+++ b/provider/k8s/controller_atom.go
@@ -166,22 +166,20 @@ func (a *AtomController) processDependency(obj *atomv1.Atom) {
 	a.logger.Logf("start processing dependency for: %s", obj.Namespace)
 	defer a.dependencyProcessor.Delete(obj.Namespace)
 	for _, dep := range obj.Spec.Dependencies {
-		app, rType, _ := parseResourceSubstitutionId(dep)
+		rs := parseResourceSubstitutionId(dep)
 
-		if strings.HasPrefix(rType, "rds-") {
+		if strings.HasPrefix(rs.RType, "rds-") {
 			if err := a.processRdsDependency(obj, dep); err != nil {
 				a.logger.Logf("%s", err.Error())
-				a.provider.systemLog(a.provider.parseTidFromNamespace(obj.Namespace),
-					app, "state", time.Now(), err.Error())
+				_ = a.provider.systemLog(rs.Tid, rs.App, "state", time.Now(), err.Error())
 				return
 			}
 		}
 
-		if strings.HasPrefix(rType, "elasticache-") {
+		if strings.HasPrefix(rs.RType, "elasticache-") {
 			if err := a.processElasticacheDependency(obj, dep); err != nil {
 				a.logger.Logf("%s", err.Error())
-				a.provider.systemLog(a.provider.parseTidFromNamespace(obj.Namespace),
-					app, "state", time.Now(), err.Error())
+				_ = a.provider.systemLog(rs.Tid, rs.App, "state", time.Now(), err.Error())
 				return
 			}
 		}
@@ -199,21 +197,20 @@ func (a *AtomController) processDependency(obj *atomv1.Atom) {
 }
 
 func (a *AtomController) processRdsDependency(obj *atomv1.Atom, dep string) error {
-	app, rType, rName := parseResourceSubstitutionId(dep)
-	resourceId := a.provider.CreateAwsResourceStateId(app, rName)
+	rs := parseResourceSubstitutionId(dep)
 
-	conn, err := a.provider.RdsProvisioner.GetConnectionInfo(resourceId)
+	conn, err := a.provider.RdsProvisioner.GetConnectionInfo(a.provider.resourceSubstitutionStateId(rs))
 	if err != nil {
-		return fmt.Errorf("failed to get connection info for resource '%s': %s", rName, err)
+		return fmt.Errorf("failed to get connection info for resource '%s': %s", rs.RName, err)
 	}
-	data, err := a.provider.releaseTemplateCustomResource(&structs.App{
-		Name: app,
+	data, err := a.provider.releaseTemplateCustomResource(rs.Tid, &structs.App{
+		Name: rs.App,
 	}, nil, manifest.Resource{
-		Type: rType,
-		Name: rName,
+		Type: rs.RType,
+		Name: rs.RName,
 	}, conn)
 	if err != nil {
-		return fmt.Errorf("failed to create resource '%s' connecton config: %s", rName, err)
+		return fmt.Errorf("failed to create resource '%s' connecton config: %s", rs.RName, err)
 	}
 	if err := a.resolveDependencyInAtomVersion(obj, dep, data); err != nil {
 		return err
@@ -222,21 +219,20 @@ func (a *AtomController) processRdsDependency(obj *atomv1.Atom, dep string) erro
 }
 
 func (a *AtomController) processElasticacheDependency(obj *atomv1.Atom, dep string) error {
-	app, rType, rName := parseResourceSubstitutionId(dep)
-	resourceId := a.provider.CreateAwsResourceStateId(app, rName)
+	rs := parseResourceSubstitutionId(dep)
 
-	conn, err := a.provider.ElasticacheProvisioner.GetConnectionInfo(resourceId)
+	conn, err := a.provider.ElasticacheProvisioner.GetConnectionInfo(a.provider.resourceSubstitutionStateId(rs))
 	if err != nil {
-		return fmt.Errorf("failed to get connection info for resource '%s': %s", rName, err)
+		return fmt.Errorf("failed to get connection info for resource '%s': %s", rs.RName, err)
 	}
-	data, err := a.provider.releaseTemplateCustomResource(&structs.App{
-		Name: app,
+	data, err := a.provider.releaseTemplateCustomResource(rs.Tid, &structs.App{
+		Name: rs.App,
 	}, nil, manifest.Resource{
-		Type: rType,
-		Name: rName,
+		Type: rs.RType,
+		Name: rs.RName,
 	}, conn)
 	if err != nil {
-		return fmt.Errorf("failed to create resource '%s' connecton config: %s", rName, err)
+		return fmt.Errorf("failed to create resource '%s' connecton config: %s", rs.RName, err)
 	}
 	if err := a.resolveDependencyInAtomVersion(obj, dep, data); err != nil {
 		return err

--- a/provider/k8s/helpers.go
+++ b/provider/k8s/helpers.go
@@ -394,9 +394,10 @@ type tempStateLogStorage struct {
 	threshold int
 }
 
-func (t *tempStateLogStorage) Add(key, value string) {
+func (t *tempStateLogStorage) Add(tid, app, value string) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
+	key := stateLogKey(tid, app)
 	if _, has := t.s[key]; !has {
 		t.s[key] = []string{}
 	}
@@ -408,16 +409,20 @@ func (t *tempStateLogStorage) Add(key, value string) {
 	}
 }
 
-func (t *tempStateLogStorage) Get(key string) []string {
+func (t *tempStateLogStorage) Get(tid, app string) []string {
 	t.lock.Lock()
 	defer t.lock.Unlock()
-	return t.s[key]
+	return t.s[stateLogKey(tid, app)]
 }
 
-func (t *tempStateLogStorage) Reset(key string) {
+func (t *tempStateLogStorage) Reset(tid, app string) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
-	t.s[key] = []string{}
+	t.s[stateLogKey(tid, app)] = []string{}
+}
+
+func stateLogKey(tid, app string) string {
+	return fmt.Sprintf("%s/%s", tid, app)
 }
 
 // gpuResourceKey maps a convox.yml gpu.vendor value to the Kubernetes
@@ -449,23 +454,51 @@ var gpuKeyToVendor = map[string]string{
 	"google.com/tpu": "google",
 }
 
-func resourceSubstitutionId(app, rType, rName string) string {
-	return fmt.Sprintf("##|app:%s|type:%s|resource:%s|##", app, rType, rName)
+type resourceSubstitution struct {
+	App     string
+	RType   string
+	RName   string
+	StateId string
+	Tid     string
 }
 
-func parseResourceSubstitutionId(id string) (string, string, string) {
-	var app, rtype, rname string
-	parts := strings.Split(id, "|")
-	for _, p := range parts {
-		if strings.HasPrefix(p, "app:") {
-			app = strings.TrimPrefix(p, "app:")
-		} else if strings.HasPrefix(p, "type:") {
-			rtype = strings.TrimPrefix(p, "type:")
-		} else if strings.HasPrefix(p, "resource:") {
-			rname = strings.TrimPrefix(p, "resource:")
+func resourceSubstitutionId(r *resourceSubstitution) string {
+	return fmt.Sprintf("##|app:%s|type:%s|resource:%s|stateId:%s|tid:%s|##", r.App, r.RType, r.RName, r.StateId, r.Tid)
+}
+
+func parseResourceSubstitutionId(id string) *resourceSubstitution {
+	rs := &resourceSubstitution{}
+
+	for _, part := range strings.Split(id, "|") {
+		k, v, has := strings.Cut(part, ":")
+		if !has {
+			continue
+		}
+
+		switch k {
+		case "app":
+			rs.App = v
+		case "type":
+			rs.RType = v
+		case "resource":
+			rs.RName = v
+		case "stateId":
+			rs.StateId = v
+		case "tid":
+			rs.Tid = v
 		}
 	}
-	return app, rtype, rname
+
+	return rs
+}
+
+// resourceSubstitutionStateId recomputes the id for dependencies recorded before
+// the state id travelled in the substitution payload.
+func (p *Provider) resourceSubstitutionStateId(rs *resourceSubstitution) string {
+	if rs.StateId != "" {
+		return rs.StateId
+	}
+	return generateResourceStateId(p.Name, rs.Tid, rs.App, rs.RName)
 }
 
 func patchBytes(patch map[string]interface{}) ([]byte, error) {

--- a/provider/k8s/log.go
+++ b/provider/k8s/log.go
@@ -23,7 +23,7 @@ func (p *Provider) systemLog(tid, app, name string, ts time.Time, message string
 	if tid != "" {
 		app = fmt.Sprintf("%s-%s", tid, app)
 	}
-	if options.GetFeatureGates()[options.FeatureGateTid] && tid == "" {
+	if options.GetFeatureGates()[options.FeatureGateTid] {
 		return p.Engine.Log(app, fmt.Sprintf("system/%s", name), ts, message)
 	}
 	return p.Engine.Log(app, fmt.Sprintf("system/k8s/%s", name), ts, message)

--- a/provider/k8s/log_test.go
+++ b/provider/k8s/log_test.go
@@ -1,0 +1,42 @@
+package k8s
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/convox/convox/pkg/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type logCaptureEngine struct {
+	*mock.TestEngine
+
+	calls []string
+}
+
+func (e *logCaptureEngine) Log(app, stream string, _ time.Time, _ string) error {
+	e.calls = append(e.calls, fmt.Sprintf("%s %s", app, stream))
+	return nil
+}
+
+func TestSystemLogStream(t *testing.T) {
+	for _, tc := range []struct {
+		gates string
+		tid   string
+		want  string
+	}{
+		{gates: "tid=true", tid: "ab12", want: "ab12-app1 system/state"},
+		{gates: "tid=true", want: "app1 system/state"},
+		{want: "app1 system/k8s/state"},
+		{tid: "ab12", want: "ab12-app1 system/k8s/state"},
+	} {
+		t.Setenv("FEATURE_GATES", tc.gates)
+
+		e := &logCaptureEngine{TestEngine: &mock.TestEngine{}}
+		p := &Provider{Engine: e}
+
+		require.NoError(t, p.systemLog(tc.tid, "app1", "state", time.Now(), "hello"))
+		require.Equal(t, []string{tc.want}, e.calls)
+	}
+}

--- a/provider/k8s/release.go
+++ b/provider/k8s/release.go
@@ -20,6 +20,8 @@ import (
 	"github.com/convox/convox/pkg/options"
 	"github.com/convox/convox/pkg/structs"
 	"github.com/convox/convox/provider/aws/provisioner"
+	"github.com/convox/convox/provider/aws/provisioner/elasticache"
+	"github.com/convox/convox/provider/aws/provisioner/rds"
 	ca "github.com/convox/convox/provider/k8s/pkg/apis/convox/v1"
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"github.com/pkg/errors"
@@ -221,6 +223,10 @@ func (p *Provider) ReleasePromote(app, id string, opts structs.ReleasePromoteOpt
 
 		// resources
 		for _, r := range m.Resources {
+			if err := p.validateAwsProviderResource(r); err != nil {
+				return err
+			}
+
 			if !r.IsCustomManagedResource() {
 				data, err := p.releaseTemplateResource(a, e, r)
 				if err != nil {
@@ -343,7 +349,7 @@ func (p *Provider) ReleasePromote(app, id string, opts structs.ReleasePromoteOpt
 		Status: options.String("start"),
 	})
 
-	p.FlushStateLog(app)
+	p.FlushStateLog(p.ContextTID(), app)
 
 	// Per-(app, release-id) lock — sync.Map.LoadOrStore is the atomic
 	// check-and-set primitive. If a watcher is already in-flight for
@@ -843,10 +849,15 @@ func (p *Provider) releaseTemplateResource(a *structs.App, e structs.Environment
 	return data, nil
 }
 
-func (p *Provider) releaseTemplateCustomResource(a *structs.App, e structs.Environment, r manifest.Resource, conn *provisioner.ConnectionInfo) ([]byte, error) {
+func (p *Provider) releaseTemplateCustomResource(tid string, a *structs.App, e structs.Environment, r manifest.Resource, conn *provisioner.ConnectionInfo) ([]byte, error) {
+	ns := p.AppNamespace(a.Name)
+	if tid != "" {
+		ns = p.tidNamespace(tid, a.Name)
+	}
+
 	params := map[string]interface{}{
 		"App":        a.Name,
-		"Namespace":  p.AppNamespace(a.Name),
+		"Namespace":  ns,
 		"Name":       r.Name,
 		"Parameters": r.Options,
 		"Rack":       p.Name,
@@ -1339,21 +1350,34 @@ func (p *Provider) releaseElasticacheResources(app *structs.App, envs structs.En
 	items := [][]byte{}
 	dependencies := []string{}
 
+	tid := p.ContextTID()
+
 	stateMap := map[string]struct{}{}
 	for _, r := range m.Resources {
 		if r.IsElastiCache() {
 			if p.FeatureGates[options.FeatureGateElasticacheDisable] {
 				return nil, nil, structs.ErrBadRequest("elasticache resource is disabled")
 			}
+
+			if p.FeatureGates[options.FeatureGatePrefixBasedAwsResourceDisable] && strings.HasPrefix(r.Name, "elasticache-") {
+				return nil, nil, structs.ErrBadRequest("resource %s must not be named with the elasticache- prefix", r.Name)
+			}
+
 			if err := r.ElastiCacheNameValidate(); err != nil {
 				return nil, nil, err
 			}
 
-			id := p.CreateAwsResourceStateId(app.Name, r.Name)
+			id, err := p.CreateAwsResourceStateId(tid, app.Name, r.Name)
+			if err != nil {
+				return nil, nil, err
+			}
 
 			stateMap[id] = struct{}{}
 
-			err := p.ElasticacheProvisioner.Provision(id, p.MapToElasticacheParameter(r.Type, app.Name, r.Options))
+			err = p.ElasticacheProvisioner.Provision(id, p.MapToElasticacheParameter(r.Type, app.Name, r.Options), elasticache.ProvisionExtraOpts{
+				Tags: p.AwsResourceTags(tid, app.Name, r.Name),
+				Meta: p.awsResourceMeta(tid, app.Name, r, nil),
+			})
 			if err != nil {
 				return nil, nil, err
 			}
@@ -1362,20 +1386,29 @@ func (p *Provider) releaseElasticacheResources(app *structs.App, envs structs.En
 			if err != nil {
 				return nil, nil, err
 			}
+
+			r.Type = awsResourceType("elasticache-", r.Type)
+
 			if isAvailable {
 				conn, err := p.ElasticacheProvisioner.GetConnectionInfo(id)
 				if err != nil {
 					return nil, nil, err
 				}
 
-				data, err := p.releaseTemplateCustomResource(app, envs, r, conn)
+				data, err := p.releaseTemplateCustomResource(tid, app, envs, r, conn)
 				if err != nil {
 					return nil, nil, errors.WithStack(err)
 				}
 
 				items = append(items, data)
 			} else {
-				substitutionId := resourceSubstitutionId(app.Name, r.Type, r.Name)
+				substitutionId := resourceSubstitutionId(&resourceSubstitution{
+					App:     app.Name,
+					RType:   r.Type,
+					RName:   r.Name,
+					StateId: id,
+					Tid:     tid,
+				})
 				dependencies = append(dependencies, substitutionId)
 				items = append(items, []byte(substitutionId))
 			}
@@ -1404,21 +1437,49 @@ func (p *Provider) releaseRdsResources(app *structs.App, envs structs.Environmen
 	items := [][]byte{}
 	dependencies := []string{}
 
+	tid := p.ContextTID()
+
 	rdsStateMap := map[string]struct{}{}
 	for _, r := range m.Resources {
 		if r.IsRds() {
 			if p.FeatureGates[options.FeatureGateRdsDisable] {
 				return nil, nil, structs.ErrBadRequest("rds resource is disabled")
 			}
+
+			if p.FeatureGates[options.FeatureGatePrefixBasedAwsResourceDisable] && strings.HasPrefix(r.Name, "rds-") {
+				return nil, nil, structs.ErrBadRequest("resource %s must not be named with the rds- prefix", r.Name)
+			}
+
 			if err := r.RdsNameValidate(); err != nil {
 				return nil, nil, err
 			}
 
-			id := p.CreateAwsResourceStateId(app.Name, r.Name)
+			var rdsParams, rdsMeta map[string]string
+			var err error
+
+			if p.FeatureGates[options.FeatureGateRDSTemplateConfig] {
+				rdsParams, rdsMeta, err = p.MapToRdsParameterAndMeta(tid, r.Type, app.Name, r)
+				if err != nil {
+					return nil, nil, err
+				}
+			} else {
+				rdsParams = p.MapToRdsParameter(r.Type, app.Name, r.Options)
+				rdsMeta = p.awsResourceMeta(tid, app.Name, r, nil)
+			}
+
+			rdsMeta[MetaRdsTypeKey] = strings.TrimPrefix(r.Type, "rds-")
+
+			id, err := p.CreateAwsResourceStateId(tid, app.Name, r.Name)
+			if err != nil {
+				return nil, nil, err
+			}
 
 			rdsStateMap[id] = struct{}{}
 
-			err := p.RdsProvisioner.Provision(id, p.MapToRdsParameter(r.Type, app.Name, r.Options))
+			err = p.RdsProvisioner.Provision(id, rdsParams, rds.ProvisionExtraOpts{
+				Tags: p.AwsResourceTags(tid, app.Name, r.Name),
+				Meta: rdsMeta,
+			})
 			if err != nil {
 				return nil, nil, err
 			}
@@ -1428,20 +1489,28 @@ func (p *Provider) releaseRdsResources(app *structs.App, envs structs.Environmen
 				return nil, nil, err
 			}
 
+			r.Type = awsResourceType("rds-", r.Type)
+
 			if isAvailable {
 				conn, err := p.RdsProvisioner.GetConnectionInfo(id)
 				if err != nil {
 					return nil, nil, err
 				}
 
-				data, err := p.releaseTemplateCustomResource(app, envs, r, conn)
+				data, err := p.releaseTemplateCustomResource(tid, app, envs, r, conn)
 				if err != nil {
 					return nil, nil, errors.WithStack(err)
 				}
 
 				items = append(items, data)
 			} else {
-				substitutionId := resourceSubstitutionId(app.Name, r.Type, r.Name)
+				substitutionId := resourceSubstitutionId(&resourceSubstitution{
+					App:     app.Name,
+					RType:   r.Type,
+					RName:   r.Name,
+					StateId: id,
+					Tid:     tid,
+				})
 				dependencies = append(dependencies, substitutionId)
 				items = append(items, []byte(substitutionId))
 			}

--- a/provider/k8s/resource.go
+++ b/provider/k8s/resource.go
@@ -95,12 +95,12 @@ func (p *Provider) ResourceGet(app, name string) (*structs.Resource, error) {
 	}
 
 	if mr.IsRds() {
-		r.Status, err = p.RdsProvisioner.GetDbStatus(p.CreateAwsResourceStateId(app, name))
+		r.Status, err = p.RdsProvisioner.GetDbStatus(generateResourceStateId(p.Name, p.ContextTID(), app, name))
 		return r, err
 	}
 
 	if mr.IsElastiCache() {
-		isAvailable, err := p.ElasticacheProvisioner.IsElastiCacheAvailable(p.CreateAwsResourceStateId(app, name))
+		isAvailable, err := p.ElasticacheProvisioner.IsElastiCacheAvailable(generateResourceStateId(p.Name, p.ContextTID(), app, name))
 		if isAvailable {
 			r.Status = "running"
 		} else {


### PR DESCRIPTION
## Testing

- `go build ./...` clean.
- `go test ./...` clean.
- `golangci-lint run --timeout 5m --new-from-rev=<merge-base>`: 0 issues.
- New unit coverage: resource classification across both syntaxes and every provider value; manifest provider validation; state id generation and both lookup paths; state saved from a callback with no tenant context landing in the tenant namespace; curated option mapping, defaults, allowlist and range rejection, and the unfiltered path as a regression guard; reserved meta keys not forgeable from a manifest; substitution id round trip including the older form; system log stream naming.