### PR TITLE
add health.grpcService, honor health.disable for grpc

### DIFF
--- a/docs/configuration/health-checks.md
+++ b/docs/configuration/health-checks.md
@@ -42,7 +42,7 @@ services:
 | **path**     | /       | The HTTP endpoint that will be requested                                         |
 | **port**     | Main service port | The port the readiness probe connects to. Set when the health endpoint listens on a different port than the main service port. Accepts a scalar (`port: 8080`) or a map with `port` and `scheme` |
 | **timeout**  | `interval - 1` | The number of seconds to wait for a valid response. Defaults to `interval` minus one |
-| **disable**  | false   | Set to `true` to disable the health check entirely                               |
+| **disable**  | false   | Set to `true` to disable the readiness probe. A liveness probe configured with `liveness.path` is unaffected |
 
 ### Separate Health Port
 
@@ -63,9 +63,9 @@ With this configuration, traffic flows to the service on HTTPS port 8080, while 
 
 If `scheme` is omitted, the readiness probe inherits the scheme of the main service port. The scalar form `port: 9090` is equivalent to the map form `port: { port: 9090 }` and inherits the service scheme. Provide `scheme` explicitly only when you need to override the inherited value.
 
-> **Scope.** `health.port` only affects the readiness probe. Startup probes continue to target the main service port regardless of `health.port`, and liveness probes use their own `liveness.port` override (see below). If your service speaks gRPC (`port: grpc:...` with `grpcHealthEnabled: true`), a `health.port` override redirects the gRPC health check to the new port; `scheme` is ignored in that case.
+> **Scope.** `health.port` only affects the readiness probe. Startup probes continue to target the main service port regardless of `health.port`, and liveness probes use their own `liveness.port` override (see below). If your service speaks gRPC (`port: grpc:...` with `grpcHealthEnabled: true`), a `health.port` override redirects the gRPC readiness probe to the new port; `scheme` is ignored in that case, and the gRPC liveness probe still follows `liveness.port`.
 
-> **Valid scheme values.** Only `http` and `https` are valid under `health.port.scheme` and `liveness.port.scheme`. Setting `scheme: grpc` on a service whose main port is **not** gRPC will silently skip the probe. Use `grpcHealthEnabled: true` with a gRPC main port instead. See [gRPC Health Checks](#grpc-health-checks) below.
+> **Valid scheme values.** Only `http` and `https` are valid under `health.port.scheme` and `liveness.port.scheme`. Setting `scheme: grpc` on a service whose main port is **not** gRPC will silently skip the probe. With `grpcHealthEnabled: true`, `health.port.scheme: grpc` instead activates the gRPC probes, putting readiness on `health.port` and liveness on `liveness.port`; `liveness.port.scheme: grpc` only drops the liveness probe. Use `grpcHealthEnabled: true` with a gRPC main port instead. See [gRPC Health Checks](#grpc-health-checks) below.
 
 ## Liveness Checks
 
@@ -284,7 +284,7 @@ services:
 
 ### Advanced Configuration
 
-You can customize the gRPC health check behavior using the same `health` attributes as HTTP health checks:
+A subset of the `health` attributes applies to gRPC health checks. See the table below.
 
 ```yaml
 services:
@@ -295,17 +295,23 @@ services:
     health:
       grace: 20
       interval: 5
-      path: /
+      grpcService: myapp.v1.Greeter
       timeout: 2
 ```
 
 | Attribute  | Default | Description                                                                      |
 | ---------- | ------- | -------------------------------------------------------------------------------- |
 | **grace**    | `interval` | The amount of time in seconds to wait for a [Process](/reference/primitives/app/process) to boot before beginning health checks. Defaults to the value of `interval` |
+| **grpcService** | empty | The gRPC health service name placed in the `HealthCheckRequest`. Empty means overall server health. Affects the readiness probe only. Requires rack version 3.25.4 or later |
 | **interval** | 5       | The number of seconds between health checks                                      |
-| **path**     | /       | The service name to check within your gRPC health implementation                 |
+| **path**     | /       | Has no effect on a gRPC service. Use `grpcService`                               |
+| **port**     | Main service port | Moves the gRPC readiness probe to another port. `scheme` is ignored. The liveness probe follows `liveness.port` |
 | **timeout**  | `interval - 1` | The number of seconds to wait for a valid response. Defaults to `interval` minus one |
-| **disable**  | false   | Set to `true` to disable the health check entirely                               |
+| **disable**  | false   | Set to `true` to disable the gRPC readiness and liveness probes. Requires rack version 3.25.4 or later |
+
+`grpcService` takes a gRPC service name such as `myapp.v1.Greeter`. It is not a URL path: a value beginning with `/` is rejected when your app is built, so moving an old `path: /` value into this key fails fast rather than at rollout. Beyond that the value is passed through as written, and the name must be registered on your server. `Check` returns `NOT_FOUND` for a name your server does not know, so readiness never passes and the deploy does not converge.
+
+`grpcService` changes the readiness probe only. The automatic liveness probe keeps sending the empty service name, so your server must report `SERVING` for both the empty name and the name you set. Go's `health.NewServer()` registers the empty name for you. A hand-written `Check` method, or a health registry you populate yourself, must handle an empty `req.Service` as well, or the liveness probe fails and the container restarts. If `liveness.port` points at a separate health listener, only that listener needs the empty name; it does not need the name you set in `grpcService`.
 
 ### Implementation Requirements
 
@@ -322,7 +328,15 @@ When `grpcHealthEnabled` is set to `true`, Convox configures both:
 
 The readinessProbe ensures that gRPC services won't receive traffic until they are fully ready, while the livenessProbe monitors the ongoing health of the service and initiates restarts if necessary.
 
-Both probes use the health settings defined in your `convox.yml`, ensuring consistent behavior throughout the service lifecycle.
+Both probes use `health.grace`, `health.interval` and `health.timeout`. They do not share a port: the readiness port comes from `health.port` and the liveness port from `liveness.port`, each defaulting to the main service port.
+
+`grpcHealthEnabled: true` is required. A `port: grpc:NNNN` service without it gets no readiness probe and no liveness probe at all.
+
+`grpcHealthEnabled: true` is inert on a service whose main port is not gRPC, unless you also set `health.port.scheme: grpc`. That activates the gRPC probes, giving you a gRPC readiness probe on `health.port` and a gRPC liveness probe on `liveness.port`, which defaults to the main port. If `liveness.path` is also set, that HTTP liveness probe is replaced by the gRPC one. Set `liveness.port` to match, or leave `health.port.scheme` unset.
+
+For the gRPC probes, only `liveness.port` has any effect; the `liveness.*` timing fields and `liveness.path` do not. Those timings are still used as the fallback timings for a [startup probe](#startup-probes), including the automatic startup probe added to GPU services.
+
+`startupProbe.path` renders a plain HTTP GET against the gRPC port and fails unless your server also answers HTTP/1.1 there. Use `startupProbe.tcpSocketPort` on a gRPC service.
 
 > gRPC probes use a hardcoded `failureThreshold` of **5** and `successThreshold` of **1** for both readiness and liveness. This differs from HTTP probes, where readiness uses a `failureThreshold` of **3** and liveness uses the configurable `liveness.failureThreshold` (default **3**). The gRPC thresholds are not configurable.
 
@@ -349,8 +363,12 @@ func main() {
 	healthServer := health.NewServer()
 	healthpb.RegisterHealthServer(server, healthServer)
 	
-	// Set your service as serving
+	// The liveness probe always checks the empty service name
 	healthServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+	
+	// Only needed when you set health.grpcService, which the readiness probe checks.
+	// Flip this to NOT_SERVING to drain traffic without restarting the container.
+	healthServer.SetServingStatus("myapp.v1.Greeter", healthpb.HealthCheckResponse_SERVING)
 	
 	// Continue with server initialization...
 }

--- a/docs/reference/primitives/app/service.md
+++ b/docs/reference/primitives/app/service.md
@@ -418,11 +418,12 @@ See [Health Checks](/configuration/health-checks) for configuring readiness, liv
 | Attribute  | Type   | Default | Description                                                                                      |
 | ---------- | ------ | ------- | ------------------------------------------------------------------------------------------------ |
 | **grace**    | number | `interval` | The number of seconds to wait for a [Process](/reference/primitives/app/process) to start before starting health checks. Defaults to the value of `interval` |
+| **grpcService** | string |      | The gRPC health service name placed in the `HealthCheckRequest`, for services using `grpcHealthEnabled`. Empty means overall server health. Affects the readiness probe only. Requires rack version 3.25.4 or later. See [gRPC Health Checks](/configuration/health-checks#grpc-health-checks) |
 | **interval** | number | 5       | The number of seconds between health checks                                                      |
-| **path**     | string | /       | The path to request for health checks                                                            |
+| **path**     | string | /       | The path to request for health checks. Has no effect on a gRPC service; use `grpcService`         |
 | **port**     | number or map | Main service port | The port the readiness probe connects to. Accepts a scalar (`port: 8080`) or a map (`port: { port: 8080, scheme: https }`). Scheme inherits from the main service port when omitted. See [Separate Health Port](/configuration/health-checks#separate-health-port) |
 | **timeout**  | number | `interval - 1` | The number of seconds to wait for a successful response. Defaults to `interval` minus one |
-| **disable**  | bool | false       | Set to `true` to disable the health check entirely |
+| **disable**  | bool | false       | Set to `true` to disable the readiness probe. A liveness probe configured with `liveness.path` is unaffected. On a gRPC service this disables both the readiness and the liveness probe, and requires rack version 3.25.4 or later |
 
 > Specifying **health** as a string will set the **path** and leave the other values as defaults.
 

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -169,6 +169,8 @@ func (m *Manifest) ApplyDefaults() error {
 			m.Services[i].Health.Timeout = m.Services[i].Health.Interval - 1
 		}
 
+		m.Services[i].Health.GrpcService = strings.TrimSpace(s.Health.GrpcService)
+
 		s.Liveness.Path = strings.TrimSpace(s.Liveness.Path)
 		if s.Liveness.Path != "" {
 			if s.Liveness.Grace == 0 {

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -791,6 +791,7 @@ func TestManifestValidate(t *testing.T) {
 		"service internal-router-invalid can not have both internal and internalRouter set as true",
 		"service name serviceF invalid, must contain only lowercase alphanumeric and dashes",
 		"service serviceF references a resource that does not exist: foo",
+		"service grpc-path-invalid health grpcService must be a grpc service name such as myapp.v1.Greeter, not a path",
 		"timer name timer_1 invalid, must contain only lowercase alphanumeric and dashes",
 		"timer timer_1 references a service that does not exist: someservice",
 	}
@@ -993,6 +994,30 @@ func TestManifestStartupProbeGpu_NoPortService_NoFailureThresholdSet(t *testing.
 	require.Equal(t, 0, noPort.StartupProbe.FailureThreshold, "GPU service with no port must not receive the 180 default")
 	require.Equal(t, 0, noPort.StartupProbe.Interval)
 	require.Equal(t, 0, noPort.StartupProbe.Timeout)
+}
+
+func TestManifestGrpcHealthService(t *testing.T) {
+	m, err := testdataManifest("grpc-health", map[string]string{})
+	require.NoError(t, err)
+	require.Equal(t, 4, len(m.Services))
+
+	named, err := m.Service("named")
+	require.NoError(t, err)
+	require.Equal(t, "myapp.v1.Greeter", named.Health.GrpcService)
+
+	padded, err := m.Service("padded")
+	require.NoError(t, err)
+	require.Equal(t, "myapp.v1.Greeter", padded.Health.GrpcService)
+
+	plain, err := m.Service("plain")
+	require.NoError(t, err)
+	require.Equal(t, "", plain.Health.GrpcService, "grpcService must stay empty when unset")
+	require.Equal(t, "/", plain.Health.Path)
+
+	shorthand, err := m.Service("shorthand")
+	require.NoError(t, err)
+	require.Equal(t, "/ready", shorthand.Health.Path)
+	require.Equal(t, "", shorthand.Health.GrpcService)
 }
 
 func TestManifestKeda(t *testing.T) {

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -285,12 +285,13 @@ type ServiceDnsConfig struct {
 }
 
 type ServiceHealth struct {
-	Disable  bool
-	Grace    int
-	Interval int
-	Path     string
-	Port     ServicePortScheme `yaml:"port,omitempty"`
-	Timeout  int
+	Disable     bool
+	Grace       int
+	GrpcService string `yaml:"grpcService,omitempty"`
+	Interval    int
+	Path        string
+	Port        ServicePortScheme `yaml:"port,omitempty"`
+	Timeout     int
 }
 
 type ServiceLiveness struct {

--- a/pkg/manifest/testdata/grpc-health.yml
+++ b/pkg/manifest/testdata/grpc-health.yml
@@ -1,0 +1,22 @@
+services:
+  named:
+    build: .
+    port: grpc:50051
+    grpcHealthEnabled: true
+    health:
+      grpcService: myapp.v1.Greeter
+  padded:
+    build: .
+    port: grpc:50052
+    grpcHealthEnabled: true
+    health:
+      grpcService: "  myapp.v1.Greeter  "
+  plain:
+    build: .
+    port: grpc:50053
+    grpcHealthEnabled: true
+  shorthand:
+    build: .
+    port: grpc:50054
+    grpcHealthEnabled: true
+    health: /ready

--- a/pkg/manifest/testdata/validate.yml
+++ b/pkg/manifest/testdata/validate.yml
@@ -24,6 +24,12 @@ services:
     build: .
     resources:
       - foo
+  grpc-path-invalid:
+    build: .
+    port: grpc:50051
+    grpcHealthEnabled: true
+    health:
+      grpcService: /ready
 timers:
   timer_1:
     service: someservice

--- a/pkg/manifest/validate.go
+++ b/pkg/manifest/validate.go
@@ -136,6 +136,10 @@ func (m *Manifest) validateServices() []error {
 			errs = append(errs, fmt.Errorf("service %s can not have both internal and internalRouter set as true", s.Name))
 		}
 
+		if strings.HasPrefix(s.Health.GrpcService, "/") {
+			errs = append(errs, fmt.Errorf("service %s health grpcService must be a grpc service name such as myapp.v1.Greeter, not a path", s.Name))
+		}
+
 		for _, r := range s.ResourcesName() {
 			if _, err := m.Resource(r); err != nil {
 				if strings.HasPrefix(err.Error(), "no such resource") {

--- a/pkg/manifest/yaml.go
+++ b/pkg/manifest/yaml.go
@@ -317,6 +317,9 @@ func (v *ServiceHealth) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if w, ok := t["disable"].(bool); ok {
 			v.Disable = w
 		}
+		if w, ok := t["grpcService"].(string); ok {
+			v.GrpcService = w
+		}
 		if p, ok := t["port"]; ok && p != nil {
 			if err := remarshal(p, &v.Port); err != nil {
 				return err

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -304,10 +304,13 @@ spec:
           timeoutSeconds: {{$.Service.Health.Timeout}}
           successThreshold: 1
           failureThreshold: 3
-        {{ else if $.Service.GrpcHealthEnabled }}
+        {{ else if and $.Service.GrpcHealthEnabled (not $.Service.Health.Disable) }}
         readinessProbe:
           grpc:
             port: {{ if gt $.Service.Health.Port.Port 0 }}{{ $.Service.Health.Port.Port }}{{ else }}{{.}}{{ end }}
+            {{ if not (eq $.Service.Health.GrpcService "") }}
+            service: "{{$.Service.Health.GrpcService}}"
+            {{ end }}
           initialDelaySeconds: {{$.Service.Health.Grace}}
           periodSeconds: {{$.Service.Health.Interval}}
           timeoutSeconds: {{$.Service.Health.Timeout}}

--- a/provider/k8s/template_test.go
+++ b/provider/k8s/template_test.go
@@ -867,4 +867,143 @@ func TestRenderTemplateServiceHealthPort(t *testing.T) {
 		assertNotContains("startupProbe does not use health port", startupBlock, "port: 9090")
 		assertNotContains("startupProbe does not use liveness port", startupBlock, "port: 9091")
 	})
+
+	// Labels elsewhere render as "service:" but never this deep inside a grpc block.
+	const grpcProbeService = "\n            service:"
+
+	grpcService := func(name string) manifest.Service {
+		return manifest.Service{
+			Name:              name,
+			Port:              manifest.ServicePortScheme{Port: 50051, Scheme: "GRPC"},
+			GrpcHealthEnabled: true,
+			Health: manifest.ServiceHealth{
+				Path: "/", Grace: 5, Interval: 5, Timeout: 4,
+			},
+		}
+	}
+
+	t.Run("grpc probes omit the service name when health.grpcService is unset", func(t *testing.T) {
+		out := render(grpcService("legacygrpc"))
+		assertNotContains("no grpc service name", out, grpcProbeService)
+		// Pins the bytes: port is the only key inside grpc, so the next key is the probe's.
+		assertContains("grpc block unchanged", out, "grpc:\n            port: 50051\n          initialDelaySeconds: 5")
+	})
+
+	t.Run("health.grpcService renders in the grpc readinessProbe only", func(t *testing.T) {
+		svc := grpcService("namedgrpc")
+		svc.Health.GrpcService = "myapp.v1.Greeter"
+		out := render(svc)
+		assertContains("readiness service name", out, "grpc:\n            port: 50051\n            service: myapp.v1.Greeter")
+		if n := countKey(out, "service: myapp.v1.Greeter"); n != 1 {
+			t.Errorf("expected the service name exactly once (readiness only); got %d:\n%s", n, out)
+		}
+	})
+
+	t.Run("health.grpcService coexists with health.port and liveness.port", func(t *testing.T) {
+		svc := grpcService("portedgrpc")
+		svc.Health.GrpcService = "myapp.v1.Greeter"
+		svc.Health.Port = manifest.ServicePortScheme{Port: 50052}
+		svc.Liveness = manifest.ServiceLiveness{
+			Port:             manifest.ServicePortScheme{Port: 50053},
+			SuccessThreshold: 1,
+			FailureThreshold: 5,
+		}
+		out := render(svc)
+		livenessIdx := strings.Index(out, "livenessProbe:")
+		readinessIdx := strings.Index(out, "readinessProbe:")
+		if livenessIdx < 0 || readinessIdx < 0 || livenessIdx > readinessIdx {
+			t.Fatalf("unexpected probe layout: %s", out)
+		}
+		livenessBlock := out[livenessIdx:readinessIdx]
+		readinessBlock := out[readinessIdx:]
+		assertContains("readiness keeps health.port and the service name", readinessBlock, "grpc:\n            port: 50052\n            service: myapp.v1.Greeter")
+		assertContains("liveness keeps liveness.port", livenessBlock, "port: 50053")
+		assertNotContains("liveness has no service name", livenessBlock, grpcProbeService)
+	})
+
+	t.Run("health.path never becomes the grpc service name", func(t *testing.T) {
+		svc := grpcService("pathgrpc")
+		svc.Health.Path = "/ready"
+		out := render(svc)
+		assertNotContains("no grpc service name", out, grpcProbeService)
+		assertNotContains("health.path is not reused", out, "service: /ready")
+		assertContains("grpc probes still render", out, "grpc:\n            port: 50051")
+	})
+
+	t.Run("http service ignores health.grpcService", func(t *testing.T) {
+		svc := manifest.Service{
+			Name: "httpsvc",
+			Port: manifest.ServicePortScheme{Port: 8080, Scheme: "http"},
+			Health: manifest.ServiceHealth{
+				Path: "/health", GrpcService: "myapp.v1.Greeter", Grace: 5, Interval: 5, Timeout: 4,
+			},
+		}
+		out := render(svc)
+		assertNotContains("no grpc block", out, "grpc:")
+		assertNotContains("no grpc service name", out, "service: myapp.v1.Greeter")
+		assertContains("httpGet still uses health.path", out, "path: /health")
+	})
+
+	t.Run("health.disable removes both grpc probes", func(t *testing.T) {
+		svc := grpcService("disabledgrpc")
+		svc.Health.Disable = true
+		out := render(svc)
+		assertNotContains("no readinessProbe", out, "readinessProbe:")
+		assertNotContains("no livenessProbe", out, "livenessProbe:")
+	})
+
+	t.Run("health.disable on an http service does not emit grpc probes", func(t *testing.T) {
+		svc := manifest.Service{
+			Name:              "httpdisabled",
+			Port:              manifest.ServicePortScheme{Port: 3000, Scheme: "http"},
+			GrpcHealthEnabled: true,
+			Health: manifest.ServiceHealth{
+				Path: "/", Disable: true, Grace: 5, Interval: 5, Timeout: 4,
+			},
+		}
+		out := render(svc)
+		assertNotContains("no readinessProbe", out, "readinessProbe:")
+		assertNotContains("no livenessProbe", out, "livenessProbe:")
+		assertNotContains("no grpc block against the http port", out, "grpc:")
+	})
+
+	t.Run("health.disable on an http service preserves the configured liveness probe", func(t *testing.T) {
+		svc := manifest.Service{
+			Name:              "httpdisabledlive",
+			Port:              manifest.ServicePortScheme{Port: 3000, Scheme: "http"},
+			GrpcHealthEnabled: true,
+			Health: manifest.ServiceHealth{
+				Path: "/", Disable: true, Grace: 5, Interval: 5, Timeout: 4,
+			},
+			Liveness: manifest.ServiceLiveness{
+				Path:             "/live",
+				Grace:            10,
+				Interval:         5,
+				Timeout:          5,
+				SuccessThreshold: 1,
+				FailureThreshold: 3,
+			},
+		}
+		out := render(svc)
+		assertContains("liveness keeps the configured path", out, "path: /live")
+		assertContains("liveness keeps the configured threshold", out, "failureThreshold: 3")
+		assertNotContains("no grpc block against the http port", out, "grpc:")
+		assertNotContains("no readinessProbe", out, "readinessProbe:")
+	})
+
+	t.Run("grpc port without grpcHealthEnabled renders no probes", func(t *testing.T) {
+		svc := grpcService("optedout")
+		svc.GrpcHealthEnabled = false
+		svc.Liveness = manifest.ServiceLiveness{
+			Path:             "/live",
+			Grace:            10,
+			Interval:         5,
+			Timeout:          5,
+			SuccessThreshold: 1,
+			FailureThreshold: 3,
+		}
+		out := render(svc)
+		assertNotContains("no readinessProbe", out, "readinessProbe:")
+		assertNotContains("no livenessProbe", out, "livenessProbe:")
+	})
 }


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: `health.grpcService` for gRPC Services**

gRPC services can now select which gRPC health service name Convox places in the `HealthCheckRequest`. A new `convox.yml` attribute, `services.<name>.health.grpcService`, is passed through to the gRPC readiness probe as its `service` field. The attribute is empty by default, which means overall server health and is the existing behavior for every gRPC service. The automatic gRPC liveness probe is unchanged and continues to send the empty service name.

**New Manifest Attribute:**

| Attribute | Type | Default | Effect |
|-----------|------|---------|--------|
| `services.<name>.health.grpcService` | string | empty | gRPC health service name placed in the `HealthCheckRequest`. Empty means overall server health. Affects the gRPC readiness probe only. |

`health.disable` is also honored on gRPC services. On a service with `grpcHealthEnabled: true`, setting `health.disable: true` renders neither the gRPC readiness probe nor the gRPC liveness probe.

The value is a gRPC service name such as `myapp.v1.Greeter`, not a URL path, and it is a separate key from `health.path`, which applies to HTTP readiness probes only. A value beginning with `/` is rejected when the app is built, by the same service validation that runs on `convox build` and `convox deploy`, with an error naming the service and the attribute. Surrounding whitespace is trimmed. Nothing else about the value is validated, so the name must be one your server has registered.

---

### Why is this important?

A gRPC server that registers more than the overall health entry can now tell Convox which entry to watch, so readiness reflects the health of a specific service rather than the server as a whole.

**Benefits:**

- **Readiness that tracks a specific gRPC service.** Your server can report `NOT_SERVING` for the named service and Convox stops routing traffic to that pod, without touching the liveness probe.
- **Draining without restarts.** Because the attribute applies to the readiness probe only, and liveness keeps checking the empty service name, reporting `NOT_SERVING` for the named service drains traffic instead of restarting the container.
- **Errors surface at build time.** A `/`-prefixed value fails the build immediately, naming the service and the attribute, rather than at rollout.
- **`health.disable` covers gRPC probes.** A gRPC service that handles its own routing and restart behavior can turn both gRPC probes off with `health.disable: true`.
- **Unchanged by default.** The attribute is empty unless you set it, and an empty value renders the gRPC probes exactly as they render today.

---

### How to use it?

Point the readiness probe at a named gRPC health service:

```yaml
services:
  api:
    build: .
    port: grpc:50051
    grpcHealthEnabled: true
    health:
      grpcService: myapp.v1.Greeter
```

Your server must report `SERVING` for both the empty service name, which the liveness probe checks, and the name you set here, which the readiness probe checks. In Go, `health.NewServer()` registers the empty name for you, and you add the named entry:

```go
healthServer := health.NewServer()
healthpb.RegisterHealthServer(server, healthServer)

healthServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
healthServer.SetServingStatus("myapp.v1.Greeter", healthpb.HealthCheckResponse_SERVING)
```

A name your server does not know returns `NOT_FOUND`, so readiness never passes. Leave `health.grpcService` unset to keep checking overall server health.

If your server cannot report `SERVING` for the empty name on its main port, point the liveness probe at a second port with `liveness.port`. The liveness probe still sends the empty service name, so a small always-`SERVING` health listener on that port satisfies it while readiness keeps watching the named service on the main port. `liveness.port` is the only `liveness.*` attribute that affects a gRPC service; both probes take their cadence from `health.grace`, `health.interval`, and `health.timeout`.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this feature.

`health.grpcService` is purely additive and empty by default. A service that does not set it, and does not set `health.disable`, renders exactly the pod spec it renders today. Rendered pod specs are produced at deploy and promote time, so nothing changes at rack update.

One combination does render differently on the next deploy or promote of the app: a service that sets both `grpcHealthEnabled: true` and `health.disable: true`. If its main port is gRPC, the gRPC readiness and liveness probes are no longer rendered, which removes readiness gating and automatic restart for that service. If its main port is not gRPC, the gRPC probes are no longer rendered and a liveness probe configured with `liveness.path` renders as configured. If you want the gRPC probes on such a service, remove `health.disable` before updating.

Downgrade is safe. There is no rack parameter and no Terraform variable, so nothing enters Terraform state. On a rack older than `3.25.4`, `health.grpcService` is parsed and ignored with no error, and `health.disable` no longer suppresses the gRPC probes, so a service relying on it gets both gRPC probes back on its next promote. If a rollback below `3.25.4` is possible, drop `grpcHealthEnabled: true` rather than relying on `health.disable`.

---

### Requirements

This feature requires version `3.25.4` or later for the rack.

**Update the Rack:** Run `convox rack update 3.25.4 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
