### PR TITLE
Add network_policy_enable rack param

### DIFF
--- a/assets/provider/aws/params.yaml
+++ b/assets/provider/aws/params.yaml
@@ -84,6 +84,17 @@ Groups:
         type: boolean
         description: Blocks application pods from reaching the EC2 Instance Metadata
           Service (IMDS), preventing workloads from assuming node IAM credentials.
+      - name: network_policy_enable
+        default: "false"
+        sideNote: "Blocks traffic between apps. Review before enabling on a rack running more than one app."
+        type: boolean
+        description: "Restricts which pods can open network connections to your app's
+          pods. &l With this on, an app receives traffic only from pods in its own
+          namespace, from the Convox system components that route and monitor it, and
+          from other namespaces sharing the same tenant label. Traffic from every other
+          app on the rack is dropped. &l &l Apps that define a &i balancers &i block are
+          left out of the restriction, because a load balancer's traffic arrives from
+          the node rather than from a pod. &l"
       - name: seccomp_default_enabled
         default: "false"
         type: boolean

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -69,8 +69,8 @@ var awsKnownParams = map[string]bool{
 	"imds_http_hop_limit": true, "imds_http_tokens": true,
 	"pod_security_standard": true, "pod_security_mode": true,
 	"imds_tags_enable": true, "internal_router": true, "contour_internal_tls": true,
-	"pod_imds_block_enabled": true,
-	"internet_gateway_id":    true, "k8s_version": true,
+	"pod_imds_block_enabled": true, "network_policy_enable": true,
+	"internet_gateway_id": true, "k8s_version": true,
 	"karpenter_arch": true, "karpenter_auth_mode": true,
 	"karpenter_build_capacity_types": true, "karpenter_build_consolidate_after": true,
 	"karpenter_build_cpu_limit": true, "karpenter_build_instance_families": true,
@@ -209,6 +209,7 @@ var boolParams = map[string]bool{
 	"gpu_tag_enable":                  true,
 	"imds_tags_enable":                true,
 	"pod_imds_block_enabled":          true,
+	"network_policy_enable":           true,
 	"internal_router":                 true,
 	"contour_internal_tls":            true,
 	"karpenter_consolidation_enabled": true,
@@ -363,6 +364,7 @@ var paramGroups = map[string]map[string]bool{
 		"imds_http_tokens":                    true,
 		"imds_tags_enable":                    true,
 		"pod_imds_block_enabled":              true,
+		"network_policy_enable":               true,
 		"karpenter_build_imds_hop_limit":      true, // dual-listed in build
 		"karpenter_build_imds_tokens":         true, // dual-listed in build
 		"pod_security_standard":               true,

--- a/pkg/cli/rack_validate_test.go
+++ b/pkg/cli/rack_validate_test.go
@@ -404,6 +404,21 @@ func TestValidateAndMutateParams_PrometheusUrl_NonAwsRejected(t *testing.T) {
 	}
 }
 
+func TestValidateAndMutateParams_NetworkPolicyEnable_NonAwsRejected(t *testing.T) {
+	for _, provider := range []string{"gcp", "azure", "do", "metal", "local"} {
+		t.Run(provider, func(t *testing.T) {
+			params := map[string]string{"network_policy_enable": "true"}
+			err := validateAndMutateParams(params, provider, map[string]string{}, false)
+			if err == nil {
+				t.Fatalf("network_policy_enable should be rejected on %s (only declared in AWS Terraform)", provider)
+			}
+			if !strings.Contains(err.Error(), "unknown parameter") {
+				t.Errorf("error %q should mention 'unknown parameter'", err.Error())
+			}
+		})
+	}
+}
+
 func TestValidateAndMutateParams_UnknownParamSpellcheckIntact(t *testing.T) {
 	// Regression guard: adding entries to KnownParams maps must not weaken
 	// the spellcheck path that rejects unknown keys.
@@ -469,7 +484,8 @@ func TestValidateAndMutateParams_BoolParam_AwsCoverage(t *testing.T) {
 		"disable_image_manifest_cache", "ebs_volume_encryption_enabled",
 		"ecr_immutable_tags_enabled", "ecr_scan_on_push_enable", "efs_csi_driver_enable", "fluentd_disable",
 		"gpu_tag_enable", "imds_tags_enable", "internal_router", "contour_internal_tls",
-		"karpenter_consolidation_enabled", "keda_enable", "pod_identity_agent_enable",
+		"karpenter_consolidation_enabled", "keda_enable", "network_policy_enable",
+		"pod_identity_agent_enable",
 		"pod_imds_block_enabled", "seccomp_default_enabled", "system_readonly_rootfs_enabled",
 		"telemetry", "vpa_enable",
 	} {

--- a/provider/k8s/k8s.go
+++ b/provider/k8s/k8s.go
@@ -102,6 +102,7 @@ type Provider struct {
 	RouterType                          string
 	ProxyProtocol                       bool
 	PodImdsBlockEnabled                 bool
+	NetworkPolicyEnabled                bool
 	PodSecurityStandard                 string
 	PodSecurityMode                     string
 	ContourInternalTLS                  bool
@@ -237,6 +238,7 @@ func FromEnv() (*Provider, error) {
 		RouterType:                       common.CoalesceString(os.Getenv("ROUTER_TYPE"), "nginx"),
 		ProxyProtocol:                    os.Getenv("PROXY_PROTOCOL") == "true",
 		PodImdsBlockEnabled:              os.Getenv("POD_IMDS_BLOCK_ENABLED") == "true",
+		NetworkPolicyEnabled:             os.Getenv("NETWORK_POLICY_ENABLED") == "true",
 		PodSecurityStandard:              os.Getenv("POD_SECURITY_STANDARD"),
 		PodSecurityMode:                  common.CoalesceString(os.Getenv("POD_SECURITY_MODE"), "warn"),
 		ContourInternalTLS:               os.Getenv("CONTOUR_INTERNAL_TLS") == "true",
@@ -429,6 +431,8 @@ func (p *Provider) Start() error {
 	go p.runOrphanedPodReaper(p.ctx)
 
 	go p.runPodImdsBlockReconciler(p.ctx)
+
+	go p.runNetworkPolicyReconciler(p.ctx)
 
 	go common.Tick(1*time.Hour, p.heartbeat)
 

--- a/provider/k8s/network_policy.go
+++ b/provider/k8s/network_policy.go
@@ -1,0 +1,165 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+	networkingv1 "k8s.io/api/networking/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	am "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	networkIsolationPolicyName     = "convox-network-isolation"
+	networkPolicyReconcileInterval = 2 * time.Minute
+)
+
+func networkIsolationPolicy(namespace, systemNamespace, rack, tid string) *networkingv1.NetworkPolicy {
+	peers := []networkingv1.NetworkPolicyPeer{
+		{PodSelector: &am.LabelSelector{}},
+		{NamespaceSelector: &am.LabelSelector{
+			MatchExpressions: []am.LabelSelectorRequirement{{
+				Key:      "kubernetes.io/metadata.name",
+				Operator: am.LabelSelectorOpIn,
+				Values:   []string{systemNamespace, "kube-system", "convox-monitoring"},
+			}},
+		}},
+	}
+
+	if tid != "" {
+		peers = append(peers, networkingv1.NetworkPolicyPeer{
+			NamespaceSelector: &am.LabelSelector{
+				MatchLabels: map[string]string{"rack": rack, "tid": tid},
+			},
+		})
+	}
+
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: am.ObjectMeta{
+			Name:      networkIsolationPolicyName,
+			Namespace: namespace,
+			Labels:    map[string]string{"system": "convox"},
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: am.LabelSelector{},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+			Ingress:     []networkingv1.NetworkPolicyIngressRule{{From: peers}},
+		},
+	}
+}
+
+func (p *Provider) reconcileNetworkPolicy(ctx context.Context) error {
+	nss, err := p.ListNamespacesFromInformer(fmt.Sprintf("system=convox,rack=%s,type=app", p.Name))
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	for i := range nss.Items {
+		ns := nss.Items[i].Name
+
+		if rerr := p.reconcileNetworkPolicyNamespace(ctx, ns, nss.Items[i].Labels["tid"]); rerr != nil {
+			fmt.Printf("ns=network_policy at=warn kind=reconcile rack=%s namespace=%s err=%q\n", p.Name, ns, rerr)
+		}
+	}
+
+	return nil
+}
+
+func (p *Provider) reconcileNetworkPolicyNamespace(ctx context.Context, namespace, tid string) error {
+	if !p.NetworkPolicyEnabled {
+		return p.removeNetworkIsolationPolicy(ctx, namespace)
+	}
+
+	// Instance-target NLB traffic arrives from whichever node received it, which no peer can match.
+	balanced, err := p.namespaceHasBalancer(ctx, namespace)
+	if err != nil {
+		return err
+	}
+
+	if balanced {
+		fmt.Printf("ns=network_policy at=skip kind=balancer rack=%s namespace=%s\n", p.Name, namespace)
+		return p.removeNetworkIsolationPolicy(ctx, namespace)
+	}
+
+	return p.ensureNetworkIsolationPolicy(ctx, namespace, tid)
+}
+
+func (p *Provider) namespaceHasBalancer(ctx context.Context, namespace string) (bool, error) {
+	ss, err := p.Cluster.CoreV1().Services(namespace).List(ctx, am.ListOptions{LabelSelector: "type=balancer"})
+	if err != nil {
+		return false, err
+	}
+
+	return len(ss.Items) > 0, nil
+}
+
+func (p *Provider) ensureNetworkIsolationPolicy(ctx context.Context, namespace, tid string) error {
+	np := networkIsolationPolicy(namespace, p.Namespace, p.Name, tid)
+
+	nps := p.Cluster.NetworkingV1().NetworkPolicies(namespace)
+
+	existing, err := nps.Get(ctx, networkIsolationPolicyName, am.GetOptions{})
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return err
+		}
+
+		if _, cerr := nps.Create(ctx, np, am.CreateOptions{}); cerr != nil && !k8serrors.IsAlreadyExists(cerr) {
+			return cerr
+		}
+
+		return nil
+	}
+
+	if apiequality.Semantic.DeepEqual(existing.Spec, np.Spec) {
+		return nil
+	}
+
+	existing.Spec = np.Spec
+
+	if _, uerr := nps.Update(ctx, existing, am.UpdateOptions{}); uerr != nil {
+		return uerr
+	}
+
+	return nil
+}
+
+func (p *Provider) removeNetworkIsolationPolicy(ctx context.Context, namespace string) error {
+	err := p.Cluster.NetworkingV1().NetworkPolicies(namespace).Delete(ctx, networkIsolationPolicyName, am.DeleteOptions{})
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return err
+	}
+
+	return nil
+}
+
+func (p *Provider) reconcileNetworkPolicySafe(ctx context.Context) {
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Printf("ns=network_policy at=error kind=panic_recovered rack=%s recovered=%v\n", p.Name, r)
+		}
+	}()
+
+	if err := p.reconcileNetworkPolicy(ctx); err != nil {
+		fmt.Printf("ns=network_policy at=warn kind=reconcile rack=%s err=%q\n", p.Name, err)
+	}
+}
+
+func (p *Provider) runNetworkPolicyReconciler(ctx context.Context) {
+	p.reconcileNetworkPolicySafe(ctx)
+
+	tick := time.NewTicker(networkPolicyReconcileInterval)
+	defer tick.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tick.C:
+			p.reconcileNetworkPolicySafe(ctx)
+		}
+	}
+}

--- a/provider/k8s/network_policy_test.go
+++ b/provider/k8s/network_policy_test.go
@@ -1,0 +1,288 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/convox/convox/pkg/manifest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	am "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func newTenantNamespace(name, rack, tid string) *corev1.Namespace {
+	labels := map[string]string{"system": "convox", "rack": rack, "type": "app", "name": name}
+	if tid != "" {
+		labels["tid"] = tid
+	}
+	return &corev1.Namespace{ObjectMeta: am.ObjectMeta{Name: name, Labels: labels}}
+}
+
+func balancerService(namespace string) *corev1.Service {
+	return &corev1.Service{ObjectMeta: am.ObjectMeta{
+		Name:      "balancer-public",
+		Namespace: namespace,
+		Labels:    map[string]string{"system": "convox", "type": "balancer", "service": "web"},
+	}}
+}
+
+func appService(namespace, app string) *corev1.Service {
+	return &corev1.Service{ObjectMeta: am.ObjectMeta{
+		Name:      "web",
+		Namespace: namespace,
+		Labels:    map[string]string{"system": "convox", "rack": "rack1", "app": app, "service": "web"},
+	}}
+}
+
+func getIsolationPolicy(t *testing.T, cs *fake.Clientset, namespace string) (*networkingv1.NetworkPolicy, error) {
+	t.Helper()
+	return cs.NetworkingV1().NetworkPolicies(namespace).Get(context.Background(), networkIsolationPolicyName, am.GetOptions{})
+}
+
+func TestNetworkIsolationPolicy_NoTid(t *testing.T) {
+	np := networkIsolationPolicy("rack1-myapp", "rack1-system", "rack1", "")
+
+	assert.Equal(t, networkIsolationPolicyName, np.Name)
+	assert.Equal(t, "rack1-myapp", np.Namespace)
+	assert.Equal(t, "convox", np.Labels["system"])
+
+	require.Len(t, np.Spec.PolicyTypes, 1)
+	assert.Equal(t, networkingv1.PolicyTypeIngress, np.Spec.PolicyTypes[0])
+	assert.Empty(t, np.Spec.Egress)
+	assert.Empty(t, np.Spec.PodSelector.MatchLabels)
+	assert.Empty(t, np.Spec.PodSelector.MatchExpressions)
+
+	require.Len(t, np.Spec.Ingress, 1)
+	assert.Empty(t, np.Spec.Ingress[0].Ports)
+
+	peers := np.Spec.Ingress[0].From
+	require.Len(t, peers, 2)
+
+	require.NotNil(t, peers[0].PodSelector)
+	assert.Nil(t, peers[0].NamespaceSelector)
+	assert.Empty(t, peers[0].PodSelector.MatchLabels)
+
+	require.NotNil(t, peers[1].NamespaceSelector)
+	require.Len(t, peers[1].NamespaceSelector.MatchExpressions, 1)
+	expr := peers[1].NamespaceSelector.MatchExpressions[0]
+	assert.Equal(t, "kubernetes.io/metadata.name", expr.Key)
+	assert.Equal(t, am.LabelSelectorOpIn, expr.Operator)
+	assert.Equal(t, []string{"rack1-system", "kube-system", "convox-monitoring"}, expr.Values)
+}
+
+func TestNetworkIsolationPolicy_WithTid(t *testing.T) {
+	np := networkIsolationPolicy("rack1-ab12-myapp", "rack1-system", "rack1", "ab12")
+
+	peers := np.Spec.Ingress[0].From
+	require.Len(t, peers, 3)
+
+	require.NotNil(t, peers[2].NamespaceSelector)
+	assert.Nil(t, peers[2].PodSelector)
+
+	// The rack value must match what reconcileNetworkPolicy feeds its namespace list selector.
+	assert.Equal(t, map[string]string{"rack": "rack1", "tid": "ab12"}, peers[2].NamespaceSelector.MatchLabels)
+}
+
+func TestReconcileNetworkPolicy_EnabledCreatesScoped(t *testing.T) {
+	cs := fake.NewSimpleClientset(
+		newTenantNamespace("rack1-app-a", "rack1", ""),
+		newTenantNamespace("rack1-ab12-app-b", "rack1", "ab12"),
+		newTenantNamespace("rack2-app-c", "rack2", ""),
+		&corev1.Namespace{ObjectMeta: am.ObjectMeta{Name: "rack1-build-app-a", Labels: map[string]string{"system": "convox", "rack": "rack1", "type": "build", "name": "app-a"}}},
+		&corev1.Namespace{ObjectMeta: am.ObjectMeta{Name: "rack1-system", Labels: map[string]string{"system": "convox", "rack": "rack1", "type": "rack"}}},
+	)
+	p := &Provider{Cluster: cs, Name: "rack1", RackName: "console-supplied-other-name", Namespace: "rack1-system", NetworkPolicyEnabled: true}
+
+	require.NoError(t, p.reconcileNetworkPolicy(context.Background()))
+	require.NoError(t, p.reconcileNetworkPolicy(context.Background()))
+
+	for _, ns := range []string{"rack1-app-a", "rack1-ab12-app-b"} {
+		np, err := getIsolationPolicy(t, cs, ns)
+		require.NoError(t, err, "expected a policy in %s", ns)
+		assert.Equal(t, networkingv1.PolicyTypeIngress, np.Spec.PolicyTypes[0])
+	}
+
+	tenant, err := getIsolationPolicy(t, cs, "rack1-ab12-app-b")
+	require.NoError(t, err)
+	require.Len(t, tenant.Spec.Ingress[0].From, 3, "a tid-labeled namespace gets the same-tenant peer")
+	assert.Equal(t, map[string]string{"rack": "rack1", "tid": "ab12"}, tenant.Spec.Ingress[0].From[2].NamespaceSelector.MatchLabels,
+		"the same-tenant peer must match the rack label apps actually carry, which comes from p.Name and not p.RackName")
+
+	plain, err := getIsolationPolicy(t, cs, "rack1-app-a")
+	require.NoError(t, err)
+	require.Len(t, plain.Spec.Ingress[0].From, 2, "a namespace with no tid label gets no same-tenant peer")
+
+	for _, ns := range []string{"rack2-app-c", "rack1-build-app-a", "rack1-system"} {
+		_, err := getIsolationPolicy(t, cs, ns)
+		assert.True(t, k8serrors.IsNotFound(err), "%s must not be policed", ns)
+	}
+}
+
+func TestReconcileNetworkPolicy_DisabledRemoves(t *testing.T) {
+	cs := fake.NewSimpleClientset(newTenantNamespace("rack1-app-a", "rack1", ""))
+	p := &Provider{Cluster: cs, Name: "rack1", Namespace: "rack1-system", NetworkPolicyEnabled: true}
+	require.NoError(t, p.reconcileNetworkPolicy(context.Background()))
+
+	p.NetworkPolicyEnabled = false
+	require.NoError(t, p.reconcileNetworkPolicy(context.Background()))
+	require.NoError(t, p.reconcileNetworkPolicy(context.Background()), "removal must be idempotent")
+
+	_, err := getIsolationPolicy(t, cs, "rack1-app-a")
+	assert.True(t, k8serrors.IsNotFound(err))
+}
+
+func TestReconcileNetworkPolicy_BalancerNamespaceExcluded(t *testing.T) {
+	require.True(t, manifest.ReservedLabelKeys["type"], "a user-settable 'type' label would let an app self-exclude from isolation")
+
+	cs := fake.NewSimpleClientset(
+		newTenantNamespace("rack1-app-a", "rack1", ""),
+		newTenantNamespace("rack1-app-b", "rack1", ""),
+	)
+	p := &Provider{Cluster: cs, Name: "rack1", Namespace: "rack1-system", NetworkPolicyEnabled: true}
+
+	_, err := cs.CoreV1().Services("rack1-app-b").Create(context.Background(), appService("rack1-app-b", "app-b"), am.CreateOptions{})
+	require.NoError(t, err)
+
+	require.NoError(t, p.reconcileNetworkPolicy(context.Background()))
+
+	_, err = cs.CoreV1().Services("rack1-app-a").Create(context.Background(), balancerService("rack1-app-a"), am.CreateOptions{})
+	require.NoError(t, err)
+
+	require.NoError(t, p.reconcileNetworkPolicy(context.Background()))
+
+	_, err = getIsolationPolicy(t, cs, "rack1-app-a")
+	assert.True(t, k8serrors.IsNotFound(err), "a namespace publishing a balancer must be left unpoliced")
+
+	_, err = getIsolationPolicy(t, cs, "rack1-app-b")
+	assert.NoError(t, err, "an ordinary app Service must not read as a balancer")
+}
+
+func TestReconcileNetworkPolicy_BalancerProbeFailureLeavesNamespaceAlone(t *testing.T) {
+	cs := fake.NewSimpleClientset(
+		newTenantNamespace("rack1-app-a", "rack1", ""),
+		newTenantNamespace("rack1-app-b", "rack1", ""),
+		newTenantNamespace("rack1-app-c", "rack1", ""),
+		networkIsolationPolicy("rack1-app-a", "rack1-system", "rack1", ""),
+	)
+	cs.PrependReactor("list", "services", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if action.GetNamespace() == "rack1-app-b" {
+			return false, nil, nil
+		}
+		return true, nil, assert.AnError
+	})
+	p := &Provider{Cluster: cs, Name: "rack1", Namespace: "rack1-system", NetworkPolicyEnabled: true}
+
+	require.NoError(t, p.reconcileNetworkPolicy(context.Background()))
+
+	_, err := getIsolationPolicy(t, cs, "rack1-app-a")
+	assert.NoError(t, err, "an unverifiable namespace must keep the policy it already has")
+
+	_, err = getIsolationPolicy(t, cs, "rack1-app-c")
+	assert.True(t, k8serrors.IsNotFound(err), "an unverifiable namespace must not be policed")
+
+	_, err = getIsolationPolicy(t, cs, "rack1-app-b")
+	assert.NoError(t, err, "a probe failure in one namespace must not skip the next")
+}
+
+func TestEnsureNetworkIsolationPolicy_RepairsDrift(t *testing.T) {
+	stale := networkIsolationPolicy("rack1-app-a", "rack1-system", "rack1", "")
+	stale.Spec.PolicyTypes = []networkingv1.PolicyType{networkingv1.PolicyTypeEgress}
+	stale.Spec.Ingress = nil
+
+	cs := fake.NewSimpleClientset(newTenantNamespace("rack1-app-a", "rack1", ""), stale)
+	p := &Provider{Cluster: cs, Name: "rack1", Namespace: "rack1-system", NetworkPolicyEnabled: true}
+
+	require.NoError(t, p.reconcileNetworkPolicy(context.Background()))
+
+	np, err := getIsolationPolicy(t, cs, "rack1-app-a")
+	require.NoError(t, err)
+	assert.Equal(t, networkIsolationPolicy("rack1-app-a", "rack1-system", "rack1", "").Spec, np.Spec)
+}
+
+func TestReconcileNetworkPolicy_NoUpdateWhenUnchanged(t *testing.T) {
+	cs := fake.NewSimpleClientset(newTenantNamespace("rack1-ab12-app-a", "rack1", "ab12"))
+	p := &Provider{Cluster: cs, Name: "rack1", Namespace: "rack1-system", NetworkPolicyEnabled: true}
+	require.NoError(t, p.reconcileNetworkPolicy(context.Background()))
+
+	updates := 0
+	cs.PrependReactor("update", "networkpolicies", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		updates++
+		return false, nil, nil
+	})
+
+	require.NoError(t, p.reconcileNetworkPolicy(context.Background()))
+	require.NoError(t, p.reconcileNetworkPolicy(context.Background()))
+
+	assert.Zero(t, updates, "a policy that already matches must not be rewritten on every tick")
+}
+
+func TestReconcileNetworkPolicy_ContinuesPastPerNamespaceError(t *testing.T) {
+	cs := fake.NewSimpleClientset(
+		newTenantNamespace("rack1-app-a", "rack1", ""),
+		newTenantNamespace("rack1-app-b", "rack1", ""),
+	)
+	cs.PrependReactor("create", "networkpolicies", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if ca, ok := action.(k8stesting.CreateAction); ok && ca.GetNamespace() == "rack1-app-a" {
+			return true, nil, assert.AnError
+		}
+		return false, nil, nil
+	})
+	p := &Provider{Cluster: cs, Name: "rack1", Namespace: "rack1-system", NetworkPolicyEnabled: true}
+
+	require.NoError(t, p.reconcileNetworkPolicy(context.Background()))
+
+	_, err := getIsolationPolicy(t, cs, "rack1-app-a")
+	assert.True(t, k8serrors.IsNotFound(err))
+
+	_, err = getIsolationPolicy(t, cs, "rack1-app-b")
+	assert.NoError(t, err, "a per-namespace create error must not skip the next namespace")
+}
+
+func TestReconcileNetworkPolicy_ListErrorReturned(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	cs.PrependReactor("list", "namespaces", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, assert.AnError
+	})
+	p := &Provider{Cluster: cs, Name: "rack1", Namespace: "rack1-system", NetworkPolicyEnabled: true}
+
+	require.Error(t, p.reconcileNetworkPolicy(context.Background()))
+}
+
+func TestReconcileNetworkPolicySafe_PanicSurvives(t *testing.T) {
+	cs := fake.NewSimpleClientset(newTenantNamespace("rack1-app-a", "rack1", ""))
+	cs.PrependReactor("create", "networkpolicies", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		panic("simulated client-go corruption mid-create")
+	})
+	p := &Provider{Cluster: cs, Name: "rack1", Namespace: "rack1-system", NetworkPolicyEnabled: true}
+
+	require.NotPanics(t, func() {
+		p.reconcileNetworkPolicySafe(context.Background())
+	})
+}
+
+func TestRunNetworkPolicyReconciler_StopsOnContextCancel(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	p := &Provider{Cluster: cs, Name: "rack1", Namespace: "rack1-system", NetworkPolicyEnabled: false}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		p.runNetworkPolicyReconciler(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("runNetworkPolicyReconciler did not return after context cancel")
+	}
+}

--- a/terraform/api/aws/main.tf
+++ b/terraform/api/aws/main.tf
@@ -81,6 +81,7 @@ module "k8s" {
     ROUTER_TYPE                               = var.router_type
     PROXY_PROTOCOL                            = var.proxy_protocol
     POD_IMDS_BLOCK_ENABLED                    = var.pod_imds_block_enabled
+    NETWORK_POLICY_ENABLED                    = var.network_policy_enable
     POD_SECURITY_STANDARD                     = var.pod_security_standard
     POD_SECURITY_MODE                         = var.pod_security_mode
     CONTOUR_INTERNAL_TLS                      = var.contour_internal_tls

--- a/terraform/api/aws/variables.tf
+++ b/terraform/api/aws/variables.tf
@@ -262,6 +262,10 @@ variable "pod_imds_block_enabled" {
   default = false
 }
 
+variable "network_policy_enable" {
+  default = false
+}
+
 variable "contour_internal_tls" {
   default = true
 }

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -671,7 +671,7 @@ resource "aws_eks_addon" "vpc_cni" {
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "OVERWRITE"
 
-  configuration_values = var.pod_imds_block_enabled ? jsonencode({
+  configuration_values = var.pod_imds_block_enabled || var.network_policy_enable ? jsonencode({
     enableNetworkPolicy = "true"
   }) : null
 }

--- a/terraform/cluster/aws/variables.tf
+++ b/terraform/cluster/aws/variables.tf
@@ -114,6 +114,11 @@ variable "pod_imds_block_enabled" {
   default = false
 }
 
+variable "network_policy_enable" {
+  type    = bool
+  default = false
+}
+
 variable "internet_gateway_id" {
   default = ""
 }

--- a/terraform/rack/aws/main.tf
+++ b/terraform/rack/aws/main.tf
@@ -81,6 +81,7 @@ module "api" {
   cert_duration                             = var.cert_duration
   proxy_protocol                            = var.proxy_protocol
   pod_imds_block_enabled                    = var.pod_imds_block_enabled
+  network_policy_enable                     = var.network_policy_enable
   contour_internal_tls                      = var.contour_internal_tls
 }
 

--- a/terraform/rack/aws/variables.tf
+++ b/terraform/rack/aws/variables.tf
@@ -213,6 +213,10 @@ variable "pod_imds_block_enabled" {
   default = false
 }
 
+variable "network_policy_enable" {
+  default = false
+}
+
 variable "release" {
   type = string
 }

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -151,6 +151,7 @@ module "cluster" {
   imds_http_hop_limit                     = var.imds_http_hop_limit
   imds_tags_enable                        = var.imds_tags_enable
   pod_imds_block_enabled                  = var.pod_imds_block_enabled
+  network_policy_enable                   = var.network_policy_enable
   eks_access_entries                      = var.eks_access_entries == "true"
   karpenter_auth_mode                     = var.karpenter_auth_mode == "true"
   karpenter_enabled                       = var.karpenter_enabled == "true"
@@ -312,6 +313,7 @@ module "rack" {
   prometheus_url                            = var.prometheus_url
   proxy_protocol                            = var.proxy_protocol
   pod_imds_block_enabled                    = var.pod_imds_block_enabled
+  network_policy_enable                     = var.network_policy_enable
   release                                   = local.release
   releases_to_retain_after_active           = var.releases_to_retain_after_active
   releases_to_retain_task_run_interval_hour = var.releases_to_retain_task_run_interval_hour

--- a/terraform/system/aws/telemetry.tf
+++ b/terraform/system/aws/telemetry.tf
@@ -107,6 +107,7 @@ locals {
     max_on_demand_count                       = var.max_on_demand_count
     min_on_demand_count                       = var.min_on_demand_count
     name                                      = var.name
+    network_policy_enable                     = var.network_policy_enable
     nginx_additional_config                   = var.nginx_additional_config
     nginx_image                               = var.nginx_image
     nlb_security_group                        = var.nlb_security_group
@@ -262,6 +263,7 @@ locals {
     max_on_demand_count                       = "100"
     min_on_demand_count                       = "1"
     name                                      = ""
+    network_policy_enable                     = "false"
     nginx_additional_config                   = ""
     nginx_image                               = "registry.k8s.io/ingress-nginx/controller:v1.12.6@sha256:c371fbf42b4f23584ce879d99303463131f4f31612f0875482b983354eeca7e6"
     nlb_security_group                        = ""

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -253,6 +253,11 @@ variable "pod_imds_block_enabled" {
   default = false
 }
 
+variable "network_policy_enable" {
+  type    = bool
+  default = false
+}
+
 variable "system_readonly_rootfs_enabled" {
   type    = bool
   default = false


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: `network_policy_enable` Rack Parameter for AWS Racks**

AWS racks gain a new parameter, `network_policy_enable`, that restricts which pods can open inbound connections to an app's pods. With it set to `true`, the rack maintains one Kubernetes NetworkPolicy named `convox-network-isolation` in each app namespace and turns on the VPC CNI network policy engine so that policy is enforced. The default is `false`, so behavior is unchanged unless the parameter is explicitly set.

**New Rack Parameter:**

| Parameter | Type | Default | Effect |
|-----------|------|---------|--------|
| `network_policy_enable` | bool | `false` | When `true`, an app's pods accept inbound connections only from its own namespace, the Convox system namespaces, and namespaces on the same rack that share its tenant label. AWS only. Default `false` preserves current behavior exactly. |

The policy is ingress only, with an empty pod selector, so it applies to every pod in the app namespace. The allowed sources are: any pod in the same namespace; the rack system namespace `<rack>-system`, where the router, the rack API, and the resolver run; `kube-system` and `convox-monitoring`, which is where DNS and metrics scraping come from; and, when the app namespace carries a tenant label, the other namespaces on the same rack that share it. Everything else is denied. Egress is left untouched, so DNS, outbound internet, and the egress policy that `pod_imds_block_enabled` installs all behave exactly as before.

---

### Why is this important?

Racks that host apps belonging to separate teams or workloads now have a single parameter that closes the direct pod-to-pod path between app namespaces, so an app's ports are reachable only from the places that legitimately need them.

**Benefits:**

- **Namespace-scoped ingress across the whole rack.** One parameter applies the same rule to every app namespace, including namespaces created after the parameter was set, so there is nothing to add per app.
- **The paths Convox depends on stay open.** The rack system namespace `<rack>-system`, where the router, the rack API, and the resolver run, along with `kube-system` and `convox-monitoring`, are explicit allowed sources, so routing, DNS, and metrics scraping keep working with the parameter on.
- **Egress is untouched.** Only inbound connections are constrained, so outbound calls from an app, including calls to third-party APIs and to the internet, are unaffected.
- **Continuously reconciled.** A reconciler in the rack API re-checks every app namespace every two minutes, so policies are created, corrected, and removed to match the parameter without a redeploy.
- **Unchanged by default.** The parameter defaults to `false` on every rack and applies to AWS only, so existing racks see no difference until they opt in.

---

### How to use it?

Turn it on for a rack:

    $ convox rack params set network_policy_enable=true -r rackName

Policies appear on each app namespace as soon as the rack API pod restarts with the new setting. App namespaces created after that are picked up on the next reconcile pass, at most two minutes later.

Turn it back off:

    $ convox rack params set network_policy_enable=false -r rackName

Setting it to `false` is what restores traffic: the reconciler deletes the `convox-network-isolation` policy from every app namespace as soon as the rack API pod restarts with the new setting.

The parameter appears in `convox rack params -r rackName` once it has been set. It can be set on its own or alongside `pod_imds_block_enabled`; the two share one VPC CNI addon configuration, so a rack that already runs `pod_imds_block_enabled=true` sees no addon change at all when enabling this parameter.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this feature.

The parameter is purely additive and defaults to `false`, which is exactly the current behavior on every rack version. It applies to AWS only; on GCP, Azure, DigitalOcean, Metal, and Local racks the CLI rejects it as an unknown parameter.

Setting it to `true` does change how apps reach each other, which is the point of the parameter and the reason it defaults off. Four cases to know before enabling:

- **Cross-namespace pod-to-pod traffic between apps stops.** On a rack where one app calls another over `<service>.<app>.<rack>.local`, those calls fail while the parameter is on. Traffic that goes through the rack router, which covers requests to a rack hostname and services with `internalRouter: true`, arrives from `<rack>-system` and is unaffected. Review this before enabling on a rack running more than one app.
- **Apps that define `balancers:` are left out of the restriction.** A `balancers:` entry creates a `type: LoadBalancer` Service with instance targets, so requests arrive from whichever node the load balancer selected, which no pod or namespace peer can express. The reconciler leaves any namespace holding a balancer Service unpoliced and logs `ns=network_policy at=skip kind=balancer` when it does.
- **Hand-written KEDA triggers under `scale.autoscale.custom` that dial an in-cluster app endpoint stop working.** The `keda` namespace is not an allowed source. Every trigger Convox generates reads CPU and memory metrics or a Prometheus endpoint rather than an app endpoint, so generated triggers are unaffected.
- **Services that publish a host port are covered like any other pod.** `agent: true` runs the service as a DaemonSet and binds its ports on the node, and the policy's empty pod selector applies to every pod in the app namespace, agents included. Review what reaches an agent's host port before enabling.

Set `network_policy_enable=false` and confirm traffic is restored **before** downgrading a rack below `3.25.4`. Releases earlier than `3.25.4` do not manage these policies, so a rack that downgrades with the parameter still on leaves the `convox-network-isolation` policy in place in each app namespace. That state is recoverable: update back to `3.25.4`, set the parameter to `false`, and the policies are removed.

---

### Requirements

This feature requires version `3.25.4` or later for the rack.

**Update the Rack:** Run `convox rack update 3.25.4 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
