### PR TITLE
Add StatefulSet services with persistent volumes

### DIFF
--- a/docs/configuration/volumes.md
+++ b/docs/configuration/volumes.md
@@ -9,6 +9,34 @@ url: /configuration/volumes
 
 Convox supports multiple types of volumes to manage both persistent and temporary data for your applications. These volumes provide flexibility for different use cases, from high-speed temporary data storage to persistent, scalable file storage across multiple services.
 
+## Per-replica persistent volumes
+
+Use a stateful service when each replica needs its own persistent disk. Convox creates a Kubernetes StatefulSet and one PersistentVolumeClaim for each replica. Kubernetes reattaches the same claim when it replaces or reschedules that replica.
+
+```yaml
+services:
+  database:
+    image: qdrant/qdrant:v1.18.2
+    stateful: true
+    podManagementPolicy: Parallel
+    scale:
+      count: 3
+    volumeOptions:
+      - persistentVolumeClaim:
+          id: data
+          mountPath: /qdrant/storage
+          size: 200Gi
+          storageClass: gp3
+```
+
+The rack must provide the named Container Storage Interface storage class. For example, use an Amazon EBS, Azure Disk or Google Persistent Disk storage class. The access mode defaults to `ReadWriteOnce`.
+
+`podManagementPolicy` defaults to `OrderedReady`. Set it to `Parallel` when every replica must start independently, as Qdrant requires.
+
+Stateful services must use a fixed replica count. They do not support agents, autoscaling, VPA, budget auto-shutdown or `convox run --use-service-volume`.
+
+Changing `stateful` on an existing service does not provide an in-place migration. Create a new service and move the data. Kubernetes also treats `podManagementPolicy` and claim template fields such as `storageClass` as immutable.
+
 ## Azure Files Volumes
 
 > Azure only. Requires the [azure_files_enable](/configuration/rack-parameters/azure/azure_files_enable) rack parameter.

--- a/docs/configuration/volumes.md
+++ b/docs/configuration/volumes.md
@@ -35,7 +35,52 @@ The rack must provide the named Container Storage Interface storage class. For e
 
 Stateful services must use a fixed replica count. They do not support agents, autoscaling, VPA, budget auto-shutdown or `convox run --use-service-volume`.
 
-Changing `stateful` on an existing service does not provide an in-place migration. Create a new service and move the data. Kubernetes also treats `podManagementPolicy` and claim template fields such as `storageClass` as immutable.
+Changing `stateful` on an existing service does not provide an in-place migration. Create a new service and move the data. Kubernetes also treats `podManagementPolicy` and claim template fields such as `size` and `storageClass` as immutable, so changing one of those on a running stateful service is rejected. Use a new service name instead, which gives the replicas new claims.
+
+### Addressing an individual replica
+
+Each replica gets a stable name and its own DNS record through a headless Service that Convox creates alongside the StatefulSet:
+
+```
+<service>-<ordinal>.<service>-headless
+```
+
+The example above is reachable inside the app as `database-0.database-headless`, `database-1.database-headless` and `database-2.database-headless`. Use these names to point clustered services such as Qdrant at their peers. The regular `<service>` name still load balances across every ready replica.
+
+### Volume ownership for non-root images
+
+A newly provisioned block volume is owned by root, so a service whose image runs as a non-root user cannot write to its mount. Set `securityContext.fsGroup` to the group that owns the data directory and Kubernetes hands the volume to that group:
+
+```yaml
+services:
+  search:
+    image: elasticsearch:8.15.0
+    stateful: true
+    securityContext:
+      fsGroup: 1000
+    volumeOptions:
+      - persistentVolumeClaim:
+          id: data
+          mountPath: /usr/share/elasticsearch/data
+          size: 50Gi
+          storageClass: gp3
+```
+
+An init container can also mount the same claim to prepare the directory before the service starts. Reference the claim by `id` and give it the path the init container should see:
+
+```yaml
+    initContainer:
+      image: busybox
+      command: chown -R 1000:1000 /data
+      volumeOptions:
+        - persistentVolumeClaim:
+            id: data
+            mountPath: /data
+```
+
+### Volume lifecycle
+
+Claims outlive the replicas that use them. Scaling a stateful service down keeps the claims for the removed replicas, so scaling back up reattaches the same data. Removing the service from `convox.yml` also leaves its claims in place. In both cases the underlying cloud disks keep billing until you delete them, and `convox apps delete` removes the whole namespace along with every claim and disk it holds.
 
 ## Azure Files Volumes
 

--- a/docs/reference/primitives/app/service.md
+++ b/docs/reference/primitives/app/service.md
@@ -521,6 +521,7 @@ Container-level security settings. These settings control Linux security feature
 | **runAsNonRoot**             | boolean |         | Require the container to run as a non-root user                                                             |
 | **runAsUser**                | number  |         | The UID to run the container as                                                                             |
 | **runAsGroup**               | number  |         | The GID to run the container as                                                                             |
+| **fsGroup**                  | number  |         | The GID that owns mounted volumes. Applies to the whole pod, not just the container. See [Volumes](/configuration/volumes#volume-ownership-for-non-root-images) |
 | **readOnlyRootFilesystem**   | boolean |         | Mount the root filesystem as read-only                                                                      |
 | **allowPrivilegeEscalation** | boolean |         | Whether a process can gain more privileges than its parent process. Set to **false** for security hardening |
 | **capabilities**             | map     |         | Linux capabilities to add or drop (see below)                                                               |
@@ -663,7 +664,7 @@ services:
 | **storageClass** | string | cluster default | Container Storage Interface storage class supplied by the rack |
 | **accessMode** | string | `ReadWriteOnce` | `ReadWriteOnce`, `ReadOnlyMany` or `ReadWriteMany` |
 
-This option requires `stateful: true`. See [per-replica persistent volumes](/configuration/volumes#per-replica-persistent-volumes) for an example and limits.
+This option requires `stateful: true`. An `initContainer` may mount a claim the service already declares by giving the same `id` and the path the init container should see. See [per-replica persistent volumes](/configuration/volumes#per-replica-persistent-volumes) for an example and limits.
 
 
 

--- a/docs/reference/primitives/app/service.md
+++ b/docs/reference/primitives/app/service.md
@@ -142,11 +142,13 @@ services:
 | **nodeSelectorLabels** | map |  | Node selector labels for workload placement. See [Workload Placement](/configuration/scaling/workload-placement) |
 | **port**        | string     |                     | The port that the default Rack balancer will use to [route incoming traffic](/configuration/load-balancers). For grpc service specify the scheme: `grpc:5051`|
 | **ports**       | list       |                     | A list of ports available for internal [service discovery](/configuration/service-discovery) or custom [Balancers](/reference/primitives/app/balancer). Supports TCP (default) and UDP protocols |
+| **podManagementPolicy** | string | `OrderedReady` | StatefulSet pod start and scale policy. Use `OrderedReady` or `Parallel`; requires `stateful: true` |
 | **privileged**  | boolean    | false               | Set to **true** to allow [Processes](/reference/primitives/app/process) of this Service to run as root inside their container. Use with caution as this grants elevated permissions |
 | **resources**   | list       |                     | A list of [Resources](/reference/primitives/app/resource) to make available to this Service (e.g. databases) |
 | **scale**       | map        | 1                   | Define scaling parameters (see below)                                                                                                      |
 | **securityContext** | map   |                     | Container security settings including capabilities, read-only filesystem, and seccomp profiles (see below)                               |
 | **singleton**   | boolean    | false               | Set to **true** to prevent extra [Processes](/reference/primitives/app/process) of this Service from being started during deployments                               |
+| **stateful**    | boolean    | false               | Set to **true** to give each replica stable identity and its own PersistentVolumeClaim. See [Volumes](/configuration/volumes#per-replica-persistent-volumes) |
 | **sticky**      | boolean    | false               | Set to **true** to enable sticky sessions                                                                                                    |
 | **termination** | map        |                     | Termination related configuration                                                                                                          |
 | **test**        | string     |                     | A command to run to test this Service when running **convox test**                                                                           |
@@ -598,6 +600,7 @@ services:
 | ---------- | ------- | ------- | ------------------------------------------------------------------------------------ |
 | **emptyDir** | map |     | Configuration for [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) volume |
 | **awsEfs** | map |     | Configuration for AWS Efs volume. To use this you have to enable efs csi driver in the rack |
+| **persistentVolumeClaim** | map | | Per-replica persistent storage for a stateful service |
 
 
 
@@ -649,6 +652,18 @@ services:
           accessMode: ReadWriteMany
           mountPath: "/my/data/"
 ```
+
+### []volumeOptions.persistentVolumeClaim
+
+| Attribute | Type | Default | Description |
+| --------- | ---- | ------- | ----------- |
+| **id** | string | | Required. ID used for the claim and volume mount |
+| **mountPath** | string | | Required. Path in the service file system to mount the volume |
+| **size** | string | | Required. Kubernetes resource quantity, such as `200Gi` |
+| **storageClass** | string | cluster default | Container Storage Interface storage class supplied by the rack |
+| **accessMode** | string | `ReadWriteOnce` | `ReadWriteOnce`, `ReadOnlyMany` or `ReadWriteMany` |
+
+This option requires `stateful: true`. See [per-replica persistent volumes](/configuration/volumes#per-replica-persistent-volumes) for an example and limits.
 
 
 

--- a/pkg/atom/atom.go
+++ b/pkg/atom/atom.go
@@ -308,6 +308,17 @@ func (c *Client) check(ns, version string) (bool, error) {
 			return false, errors.WithStack(err)
 		}
 
+		if strings.EqualFold(c.Kind, "StatefulSet") {
+			ready, err := statefulSetReady(data)
+			if err != nil {
+				return false, errors.WithStack(err)
+			}
+			if !ready {
+				return false, nil
+			}
+			continue
+		}
+
 		var o struct {
 			Status struct {
 				Conditions []struct {
@@ -341,6 +352,47 @@ func (c *Client) check(ns, version string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+func statefulSetReady(data []byte) (bool, error) {
+	var o struct {
+		Metadata struct {
+			Generation int64 `json:"generation"`
+		} `json:"metadata"`
+		Spec struct {
+			Replicas *int32 `json:"replicas"`
+		} `json:"spec"`
+		Status struct {
+			AvailableReplicas  int32  `json:"availableReplicas"`
+			CurrentRevision    string `json:"currentRevision"`
+			ObservedGeneration int64  `json:"observedGeneration"`
+			ReadyReplicas      int32  `json:"readyReplicas"`
+			Replicas           int32  `json:"replicas"`
+			UpdatedReplicas    int32  `json:"updatedReplicas"`
+			UpdateRevision     string `json:"updateRevision"`
+		} `json:"status"`
+	}
+
+	if err := json.Unmarshal(data, &o); err != nil {
+		return false, err
+	}
+
+	desired := int32(1)
+	if o.Spec.Replicas != nil {
+		desired = *o.Spec.Replicas
+	}
+	if o.Status.ObservedGeneration < o.Metadata.Generation ||
+		o.Status.Replicas != desired ||
+		o.Status.ReadyReplicas != desired ||
+		o.Status.AvailableReplicas != desired ||
+		o.Status.UpdatedReplicas != desired {
+		return false, nil
+	}
+	if desired == 0 {
+		return true, nil
+	}
+
+	return o.Status.CurrentRevision != "" && o.Status.CurrentRevision == o.Status.UpdateRevision, nil
 }
 
 func (c *Client) createNamespace(ns string) error {

--- a/pkg/atom/atom_test.go
+++ b/pkg/atom/atom_test.go
@@ -2,6 +2,7 @@ package atom
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	aa "github.com/convox/convox/pkg/atom/pkg/apis/atom/v1"
@@ -180,6 +181,54 @@ func TestIsRecoverableApplyError(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestStatefulSetReady(t *testing.T) {
+	tests := []struct {
+		name       string
+		desired    int
+		generation int
+		observed   int
+		replicas   int
+		ready      int
+		available  int
+		updated    int
+		current    string
+		update     string
+		want       bool
+	}{
+		{name: "ready", desired: 3, generation: 2, observed: 2, replicas: 3, ready: 3, available: 3, updated: 3, current: "rev2", update: "rev2", want: true},
+		{name: "pvc or pod pending", desired: 3, generation: 2, observed: 2, replicas: 2, ready: 1, available: 1, updated: 2, current: "rev1", update: "rev2"},
+		{name: "controller has not observed update", desired: 3, generation: 3, observed: 2, replicas: 3, ready: 3, available: 3, updated: 3, current: "rev3", update: "rev3"},
+		{name: "rolling update incomplete", desired: 3, generation: 3, observed: 3, replicas: 3, ready: 3, available: 3, updated: 2, current: "rev2", update: "rev3"},
+		{name: "scaled to zero", desired: 0, generation: 4, observed: 4, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := []byte(fmt.Sprintf(`{"metadata":{"generation":%d},"spec":{"replicas":%d},"status":{"observedGeneration":%d,"replicas":%d,"readyReplicas":%d,"availableReplicas":%d,"updatedReplicas":%d,"currentRevision":%q,"updateRevision":%q}}`,
+				tt.generation, tt.desired, tt.observed, tt.replicas, tt.ready, tt.available, tt.updated, tt.current, tt.update))
+			got, err := statefulSetReady(data)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestExtractStatefulSetConditions(t *testing.T) {
+	data := []byte(`apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  namespace: app
+  name: database
+  annotations:
+    atom.conditions: Ready=True
+`)
+	conditions, err := extractConditions(data)
+	require.NoError(t, err)
+	require.Len(t, conditions, 1)
+	require.Equal(t, "StatefulSet", conditions[0].Kind)
+	require.Equal(t, "database", conditions[0].Name)
 }
 
 func atomCreate(ac av.Interface, namespace, name, status, version string, spec aa.AtomSpec) error {

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -171,7 +171,7 @@ type VolumePersistentVolumeClaim struct {
 	StorageClass string `yaml:"storageClass,omitempty"`
 }
 
-func (v VolumePersistentVolumeClaim) Validate() error {
+func (v *VolumePersistentVolumeClaim) Validate() error {
 	if v.Id == "" {
 		return fmt.Errorf("persistentVolumeClaim.id is required")
 	}
@@ -184,8 +184,8 @@ func (v VolumePersistentVolumeClaim) Validate() error {
 	if v.MountPath == "" {
 		return fmt.Errorf("persistentVolumeClaim.mountPath is required")
 	}
-	if !path.IsAbs(v.MountPath) || path.Clean(v.MountPath) != v.MountPath {
-		return fmt.Errorf("persistentVolumeClaim.mountPath must be an absolute, clean path")
+	if !path.IsAbs(v.MountPath) || path.Clean(v.MountPath) != strings.TrimSuffix(v.MountPath, "/") {
+		return fmt.Errorf("persistentVolumeClaim.mountPath must be an absolute path with no . or .. segments")
 	}
 	if v.StorageClass != "" {
 		if errs := validation.IsDNS1123Subdomain(v.StorageClass); len(errs) > 0 {
@@ -873,6 +873,7 @@ type ServiceSecurityContext struct {
 	RunAsNonRoot             *bool                               `yaml:"runAsNonRoot,omitempty"`
 	RunAsUser                *int64                              `yaml:"runAsUser,omitempty"`
 	RunAsGroup               *int64                              `yaml:"runAsGroup,omitempty"`
+	FsGroup                  *int64                              `yaml:"fsGroup,omitempty"`
 	ReadOnlyRootFilesystem   *bool                               `yaml:"readOnlyRootFilesystem,omitempty"`
 	AllowPrivilegeEscalation *bool                               `yaml:"allowPrivilegeEscalation,omitempty"`
 	Capabilities             *ServiceSecurityContextCapabilities `yaml:"capabilities,omitempty"`

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"os"
+	"path"
 	"regexp"
 	"sort"
 	"strings"
@@ -15,6 +16,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 	vpav1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 )
 
@@ -61,6 +63,7 @@ type Service struct {
 	SecurityContext    ServiceSecurityContext   `yaml:"securityContext,omitempty"`
 	Scale              ServiceScale             `yaml:"scale,omitempty"`
 	Singleton          bool                     `yaml:"singleton,omitempty"`
+	Stateful           bool                     `yaml:"stateful,omitempty"`
 	Sticky             bool                     `yaml:"sticky,omitempty"`
 	Termination        ServiceTermination       `yaml:"termination,omitempty"`
 	Test               string                   `yaml:"test,omitempty"`
@@ -70,6 +73,8 @@ type Service struct {
 	VolumeOptions      []VolumeOption           `yaml:"volumeOptions,omitempty"`
 	Whitelist          string                   `yaml:"whitelist,omitempty"`
 	AccessControl      AccessControlOptions     `yaml:"accessControl,omitempty"`
+
+	PodManagementPolicy string `yaml:"podManagementPolicy,omitempty"`
 }
 
 // ServiceImagePullSecret declares a private-registry credential for pulling a
@@ -128,20 +133,74 @@ type InitContainer struct {
 }
 
 type VolumeOption struct {
-	EmptyDir   *VolumeEmptyDir   `yaml:"emptyDir,omitempty"`
-	AwsEfs     *VolumeAwsEfs     `yaml:"awsEfs,omitempty"`
-	AzureFiles *VolumeAzureFiles `yaml:"azureFiles,omitempty"`
+	EmptyDir              *VolumeEmptyDir              `yaml:"emptyDir,omitempty"`
+	AwsEfs                *VolumeAwsEfs                `yaml:"awsEfs,omitempty"`
+	AzureFiles            *VolumeAzureFiles            `yaml:"azureFiles,omitempty"`
+	PersistentVolumeClaim *VolumePersistentVolumeClaim `yaml:"persistentVolumeClaim,omitempty"`
 }
 
 func (v VolumeOption) Validate() error {
 	if v.EmptyDir != nil {
-		return v.EmptyDir.Validate()
+		if err := v.EmptyDir.Validate(); err != nil {
+			return err
+		}
 	}
 	if v.AwsEfs != nil {
-		return v.AwsEfs.Validate()
+		if err := v.AwsEfs.Validate(); err != nil {
+			return err
+		}
 	}
 	if v.AzureFiles != nil {
-		return v.AzureFiles.Validate()
+		if err := v.AzureFiles.Validate(); err != nil {
+			return err
+		}
+	}
+	if v.PersistentVolumeClaim != nil {
+		if err := v.PersistentVolumeClaim.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type VolumePersistentVolumeClaim struct {
+	Id           string `yaml:"id"`
+	AccessMode   string `yaml:"accessMode,omitempty"`
+	MountPath    string `yaml:"mountPath"`
+	Size         string `yaml:"size"`
+	StorageClass string `yaml:"storageClass,omitempty"`
+}
+
+func (v VolumePersistentVolumeClaim) Validate() error {
+	if v.Id == "" {
+		return fmt.Errorf("persistentVolumeClaim.id is required")
+	}
+	if !NameValidator.MatchString(v.Id) {
+		return fmt.Errorf("persistentVolumeClaim.id must match %s", NameValidator.String())
+	}
+	if len(v.Id) > 59 {
+		return fmt.Errorf("persistentVolumeClaim.id must be 59 characters or fewer")
+	}
+	if v.MountPath == "" {
+		return fmt.Errorf("persistentVolumeClaim.mountPath is required")
+	}
+	if !path.IsAbs(v.MountPath) || path.Clean(v.MountPath) != v.MountPath {
+		return fmt.Errorf("persistentVolumeClaim.mountPath must be an absolute, clean path")
+	}
+	if v.StorageClass != "" {
+		if errs := validation.IsDNS1123Subdomain(v.StorageClass); len(errs) > 0 {
+			return fmt.Errorf("persistentVolumeClaim.storageClass is invalid: %s", strings.Join(errs, ", "))
+		}
+	}
+	qty, err := resource.ParseQuantity(v.Size)
+	if err != nil || qty.Sign() <= 0 {
+		return fmt.Errorf("persistentVolumeClaim.size is invalid: %s", v.Size)
+	}
+	if v.AccessMode != "" {
+		allowedModes := []string{PVCAccessModeReadOnlyMany, PVCAccessModeReadWriteMany, PVCAccessModeReadWriteOnce}
+		if !containsInStringSlice(allowedModes, v.AccessMode) {
+			return fmt.Errorf("persistentVolumeClaim.accessMode must be one of these values: %s", strings.Join(allowedModes, ", "))
+		}
 	}
 	return nil
 }

--- a/pkg/manifest/service_test.go
+++ b/pkg/manifest/service_test.go
@@ -420,8 +420,9 @@ func TestVolumePersistentVolumeClaimValidate(t *testing.T) {
 		{name: "missing id", volume: manifest.VolumePersistentVolumeClaim{MountPath: "/data", Size: "1Gi"}, wantErr: "id is required"},
 		{name: "invalid id", volume: manifest.VolumePersistentVolumeClaim{Id: "Data", MountPath: "/data", Size: "1Gi"}, wantErr: "id must match"},
 		{name: "missing mount path", volume: manifest.VolumePersistentVolumeClaim{Id: "data", Size: "1Gi"}, wantErr: "mountPath is required"},
-		{name: "relative mount path", volume: manifest.VolumePersistentVolumeClaim{Id: "data", MountPath: "data", Size: "1Gi"}, wantErr: "mountPath must be an absolute, clean path"},
-		{name: "unclean mount path", volume: manifest.VolumePersistentVolumeClaim{Id: "data", MountPath: "/data/../backup", Size: "1Gi"}, wantErr: "mountPath must be an absolute, clean path"},
+		{name: "trailing slash mount path", volume: manifest.VolumePersistentVolumeClaim{Id: "data", MountPath: "/my/data/", Size: "1Gi"}},
+		{name: "relative mount path", volume: manifest.VolumePersistentVolumeClaim{Id: "data", MountPath: "data", Size: "1Gi"}, wantErr: "mountPath must be an absolute path"},
+		{name: "unclean mount path", volume: manifest.VolumePersistentVolumeClaim{Id: "data", MountPath: "/data/../backup", Size: "1Gi"}, wantErr: "mountPath must be an absolute path"},
 		{name: "missing size", volume: manifest.VolumePersistentVolumeClaim{Id: "data", MountPath: "/data"}, wantErr: "size is invalid"},
 		{name: "zero size", volume: manifest.VolumePersistentVolumeClaim{Id: "data", MountPath: "/data", Size: "0"}, wantErr: "size is invalid"},
 		{name: "id too long", volume: manifest.VolumePersistentVolumeClaim{Id: strings.Repeat("a", 60), MountPath: "/data", Size: "1Gi"}, wantErr: "59 characters or fewer"},
@@ -508,6 +509,48 @@ func TestStatefulServiceValidation(t *testing.T) {
 			name:    "pod policy needs stateful service",
 			service: `podManagementPolicy: Parallel`,
 			wantErr: "podManagementPolicy requires stateful: true",
+		},
+		{
+			name: "init container may mount a declared claim",
+			service: `stateful: true
+    initContainer:
+      image: busybox
+      command: chown -R 1000:1000 /data
+      volumeOptions:
+        - persistentVolumeClaim:
+            id: data
+            mountPath: /data
+    volumeOptions:
+      - persistentVolumeClaim:
+          id: data
+          mountPath: /data
+          size: 1Gi`,
+		},
+		{
+			name: "init container claim must be declared",
+			service: `stateful: true
+    initContainer:
+      image: busybox
+      volumeOptions:
+        - persistentVolumeClaim:
+            id: other
+            mountPath: /data
+    volumeOptions:
+      - persistentVolumeClaim:
+          id: data
+          mountPath: /data
+          size: 1Gi`,
+			wantErr: "initContainer persistentVolumeClaim id other is not declared in volumeOptions",
+		},
+		{
+			name: "init container claim needs stateful service",
+			service: `initContainer:
+      image: busybox
+      volumeOptions:
+        - persistentVolumeClaim:
+            id: data
+            mountPath: /data`,
+			wantErr: "initContainer persistentVolumeClaim requires stateful: true",
 		},
 		{
 			name: "pod policy must be supported",

--- a/pkg/manifest/service_test.go
+++ b/pkg/manifest/service_test.go
@@ -404,3 +404,178 @@ func TestAnnotationsMapReadsAnnotations(t *testing.T) {
 	require.NotContains(t, got, "ingress-key",
 		"AnnotationsMap must not return ingress annotations")
 }
+
+func TestVolumePersistentVolumeClaimValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		volume  manifest.VolumePersistentVolumeClaim
+		wantErr string
+	}{
+		{
+			name: "valid",
+			volume: manifest.VolumePersistentVolumeClaim{
+				Id: "data", MountPath: "/data", Size: "200Gi", StorageClass: "gp3",
+			},
+		},
+		{name: "missing id", volume: manifest.VolumePersistentVolumeClaim{MountPath: "/data", Size: "1Gi"}, wantErr: "id is required"},
+		{name: "invalid id", volume: manifest.VolumePersistentVolumeClaim{Id: "Data", MountPath: "/data", Size: "1Gi"}, wantErr: "id must match"},
+		{name: "missing mount path", volume: manifest.VolumePersistentVolumeClaim{Id: "data", Size: "1Gi"}, wantErr: "mountPath is required"},
+		{name: "relative mount path", volume: manifest.VolumePersistentVolumeClaim{Id: "data", MountPath: "data", Size: "1Gi"}, wantErr: "mountPath must be an absolute, clean path"},
+		{name: "unclean mount path", volume: manifest.VolumePersistentVolumeClaim{Id: "data", MountPath: "/data/../backup", Size: "1Gi"}, wantErr: "mountPath must be an absolute, clean path"},
+		{name: "missing size", volume: manifest.VolumePersistentVolumeClaim{Id: "data", MountPath: "/data"}, wantErr: "size is invalid"},
+		{name: "zero size", volume: manifest.VolumePersistentVolumeClaim{Id: "data", MountPath: "/data", Size: "0"}, wantErr: "size is invalid"},
+		{name: "id too long", volume: manifest.VolumePersistentVolumeClaim{Id: strings.Repeat("a", 60), MountPath: "/data", Size: "1Gi"}, wantErr: "59 characters or fewer"},
+		{name: "invalid access mode", volume: manifest.VolumePersistentVolumeClaim{Id: "data", MountPath: "/data", Size: "1Gi", AccessMode: "WriteOnly"}, wantErr: "accessMode must be one of"},
+		{name: "invalid storage class", volume: manifest.VolumePersistentVolumeClaim{Id: "data", MountPath: "/data", Size: "1Gi", StorageClass: "gp3\nvolumeName: injected"}, wantErr: "storageClass is invalid"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.volume.Validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestVolumeOptionValidatesEveryConfiguredSource(t *testing.T) {
+	err := (manifest.VolumeOption{
+		EmptyDir:              &manifest.VolumeEmptyDir{Id: "cache", MountPath: "/cache"},
+		PersistentVolumeClaim: &manifest.VolumePersistentVolumeClaim{Id: "data", MountPath: "/data", Size: "0"},
+	}).Validate()
+	require.ErrorContains(t, err, "persistentVolumeClaim.size is invalid")
+}
+
+func TestStatefulServiceValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		service string
+		wantErr string
+	}{
+		{
+			name: "valid",
+			service: `stateful: true
+    podManagementPolicy: Parallel
+    scale:
+      count: 3
+    volumeOptions:
+      - persistentVolumeClaim:
+          id: data
+          mountPath: /data
+          size: 200Gi
+          storageClass: gp3`,
+		},
+		{
+			name: "claim needs stateful service",
+			service: `volumeOptions:
+      - persistentVolumeClaim:
+          id: data
+          mountPath: /data
+          size: 1Gi`,
+			wantErr: "persistentVolumeClaim requires stateful: true",
+		},
+		{name: "stateful service needs claim", service: `stateful: true`, wantErr: "require a persistentVolumeClaim"},
+		{
+			name: "stateful service needs fixed count",
+			service: `stateful: true
+    scale:
+      count: 1-3
+    volumeOptions:
+      - persistentVolumeClaim:
+          id: data
+          mountPath: /data
+          size: 1Gi`,
+			wantErr: "require a fixed scale count",
+		},
+		{
+			name: "claim ids must be unique",
+			service: `stateful: true
+    volumeOptions:
+      - persistentVolumeClaim:
+          id: data
+          mountPath: /data
+          size: 1Gi
+      - persistentVolumeClaim:
+          id: data
+          mountPath: /backup
+          size: 1Gi`,
+			wantErr: "duplicate persistentVolumeClaim id data",
+		},
+		{
+			name:    "pod policy needs stateful service",
+			service: `podManagementPolicy: Parallel`,
+			wantErr: "podManagementPolicy requires stateful: true",
+		},
+		{
+			name: "pod policy must be supported",
+			service: `stateful: true
+    podManagementPolicy: Serial
+    volumeOptions:
+      - persistentVolumeClaim:
+          id: data
+          mountPath: /data
+          size: 1Gi`,
+			wantErr: "podManagementPolicy must be OrderedReady or Parallel",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			yaml := []byte("services:\n  database:\n    " + tt.service + "\n")
+			m, err := manifest.Load(yaml, map[string]string{})
+			require.NoError(t, err)
+			err = m.Validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestStatefulServiceGeneratedNames(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{
+			name: "headless service collision",
+			yaml: `services:
+  database:
+    stateful: true
+    volumeOptions:
+      - persistentVolumeClaim:
+          id: data
+          mountPath: /data
+          size: 1Gi
+  database-headless:
+    image: example/web`,
+			wantErr: "generated headless service name database-headless conflicts",
+		},
+		{
+			name: "headless service name too long",
+			yaml: `services:
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:
+    stateful: true
+    volumeOptions:
+      - persistentVolumeClaim:
+          id: data
+          mountPath: /data
+          size: 1Gi`,
+			wantErr: "stateful service name must be 54 characters or fewer",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := manifest.Load([]byte(tt.yaml), map[string]string{})
+			require.NoError(t, err)
+			require.ErrorContains(t, m.Validate(), tt.wantErr)
+		})
+	}
+}

--- a/pkg/manifest/validate.go
+++ b/pkg/manifest/validate.go
@@ -110,6 +110,10 @@ func (m *Manifest) validateServices() []error {
 	for i := range m.Configs {
 		configMap[m.Configs[i].Id] = struct{}{}
 	}
+	serviceNames := map[string]struct{}{}
+	for i := range m.Services {
+		serviceNames[m.Services[i].Name] = struct{}{}
+	}
 
 	for _, s := range m.Services {
 		if !NameValidator.MatchString(s.Name) {
@@ -147,6 +151,58 @@ func (m *Manifest) validateServices() []error {
 		for i := range s.VolumeOptions {
 			if err := s.VolumeOptions[i].Validate(); err != nil {
 				errs = append(errs, err)
+			}
+			if s.VolumeOptions[i].PersistentVolumeClaim != nil && !s.Stateful {
+				errs = append(errs, fmt.Errorf("service %s: persistentVolumeClaim requires stateful: true", s.Name))
+			}
+		}
+
+		if s.Stateful {
+			headlessName := s.Name + "-headless"
+			if len(headlessName) > 63 {
+				errs = append(errs, fmt.Errorf("service %s: stateful service name must be 54 characters or fewer", s.Name))
+			}
+			if _, exists := serviceNames[headlessName]; exists {
+				errs = append(errs, fmt.Errorf("service %s: generated headless service name %s conflicts with another service", s.Name, headlessName))
+			}
+			hasClaim := false
+			claimIds := map[string]bool{}
+			for i := range s.VolumeOptions {
+				claim := s.VolumeOptions[i].PersistentVolumeClaim
+				if claim == nil {
+					continue
+				}
+				hasClaim = true
+				if claimIds[claim.Id] {
+					errs = append(errs, fmt.Errorf("service %s: duplicate persistentVolumeClaim id %s", s.Name, claim.Id))
+				}
+				claimIds[claim.Id] = true
+			}
+			if !hasClaim {
+				errs = append(errs, fmt.Errorf("service %s: stateful services require a persistentVolumeClaim", s.Name))
+			}
+			if s.Agent.Enabled {
+				errs = append(errs, fmt.Errorf("service %s: stateful services can not run as agents", s.Name))
+			}
+			if s.Scale.Count.Min != s.Scale.Count.Max || s.Scale.Autoscale.IsEnabled() || s.Scale.IsKedaEnabled() {
+				errs = append(errs, fmt.Errorf("service %s: stateful services require a fixed scale count", s.Name))
+			}
+			if s.Scale.VPA != nil {
+				errs = append(errs, fmt.Errorf("service %s: stateful services do not support vpa", s.Name))
+			}
+			switch s.PodManagementPolicy {
+			case "", "OrderedReady", "Parallel":
+			default:
+				errs = append(errs, fmt.Errorf("service %s: podManagementPolicy must be OrderedReady or Parallel", s.Name))
+			}
+		} else if s.PodManagementPolicy != "" {
+			errs = append(errs, fmt.Errorf("service %s: podManagementPolicy requires stateful: true", s.Name))
+		}
+		if s.InitContainer != nil {
+			for i := range s.InitContainer.VolumeOptions {
+				if s.InitContainer.VolumeOptions[i].PersistentVolumeClaim != nil {
+					errs = append(errs, fmt.Errorf("service %s: initContainer does not support persistentVolumeClaim", s.Name))
+				}
 			}
 		}
 

--- a/pkg/manifest/validate.go
+++ b/pkg/manifest/validate.go
@@ -148,13 +148,23 @@ func (m *Manifest) validateServices() []error {
 			}
 		}
 
+		claimIds := map[string]bool{}
+
 		for i := range s.VolumeOptions {
 			if err := s.VolumeOptions[i].Validate(); err != nil {
 				errs = append(errs, err)
 			}
-			if s.VolumeOptions[i].PersistentVolumeClaim != nil && !s.Stateful {
+			claim := s.VolumeOptions[i].PersistentVolumeClaim
+			if claim == nil {
+				continue
+			}
+			if !s.Stateful {
 				errs = append(errs, fmt.Errorf("service %s: persistentVolumeClaim requires stateful: true", s.Name))
 			}
+			if claimIds[claim.Id] {
+				errs = append(errs, fmt.Errorf("service %s: duplicate persistentVolumeClaim id %s", s.Name, claim.Id))
+			}
+			claimIds[claim.Id] = true
 		}
 
 		if s.Stateful {
@@ -165,20 +175,7 @@ func (m *Manifest) validateServices() []error {
 			if _, exists := serviceNames[headlessName]; exists {
 				errs = append(errs, fmt.Errorf("service %s: generated headless service name %s conflicts with another service", s.Name, headlessName))
 			}
-			hasClaim := false
-			claimIds := map[string]bool{}
-			for i := range s.VolumeOptions {
-				claim := s.VolumeOptions[i].PersistentVolumeClaim
-				if claim == nil {
-					continue
-				}
-				hasClaim = true
-				if claimIds[claim.Id] {
-					errs = append(errs, fmt.Errorf("service %s: duplicate persistentVolumeClaim id %s", s.Name, claim.Id))
-				}
-				claimIds[claim.Id] = true
-			}
-			if !hasClaim {
+			if len(claimIds) == 0 {
 				errs = append(errs, fmt.Errorf("service %s: stateful services require a persistentVolumeClaim", s.Name))
 			}
 			if s.Agent.Enabled {
@@ -200,8 +197,19 @@ func (m *Manifest) validateServices() []error {
 		}
 		if s.InitContainer != nil {
 			for i := range s.InitContainer.VolumeOptions {
-				if s.InitContainer.VolumeOptions[i].PersistentVolumeClaim != nil {
-					errs = append(errs, fmt.Errorf("service %s: initContainer does not support persistentVolumeClaim", s.Name))
+				claim := s.InitContainer.VolumeOptions[i].PersistentVolumeClaim
+				if claim == nil {
+					continue
+				}
+				if !s.Stateful {
+					errs = append(errs, fmt.Errorf("service %s: initContainer persistentVolumeClaim requires stateful: true", s.Name))
+					continue
+				}
+				if !claimIds[claim.Id] {
+					errs = append(errs, fmt.Errorf("service %s: initContainer persistentVolumeClaim id %s is not declared in volumeOptions", s.Name, claim.Id))
+				}
+				if claim.MountPath == "" {
+					errs = append(errs, fmt.Errorf("service %s: initContainer persistentVolumeClaim.mountPath is required", s.Name))
 				}
 			}
 		}

--- a/provider/k8s/autoscale_test.go
+++ b/provider/k8s/autoscale_test.go
@@ -69,6 +69,43 @@ func seedDeployment(t *testing.T, kk *kfake.Clientset, ns, name string, replicas
 	require.NoError(t, err)
 }
 
+func seedStatefulset(t *testing.T, kk *kfake.Clientset, ns, name string, replicas int32) {
+	t.Helper()
+	r := replicas
+	_, err := kk.AppsV1().StatefulSets(ns).Create(context.TODO(), &appsv1.StatefulSet{
+		ObjectMeta: am.ObjectMeta{Name: name, Namespace: ns, Labels: map[string]string{"app": "app1", "type": "service", "service": name}},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &r,
+			Template: ac.PodTemplateSpec{Spec: ac.PodSpec{Containers: []ac.Container{{
+				Name: "app1", Resources: ac.ResourceRequirements{Requests: ac.ResourceList{}, Limits: ac.ResourceList{}},
+			}}}},
+		},
+	}, am.CreateOptions{})
+	require.NoError(t, err)
+}
+
+func TestServiceUpdateStatefulset(t *testing.T) {
+	testProvider(t, func(p *k8s.Provider) {
+		kk, _ := p.Cluster.(*kfake.Clientset)
+		require.NoError(t, appCreate(kk, "rack1", "app1"))
+		seedStatefulset(t, kk, "rack1-app1", "database", 1)
+
+		err := p.ServiceUpdate("app1", "database", structs.ServiceUpdateOptions{
+			Count: options.Int(3), Cpu: options.Int(1500), Memory: options.Int(12288),
+		})
+		require.NoError(t, err)
+
+		s, err := kk.AppsV1().StatefulSets("rack1-app1").Get(context.TODO(), "database", am.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, int32(3), *s.Spec.Replicas)
+		require.Equal(t, int64(1500), s.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().MilliValue())
+		require.Equal(t, int64(12*1024*1024*1024), s.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().Value())
+
+		err = p.ServiceUpdate("app1", "database", structs.ServiceUpdateOptions{Min: options.Int(1), Max: options.Int(3)})
+		require.ErrorContains(t, err, "stateful services require a fixed scale count")
+	})
+}
+
 func TestServiceUpdateKedaSync(t *testing.T) {
 	testProvider(t, func(p *k8s.Provider) {
 		kk, _ := p.Cluster.(*kfake.Clientset)

--- a/provider/k8s/budget_auto_shutdown_test.go
+++ b/provider/k8s/budget_auto_shutdown_test.go
@@ -430,6 +430,40 @@ func TestReconcileAutoShutdown_NoopReason_RuntimeDrift(t *testing.T) {
 	})
 }
 
+func TestReconcileAutoShutdown_StatefulServiceIsNotEligible(t *testing.T) {
+	t.Setenv("COST_TRACKING_ENABLE", "true")
+	testProvider(t, func(p *k8s.Provider) {
+		kk, _ := p.Cluster.(*fake.Clientset)
+		require.NoError(t, appCreate(kk, "rack1", "app1"))
+		installFakeDynamicClient(p)
+
+		cap := newEventCapture(t)
+		k8s.SetWebhooksForTest(p, []string{cap.server.URL})
+		now := time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC)
+		writeConfig(t, kk, "rack1-app1", &structs.AppBudget{
+			MonthlyCapUsd: 100, AlertThresholdPercent: 80,
+			AtCapAction: structs.BudgetAtCapActionAutoShutdown, PricingAdjustment: 1,
+		})
+		baseState := &structs.AppBudgetState{
+			MonthStart: startOfApril(), CurrentMonthSpendUsd: 105, CurrentMonthSpendAsOf: now, AlertFiredAtCap: now,
+		}
+		writeState(t, kk, "rack1-app1", baseState)
+
+		cfg, _, err := p.AppBudgetGet("app1")
+		require.NoError(t, err)
+		cfg.AtCapAction = structs.BudgetAtCapActionAutoShutdown
+		m := buildAutoShutdownManifest(30)
+		m.Services[0].Stateful = true
+
+		k8s.ReconcileAutoShutdownWithManifestForTest(p, context.Background(), "app1", cfg, baseState, m, now)
+		cap.drain()
+
+		noopEvts := cap.findActions(":noop")
+		require.Len(t, noopEvts, 1)
+		assert.Equal(t, "no-eligible-services", noopEvts[0].Data["reason"])
+	})
+}
+
 // TestReconcileAutoShutdown_NoopReason_ExternalEditDetected verifies
 // the external-edit scenario: shutdownState is nil but every eligible
 // service is already at 0 replicas (operator hand-recovery / CD

--- a/provider/k8s/budget_shutdown.go
+++ b/provider/k8s/budget_shutdown.go
@@ -771,6 +771,12 @@ func (p *Provider) computeShutdownPlanForApp(ctx context.Context, app string, m 
 			})
 			continue
 		}
+		if svc.Stateful {
+			eligibility = append(eligibility, structs.AppBudgetSimulationEligibility{
+				Service: svc.Name, Eligible: false, Reason: "stateful service (StatefulSet)",
+			})
+			continue
+		}
 		if exempt[svc.Name] {
 			eligibility = append(eligibility, structs.AppBudgetSimulationEligibility{
 				Service: svc.Name, Eligible: false, Reason: "in neverAutoShutdown",

--- a/provider/k8s/controller_node.go
+++ b/provider/k8s/controller_node.go
@@ -12,6 +12,7 @@ import (
 	"github.com/convox/logger"
 	"github.com/pkg/errors"
 	ac "k8s.io/api/core/v1"
+	kerr "k8s.io/apimachinery/pkg/api/errors"
 	am "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	appsv1 "k8s.io/client-go/applyconfigurations/apps/v1"
@@ -253,7 +254,7 @@ func (c *NodeController) findAndRescheduleDeploymentWithOneReplica(node string) 
 				d := pdbList.Items[0]
 				if d.Status.DisruptionsAllowed == 0 {
 					c.logger.Logf("Found a deployment blocking draing node %s/%s", d.Namespace, d.Name)
-					// pdb will always have the same name as deployment
+					// pdb has the same name as its workload, which is not always a deployment
 					if err := c.triggerDeploymentReschedule(d.Name, d.Namespace, node); err != nil {
 						c.logger.Errorf("failed to trigger deployment reschedule: %s", err)
 					}
@@ -269,6 +270,13 @@ func (c *NodeController) findAndRescheduleDeploymentWithOneReplica(node string) 
 }
 
 func (c *NodeController) triggerDeploymentReschedule(name, ns, node string) error {
+	if _, err := c.provider.Cluster.AppsV1().Deployments(ns).Get(context.TODO(), name, am.GetOptions{}); err != nil {
+		if kerr.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
 	c.logger.Logf("Trigger reschedule for deployment %s/%s", ns, name)
 	sObj := &appsv1.DeploymentApplyConfiguration{
 		TypeMetaApplyConfiguration: amv1.TypeMetaApplyConfiguration{

--- a/provider/k8s/controller_node_test.go
+++ b/provider/k8s/controller_node_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/convox/logger"
 	"github.com/stretchr/testify/require"
 	ac "k8s.io/api/core/v1"
+	kerr "k8s.io/apimachinery/pkg/api/errors"
 	am "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
@@ -168,4 +169,13 @@ func TestReconcileGpuLabelsEmptyCluster(t *testing.T) {
 
 	// Should not panic or error on empty node list
 	nc.ReconcileGpuLabels()
+}
+
+func TestTriggerDeploymentRescheduleSkipsMissingDeployment(t *testing.T) {
+	c := newGpuTestController(fake.NewSimpleClientset(), &gpuTestEngine{})
+
+	require.NoError(t, c.triggerDeploymentReschedule("database", "rack1-app1", "node1"))
+
+	_, err := c.provider.Cluster.AppsV1().Deployments("rack1-app1").Get(context.TODO(), "database", am.GetOptions{})
+	require.True(t, kerr.IsNotFound(err))
 }

--- a/provider/k8s/controller_statefulset.go
+++ b/provider/k8s/controller_statefulset.go
@@ -88,7 +88,10 @@ func (c *StatefulSetController) sync(obj interface{}, remove bool) error {
 	if !dc.isConvoxManaged(d) {
 		return nil
 	}
-	return dc.SyncPDB(d, remove)
+	if err := dc.SyncPDB(d, remove); err != nil {
+		_ = c.logger.Errorf("failed to sync pdb for statefulset %s/%s: %s", s.Namespace, s.Name, err)
+	}
+	return nil
 }
 
 func assertStatefulSet(obj interface{}) (*apps.StatefulSet, error) {

--- a/provider/k8s/controller_statefulset.go
+++ b/provider/k8s/controller_statefulset.go
@@ -1,0 +1,114 @@
+package k8s
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/convox/convox/pkg/kctl"
+	"github.com/convox/logger"
+	"github.com/pkg/errors"
+	apps "k8s.io/api/apps/v1"
+	ac "k8s.io/api/core/v1"
+	am "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ic "k8s.io/client-go/informers/apps/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+type StatefulSetController struct {
+	Controller *kctl.Controller
+	Provider   *Provider
+
+	logger *logger.Logger
+	start  time.Time
+}
+
+func NewStatefulSetController(p *Provider) (*StatefulSetController, error) {
+	sc := &StatefulSetController{
+		Provider: p,
+		logger:   logger.New("ns=statefulset-controller"),
+		start:    time.Now().UTC(),
+	}
+	c, err := kctl.NewController(p.Namespace, "convox-k8s-statefulset", sc)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	sc.Controller = c
+	return sc, nil
+}
+
+func (c *StatefulSetController) Client() kubernetes.Interface {
+	return c.Provider.Cluster
+}
+
+func (c *StatefulSetController) Informer() cache.SharedInformer {
+	return ic.NewFilteredStatefulSetInformer(c.Provider.Cluster, ac.NamespaceAll, 0, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, c.ListOptions)
+}
+
+func (c *StatefulSetController) ListOptions(opts *am.ListOptions) {
+	opts.LabelSelector = fmt.Sprintf("system=convox,rack=%s", c.Provider.Name)
+}
+
+func (c *StatefulSetController) Run() {
+	ch := make(chan error)
+	go c.Controller.Run(ch)
+	for err := range ch {
+		fmt.Printf("err = %+v\n", err)
+	}
+}
+
+func (c *StatefulSetController) Start() error {
+	c.start = time.Now().UTC()
+	return nil
+}
+
+func (c *StatefulSetController) Stop() error { return nil }
+
+func (c *StatefulSetController) Add(obj interface{}) error {
+	return c.sync(obj, false)
+}
+
+func (c *StatefulSetController) Delete(obj interface{}) error {
+	return c.sync(obj, true)
+}
+
+func (c *StatefulSetController) Update(_, cur interface{}) error {
+	return c.sync(cur, false)
+}
+
+func (c *StatefulSetController) sync(obj interface{}, remove bool) error {
+	s, err := assertStatefulSet(obj)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	c.logger.Logf("statefulset sync: %s/%s\n", s.Namespace, s.Name)
+
+	d := deploymentFromStatefulSet(s)
+	dc := &DeployController{Provider: c.Provider, logger: c.logger}
+	if !dc.isConvoxManaged(d) {
+		return nil
+	}
+	return dc.SyncPDB(d, remove)
+}
+
+func assertStatefulSet(obj interface{}) (*apps.StatefulSet, error) {
+	switch v := obj.(type) {
+	case *apps.StatefulSet:
+		return v, nil
+	case cache.DeletedFinalStateUnknown:
+		return assertStatefulSet(v.Obj)
+	default:
+		return nil, fmt.Errorf("could not assert statefulset for type: %T", obj)
+	}
+}
+
+func deploymentFromStatefulSet(s *apps.StatefulSet) *apps.Deployment {
+	return &apps.Deployment{
+		ObjectMeta: *s.ObjectMeta.DeepCopy(),
+		Spec: apps.DeploymentSpec{
+			Replicas: s.Spec.Replicas,
+			Selector: s.Spec.Selector.DeepCopy(),
+			Template: *s.Spec.Template.DeepCopy(),
+		},
+	}
+}

--- a/provider/k8s/controller_statefulset_test.go
+++ b/provider/k8s/controller_statefulset_test.go
@@ -1,0 +1,48 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	apps "k8s.io/api/apps/v1"
+	ac "k8s.io/api/core/v1"
+	kerr "k8s.io/apimachinery/pkg/api/errors"
+	am "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestStatefulSetControllerSyncPDB(t *testing.T) {
+	c := syncPDBController(t)
+	sc := &StatefulSetController{Provider: c.Provider, logger: c.logger}
+	replicas := int32(3)
+	s := &apps.StatefulSet{
+		ObjectMeta: am.ObjectMeta{
+			Name: "database", Namespace: "ns1",
+			Labels: map[string]string{"system": "convox", "rack": "test", "app": "app1", "service": "database"},
+		},
+		Spec: apps.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &am.LabelSelector{MatchLabels: map[string]string{"service": "database"}},
+			Template: ac.PodTemplateSpec{ObjectMeta: am.ObjectMeta{}},
+		},
+	}
+
+	if err := sc.sync(s, false); err != nil {
+		t.Fatalf("sync() error: %v", err)
+	}
+	pdb, err := c.Provider.Cluster.PolicyV1().PodDisruptionBudgets("ns1").Get(context.Background(), "database", am.GetOptions{})
+	if err != nil {
+		t.Fatalf("get pdb: %v", err)
+	}
+	if pdb.Spec.MinAvailable == nil || pdb.Spec.MinAvailable.String() != "50%" {
+		t.Fatalf("MinAvailable = %v, want 50%%", pdb.Spec.MinAvailable)
+	}
+
+	if err := sc.Delete(cache.DeletedFinalStateUnknown{Key: "ns1/database", Obj: s}); err != nil {
+		t.Fatalf("Delete() error: %v", err)
+	}
+	_, err = c.Provider.Cluster.PolicyV1().PodDisruptionBudgets("ns1").Get(context.Background(), "database", am.GetOptions{})
+	if !kerr.IsNotFound(err) {
+		t.Fatalf("get deleted pdb error = %v, want NotFound", err)
+	}
+}

--- a/provider/k8s/k8s.go
+++ b/provider/k8s/k8s.go
@@ -406,6 +406,11 @@ func (p *Provider) Start() error {
 		return errors.WithStack(log.Error(err))
 	}
 
+	stsc, err := NewStatefulSetController(p)
+	if err != nil {
+		return errors.WithStack(log.Error(err))
+	}
+
 	sc, err := NewSecretController(p)
 	if err != nil {
 		return errors.WithStack(err)
@@ -421,6 +426,7 @@ func (p *Provider) Start() error {
 	go wc.Run()
 	go nc.Run()
 	go dc.Run()
+	go stsc.Run()
 	go sc.Run()
 	go atomCtrl.Run()
 

--- a/provider/k8s/process.go
+++ b/provider/k8s/process.go
@@ -404,6 +404,20 @@ func (p *Provider) ProcessRun(app, service string, opts structs.ProcessRunOption
 		}
 	}
 
+	if opts.UseServiceVolume != nil && *opts.UseServiceVolume {
+		m, _, err := common.AppManifest(p, app)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		s, err := m.Service(service)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		if s.Stateful {
+			return nil, structs.ErrBadRequest("--use-service-volume is not supported for stateful services because each replica has its own volume")
+		}
+	}
+
 	// Build pods run in a dedicated namespace while PSA enforcement applies so
 	// the app namespace's enforce label does not reject them. Ensure it before
 	// podSpecFromRunOptions, which writes the pull secret into this namespace.

--- a/provider/k8s/release.go
+++ b/provider/k8s/release.go
@@ -153,10 +153,10 @@ func (p *Provider) ReleasePromote(app, id string, opts structs.ReleasePromoteOpt
 			if err != nil {
 				return errors.WithStack(err)
 			}
-			for _, service := range m.Services {
-				previous, err := current.Service(service.Name)
-				if err == nil && previous.Stateful != service.Stateful {
-					return structs.ErrBadRequest("service %s: changing stateful on an existing service is not supported; create a new service and move the data", service.Name)
+			for i := range m.Services {
+				previous, err := current.Service(m.Services[i].Name)
+				if err == nil && previous.Stateful != m.Services[i].Stateful {
+					return structs.ErrBadRequest("service %s: changing stateful on an existing service is not supported; create a new service and move the data", m.Services[i].Name)
 				}
 			}
 		}

--- a/provider/k8s/release.go
+++ b/provider/k8s/release.go
@@ -148,6 +148,18 @@ func (p *Provider) ReleasePromote(app, id string, opts structs.ReleasePromoteOpt
 		if err != nil {
 			return errors.WithStack(err)
 		}
+		if a.Release != "" && a.Release != id {
+			current, _, err := common.ReleaseManifest(p, app, a.Release)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+			for _, service := range m.Services {
+				previous, err := current.Service(service.Name)
+				if err == nil && previous.Stateful != service.Stateful {
+					return structs.ErrBadRequest("service %s: changing stateful on an existing service is not supported; create a new service and move the data", service.Name)
+				}
+			}
+		}
 
 		// Reject manifest-tier budget enforcement when the rack-level
 		// cost accumulator is disabled. Mirrors the AppBudgetSet gate

--- a/provider/k8s/release_scale_override_test.go
+++ b/provider/k8s/release_scale_override_test.go
@@ -56,6 +56,24 @@ func scaleSeedDeployment(t *testing.T, c *fake.Clientset, ns, name string, repli
 	require.NoError(t, err)
 }
 
+func scaleSeedStatefulSet(t *testing.T, c *fake.Clientset, ns, name string, replicas int32) {
+	t.Helper()
+	r := replicas
+	_, err := c.AppsV1().StatefulSets(ns).Create(context.TODO(), &appsv1.StatefulSet{
+		ObjectMeta: am.ObjectMeta{
+			Name:        name,
+			Namespace:   ns,
+			Labels:      map[string]string{"app": "app1", "type": "service", "service": name},
+			Annotations: map[string]string{k8s.ServiceScaleOverrideAnnotation: k8s.ServiceScaleOverrideValueOn},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &r,
+			Template: ac.PodTemplateSpec{Spec: ac.PodSpec{Containers: []ac.Container{{Name: "app1"}}}},
+		},
+	}, am.CreateOptions{})
+	require.NoError(t, err)
+}
+
 // scaleManifestYaml builds a minimal manifest YAML string with
 // scale.count.{min,max} per service. Used by both the in-test
 // manifest.Services (for the helper input) and the seeded
@@ -76,6 +94,10 @@ func scaleManifestYaml(services map[string]int) string {
 		b.WriteString("\n")
 	}
 	return b.String()
+}
+
+func scaleStatefulManifestYaml(services map[string]int) string {
+	return strings.ReplaceAll(scaleManifestYaml(services), "    image:", "    stateful: true\n    image:")
 }
 
 // scaleManifestServices builds a minimal manifest.Services slice. The
@@ -328,6 +350,31 @@ func TestReleasePromote_ServiceScaleOverrideHonor_RuntimeCountZeroYamlMinNonzero
 	require.Len(t, honored, 1)
 	data, _ := honored[0]["data"].(map[string]any)
 	assert.Equal(t, "0", data["preserved_count"], "preserved_count must equal sc[s.Name]=0 — explicit zero, NOT yaml fallback")
+	assert.Equal(t, "2", data["yaml_count_min"])
+}
+
+func TestReleasePromote_StatefulServiceScaleOverrideHonor_RuntimeCountZero(t *testing.T) {
+	_, events, err := runReleaseTemplateServicesEvents(t, func(p *k8s.Provider) (*structs.App, *structs.Release, manifest.Services) {
+		kk, _ := p.Cluster.(*fake.Clientset)
+		require.NoError(t, appCreate(kk, "rack1", "app1"))
+		scaleSeedStatefulSet(t, kk, "rack1-app1", "database", 0)
+
+		yaml := scaleStatefulManifestYaml(map[string]int{"database": 2})
+		m, err := manifest.Load([]byte(yaml), structs.Environment{})
+		require.NoError(t, err)
+		aa, _ := p.Atom.(*atom.MockInterface)
+		cc, _ := p.Convox.(*cvfake.Clientset)
+		aa.On("Status", "rack1-app1", "app").Return("Running", "release1", nil)
+		require.NoError(t, releaseCreateInline(cc, "rack1-app1", "release1", yaml))
+
+		return &structs.App{Name: "app1", Release: "release1"}, &structs.Release{Id: "release1", App: "app1"}, m.Services
+	})
+	require.NoError(t, err)
+	honored := findAllByAction(events, "app:scale-override:honored")
+	require.Len(t, honored, 1)
+	data, _ := honored[0]["data"].(map[string]any)
+	assert.Equal(t, "database", data["service"])
+	assert.Equal(t, "0", data["preserved_count"])
 	assert.Equal(t, "2", data["yaml_count_min"])
 }
 

--- a/provider/k8s/release_test.go
+++ b/provider/k8s/release_test.go
@@ -99,6 +99,34 @@ func TestReleasePromote(t *testing.T) {
 	})
 }
 
+func TestReleasePromoteRejectsStatefulMigration(t *testing.T) {
+	testProvider(t, func(p *k8s.Provider) {
+		aa := p.Atom.(*atom.MockInterface)
+		kc := p.Convox.(*cvfake.Clientset)
+		kk := p.Cluster.(*fake.Clientset)
+
+		require.NoError(t, appCreate(kk, "rack1", "app1"))
+		require.NoError(t, releaseCreateInline(kc, "rack1-app1", "release1", `services:
+  database:
+    image: qdrant/qdrant:v1.18.2
+`))
+		require.NoError(t, releaseCreateInline(kc, "rack1-app1", "release2", `services:
+  database:
+    image: qdrant/qdrant:v1.18.2
+    stateful: true
+    volumeOptions:
+      - persistentVolumeClaim:
+          id: data
+          mountPath: /qdrant/storage
+          size: 200Gi
+`))
+
+		aa.On("Status", "rack1-app1", "app").Return("Running", "release1", nil)
+		err := p.ReleasePromote("app1", "release2", structs.ReleasePromoteOptions{})
+		require.ErrorContains(t, err, "changing stateful on an existing service is not supported")
+	})
+}
+
 func releaseApply(aa *atom.MockInterface, ns, id, atm, fixture string) error {
 	data, err := os.ReadFile(fmt.Sprintf("testdata/release-%s.yml", fixture))
 	if err != nil {

--- a/provider/k8s/release_test.go
+++ b/provider/k8s/release_test.go
@@ -101,9 +101,9 @@ func TestReleasePromote(t *testing.T) {
 
 func TestReleasePromoteRejectsStatefulMigration(t *testing.T) {
 	testProvider(t, func(p *k8s.Provider) {
-		aa := p.Atom.(*atom.MockInterface)
-		kc := p.Convox.(*cvfake.Clientset)
-		kk := p.Cluster.(*fake.Clientset)
+		aa, _ := p.Atom.(*atom.MockInterface)
+		kc, _ := p.Convox.(*cvfake.Clientset)
+		kk, _ := p.Cluster.(*fake.Clientset)
 
 		require.NoError(t, appCreate(kk, "rack1", "app1"))
 		require.NoError(t, releaseCreateInline(kc, "rack1-app1", "release1", `services:

--- a/provider/k8s/service.go
+++ b/provider/k8s/service.go
@@ -150,11 +150,21 @@ func (p *Provider) ServiceList(app string) (structs.Services, error) {
 		ss = append(ss, s)
 	}
 
+	hasStateful := false
 	hasAgent := false
 	for _, s := range m.Services {
+		if s.Stateful {
+			hasStateful = true
+		}
 		if s.Agent.Enabled {
 			hasAgent = true
-			break
+		}
+	}
+
+	if hasStateful {
+		ss, err = p.serviceListAppendStatefulsets(app, ss, &lopts, m)
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -166,6 +176,56 @@ func (p *Provider) ServiceList(app string) (structs.Services, error) {
 	}
 
 	p.enrichGpuTelemetry(context.Background(), app, ss)
+
+	return ss, nil
+}
+
+func (p *Provider) serviceListAppendStatefulsets(app string, ss structs.Services, lopts *am.ListOptions, m *manifest.Manifest) (structs.Services, error) {
+	statefulsets, err := p.Cluster.AppsV1().StatefulSets(p.AppNamespace(app)).List(context.TODO(), *lopts)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	for _, statefulset := range statefulsets.Items {
+		c, err := primaryContainer(statefulset.Spec.Template.Spec.Containers, app)
+		if err != nil {
+			return nil, err
+		}
+
+		ms, err := m.Service(statefulset.Name)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+
+		s := structs.Service{
+			Count:  int(common.DefaultInt32(statefulset.Spec.Replicas, 0)),
+			Domain: p.ServiceHost(app, *ms),
+			Name:   statefulset.Name,
+			Ports:  serviceContainerPorts(*c, ms.Internal),
+			Min:    &ms.Scale.Count.Min,
+			Max:    &ms.Scale.Count.Max,
+		}
+		if v := c.Resources.Requests.Cpu(); v != nil {
+			s.Cpu = int(v.MilliValue())
+		}
+		if v := c.Resources.Requests.Memory(); v != nil {
+			s.Memory = int(v.Value() / (1024 * 1024))
+		}
+		for key, vendor := range gpuKeyToVendor {
+			if q, ok := c.Resources.Requests[v1.ResourceName(key)]; ok {
+				s.Gpu = int(q.Value())
+				s.GpuVendor = vendor
+				break
+			}
+		}
+		if statefulset.Annotations != nil && statefulset.Annotations[ServiceScaleOverrideAnnotation] == ServiceScaleOverrideValueOn {
+			s.ScaleOverrideActive = options.Bool(true)
+		} else {
+			s.ScaleOverrideActive = options.Bool(false)
+		}
+		s.TriggersOverrideActive = options.Bool(false)
+		ss = append(ss, s)
+	}
 
 	return ss, nil
 }
@@ -402,8 +462,28 @@ func (p *Provider) ServiceRestart(app, name string) error {
 	if s.Agent.Enabled {
 		return p.serviceRestartDaemonset(app, name)
 	}
+	if s.Stateful {
+		return p.serviceRestartStatefulset(app, name)
+	}
 
 	return p.serviceRestartDeployment(app, name)
+}
+
+func (p *Provider) serviceRestartStatefulset(app, name string) error {
+	statefulsets := p.Cluster.AppsV1().StatefulSets(p.AppNamespace(app))
+
+	s, err := statefulsets.Get(context.TODO(), name, am.GetOptions{})
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	if s.Spec.Template.Annotations == nil {
+		s.Spec.Template.Annotations = map[string]string{}
+	}
+	s.Spec.Template.Annotations["convox.com/restart"] = strconv.FormatInt(time.Now().UTC().UnixNano(), 10)
+
+	_, err = statefulsets.Update(context.TODO(), s, am.UpdateOptions{})
+	return errors.WithStack(err)
 }
 
 func (p *Provider) serviceRestartDaemonset(app, name string) error {
@@ -450,6 +530,14 @@ func (p *Provider) serviceRestartDeployment(app, name string) error {
 
 func (p *Provider) ServiceUpdate(app, name string, opts structs.ServiceUpdateOptions) error {
 	if err := p.budgetCircuitBreakerTripped(app); err != nil {
+		return errors.WithStack(err)
+	}
+
+	statefulset, err := p.Cluster.AppsV1().StatefulSets(p.AppNamespace(app)).Get(context.TODO(), name, am.GetOptions{})
+	if err == nil {
+		return p.serviceUpdateStatefulset(statefulset, opts)
+	}
+	if !kerr.IsNotFound(err) {
 		return errors.WithStack(err)
 	}
 
@@ -555,6 +643,60 @@ func (p *Provider) ServiceUpdate(app, name string, opts structs.ServiceUpdateOpt
 	}
 
 	return nil
+}
+
+func (p *Provider) serviceUpdateStatefulset(s *appsv1.StatefulSet, opts structs.ServiceUpdateOptions) error {
+	if opts.Min != nil || opts.Max != nil {
+		return structs.ErrBadRequest("stateful services require a fixed scale count; use --count")
+	}
+
+	container := &s.Spec.Template.Spec.Containers[0]
+	if container.Resources.Requests == nil {
+		container.Resources.Requests = v1.ResourceList{}
+	}
+	if container.Resources.Limits == nil {
+		container.Resources.Limits = v1.ResourceList{}
+	}
+
+	if opts.Count != nil {
+		count := int32(*opts.Count) //nolint:gosec // replica counts are user-validated and bounded
+		s.Spec.Replicas = &count
+	}
+	if opts.Cpu != nil {
+		container.Resources.Requests[v1.ResourceCPU] = resource.MustParse(fmt.Sprintf("%dm", *opts.Cpu))
+	}
+	if opts.Memory != nil {
+		memory := resource.MustParse(fmt.Sprintf("%dMi", *opts.Memory))
+		container.Resources.Limits[v1.ResourceMemory] = memory
+		container.Resources.Requests[v1.ResourceMemory] = memory
+	}
+	if opts.Gpu != nil {
+		vendor := ""
+		if opts.GpuVendor != nil {
+			vendor = *opts.GpuVendor
+		}
+		key := v1.ResourceName(gpuResourceKey(vendor))
+		quantity := resource.MustParse(fmt.Sprintf("%d", *opts.Gpu))
+		container.Resources.Requests[key] = quantity
+		container.Resources.Limits[key] = quantity
+		if *opts.Gpu > 0 {
+			hasToleration := false
+			for _, toleration := range s.Spec.Template.Spec.Tolerations {
+				if toleration.Key == string(key) && toleration.Effect == v1.TaintEffectNoSchedule && toleration.Operator == v1.TolerationOpExists {
+					hasToleration = true
+					break
+				}
+			}
+			if !hasToleration {
+				s.Spec.Template.Spec.Tolerations = append(s.Spec.Template.Spec.Tolerations, v1.Toleration{
+					Key: string(key), Operator: v1.TolerationOpExists, Effect: v1.TaintEffectNoSchedule,
+				})
+			}
+		}
+	}
+
+	_, err := p.Cluster.AppsV1().StatefulSets(s.Namespace).Update(context.TODO(), s, am.UpdateOptions{})
+	return errors.WithStack(err)
 }
 
 func (p *Provider) serviceDaemonset(app, name string) (*appsv1.DaemonSet, error) {

--- a/provider/k8s/service.go
+++ b/provider/k8s/service.go
@@ -186,7 +186,8 @@ func (p *Provider) serviceListAppendStatefulsets(app string, ss structs.Services
 		return nil, errors.WithStack(err)
 	}
 
-	for _, statefulset := range statefulsets.Items {
+	for i := range statefulsets.Items {
+		statefulset := &statefulsets.Items[i]
 		c, err := primaryContainer(statefulset.Spec.Template.Spec.Containers, app)
 		if err != nil {
 			return nil, err

--- a/provider/k8s/service_scale_override.go
+++ b/provider/k8s/service_scale_override.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/convox/convox/pkg/structs"
 	"github.com/pkg/errors"
+	kerr "k8s.io/apimachinery/pkg/api/errors"
 	am "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -17,15 +18,23 @@ const (
 
 func (p *Provider) ServiceScaleOverrideSet(app, service string, active bool, ackBy string) error {
 	ackBy = sanitizeAckBy(ackBy)
-
-	d, err := p.GetDeploymentFromInformer(service, p.AppNamespace(app))
-	if err != nil {
-		return errors.WithStack(err)
-	}
+	ns := p.AppNamespace(app)
 
 	prevActive := false
-	if d.Annotations != nil && d.Annotations[ServiceScaleOverrideAnnotation] == ServiceScaleOverrideValueOn {
-		prevActive = true
+	stateful := false
+	s, err := p.Cluster.AppsV1().StatefulSets(ns).Get(context.TODO(), service, am.GetOptions{})
+	switch {
+	case err == nil:
+		stateful = true
+		prevActive = s.Annotations != nil && s.Annotations[ServiceScaleOverrideAnnotation] == ServiceScaleOverrideValueOn
+	case !kerr.IsNotFound(err):
+		return errors.WithStack(err)
+	default:
+		d, err := p.GetDeploymentFromInformer(service, ns)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		prevActive = d.Annotations != nil && d.Annotations[ServiceScaleOverrideAnnotation] == ServiceScaleOverrideValueOn
 	}
 
 	if prevActive == active {
@@ -49,14 +58,14 @@ func (p *Provider) ServiceScaleOverrideSet(app, service string, active bool, ack
 		patch = []byte(fmt.Sprintf(`{"metadata":{"annotations":{%q:null}}}`, ServiceScaleOverrideAnnotation))
 	}
 
-	if _, err := p.Cluster.AppsV1().Deployments(p.AppNamespace(app)).Patch(
-		context.TODO(),
-		service,
-		types.MergePatchType,
-		patch,
-		am.PatchOptions{},
-	); err != nil {
-		return errors.WithStack(err)
+	if stateful {
+		if _, err := p.Cluster.AppsV1().StatefulSets(ns).Patch(context.TODO(), service, types.MergePatchType, patch, am.PatchOptions{}); err != nil {
+			return errors.WithStack(err)
+		}
+	} else {
+		if _, err := p.Cluster.AppsV1().Deployments(ns).Patch(context.TODO(), service, types.MergePatchType, patch, am.PatchOptions{}); err != nil {
+			return errors.WithStack(err)
+		}
 	}
 
 	state := "off"

--- a/provider/k8s/service_scale_override_test.go
+++ b/provider/k8s/service_scale_override_test.go
@@ -386,6 +386,66 @@ func TestServiceList_PopulatesAgentField(t *testing.T) {
 	})
 }
 
+func TestServiceListIncludesStatefulsets(t *testing.T) {
+	testProvider(t, func(p *k8s.Provider) {
+		kk, _ := p.Cluster.(*fake.Clientset)
+		require.NoError(t, appCreate(kk, "rack1", "app1"))
+
+		replicas := int32(3)
+		_, err := kk.AppsV1().StatefulSets("rack1-app1").Create(context.TODO(), &appsv1.StatefulSet{
+			ObjectMeta: am.ObjectMeta{
+				Name: "database", Namespace: "rack1-app1",
+				Labels:      map[string]string{"app": "app1", "type": "service", "service": "database"},
+				Annotations: map[string]string{k8s.ServiceScaleOverrideAnnotation: k8s.ServiceScaleOverrideValueOn},
+			},
+			Spec: appsv1.StatefulSetSpec{
+				Replicas: &replicas,
+				Template: ac.PodTemplateSpec{Spec: ac.PodSpec{Containers: []ac.Container{{Name: "app1"}}}},
+			},
+		}, am.CreateOptions{})
+		require.NoError(t, err)
+
+		manifestYaml := "services:\n" +
+			"  database:\n" +
+			"    image: qdrant/qdrant\n" +
+			"    stateful: true\n" +
+			"    scale:\n" +
+			"      count: 3\n" +
+			"    volumeOptions:\n" +
+			"      - persistentVolumeClaim:\n" +
+			"          id: data\n" +
+			"          mountPath: /data\n" +
+			"          size: 1Gi\n"
+
+		aa, _ := p.Atom.(*atom.MockInterface)
+		cc, _ := p.Convox.(*cvfake.Clientset)
+		aa.On("Status", "rack1-app1", "app").Return("Running", "release1", nil)
+		require.NoError(t, releaseCreateInline(cc, "rack1-app1", "release1", manifestYaml))
+
+		services, err := p.ServiceList("app1")
+		require.NoError(t, err)
+		require.Len(t, services, 1)
+		require.Equal(t, "database", services[0].Name)
+		require.Equal(t, 3, services[0].Count)
+		require.True(t, *services[0].ScaleOverrideActive)
+
+		require.NoError(t, p.ServiceScaleOverrideSet("app1", "database", false, "test"))
+		statefulset, err := kk.AppsV1().StatefulSets("rack1-app1").Get(context.TODO(), "database", am.GetOptions{})
+		require.NoError(t, err)
+		_, hasOverride := statefulset.Annotations[k8s.ServiceScaleOverrideAnnotation]
+		require.False(t, hasOverride)
+
+		require.NoError(t, p.ServiceRestart("app1", "database"))
+		statefulset, err = kk.AppsV1().StatefulSets("rack1-app1").Get(context.TODO(), "database", am.GetOptions{})
+		require.NoError(t, err)
+		require.NotEmpty(t, statefulset.Spec.Template.Annotations["convox.com/restart"])
+
+		useServiceVolume := true
+		_, err = p.ProcessRun("app1", "database", structs.ProcessRunOptions{UseServiceVolume: &useServiceVolume})
+		require.ErrorContains(t, err, "not supported for stateful services")
+	})
+}
+
 // TestServiceScaleOverrideSet_AdminRBAC_AdminPermitted verifies the
 // provider-method is RBAC-agnostic (the gate is at the API controller
 // layer). The negative case is asserted in pkg/api/service_test.go.

--- a/provider/k8s/service_test.go
+++ b/provider/k8s/service_test.go
@@ -92,13 +92,16 @@ func TestServiceList(t *testing.T) {
 		for _, test := range tests {
 			fn := func(t *testing.T) {
 				aa := p.Atom.(*atom.MockInterface)
+				var kk *fake.Clientset
+				actionsBefore := 0
 
 				if test.CreateApp {
-					kk := p.Cluster.(*fake.Clientset)
+					kk = p.Cluster.(*fake.Clientset)
 					aa.On("Status", test.Namespace, test.AppName).Return("Running", test.Release, nil).Once()
 
 					require.NoError(t, appCreate(kk, test.RackName, test.AppName))
 					require.NoError(t, releaseCreate(p.Convox, test.Namespace, test.Release, "basic"))
+					actionsBefore = len(kk.Actions())
 				}
 
 				_, err := p.ServiceList(test.AppName)
@@ -106,6 +109,9 @@ func TestServiceList(t *testing.T) {
 					assert.Equal(t, test.Err.Error(), err.Error())
 				} else {
 					require.NoError(t, err)
+					for _, action := range kk.Actions()[actionsBefore:] {
+						require.NotEqual(t, "statefulsets", action.GetResource().Resource)
+					}
 				}
 			}
 

--- a/provider/k8s/service_test.go
+++ b/provider/k8s/service_test.go
@@ -96,7 +96,7 @@ func TestServiceList(t *testing.T) {
 				actionsBefore := 0
 
 				if test.CreateApp {
-					kk = p.Cluster.(*fake.Clientset)
+					kk, _ = p.Cluster.(*fake.Clientset)
 					aa.On("Status", test.Namespace, test.AppName).Return("Running", test.Release, nil).Once()
 
 					require.NoError(t, appCreate(kk, test.RackName, test.AppName))

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -32,12 +32,14 @@ metadata:
     {{ end }}
 ---
 apiVersion: apps/v1
-kind: {{ if .Service.Agent.Enabled }} DaemonSet {{ else }} Deployment {{ end }}
+kind: {{ if .Service.Agent.Enabled }} DaemonSet {{ else if .Service.Stateful }} StatefulSet {{ else }} Deployment {{ end }}
 metadata:
   namespace: {{.Namespace}}
   name: {{.Service.Name}}
   annotations:
-    {{ if not .Service.Agent.Enabled }}
+    {{ if .Service.Stateful }}
+    atom.conditions: Ready=True
+    {{ else if not .Service.Agent.Enabled }}
     atom.conditions: Available=True,Progressing=True/NewReplicaSetAvailable
     {{ end }}
   labels:
@@ -54,7 +56,13 @@ spec:
       rack: {{.Rack}}
       app: {{.App.Name}}
       service: {{.Service.Name}}
-  {{ if not .Service.Agent.Enabled }}
+  {{ if .Service.Stateful }}
+  serviceName: {{.Service.Name}}-headless
+  podManagementPolicy: {{ coalesce .Service.PodManagementPolicy "OrderedReady" }}
+  replicas: {{.Replicas}}
+  updateStrategy:
+    type: RollingUpdate
+  {{ else if not .Service.Agent.Enabled }}
   replicas: {{.Replicas}}
   strategy:
     type: RollingUpdate
@@ -424,6 +432,13 @@ spec:
         - name: azurefiles-{{ .Id }}
           mountPath: {{ .MountPath }}
         {{ end }}
+        {{ with .PersistentVolumeClaim }}
+        - name: pvc-{{ .Id }}
+          mountPath: {{ json .MountPath }}
+          {{ if eq .AccessMode "ReadOnlyMany" }}
+          readOnly: true
+          {{ end }}
+        {{ end }}
         {{ end }}
       volumes:
       - name: ca
@@ -473,8 +488,27 @@ spec:
             - key: app.json
               path: {{ .Filename }}
       {{ end }}
+  {{ if .Service.Stateful }}
+  volumeClaimTemplates:
+  {{ range .Service.VolumeOptions }}
+  {{ with .PersistentVolumeClaim }}
+  - metadata:
+      name: pvc-{{ .Id }}
+    spec:
+      accessModes:
+      - {{ coalesce .AccessMode "ReadWriteOnce" }}
+      {{ with .StorageClass }}
+      storageClassName: {{ json . }}
+      {{ end }}
+      volumeMode: Filesystem
+      resources:
+        requests:
+          storage: {{ .Size }}
+  {{ end }}
+  {{ end }}
+  {{ end }}
  
-{{ if and (and (and (and (not (eq .Service.Scale.Count.Min .Service.Scale.Count.Max)) (not $.KedaIsEnabled)) (not $.AutoscaleIsEnabled)) (not .Service.Agent.Enabled)) (not $.TriggersOverrideActive) }}
+{{ if and (and (and (and (and (not (eq .Service.Scale.Count.Min .Service.Scale.Count.Max)) (not $.KedaIsEnabled)) (not $.AutoscaleIsEnabled)) (not .Service.Agent.Enabled)) (not .Service.Stateful)) (not $.TriggersOverrideActive) }}
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
@@ -529,6 +563,25 @@ spec:
         value: {{ .Value }}
         {{ end }}
   {{ end }}
+{{ end }}
+{{ if .Service.Stateful }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: {{.Namespace}}
+  name: {{.Service.Name}}-headless
+  labels:
+    app: {{.App.Name}}
+    service: {{.Service.Name}}
+    rack: {{.Rack}}
+    system: convox
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    service: {{.Service.Name}}
+    type: service
 {{ end }}
 {{ if or .Service.Port.Port .Service.Ports }}
 ---

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -93,6 +93,11 @@ spec:
         {{.Key}}: "{{.Value}}"
         {{ end }}
     spec:
+      {{ with .Service.SecurityContext.FsGroup }}
+      securityContext:
+        fsGroup: {{ . }}
+        fsGroupChangePolicy: OnRootMismatch
+      {{ end }}
       {{ if or (.Service.NodeSelectorLabels) (.Service.NodeAffinityLabels) }}
       affinity:
         nodeAffinity:
@@ -217,6 +222,10 @@ spec:
         {{ with .AzureFiles }}
         - name: azurefiles-{{ .Id }}
           mountPath: {{ .MountPath }}
+        {{ end }}
+        {{ with .PersistentVolumeClaim }}
+        - name: pvc-{{ .Id }}
+          mountPath: {{ json .MountPath }}
         {{ end }}
         {{ end }}
         {{ range .Service.InitContainer.ConfigMounts }}
@@ -576,6 +585,9 @@ metadata:
     service: {{.Service.Name}}
     rack: {{.Rack}}
     system: convox
+    {{ range keyValue .Service.Labels }}
+    {{.Key}}: "{{.Value}}"
+    {{ end }}
 spec:
   clusterIP: None
   publishNotReadyAddresses: true

--- a/provider/k8s/template_test.go
+++ b/provider/k8s/template_test.go
@@ -327,6 +327,58 @@ func TestRenderServiceGpuVendorUnset(t *testing.T) {
 	require.Contains(t, string(data), `nvidia.com/gpu: "1"`)
 }
 
+func TestRenderStatefulServicePersistentVolumeClaim(t *testing.T) {
+	src := `services:
+  database:
+    build: .
+    port: 6333
+    stateful: true
+    podManagementPolicy: Parallel
+    scale:
+      count: 3
+    volumeOptions:
+      - persistentVolumeClaim:
+          id: data
+          mountPath: /qdrant/storage
+          size: 200Gi
+          storageClass: gp3
+`
+	p, params := gpuTemplateFixture(t, src)
+	data, err := p.RenderTemplate("app/service", params)
+	require.NoError(t, err)
+
+	rendered := string(data)
+	require.Contains(t, rendered, "kind: StatefulSet")
+	require.Contains(t, rendered, "atom.conditions: Ready=True")
+	require.Contains(t, rendered, "serviceName: database-headless")
+	require.Contains(t, rendered, "podManagementPolicy: Parallel")
+	require.Contains(t, rendered, "name: pvc-data")
+	require.Contains(t, rendered, "mountPath: /qdrant/storage")
+	require.Contains(t, rendered, "storageClassName: gp3")
+	require.Contains(t, rendered, "storage: 200Gi")
+	require.Contains(t, rendered, "name: database-headless")
+	require.Contains(t, rendered, "clusterIP: None")
+	require.NotContains(t, rendered, "kind: Deployment")
+}
+
+func TestRenderStatefulReadOnlyPersistentVolumeClaim(t *testing.T) {
+	src := `services:
+  database:
+    build: .
+    stateful: true
+    volumeOptions:
+      - persistentVolumeClaim:
+          id: data
+          accessMode: ReadOnlyMany
+          mountPath: /data
+          size: 1Gi
+`
+	p, params := gpuTemplateFixture(t, src)
+	data, err := p.RenderTemplate("app/service", params)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "readOnly: true")
+}
+
 func TestRenderServiceTolerationMerger(t *testing.T) {
 	cases := []struct {
 		name            string

--- a/provider/k8s/template_test.go
+++ b/provider/k8s/template_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/convox/convox/pkg/templater"
 	"github.com/convox/convox/provider/k8s/template"
 	"github.com/stretchr/testify/require"
+	yaml "gopkg.in/yaml.v3"
 )
 
 func TestRenderTemplate(t *testing.T) {
@@ -377,6 +378,106 @@ func TestRenderStatefulReadOnlyPersistentVolumeClaim(t *testing.T) {
 	data, err := p.RenderTemplate("app/service", params)
 	require.NoError(t, err)
 	require.Contains(t, string(data), "readOnly: true")
+}
+
+func TestRenderStatefulServiceInitContainerClaimAndLabels(t *testing.T) {
+	src := `services:
+  database:
+    build: .
+    stateful: true
+    labels:
+      team: data
+    initContainer:
+      image: busybox
+      command: chown -R 1000:1000 /data
+      volumeOptions:
+        - persistentVolumeClaim:
+            id: data
+            mountPath: /data
+    securityContext:
+      runAsUser: 1000
+      fsGroup: 1000
+    volumeOptions:
+      - persistentVolumeClaim:
+          id: data
+          mountPath: /data
+          size: 1Gi
+`
+	p, params := gpuTemplateFixture(t, src)
+	data, err := p.RenderTemplate("app/service", params)
+	require.NoError(t, err)
+
+	docs := splitYamlDocuments(t, string(data))
+
+	sts := findRenderedDocument(t, docs, "StatefulSet", "database")
+	podSpec := nestedMap(t, sts, "spec", "template", "spec")
+	sc := nestedMap(t, podSpec, "securityContext")
+	require.Equal(t, 1000, sc["fsGroup"])
+	require.Equal(t, "OnRootMismatch", sc["fsGroupChangePolicy"])
+
+	initContainers, _ := podSpec["initContainers"].([]interface{})
+	require.Len(t, initContainers, 1)
+	init, _ := initContainers[0].(map[string]interface{})
+	require.Contains(t, fmt.Sprintf("%v", init["volumeMounts"]), "pvc-data")
+
+	headless := findRenderedDocument(t, docs, "Service", "database-headless")
+	labels := nestedMap(t, headless, "metadata", "labels")
+	require.Equal(t, "data", labels["team"])
+}
+
+func TestRenderServiceOmitsPodSecurityContextWithoutFsGroup(t *testing.T) {
+	src := `services:
+  web:
+    build: .
+    securityContext:
+      runAsUser: 1000
+`
+	p, params := gpuTemplateFixture(t, src)
+	data, err := p.RenderTemplate("app/service", params)
+	require.NoError(t, err)
+
+	require.NotContains(t, string(data), "fsGroup")
+
+	deployment := findRenderedDocument(t, splitYamlDocuments(t, string(data)), "Deployment", "web")
+	podSpec := nestedMap(t, deployment, "spec", "template", "spec")
+	require.NotContains(t, podSpec, "securityContext")
+}
+
+func splitYamlDocuments(t *testing.T, data string) []map[string]interface{} {
+	t.Helper()
+	docs := []map[string]interface{}{}
+	for _, part := range strings.Split(data, "---\n") {
+		var v map[string]interface{}
+		require.NoError(t, yaml.Unmarshal([]byte(part), &v))
+		if v != nil {
+			docs = append(docs, v)
+		}
+	}
+	return docs
+}
+
+func findRenderedDocument(t *testing.T, docs []map[string]interface{}, kind, name string) map[string]interface{} {
+	t.Helper()
+	for _, d := range docs {
+		if d["kind"] != kind {
+			continue
+		}
+		if nestedMap(t, d, "metadata")["name"] == name {
+			return d
+		}
+	}
+	t.Fatalf("no rendered %s named %s", kind, name)
+	return nil
+}
+
+func nestedMap(t *testing.T, v map[string]interface{}, keys ...string) map[string]interface{} {
+	t.Helper()
+	for _, k := range keys {
+		next, ok := v[k].(map[string]interface{})
+		require.True(t, ok, "expected map at %s", k)
+		v = next
+	}
+	return v
 }
 
 func TestRenderServiceTolerationMerger(t *testing.T) {


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: Stateful Services with Per-Replica Persistent Volumes**

Setting `stateful: true` on a service renders it as a Kubernetes StatefulSet. Each replica gets a stable name, its own DNS record through a headless Service that Convox creates alongside the workload, and its own PersistentVolumeClaim that Kubernetes reattaches to that same replica when it is replaced or rescheduled. Services that do not set the flag render exactly as before.

| convox.yml key | Type | Default | Effect |
|----------------|------|---------|--------|
| `stateful` | boolean | `false` | Renders the service as a StatefulSet with a stable identity and one PersistentVolumeClaim per replica |
| `podManagementPolicy` | string | `OrderedReady` | `OrderedReady` or `Parallel`. Requires `stateful: true` |
| `volumeOptions[].persistentVolumeClaim` | map | | Per-replica claim definition. Requires `stateful: true` |
| `securityContext.fsGroup` | number | | GID that owns mounted volumes. Applies to the whole pod, not just the container |

Fields of `persistentVolumeClaim`:

| Field | Type | Default | Effect |
|-------|------|---------|--------|
| `id` | string | required | ID used for the claim and its volume mount. Must match `^[a-z][a-z0-9-]*$` and be 59 characters or fewer |
| `mountPath` | string | required | Absolute path where the volume is mounted |
| `size` | string | required | Kubernetes resource quantity, such as `200Gi` |
| `storageClass` | string | cluster default | Container Storage Interface storage class supplied by the rack |
| `accessMode` | string | `ReadWriteOnce` | `ReadWriteOnce`, `ReadOnlyMany` or `ReadWriteMany` |

Replicas are individually addressable inside the app as `<service>-<ordinal>.<service>-headless`, for example `database-0.database-headless`, while the regular `<service>` name still balances across every ready replica. An `initContainer` may mount a claim the service already declares by repeating the same `id` with the path the init container should see. A stateful service name must be 54 characters or fewer, since Convox appends `-headless` to it for the peer discovery Service.

A stateful service declares at least one `persistentVolumeClaim` and runs at a fixed replica count. `agent`, `scale.autoscale`, `scale.keda` triggers, a `scale.count` range and `scale.vpa` are rejected in the manifest for a stateful service, and no HorizontalPodAutoscaler is rendered for it. Budget auto-shutdown reports it as ineligible, `convox run --use-service-volume` is rejected for it because each replica has its own volume, and `convox scale` or `convox services update` with `--min` or `--max` is rejected in favor of `--count`.

Deploys wait for the StatefulSet rollout to reach the target revision with every replica ready, `convox services` lists stateful services with their counts and resources, `convox services restart` rolls them, `convox scale` adjusts their count, cpu, memory and gpu, and they receive the same pod disruption budget treatment as a Deployment service. Finished-pod cleanup is scoped to the exact pod it observed, so a replacement replica that reuses a departing replica's name is left alone.

---

### Why is this important?

Clustered data workloads such as vector databases, search engines and other stores that keep data on local disk need each replica to own its storage and keep the same identity across restarts, rescheduling and node replacement. This makes that a first-class service type in `convox.yml`, so those workloads run inside the app alongside everything else instead of living outside the rack.

**Benefits:**

- **Data follows the replica.** Every replica owns a PersistentVolumeClaim that Kubernetes reattaches when the replica is replaced or moved to another node, so a restart or a node rotation does not lose the data on disk.
- **Stable peer addresses.** The headless Service gives each replica a fixed DNS name, which is what clustered software needs to point its members at each other.
- **Ordered or parallel scaling.** `podManagementPolicy` selects between bringing replicas up one at a time and starting all of them independently when the service is created or scaled, which some clustered images require. Rolling updates replace replicas one at a time in reverse order under either setting.
- **Volume ownership for non-root images.** `securityContext.fsGroup` hands a newly provisioned volume to the group that owns the data directory, so an image that runs as a non-root user can write to its mount.
- **The same operational commands.** `convox deploy`, `convox services`, `convox scale` and `convox services restart` work on stateful services, and a deploy reports success only once every replica is ready on the new revision.

---

### How to use it?

Define a stateful service with a fixed replica count and a per-replica claim:

```yaml
services:
  database:
    image: qdrant/qdrant:v1.18.2
    stateful: true
    podManagementPolicy: Parallel
    scale:
      count: 3
    volumeOptions:
      - persistentVolumeClaim:
          id: data
          mountPath: /qdrant/storage
          size: 200Gi
          storageClass: gp3
```

For an image that runs as a non-root user, set the group that owns the data directory, and optionally prepare the directory from an init container that mounts the same claim:

```yaml
services:
  search:
    image: elasticsearch:8.15.0
    stateful: true
    securityContext:
      fsGroup: 1000
    scale:
      count: 3
    volumeOptions:
      - persistentVolumeClaim:
          id: data
          mountPath: /usr/share/elasticsearch/data
          size: 50Gi
          storageClass: gp3
    initContainer:
      image: busybox
      command: chown -R 1000:1000 /data
      volumeOptions:
        - persistentVolumeClaim:
            id: data
            mountPath: /data
```

Deploy and operate the service with the usual commands:

    $ convox deploy -a my-app
    $ convox services -a my-app
    $ convox scale database --count 5 -a my-app
    $ convox services restart database -a my-app

---

### Does it have a breaking change?

**No breaking changes** are introduced with this feature.

Services render exactly as before unless they set `stateful: true`, and `securityContext.fsGroup` is written into the pod spec only when it is set.

Two constraints are worth planning for. The `storageClass` named by a claim must already exist on the rack, for example an Amazon EBS, Azure Disk or Google Persistent Disk class. And a service cannot be converted between the two workload types in place: a deploy that flips `stateful` on an existing service is rejected, so create a new service under a new name and move the data across. Kubernetes also treats `podManagementPolicy` and claim template fields such as `size` and `storageClass` as immutable on a running StatefulSet, so changing one of those needs a new service name as well.

Redeploying a stateful service takes longer than redeploying a Deployment service. Kubernetes replaces replicas one at a time in reverse order, waiting for each to become ready and reattach its volume before starting the next, so the time scales with the replica count. If the CLI stops waiting before the rollout finishes, the rack carries on with it: the app reports `updating` and `convox ps` shows a mix of ordinals on the old and new releases until every replica has been replaced.

Claims outlive the replicas that use them. Scaling a stateful service down keeps the claims for the removed replicas, so scaling back up reattaches the same data, and removing the service from `convox.yml` leaves its claims in place. The underlying cloud disks keep billing until they are deleted, and `convox apps delete` removes the whole namespace along with every claim and disk it holds.

---

### Requirements

This feature requires version `3.25.4` or later for the rack.

**Update the Rack:** Run `convox rack update 3.25.4 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
