### PR TITLE
Scope rack proxy

### DIFF
--- a/pkg/api/actor_header_test.go
+++ b/pkg/api/actor_header_test.go
@@ -36,12 +36,10 @@ func TestAuthenticate_BasicAuthWithConvoxActorHeader_SetsActor(t *testing.T) {
 		"ConvoxJwtUserParam must be set to the Convox-Actor header value")
 }
 
-// TestAuthenticate_BasicAuthWithLegacyXConvoxActorHeader_SetsActor —
-// dual-read pattern (matches the X-Convox-TID precedent at
-// pkg/api/helpers.go:32-35). Pre-3.24.6 callers may continue sending
-// X-Convox-Actor; the rack honors the legacy form when no canonical
-// Convox-Actor header is present.
-func TestAuthenticate_BasicAuthWithLegacyXConvoxActorHeader_SetsActor(t *testing.T) {
+// TestAuthenticate_BasicAuthWithXConvoxActorHeader_SetsActor — dual-read
+// pattern matching the tid header in pkg/api/helpers.go. X-Convox-Actor is
+// the form Console stamps and is read first.
+func TestAuthenticate_BasicAuthWithXConvoxActorHeader_SetsActor(t *testing.T) {
 	s := &Server{JwtMngr: nil, Password: "rack-pass"}
 
 	req := httptest.NewRequest(http.MethodGet, "http://example.com/auth", nil)
@@ -51,25 +49,24 @@ func TestAuthenticate_BasicAuthWithLegacyXConvoxActorHeader_SetsActor(t *testing
 	got, code := captureMiddlewareValue(t, s, req, structs.ConvoxJwtUserParam)
 	assert.Equal(t, http.StatusOK, code, "basic-auth with X-Convox-Actor must return 200")
 	assert.Equal(t, "bob@example.com", got,
-		"ConvoxJwtUserParam must be set to the legacy X-Convox-Actor header value")
+		"ConvoxJwtUserParam must be set to the X-Convox-Actor header value")
 }
 
-// TestAuthenticate_BasicAuthWithBothHeaders_CanonicalWins — when both
-// canonical and legacy forms are present (e.g. a Console3 upgrade in
-// flight where one proxy sends both for safety), canonical wins. Matches
-// the X-Convox-TID precedent at pkg/api/helpers.go.
-func TestAuthenticate_BasicAuthWithBothHeaders_CanonicalWins(t *testing.T) {
+// TestAuthenticate_BasicAuthWithBothHeaders_XPrefixedWins — when both forms
+// are present, the stamped X-Convox-Actor wins. Console sets only that form,
+// so a Convox-Actor the original client supplied must not displace it.
+func TestAuthenticate_BasicAuthWithBothHeaders_XPrefixedWins(t *testing.T) {
 	s := &Server{JwtMngr: nil, Password: "rack-pass"}
 
 	req := httptest.NewRequest(http.MethodGet, "http://example.com/auth", nil)
 	req.Header.Set("Authorization", basicAuthHeader("convox", "rack-pass"))
-	req.Header.Set("X-Convox-Actor", "legacy@example.com")
-	req.Header.Set("Convox-Actor", "canonical@example.com")
+	req.Header.Set("X-Convox-Actor", "stamped@example.com")
+	req.Header.Set("Convox-Actor", "supplied@example.com")
 
 	got, code := captureMiddlewareValue(t, s, req, structs.ConvoxJwtUserParam)
 	assert.Equal(t, http.StatusOK, code)
-	assert.Equal(t, "canonical@example.com", got,
-		"when both forms present, canonical Convox-Actor must win over legacy X-Convox-Actor")
+	assert.Equal(t, "stamped@example.com", got,
+		"when both forms present, the stamped X-Convox-Actor must win over a client-supplied Convox-Actor")
 }
 
 // TestAuthenticate_BasicAuthEmptyActorHeader_FallsBackToRackPassword —

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -92,9 +92,9 @@ func (s *Server) authenticate(next stdapi.HandlerFunc) stdapi.HandlerFunc {
 				}
 				return sanitized
 			}
-			actor := pickActor(c.Request().Header.Get("Convox-Actor"))
+			actor := pickActor(c.Request().Header.Get("X-Convox-Actor"))
 			if actor == "" {
-				actor = pickActor(c.Request().Header.Get("X-Convox-Actor"))
+				actor = pickActor(c.Request().Header.Get("Convox-Actor"))
 			}
 			if actor == "" {
 				actor = "rack-password"

--- a/pkg/api/controllers.go
+++ b/pkg/api/controllers.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/convox/convox/pkg/manifest"
+	"github.com/convox/convox/pkg/options"
 	"github.com/convox/convox/pkg/structs"
 	"github.com/convox/stdapi"
 	"github.com/convox/stdsdk"
@@ -1472,6 +1473,10 @@ func (s *Server) Proxy(c *stdapi.Context) error {
 		return stdapi.Errorf(http.StatusBadRequest, "invalid proxy host")
 	}
 
+	if !s.proxyTargetPermitted(c, host) {
+		return stdapi.Errorf(http.StatusForbidden, "invalid proxy host")
+	}
+
 	port, cerr := strconv.Atoi(c.Var("port"))
 	if cerr != nil || port < 1 || port > 65535 {
 		return stdapi.Errorf(http.StatusBadRequest, "invalid proxy port")
@@ -1551,6 +1556,58 @@ func isAllowedProxyHost(host string) bool {
 	return validProxyHost.MatchString(h)
 }
 
+type tenantScopedProvider interface {
+	TenantNamespacePrefix(tid string) string
+}
+
+var proxyDNSLabel = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
+
+func internalProxySuffixes() []string {
+	suffixes := []string{"svc.cluster.local"}
+	if s := strings.Trim(strings.ToLower(options.GetFeatureGateValue(options.FeatureGateResourceInternalDomainSuffix)), "."); s != "" && s != suffixes[0] {
+		suffixes = append(suffixes, s)
+	}
+	return suffixes
+}
+
+func proxyTargetAllowedForTenant(host, prefix string, suffixes []string) bool {
+	h := strings.ToLower(strings.TrimSuffix(strings.TrimSpace(host), "."))
+	for _, suffix := range suffixes {
+		rest, found := strings.CutSuffix(h, "."+suffix)
+		if !found {
+			continue
+		}
+		labels := strings.Split(rest, ".")
+		if len(labels) != 2 || !proxyDNSLabel.MatchString(labels[0]) || !proxyDNSLabel.MatchString(labels[1]) {
+			continue
+		}
+		if strings.HasPrefix(labels[1], prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Server) proxyTargetPermitted(c *stdapi.Context, host string) bool {
+	tid := requestTID(c)
+	if tid == "" {
+		// On a tid-gated rack a missing tid means a suppressed header, not a normal rack.
+		return !options.GetFeatureGates()[options.FeatureGateTid]
+	}
+
+	p, ok := s.provider(c).(tenantScopedProvider)
+	if !ok {
+		return false
+	}
+
+	prefix := p.TenantNamespacePrefix(tid)
+	if prefix == "" {
+		return false
+	}
+
+	return proxyTargetAllowedForTenant(host, prefix, internalProxySuffixes())
+}
+
 func (s *Server) ProxyHttpService(c *stdapi.Context) error {
 	if !CanWrite(c) {
 		return stdapi.Errorf(http.StatusForbidden, "proxy requires write access")
@@ -1559,6 +1616,10 @@ func (s *Server) ProxyHttpService(c *stdapi.Context) error {
 	host := strings.TrimSpace(c.Header("X-Host"))
 	if !isAllowedProxyHost(host) {
 		return stdapi.Errorf(http.StatusBadRequest, "invalid proxy host")
+	}
+
+	if !s.proxyTargetPermitted(c, host) {
+		return stdapi.Errorf(http.StatusForbidden, "invalid proxy host")
 	}
 
 	port, cerr := strconv.Atoi(c.Header("X-Port"))
@@ -2138,6 +2199,11 @@ func (s *Server) SystemJwtSignKeyRotate(c *stdapi.Context) error {
 }
 
 func (s *Server) SystemJwtToken(c *stdapi.Context) error {
+	// These tokens are rack-wide and carry no tenant scope.
+	if options.GetFeatureGates()[options.FeatureGateTid] {
+		return stdapi.Errorf(http.StatusForbidden, "token minting is not available on this rack")
+	}
+
 	role := c.Value("role")
 	durationInHour, err := strconv.Atoi(c.Value("durationInHour"))
 	if err != nil {

--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/convox/convox/pkg/options"
 	"github.com/convox/convox/pkg/structs"
 	"github.com/convox/stdapi"
 )
@@ -14,13 +15,21 @@ func renderStatusCode(w io.Writer, code int) error {
 	return err
 }
 
-func contextFrom(c *stdapi.Context) context.Context {
-	// Read both header names for backward compat (RFC 6648 migration).
-	tid := c.Header("Convox-TID")
-	if tid == "" {
-		tid = c.Header("X-Convox-TID")
+// requestTID reads the tenant ID stamped on the request. X-Convox-TID is the
+// form every producer sets; the unprefixed spelling has none, so on a rack
+// serving tenants it can only be caller input and is ignored there.
+func requestTID(c *stdapi.Context) string {
+	if tid := c.Header("X-Convox-TID"); tid != "" {
+		return tid
 	}
-	ctx := context.WithValue(c.Context(), structs.ConvoxTIDCtxKey, tid)
+	if options.GetFeatureGates()[options.FeatureGateTid] {
+		return ""
+	}
+	return c.Header("Convox-TID")
+}
+
+func contextFrom(c *stdapi.Context) context.Context {
+	ctx := context.WithValue(c.Context(), structs.ConvoxTIDCtxKey, requestTID(c))
 	if v, ok := c.Get(structs.ConvoxJwtUserParam).(string); ok && v != "" {
 		ctx = context.WithValue(ctx, structs.ConvoxJwtUserCtxKey, v)
 	}

--- a/pkg/api/internal_audit_test.go
+++ b/pkg/api/internal_audit_test.go
@@ -156,15 +156,15 @@ func TestContextFrom_AcceptsConvoxTIDCanonical(t *testing.T) {
 		"Convox-TID (canonical, RFC 6648 compliant) must populate the same ctx key as X-Convox-TID")
 }
 
-func TestContextFrom_CanonicalWinsOverLegacy(t *testing.T) {
+func TestContextFrom_XPrefixedWinsOverCanonical(t *testing.T) {
 	c := stdapi.NewContext(nil, httptest.NewRequest(http.MethodGet, "http://example.com", nil))
-	c.Request().Header.Set("X-Convox-TID", "tid-legacy")
-	c.Request().Header.Set("Convox-TID", "tid-canonical")
+	c.Request().Header.Set("X-Convox-TID", "tid-stamped")
+	c.Request().Header.Set("Convox-TID", "tid-supplied")
 
 	ctx := contextFrom(c)
 	tid, _ := ctx.Value(structs.ConvoxTIDCtxKey).(string)
-	assert.Equal(t, "tid-canonical", tid,
-		"when both forms present, canonical Convox-TID must win over legacy X-Convox-TID")
+	assert.Equal(t, "tid-stamped", tid,
+		"X-Convox-TID is the form every producer stamps, so it must win over a Convox-TID the original client supplied")
 }
 
 func TestContextFrom_NoTIDHeader(t *testing.T) {
@@ -193,4 +193,16 @@ func TestContextFrom_ConcurrentReads(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+func TestContextFrom_IgnoresCanonicalTIDOnGatedRack(t *testing.T) {
+	t.Setenv("FEATURE_GATES", "tid=true")
+
+	c := stdapi.NewContext(nil, httptest.NewRequest(http.MethodGet, "http://example.com", nil))
+	c.Request().Header.Set("Convox-TID", "tid-supplied")
+
+	ctx := contextFrom(c)
+	tid, _ := ctx.Value(structs.ConvoxTIDCtxKey).(string)
+	assert.Equal(t, "", tid,
+		"on a tenant rack the unprefixed spelling has no producer, so it can only be caller input")
 }

--- a/pkg/api/proxy_tid_test.go
+++ b/pkg/api/proxy_tid_test.go
@@ -1,0 +1,204 @@
+package api_test
+
+import (
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/convox/convox/pkg/api"
+	"github.com/convox/convox/pkg/structs"
+	"github.com/convox/logger"
+	"github.com/convox/stdapi"
+	"github.com/convox/stdsdk"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"net/http/httptest"
+)
+
+type tenantProvider struct {
+	*structs.MockProvider
+}
+
+func (p *tenantProvider) TenantNamespacePrefix(tid string) string {
+	if tid == "" {
+		return ""
+	}
+	return "rk-" + tid + "-"
+}
+
+func testTenantServer(t *testing.T, fn func(*stdsdk.Client, *structs.MockProvider)) {
+	t.Helper()
+
+	p := &structs.MockProvider{}
+	p.On("Initialize", mock.Anything).Return(nil)
+	p.On("Start").Return(nil)
+	p.On("WithContext", mock.Anything).Return(p).Maybe()
+	p.On("SystemJwtSignKey").Return("test", nil)
+
+	s := api.NewWithProvider(&tenantProvider{p})
+	s.Logger = logger.Discard
+	s.Recover = func(err error, c *stdapi.Context) {
+		require.NoError(t, err, "httptest server panic")
+	}
+
+	ht := httptest.NewServer(s)
+	defer ht.Close()
+
+	c, err := stdsdk.New(ht.URL)
+	require.NoError(t, err)
+
+	fn(c, p)
+
+	p.AssertExpectations(t)
+}
+
+func tidHeaders(tid string) stdsdk.Headers {
+	return stdsdk.Headers{"X-Convox-TID": tid}
+}
+
+func TestProxySameTenantTargetConnects(t *testing.T) {
+	testTenantServer(t, func(c *stdsdk.Client, p *structs.MockProvider) {
+		host := "web.rk-ab12-app.svc.cluster.local"
+
+		p.On("Proxy", host, 5000, mock.Anything, structs.ProxyOptions{}).Return(nil).Run(func(args mock.Arguments) {
+			rw, ok := args.Get(2).(io.ReadWriter)
+			require.True(t, ok)
+			_, err := rw.Write([]byte("out"))
+			require.NoError(t, err)
+		})
+
+		r, err := c.Websocket("/proxy/"+host+"/5000", stdsdk.RequestOptions{Headers: tidHeaders("ab12")})
+		require.NoError(t, err)
+
+		data, err := io.ReadAll(r)
+		require.NoError(t, err)
+		require.Equal(t, "out", string(data))
+	})
+}
+
+func TestProxyCrossTenantTargetRejected(t *testing.T) {
+	testTenantServer(t, func(c *stdsdk.Client, p *structs.MockProvider) {
+		r, err := c.Websocket("/proxy/web.rk-cd34-app.svc.cluster.local/5000", stdsdk.RequestOptions{Headers: tidHeaders("ab12")})
+		require.NoError(t, err)
+
+		data, err := io.ReadAll(r)
+		require.NoError(t, err)
+		require.Equal(t, []byte("ERROR: invalid proxy host\n"), data)
+
+		p.AssertNotCalled(t, "Proxy", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	})
+}
+
+func TestProxyBareLocalTargetRejectedForTenant(t *testing.T) {
+	testTenantServer(t, func(c *stdsdk.Client, p *structs.MockProvider) {
+		r, err := c.Websocket("/proxy/web.app.rk.local/5000", stdsdk.RequestOptions{Headers: tidHeaders("ab12")})
+		require.NoError(t, err)
+
+		data, err := io.ReadAll(r)
+		require.NoError(t, err)
+		require.Equal(t, []byte("ERROR: invalid proxy host\n"), data)
+
+		p.AssertNotCalled(t, "Proxy", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	})
+}
+
+func TestProxySuppressedTIDRejectedOnGatedRack(t *testing.T) {
+	t.Setenv("FEATURE_GATES", "tid=true")
+
+	testTenantServer(t, func(c *stdsdk.Client, p *structs.MockProvider) {
+		r, err := c.Websocket("/proxy/web.rk-ab12-app.svc.cluster.local/5000", stdsdk.RequestOptions{})
+		require.NoError(t, err)
+
+		data, err := io.ReadAll(r)
+		require.NoError(t, err)
+		require.Equal(t, []byte("ERROR: invalid proxy host\n"), data)
+
+		p.AssertNotCalled(t, "Proxy", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	})
+}
+
+func TestProxyCanonicalTIDCannotOverrideStampedTID(t *testing.T) {
+	testTenantServer(t, func(c *stdsdk.Client, p *structs.MockProvider) {
+		ro := stdsdk.RequestOptions{Headers: stdsdk.Headers{
+			"X-Convox-TID": "ab12",
+			"Convox-TID":   "cd34",
+		}}
+
+		r, err := c.Websocket("/proxy/web.rk-cd34-app.svc.cluster.local/5000", ro)
+		require.NoError(t, err)
+
+		data, err := io.ReadAll(r)
+		require.NoError(t, err)
+		require.Equal(t, []byte("ERROR: invalid proxy host\n"), data)
+
+		p.AssertNotCalled(t, "Proxy", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	})
+}
+
+func TestProxySuppliedCanonicalTIDIgnoredOnGatedRack(t *testing.T) {
+	t.Setenv("FEATURE_GATES", "tid=true")
+
+	testTenantServer(t, func(c *stdsdk.Client, p *structs.MockProvider) {
+		ro := stdsdk.RequestOptions{Headers: stdsdk.Headers{"Convox-TID": "cd34"}}
+
+		r, err := c.Websocket("/proxy/web.rk-cd34-app.svc.cluster.local/5000", ro)
+		require.NoError(t, err)
+
+		data, err := io.ReadAll(r)
+		require.NoError(t, err)
+		require.Equal(t, []byte("ERROR: invalid proxy host\n"), data,
+			"a suppressed X-Convox-TID must not let the unprefixed spelling name the tenant")
+
+		p.AssertNotCalled(t, "Proxy", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	})
+}
+
+func TestProxyHttpServiceCrossTenantTargetRejected(t *testing.T) {
+	testTenantServer(t, func(c *stdsdk.Client, p *structs.MockProvider) {
+		res, err := proxyHttpServiceRequest(c, "web.rk-cd34-app.svc.cluster.local", "ab12")
+		require.NoError(t, err)
+		defer res.Body.Close()
+
+		require.Equal(t, http.StatusForbidden, res.StatusCode)
+	})
+}
+
+func TestProxyHttpServiceSameTenantTargetPasses(t *testing.T) {
+	testTenantServer(t, func(c *stdsdk.Client, p *structs.MockProvider) {
+		res, err := proxyHttpServiceRequest(c, "web.rk-ab12-app.svc.cluster.local", "ab12")
+		require.NoError(t, err)
+		defer res.Body.Close()
+
+		require.NotEqual(t, http.StatusForbidden, res.StatusCode,
+			"a same-tenant target must reach the reverse proxy, which then fails to dial")
+	})
+}
+
+func TestSystemJwtTokenRejectedOnGatedRack(t *testing.T) {
+	t.Setenv("FEATURE_GATES", "tid=true")
+
+	testTenantServer(t, func(c *stdsdk.Client, p *structs.MockProvider) {
+		req, err := http.NewRequest(http.MethodPost, c.Endpoint.String()+"/system/jwt/token", nil)
+		require.NoError(t, err)
+
+		res, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer res.Body.Close()
+
+		require.Equal(t, http.StatusForbidden, res.StatusCode)
+	})
+}
+
+func proxyHttpServiceRequest(c *stdsdk.Client, host, tid string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodGet, c.Endpoint.String()+"/custom/http/proxy/", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("X-Host", host)
+	req.Header.Set("X-Port", "5000")
+	req.Header.Set("X-Convox-TID", tid)
+
+	return http.DefaultClient.Do(req)
+}

--- a/pkg/api/security_internal_test.go
+++ b/pkg/api/security_internal_test.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"testing"
+
+	"github.com/convox/convox/provider/k8s"
 )
 
 func TestIsSafeProxyTarget(t *testing.T) {
@@ -177,3 +179,86 @@ func TestSanitizeObjectKey(t *testing.T) {
 		})
 	}
 }
+
+func TestProxyTargetAllowedForTenant(t *testing.T) {
+	suffixes := []string{"svc.cluster.local", "machine.convox.internal"}
+
+	tests := []struct {
+		host  string
+		allow bool
+	}{
+		{"web.rk-ab12-app.svc.cluster.local", true},
+		{"resource-db.rk-ab12-app.machine.convox.internal", true},
+		{"WEB.RK-AB12-APP.SVC.CLUSTER.LOCAL", true},
+		{"web.rk-ab12-app.svc.cluster.local.", true},
+		{"  web.rk-ab12-app.svc.cluster.local  ", true},
+		{"web.rk-ab12-app-two.svc.cluster.local", true},
+
+		// Another tenant.
+		{"web.rk-cd34-app.svc.cluster.local", false},
+		{"resource-db.rk-cd34-app.machine.convox.internal", false},
+
+		// Prefix must include the trailing hyphen.
+		{"web.rk-ab12x-app.svc.cluster.local", false},
+		{"web.rk-ab12.svc.cluster.local", false},
+
+		// Rack system namespace.
+		{"api.rk-system.svc.cluster.local", false},
+
+		// Bare .local carries no namespace.
+		{"web.app.rk.local", false},
+		{"web.rk-ab12-app.local", false},
+
+		// Wrong label count.
+		{"rk-ab12-app.svc.cluster.local", false},
+		{"a.web.rk-ab12-app.svc.cluster.local", false},
+		{"web.rk-cd34-app.rk-ab12-app.svc.cluster.local", false},
+
+		// Empty and malformed labels.
+		{"web..svc.cluster.local", false},
+		{".rk-ab12-app.svc.cluster.local", false},
+		{"web.-rk-ab12-app.svc.cluster.local", false},
+		{"*.rk-ab12-app.svc.cluster.local", false},
+		{"web.*.svc.cluster.local", false},
+		{"u@web.rk-ab12-app.svc.cluster.local", false},
+		{"web.rk-ab12-app.svc.cluster.local%eth0", false},
+		{"[web.rk-ab12-app.svc.cluster.local]", false},
+		{"web.rk-ab12-app.svc.cluster.local\x00.rk-ab12-app.svc.cluster.local", false},
+
+		// Addresses and unrelated hosts.
+		{"10.1.2.3", false},
+		{"db.abc123.us-east-1.rds.amazonaws.com", false},
+		{"", false},
+		{"svc.cluster.local", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			if got := proxyTargetAllowedForTenant(tt.host, "rk-ab12-", suffixes); got != tt.allow {
+				t.Errorf("proxyTargetAllowedForTenant(%q) = %v, want %v", tt.host, got, tt.allow)
+			}
+		})
+	}
+}
+
+func TestInternalProxySuffixes(t *testing.T) {
+	t.Setenv("FEATURE_GATES", "")
+	if got := internalProxySuffixes(); len(got) != 1 || got[0] != "svc.cluster.local" {
+		t.Errorf("ungated suffixes = %v, want [svc.cluster.local]", got)
+	}
+
+	t.Setenv("FEATURE_GATES", "resource-internal-domain-suffix=Machine.Convox.Internal.")
+	got := internalProxySuffixes()
+	if len(got) != 2 || got[1] != "machine.convox.internal" {
+		t.Errorf("gated suffixes = %v, want the normalized gate value appended", got)
+	}
+
+	t.Setenv("FEATURE_GATES", "resource-internal-domain-suffix=svc.cluster.local")
+	if got := internalProxySuffixes(); len(got) != 1 {
+		t.Errorf("suffixes = %v, want no duplicate of the default", got)
+	}
+}
+
+// The proxy guard reaches the rack name through a type assertion, so the
+// promotion from the embedded provider has to stay compiler-checked.
+var _ tenantScopedProvider = (*k8s.Provider)(nil)

--- a/pkg/cli/builds.go
+++ b/pkg/cli/builds.go
@@ -384,6 +384,10 @@ func buildExternal(rack sdk.Interface, c *stdcli.Context, opts structs.BuildCrea
 		return nil, err
 	}
 
+	if b.Repository == "" {
+		return nil, fmt.Errorf("external builds are not available on this rack")
+	}
+
 	u, err := url.Parse(b.Repository)
 	if err != nil {
 		return nil, err

--- a/pkg/start/gen2.go
+++ b/pkg/start/gen2.go
@@ -264,6 +264,10 @@ func (opts Options2) buildCreateExternal(ctx context.Context, pw *prefix.Writer,
 		return nil, err
 	}
 
+	if b.Repository == "" {
+		return nil, fmt.Errorf("external builds are not available on this rack")
+	}
+
 	u, err := url.Parse(b.Repository)
 	if err != nil {
 		return nil, err

--- a/provider/k8s/app.go
+++ b/provider/k8s/app.go
@@ -379,10 +379,14 @@ func (p *Provider) buildNamespace(app string) string {
 	return strings.TrimRight(prefix, "-") + "-" + hex.EncodeToString(sum[:])[:8]
 }
 
-// processBuildNamespace returns where the build pod runs. Params enforce or an
-// app namespace still carrying an enforce label (it persists until the next
-// promote after leaving enforce) routes to the dedicated unlabeled namespace.
+// processBuildNamespace returns where the build pod runs. A tid-gated rack keeps it
+// out of the tenant's own namespace; params enforce, or an app namespace still
+// carrying an enforce label, routes it to the same dedicated namespace.
 func (p *Provider) processBuildNamespace(app string) string {
+	if p.FeatureGates[options.FeatureGateTid] {
+		return p.buildNamespace(app)
+	}
+
 	if p.PodSecurityStandard != "" && p.PodSecurityMode == "enforce" {
 		return p.buildNamespace(app)
 	}

--- a/provider/k8s/build.go
+++ b/provider/k8s/build.go
@@ -64,7 +64,11 @@ func (p *Provider) BuildCreate(app, url string, opts structs.BuildCreateOptions)
 			return nil, err
 		}
 
-		b.Repository = fmt.Sprintf("https://convox:%s@api.%s/%s%s", p.Password, p.Domain, p.Engine.RepositoryPrefix(), app)
+		// This URL embeds the rack password, which is not tenant-scoped. Image
+		// import never reads it, so withhold it rather than refusing the build.
+		if !p.FeatureGates[options.FeatureGateTid] {
+			b.Repository = fmt.Sprintf("https://convox:%s@api.%s/%s%s", p.Password, p.Domain, p.Engine.RepositoryPrefix(), app)
+		}
 
 		return b, nil
 	}

--- a/provider/k8s/k8s.go
+++ b/provider/k8s/k8s.go
@@ -298,6 +298,14 @@ func (p *Provider) ContextTID() string {
 	return ""
 }
 
+// TenantNamespacePrefix returns the namespace prefix tid owns on this rack.
+func (p *Provider) TenantNamespacePrefix(tid string) string {
+	if p == nil || tid == "" || p.Name == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s-%s-", p.Name, tid)
+}
+
 // ContextActor returns the JWT user from ctx, or "unknown". Nil-safe.
 func (p *Provider) ContextActor() string {
 	if p == nil || p.ctx == nil {

--- a/provider/k8s/tenant_scope_test.go
+++ b/provider/k8s/tenant_scope_test.go
@@ -1,0 +1,89 @@
+package k8s_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/convox/convox/pkg/atom"
+	"github.com/convox/convox/pkg/options"
+	"github.com/convox/convox/pkg/structs"
+	"github.com/convox/convox/provider/k8s"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestTenantNamespacePrefix(t *testing.T) {
+	p := &k8s.Provider{Name: "rk"}
+
+	require.Equal(t, "rk-ab12-", p.TenantNamespacePrefix("ab12"))
+	require.Equal(t, "", p.TenantNamespacePrefix(""))
+	require.Equal(t, "", (&k8s.Provider{}).TenantNamespacePrefix("ab12"))
+
+	var nilp *k8s.Provider
+	require.Equal(t, "", nilp.TenantNamespacePrefix("ab12"))
+}
+
+func TestProcessBuildNamespaceStaysInAppNamespaceWithoutTidGate(t *testing.T) {
+	testProvider(t, func(p *k8s.Provider) {
+		require.Equal(t, p.AppNamespace("app1"), p.ProcessBuildNamespaceForTest("app1"))
+	})
+}
+
+func TestProcessBuildNamespaceIsolatedOnTenantRack(t *testing.T) {
+	testProvider(t, func(base *k8s.Provider) {
+		base.FeatureGates = map[string]bool{options.FeatureGateTid: true}
+		p := withTID(t, base, "ab12")
+
+		ns := p.ProcessBuildNamespaceForTest("app1")
+
+		require.NotEqual(t, p.AppNamespace("app1"), ns,
+			"the build pod carries the rack password in its environment, so a tenant must not share its namespace")
+		require.False(t, strings.HasPrefix(ns, p.TenantNamespacePrefix("ab12")),
+			"the build namespace must also fall outside the prefix the proxy guard admits")
+	})
+}
+
+func TestBuildCreateExternalWithholdsCredentialOnTenantRack(t *testing.T) {
+	testProvider(t, func(p *k8s.Provider) {
+		p.FeatureGates = map[string]bool{options.FeatureGateTid: true}
+		p.Password = "rack-pass"
+
+		b, err := p.BuildCreate("tidapp", "", externalBuildFixture(t, p, "tidapp"))
+		require.NoError(t, err, "image import uses this same path and must keep working")
+		require.Equal(t, "", b.Repository, "the repository URL embeds the rack password")
+	})
+}
+
+func TestBuildCreateExternalReturnsCredentialWithoutTidGate(t *testing.T) {
+	testProvider(t, func(p *k8s.Provider) {
+		p.Password = "rack-pass"
+
+		b, err := p.BuildCreate("plainapp", "", externalBuildFixture(t, p, "plainapp"))
+		require.NoError(t, err)
+		require.Contains(t, b.Repository, "rack-pass", "an ungated rack must still return a pushable URL")
+	})
+}
+
+func withTID(t *testing.T, p *k8s.Provider, tid string) *k8s.Provider {
+	t.Helper()
+
+	tp, ok := p.WithContext(context.WithValue(context.Background(), structs.ConvoxTIDCtxKey, tid)).(*k8s.Provider)
+	require.True(t, ok)
+
+	return tp
+}
+
+func externalBuildFixture(t *testing.T, p *k8s.Provider, app string) structs.BuildCreateOptions {
+	t.Helper()
+
+	kk, ok := p.Cluster.(*fake.Clientset)
+	require.True(t, ok)
+	require.NoError(t, appCreate(kk, p.Name, app))
+
+	aa, ok := p.Atom.(*atom.MockInterface)
+	require.True(t, ok)
+	aa.On("Status", p.AppNamespace(app), "app").Return("Running", "R1234567", nil).Maybe()
+
+	return structs.BuildCreateOptions{External: options.Bool(true)}
+}


### PR DESCRIPTION
## Proxy target scoping

This adds a target check to both routes, plus two related changes that keep the tenant ID meaningful.

Both handlers now run a shared guard after the existing SSRF validation.