### PR TITLE
add node pool pre-flight checks

### DIFF
--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -1475,6 +1475,123 @@ func validateKarpenterArchFamilies(params, currentParams map[string]string) erro
 	return checkArchFamilies("karpenter_build_instance_families", effective("karpenter_build_instance_families"), buildArchs, "build_node_type")
 }
 
+func decodeConfigParam(raw string, out interface{}) bool {
+	if strings.TrimSpace(raw) == "" {
+		return false
+	}
+
+	data := []byte(raw)
+	if decoded, err := base64.StdEncoding.DecodeString(raw); err == nil {
+		data = decoded
+	}
+
+	return json.Unmarshal(data, out) == nil
+}
+
+func nodePoolNames(raw string) ([]string, bool) {
+	cfgs := KarpenterNodePools{}
+	if !decodeConfigParam(raw, &cfgs) {
+		return nil, false
+	}
+
+	names := []string{}
+	for i := range cfgs {
+		if cfgs[i].Name != "" {
+			names = append(names, cfgs[i].Name)
+		}
+	}
+
+	return names, true
+}
+
+// nodeGroupLabels skips unlabelled groups: their Terraform fallback is shared across groups and varies by provider.
+func nodeGroupLabels(raw string) ([]string, bool) {
+	cfgs := AdditionalNodeGroups{}
+	if !decodeConfigParam(raw, &cfgs) {
+		return nil, false
+	}
+
+	labels := []string{}
+	for i := range cfgs {
+		if cfgs[i].Label != nil && *cfgs[i].Label != "" {
+			labels = append(labels, *cfgs[i].Label)
+		}
+	}
+
+	return labels, true
+}
+
+func droppedFrom(old, next []string) []string {
+	kept := map[string]bool{}
+	for _, n := range next {
+		kept[n] = true
+	}
+
+	dropped := []string{}
+
+	for _, o := range old {
+		if kept[o] {
+			continue
+		}
+
+		kept[o] = true
+		dropped = append(dropped, o)
+	}
+
+	sort.Strings(dropped)
+
+	return dropped
+}
+
+func validateNodePoolRemoval(params, currentParams map[string]string, force bool) error {
+	if force {
+		return nil
+	}
+
+	for _, c := range []struct {
+		key      string
+		label    string
+		noun     string
+		affected string
+		extract  func(string) ([]string, bool)
+	}{
+		{"additional_karpenter_nodepools_config", "convox.io/nodepool", "node pools", "Services pinned to", nodePoolNames},
+		{"additional_node_groups_config", "convox.io/label", "node groups", "Services pinned to", nodeGroupLabels},
+		{"additional_build_groups_config", "convox.io/label", "build groups", "Builds pinned by BuildLabels to", nodeGroupLabels},
+	} {
+		if _, ok := params[c.key]; !ok {
+			continue
+		}
+
+		old, ok := c.extract(currentParams[c.key])
+		if !ok {
+			continue
+		}
+
+		next, ok := c.extract(params[c.key])
+		if !ok {
+			continue
+		}
+
+		dropped := droppedFrom(old, next)
+		if len(dropped) == 0 {
+			continue
+		}
+
+		pinned := make([]string, len(dropped))
+		for i, d := range dropped {
+			pinned[i] = fmt.Sprintf("%s=%s", c.label, d)
+		}
+
+		return fmt.Errorf("this change removes %s that exist on this rack: %s\n"+
+			"  %s %s can no longer be scheduled, and the nodes are drained with no replacement.\n"+
+			"  Re-run with --force to proceed",
+			c.noun, strings.Join(dropped, ", "), c.affected, strings.Join(pinned, " or "))
+	}
+
+	return nil
+}
+
 func validateAndMutateParams(params map[string]string, provider string, currentParams map[string]string, force bool) error {
 	// Install-only params — these define infrastructure that cannot be changed
 	// after rack creation without catastrophic consequences (network recreation,
@@ -2196,6 +2313,10 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 			return fmt.Errorf("failed to process param '%s': %s", k, err)
 		}
 		params[k] = base64.StdEncoding.EncodeToString(data)
+	}
+
+	if err := validateNodePoolRemoval(params, currentParams, force); err != nil {
+		return err
 	}
 
 	// karpenter_node_overlays_config: validate NodeOverlay entries and re-encode

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -1583,8 +1583,8 @@ func validateNodePoolRemoval(params, currentParams map[string]string, force bool
 			pinned[i] = fmt.Sprintf("%s=%s", c.label, d)
 		}
 
-		return fmt.Errorf("this change removes %s that exist on this rack: %s\n"+
-			"  %s %s can no longer be scheduled, and the nodes are drained with no replacement.\n"+
+		return fmt.Errorf("destructive change, removes %s from the rack: %s\n"+
+			"  Their nodes are drained and deleted. %s %s become unschedulable.\n"+
 			"  Re-run with --force to proceed",
 			c.noun, strings.Join(dropped, ", "), c.affected, strings.Join(pinned, " or "))
 	}

--- a/pkg/cli/rack_validate_test.go
+++ b/pkg/cli/rack_validate_test.go
@@ -898,7 +898,7 @@ func TestValidateAndMutateParams_NodePoolRemoval(t *testing.T) {
 			name:    "clear blocked",
 			params:  map[string]string{"additional_karpenter_nodepools_config": ""},
 			current: map[string]string{"additional_karpenter_nodepools_config": pools("gpu")},
-			err:     "node pools that exist on this rack: gpu",
+			err:     "node pools from the rack: gpu",
 		},
 		{
 			name:    "removal allowed with force",
@@ -931,7 +931,7 @@ func TestValidateAndMutateParams_NodePoolRemoval(t *testing.T) {
 			name:    "node group label removed",
 			params:  map[string]string{"additional_node_groups_config": `[{"type":"t3.medium","label":"web"}]`},
 			current: map[string]string{"additional_node_groups_config": `[{"type":"t3.medium","label":"web"},{"type":"t3.large","label":"analytics"}]`},
-			err:     "node groups that exist on this rack: analytics",
+			err:     "node groups from the rack: analytics",
 		},
 		{
 			name:    "label moved to build groups is a removal",
@@ -953,7 +953,7 @@ func TestValidateAndMutateParams_NodePoolRemoval(t *testing.T) {
 			name:    "duplicate label fully removed is listed once",
 			params:  map[string]string{"additional_node_groups_config": `[]`},
 			current: map[string]string{"additional_node_groups_config": `[{"type":"t3.medium","label":"web"},{"type":"t3.large","label":"web"}]`},
-			err:     "node groups that exist on this rack: web\n",
+			err:     "node groups from the rack: web\n",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -974,6 +974,9 @@ func TestValidateAndMutateParams_NodePoolRemoval(t *testing.T) {
 			}
 			if !strings.Contains(err.Error(), "--force") {
 				t.Errorf("error %q should mention --force", err.Error())
+			}
+			if !strings.HasPrefix(err.Error(), "destructive change,") {
+				t.Errorf("error %q should lead with the destructive warning", err.Error())
 			}
 		})
 	}
@@ -1031,7 +1034,7 @@ func TestValidateAndMutateParams_BuildGroupRemovalNamesBuilds(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for removed build group")
 	}
-	if !strings.Contains(err.Error(), "build groups that exist on this rack: bigbuild") {
+	if !strings.Contains(err.Error(), "build groups from the rack: bigbuild") {
 		t.Errorf("error %q should name build groups, not node groups", err.Error())
 	}
 	if !strings.Contains(err.Error(), "Builds pinned by BuildLabels to convox.io/label=bigbuild") {

--- a/pkg/cli/rack_validate_test.go
+++ b/pkg/cli/rack_validate_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -857,5 +858,183 @@ func TestValidateAndMutateParams_CloudwatchDisableBoolValidation(t *testing.T) {
 	})
 	if err := validateAndMutateParams(map[string]string{"cloudwatch_disable": "maybe"}, "aws", map[string]string{}, false); err == nil {
 		t.Error("cloudwatch_disable=maybe: expected error, got nil")
+	}
+}
+
+func b64json(t *testing.T, s string) string {
+	t.Helper()
+	return base64.StdEncoding.EncodeToString([]byte(s))
+}
+
+func TestValidateAndMutateParams_NodePoolRemoval(t *testing.T) {
+	pools := func(names ...string) string {
+		entries := make([]string, len(names))
+		for i, n := range names {
+			entries[i] = `{"name":"` + n + `"}`
+		}
+		return "[" + strings.Join(entries, ",") + "]"
+	}
+
+	for _, tc := range []struct {
+		name    string
+		params  map[string]string
+		current map[string]string
+		force   bool
+		err     string
+	}{
+		{
+			name:    "removal blocked",
+			params:  map[string]string{"additional_karpenter_nodepools_config": pools("gpu")},
+			current: map[string]string{"additional_karpenter_nodepools_config": pools("batch", "gpu")},
+			err:     "convox.io/nodepool=batch",
+		},
+		{
+			name:    "rename blocked",
+			params:  map[string]string{"additional_karpenter_nodepools_config": pools("gpu-large")},
+			current: map[string]string{"additional_karpenter_nodepools_config": pools("gpu")},
+			err:     "convox.io/nodepool=gpu",
+		},
+		{
+			name:    "clear blocked",
+			params:  map[string]string{"additional_karpenter_nodepools_config": ""},
+			current: map[string]string{"additional_karpenter_nodepools_config": pools("gpu")},
+			err:     "node pools that exist on this rack: gpu",
+		},
+		{
+			name:    "removal allowed with force",
+			params:  map[string]string{"additional_karpenter_nodepools_config": pools("gpu")},
+			current: map[string]string{"additional_karpenter_nodepools_config": pools("batch", "gpu")},
+			force:   true,
+		},
+		{
+			name:    "addition only",
+			params:  map[string]string{"additional_karpenter_nodepools_config": pools("batch", "gpu")},
+			current: map[string]string{"additional_karpenter_nodepools_config": pools("gpu")},
+		},
+		{
+			name:    "current value base64 encoded",
+			params:  map[string]string{"additional_karpenter_nodepools_config": pools("gpu")},
+			current: map[string]string{"additional_karpenter_nodepools_config": b64json(t, pools("batch", "gpu"))},
+			err:     "convox.io/nodepool=batch",
+		},
+		{
+			name:    "no current value",
+			params:  map[string]string{"additional_karpenter_nodepools_config": pools("gpu")},
+			current: map[string]string{},
+		},
+		{
+			name:    "unrelated param on a rack with pools",
+			params:  map[string]string{"node_disk": "50"},
+			current: map[string]string{"additional_karpenter_nodepools_config": pools("gpu")},
+		},
+		{
+			name:    "node group label removed",
+			params:  map[string]string{"additional_node_groups_config": `[{"type":"t3.medium","label":"web"}]`},
+			current: map[string]string{"additional_node_groups_config": `[{"type":"t3.medium","label":"web"},{"type":"t3.large","label":"analytics"}]`},
+			err:     "node groups that exist on this rack: analytics",
+		},
+		{
+			name:    "label moved to build groups is a removal",
+			params:  map[string]string{"additional_node_groups_config": `[]`, "additional_build_groups_config": `[{"type":"t3.large","label":"analytics"}]`},
+			current: map[string]string{"additional_node_groups_config": `[{"type":"t3.large","label":"analytics"}]`},
+			err:     "convox.io/label=analytics",
+		},
+		{
+			name:    "duplicate label with one entry removed",
+			params:  map[string]string{"additional_node_groups_config": `[{"type":"t3.medium","label":"web"}]`},
+			current: map[string]string{"additional_node_groups_config": `[{"type":"t3.medium","label":"web"},{"type":"t3.large","label":"web"}]`},
+		},
+		{
+			name:    "unlabelled group removed",
+			params:  map[string]string{"additional_node_groups_config": `[{"type":"t3.medium","label":"web"}]`},
+			current: map[string]string{"additional_node_groups_config": `[{"type":"t3.medium","label":"web"},{"type":"t3.large"}]`},
+		},
+		{
+			name:    "duplicate label fully removed is listed once",
+			params:  map[string]string{"additional_node_groups_config": `[]`},
+			current: map[string]string{"additional_node_groups_config": `[{"type":"t3.medium","label":"web"},{"type":"t3.large","label":"web"}]`},
+			err:     "node groups that exist on this rack: web\n",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateAndMutateParams(tc.params, "aws", tc.current, tc.force)
+
+			if tc.err == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("expected error containing %q", tc.err)
+			}
+			if !strings.Contains(err.Error(), tc.err) {
+				t.Errorf("error %q should contain %q", err.Error(), tc.err)
+			}
+			if !strings.Contains(err.Error(), "--force") {
+				t.Errorf("error %q should mention --force", err.Error())
+			}
+		})
+	}
+}
+
+func TestValidateAndMutateParams_NodePoolRemovalFromFile(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "pools.json")
+	if err := os.WriteFile(f, []byte(`[{"name":"gpu"}]`), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	err := validateAndMutateParams(
+		map[string]string{"additional_karpenter_nodepools_config": f},
+		"aws",
+		map[string]string{"additional_karpenter_nodepools_config": `[{"name":"batch"},{"name":"gpu"}]`},
+		false,
+	)
+	if err == nil {
+		t.Fatal("expected error for pool removed via a .json file value")
+	}
+	if !strings.Contains(err.Error(), "convox.io/nodepool=batch") {
+		t.Errorf("error %q should name the removed pool", err.Error())
+	}
+}
+
+func TestValidateAndMutateParams_NodeGroupRemovalFromFile(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "groups.json")
+	if err := os.WriteFile(f, []byte(`[{"id":0,"type":"t3.medium","label":"web"}]`), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	err := validateAndMutateParams(
+		map[string]string{"additional_node_groups_config": f},
+		"aws",
+		map[string]string{"additional_node_groups_config": `[{"id":0,"type":"t3.medium","label":"web"},{"id":1,"type":"t3.large","label":"analytics"}]`},
+		false,
+	)
+	if err == nil {
+		t.Fatal("expected error for group removed via a .json file value")
+	}
+	if !strings.Contains(err.Error(), "convox.io/label=analytics") {
+		t.Errorf("error %q should name the removed group", err.Error())
+	}
+}
+
+func TestValidateAndMutateParams_BuildGroupRemovalNamesBuilds(t *testing.T) {
+	err := validateAndMutateParams(
+		map[string]string{"additional_build_groups_config": `[]`},
+		"aws",
+		map[string]string{"additional_build_groups_config": `[{"id":0,"type":"t3.large","label":"bigbuild"}]`},
+		false,
+	)
+	if err == nil {
+		t.Fatal("expected error for removed build group")
+	}
+	if !strings.Contains(err.Error(), "build groups that exist on this rack: bigbuild") {
+		t.Errorf("error %q should name build groups, not node groups", err.Error())
+	}
+	if !strings.Contains(err.Error(), "Builds pinned by BuildLabels to convox.io/label=bigbuild") {
+		t.Errorf("error %q should attribute the breakage to builds, not services", err.Error())
 	}
 }

--- a/provider/k8s/karpenter.go
+++ b/provider/k8s/karpenter.go
@@ -4,18 +4,98 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
+	"github.com/convox/convox/pkg/manifest"
+	"github.com/convox/convox/pkg/structs"
 	"github.com/pkg/errors"
 	ac "k8s.io/api/core/v1"
 	ae "k8s.io/apimachinery/pkg/api/errors"
 	am "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
 	KarpenterNodePoolLabel = "karpenter.sh/nodepool"
+
+	// NodePoolLabel is the node label a workload sets to pin itself to a Karpenter pool.
+	NodePoolLabel = "convox.io/nodepool"
 )
+
+var nodePoolGVR = schema.GroupVersionResource{Group: "karpenter.sh", Version: "v1", Resource: "nodepools"}
+
+// karpenterNodePools returns the pool labels this rack provides, or false when the set is unknowable.
+func (p *Provider) karpenterNodePools() ([]string, bool) {
+	if !p.IsKarpenterEnabled || p.DynamicClient == nil {
+		return nil, false
+	}
+
+	list, err := p.DynamicClient.Resource(nodePoolGVR).List(p.Context(), am.ListOptions{})
+	if err != nil || list == nil {
+		return nil, false
+	}
+
+	pools := []string{}
+
+	for i := range list.Items {
+		// The label, never metadata.name: a pool relabelled through the template's
+		// user-label splat has nodes carrying only the override.
+		v, ok, err := unstructured.NestedString(list.Items[i].Object, "spec", "template", "metadata", "labels", NodePoolLabel)
+		if err == nil && ok && v != "" {
+			pools = append(pools, v)
+		}
+	}
+
+	if len(pools) == 0 {
+		return nil, false
+	}
+
+	sort.Strings(pools)
+
+	return pools, true
+}
+
+func (p *Provider) validateManifestNodePools(m *manifest.Manifest) error {
+	pools, ok := p.karpenterNodePools()
+	if !ok {
+		return nil
+	}
+
+	for i := range m.Services {
+		s := &m.Services[i]
+
+		if err := validateNodePool(s.NodeSelectorLabels[NodePoolLabel], pools, fmt.Sprintf("convox.yml: service %q", s.Name)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateNodePool(target string, pools []string, subject string) error {
+	if target == "" {
+		return nil
+	}
+
+	for _, pool := range pools {
+		if pool == target {
+			return nil
+		}
+	}
+
+	return structs.ErrBadRequest(
+		"%s targets Karpenter node pool %q, which does not exist on this rack.\n"+
+			"  Existing pools: %s\n"+
+			"  If you just added this pool, wait for the rack update to finish and retry.\n"+
+			"  Otherwise correct the node pool name, or add the pool:\n"+
+			"    convox rack params set additional_karpenter_nodepools_config=...",
+		subject, target, strings.Join(pools, ", "),
+	)
+}
 
 func (p *Provider) KarpenterCleanup() error {
 	ctx := p.Context()
@@ -154,5 +234,3 @@ func (p *Provider) drainKarpenterNode(ctx context.Context, nodeName string) erro
 
 	return nil
 }
-
-

--- a/provider/k8s/karpenter_test.go
+++ b/provider/k8s/karpenter_test.go
@@ -2,15 +2,26 @@ package k8s
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/convox/convox/pkg/atom"
+	"github.com/convox/convox/pkg/manifest"
 	"github.com/convox/convox/pkg/mock"
+	"github.com/convox/convox/pkg/options"
+	"github.com/convox/convox/pkg/structs"
+	cvfake "github.com/convox/convox/provider/k8s/pkg/client/clientset/versioned/fake"
+	tmock "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	ac "k8s.io/api/core/v1"
+	kerr "k8s.io/apimachinery/pkg/api/errors"
 	am "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
-	cvfake "github.com/convox/convox/provider/k8s/pkg/client/clientset/versioned/fake"
+	k8stesting "k8s.io/client-go/testing"
 	metricfake "k8s.io/metrics/pkg/client/clientset/versioned/fake"
 )
 
@@ -145,4 +156,206 @@ func TestKarpenterCleanupSkipsMirrorPods(t *testing.T) {
 
 	_, err = c.CoreV1().Pods("kube-system").Get(context.TODO(), "kube-apiserver-mirror", am.GetOptions{})
 	require.NoError(t, err)
+}
+
+func nodePoolObject(name, label string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "karpenter.sh/v1",
+		"kind":       "NodePool",
+		"metadata":   map[string]interface{}{"name": name},
+	}}
+
+	if label != "" {
+		u.Object["spec"] = map[string]interface{}{
+			"template": map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"labels": map[string]interface{}{NodePoolLabel: label},
+				},
+			},
+		}
+	}
+
+	return u
+}
+
+func nodePoolTestProvider(objs ...runtime.Object) *Provider {
+	p, _ := karpenterTestProvider()
+
+	p.IsKarpenterEnabled = true
+	p.DynamicClient = dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+		nodePoolGVR: "NodePoolList",
+	}, objs...)
+
+	return p
+}
+
+// Pool names are deliberately reverse-sorted against their labels, so this fails
+// if the label read is swapped for metadata.name or if the sort is dropped.
+func TestKarpenterNodePoolsReadsLabelNotNameAndSorts(t *testing.T) {
+	p := nodePoolTestProvider(nodePoolObject("aaa", "zebra"), nodePoolObject("zzz", "alpha"))
+
+	pools, ok := p.karpenterNodePools()
+	require.True(t, ok)
+	require.Equal(t, []string{"alpha", "zebra"}, pools)
+}
+
+func TestKarpenterNodePoolsSkipsPoolsWithoutLabel(t *testing.T) {
+	p := nodePoolTestProvider(nodePoolObject("workload", "workload"), nodePoolObject("handmade", ""))
+
+	pools, ok := p.karpenterNodePools()
+	require.True(t, ok)
+	require.Equal(t, []string{"workload"}, pools)
+}
+
+func TestKarpenterNodePoolsUndeterminable(t *testing.T) {
+	listErr := func(err error) func(*Provider) {
+		return func(p *Provider) {
+			if dc, ok := p.DynamicClient.(*dynamicfake.FakeDynamicClient); ok {
+				dc.PrependReactor("list", "nodepools", func(k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, err
+				})
+			}
+		}
+	}
+
+	for _, tc := range []struct {
+		name   string
+		objs   []runtime.Object
+		mutate func(*Provider)
+	}{
+		{name: "karpenter disabled", objs: []runtime.Object{nodePoolObject("workload", "workload")}, mutate: func(p *Provider) { p.IsKarpenterEnabled = false }},
+		{name: "nil dynamic client", objs: []runtime.Object{nodePoolObject("workload", "workload")}, mutate: func(p *Provider) { p.DynamicClient = nil }},
+		{name: "empty list", objs: nil},
+		{name: "crd absent", objs: []runtime.Object{nodePoolObject("workload", "workload")}, mutate: listErr(kerr.NewNotFound(schema.GroupResource{Group: "karpenter.sh", Resource: "nodepools"}, ""))},
+		{name: "generic list error", objs: []runtime.Object{nodePoolObject("workload", "workload")}, mutate: listErr(fmt.Errorf("connection refused"))},
+		{name: "no pool carries the label", objs: []runtime.Object{nodePoolObject("handmade", "")}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := nodePoolTestProvider(tc.objs...)
+			if tc.mutate != nil {
+				tc.mutate(p)
+			}
+
+			pools, ok := p.karpenterNodePools()
+			require.False(t, ok)
+			require.Nil(t, pools)
+
+			require.NoError(t, p.validateManifestNodePools(&manifest.Manifest{
+				Services: manifest.Services{{Name: "web", NodeSelectorLabels: manifest.Labels{NodePoolLabel: "nonexistent"}}},
+			}))
+		})
+	}
+}
+
+func TestValidateManifestNodePools(t *testing.T) {
+	p := nodePoolTestProvider(nodePoolObject("workload", "workload"), nodePoolObject("gpu", "gpu"))
+
+	for _, tc := range []struct {
+		name   string
+		labels manifest.Labels
+		err    string
+	}{
+		{name: "existing pool", labels: manifest.Labels{NodePoolLabel: "gpu"}},
+		{name: "no labels"},
+		{name: "unrelated key only", labels: manifest.Labels{"convox.io/label": "analytics", "topology.kubernetes.io/zone": "us-east-1a"}},
+		{name: "empty value", labels: manifest.Labels{NodePoolLabel: ""}},
+		{name: "unknown pool", labels: manifest.Labels{NodePoolLabel: "gpu-lg"}, err: `service "web" targets Karpenter node pool "gpu-lg"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := p.validateManifestNodePools(&manifest.Manifest{
+				Services: manifest.Services{{Name: "web", NodeSelectorLabels: tc.labels}},
+			})
+
+			if tc.err == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.err)
+			require.Contains(t, err.Error(), "Existing pools: gpu, workload")
+		})
+	}
+}
+
+func TestValidateManifestNodePoolsReportsOffendingService(t *testing.T) {
+	p := nodePoolTestProvider(nodePoolObject("workload", "workload"))
+
+	err := p.validateManifestNodePools(&manifest.Manifest{
+		Services: manifest.Services{
+			{Name: "web", NodeSelectorLabels: manifest.Labels{NodePoolLabel: "workload"}},
+			{Name: "worker", NodeSelectorLabels: manifest.Labels{NodePoolLabel: "batch"}},
+		},
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `service "worker"`)
+}
+
+func releasePromoteNodePoolProvider(t *testing.T, badManifestRelease string) *Provider {
+	t.Helper()
+	t.Setenv("TEST", "true")
+
+	p, kk, kc := minimalProvider(t)
+
+	_, err := kk.CoreV1().Namespaces().Create(context.TODO(), &ac.Namespace{
+		ObjectMeta: am.ObjectMeta{Name: p.Namespace},
+	}, am.CreateOptions{})
+	require.NoError(t, err)
+	require.NoError(t, p.Initialize(structs.ProviderOptions{}))
+
+	// A promote that reaches Apply spawns runReleasePromoteWatcher, which polls
+	// until its context is done and holds a package-global watch slot meanwhile.
+	ctx, cancel := context.WithCancel(context.Background())
+	p.ctx = ctx
+	t.Cleanup(cancel)
+
+	createAppNamespace(t, kk, "rack1", "app1")
+	createBuild(t, kc, "rack1-app1", "build1")
+	createRelease(t, kc, "rack1-app1", "rel1", manifestWithNodeSelectors)
+	createRelease(t, kc, "rack1-app1", badManifestRelease, manifestWithNodeSelectors)
+
+	aa, ok := p.Atom.(*atom.MockInterface)
+	require.True(t, ok)
+	aa.On("Apply", tmock.Anything, tmock.Anything, tmock.Anything).Return(nil).Maybe()
+
+	p.IsKarpenterEnabled = true
+	p.DynamicClient = dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+		nodePoolGVR: "NodePoolList",
+	}, nodePoolObject("workload", "workload"))
+
+	return p
+}
+
+// manifestWithNodeSelectors pins gpu-worker to convox.io/nodepool=gpu, which the
+// provider above does not have, so a promote of any release carrying it is rejected.
+const nodePoolRejection = `targets Karpenter node pool "gpu"`
+
+func TestReleasePromote_RejectsUnknownNodePool(t *testing.T) {
+	p := releasePromoteNodePoolProvider(t, "rel2")
+
+	err := p.ReleasePromote("app1", "rel2", structs.ReleasePromoteOptions{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), nodePoolRejection)
+	require.Contains(t, err.Error(), `service "gpu-worker"`)
+}
+
+func TestReleasePromote_SkipsNodePoolCheckOnCurrentRelease(t *testing.T) {
+	p := releasePromoteNodePoolProvider(t, "rel2")
+
+	// minimalProvider's Atom mock reports rel1 as current, so this is the
+	// AppUpdate re-promote path that apps params set and apps lock use.
+	err := p.ReleasePromote("app1", "rel1", structs.ReleasePromoteOptions{})
+	if err != nil {
+		require.NotContains(t, err.Error(), nodePoolRejection)
+	}
+}
+
+func TestReleasePromote_SkipsNodePoolCheckOnForce(t *testing.T) {
+	p := releasePromoteNodePoolProvider(t, "rel2")
+
+	err := p.ReleasePromote("app1", "rel2", structs.ReleasePromoteOptions{Force: options.Bool(true)})
+	if err != nil {
+		require.NotContains(t, err.Error(), nodePoolRejection)
+	}
 }

--- a/provider/k8s/process.go
+++ b/provider/k8s/process.go
@@ -1015,6 +1015,19 @@ func (p *Provider) podSpecFromRunOptions(app, service, ns string, opts structs.P
 			}
 		}
 
+		if target := s.NodeSelector[NodePoolLabel]; target != "" {
+			subject := "--node-labels"
+			if opts.IsBuild {
+				subject = "the BuildLabels app parameter"
+			}
+
+			if pools, ok := p.karpenterNodePools(); ok {
+				if err := validateNodePool(target, pools, subject); err != nil {
+					return nil, err
+				}
+			}
+		}
+
 		if s.Tolerations == nil {
 			s.Tolerations = []ac.Toleration{}
 		}

--- a/provider/k8s/process_nodeselector_test.go
+++ b/provider/k8s/process_nodeselector_test.go
@@ -15,6 +15,9 @@ import (
 	"github.com/stretchr/testify/require"
 	ac "k8s.io/api/core/v1"
 	am "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
 	metricfake "k8s.io/metrics/pkg/client/clientset/versioned/fake"
 )
@@ -300,4 +303,68 @@ func TestProcessRun_BuildIgnoresNodeSelectorLabels(t *testing.T) {
 	// (the isBuild check in podSpecFromService skips the manifest lookup)
 	require.Nil(t, spec.Affinity)
 	require.Empty(t, spec.Tolerations)
+}
+
+func nodePoolProvider(t *testing.T, labels ...string) *Provider {
+	t.Helper()
+	p, kk, kc := minimalProvider(t)
+	createAppNamespace(t, kk, "rack1", "app1")
+	createBuild(t, kc, "rack1-app1", "build1")
+	createRelease(t, kc, "rack1-app1", "rel1", manifestWithNodeSelectors)
+
+	objs := make([]runtime.Object, len(labels))
+	for i, l := range labels {
+		objs[i] = nodePoolObject(l, l)
+	}
+
+	p.IsKarpenterEnabled = true
+	p.DynamicClient = dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
+		nodePoolGVR: "NodePoolList",
+	}, objs...)
+
+	return p
+}
+
+func TestProcessRun_NodeLabelsRejectsUnknownNodePool(t *testing.T) {
+	p := nodePoolProvider(t, "workload", "gpu")
+
+	_, err := p.ProcessRun("app1", "web", structs.ProcessRunOptions{
+		Release:    options.String("rel1"),
+		Command:    options.String("ls"),
+		NodeLabels: options.String("convox.io/nodepool=gpu-lg"),
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `--node-labels targets Karpenter node pool "gpu-lg"`)
+	require.Contains(t, err.Error(), "Existing pools: gpu, workload")
+}
+
+func TestProcessRun_NodeLabelsBuildNamesTheAppParameter(t *testing.T) {
+	p := nodePoolProvider(t, "workload")
+
+	_, err := p.ProcessRun("app1", "build", structs.ProcessRunOptions{
+		Release:    options.String("rel1"),
+		Command:    options.String("build"),
+		IsBuild:    true,
+		NodeLabels: options.String("convox.io/nodepool=typo"),
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "the BuildLabels app parameter targets Karpenter node pool")
+}
+
+func TestProcessRun_NodeLabelsAcceptsKnownAndUnrelatedLabels(t *testing.T) {
+	for _, labels := range []string{"convox.io/nodepool=gpu", "convox.io/label=analytics", "team=ml"} {
+		t.Run(labels, func(t *testing.T) {
+			p := nodePoolProvider(t, "workload", "gpu")
+
+			_, err := p.ProcessRun("app1", "web", structs.ProcessRunOptions{
+				Release:    options.String("rel1"),
+				Command:    options.String("ls"),
+				NodeLabels: options.String(labels),
+			})
+
+			require.NoError(t, err)
+		})
+	}
 }

--- a/provider/k8s/release.go
+++ b/provider/k8s/release.go
@@ -173,6 +173,14 @@ func (p *Provider) ReleasePromote(app, id string, opts structs.ReleasePromoteOpt
 			return errors.WithStack(err)
 		}
 
+		// AppUpdate re-promotes the current release to apply app params and lock
+		// changes, and must keep working when the manifest names a removed pool.
+		if id != a.Release && !common.DefaultBool(opts.Force, false) {
+			if err := p.validateManifestNodePools(m); err != nil {
+				return errors.WithStack(err)
+			}
+		}
+
 		e, err := structs.NewEnvironment([]byte(r.Env))
 		if err != nil {
 			return errors.WithStack(err)


### PR DESCRIPTION
### What is the feature/update/fix?

**Update: Node Pool Pre-flight Checks**

Convox now validates Karpenter node pool references before the work that depends on them starts. Three checks ship: one on release promotion, one on the process run path that backs `convox run --node-labels` and the `BuildLabels` app parameter, and one in `convox rack params set` that requires `--force` before a node pool, node group, or build group identifier is dropped from a rack.

**What each check covers:**

| Check | Runs on | Compares |
|-------|---------|----------|
| Manifest node pools | `ReleasePromote` (server side) | Each service's `nodeSelectorLabels` entry keyed `convox.io/nodepool` against the pools the rack has |
| Run and build node labels | `convox run --node-labels` and the `BuildLabels` app parameter (server side) | The `convox.io/nodepool` entry in the requested node labels against the pools the rack has |
| Parameter removal | `convox rack params set` (client side) | The incoming `additional_karpenter_nodepools_config`, `additional_node_groups_config`, and `additional_build_groups_config` against the values the rack already stores, by pool `name` and group `label` |

The list of pools comes from the Karpenter `NodePool` objects themselves, read from the cluster, and the value compared is each pool's `convox.io/nodepool` label rather than its `metadata.name`, because the label is what a pod actually matches on. Reading the objects rather than live nodes matters because a Karpenter pool consolidated to zero nodes is a normal steady state.

The first two checks return the same message, naming the surface that supplied the value (`convox.yml: service "web"`, `--node-labels`, or `the BuildLabels app parameter`):

```
convox.yml: service "web" targets Karpenter node pool "gpu-lg", which does not exist on this rack.
  Existing pools: build, workload
  If you just added this pool, wait for the rack update to finish and retry.
  Otherwise correct the node pool name, or add the pool:
    convox rack params set additional_karpenter_nodepools_config=...
```

The parameter check reports which identifiers the change drops, and what pins to them. Renaming an entry and clearing the parameter are both treated as removals:

```
destructive change, removes node pools from the rack: batch, gpu
  Their nodes are drained and deleted. Services pinned to convox.io/nodepool=batch or convox.io/nodepool=gpu become unschedulable.
  Re-run with --force to proceed
```

Timers are covered by the manifest check, since a timer renders the node selector labels of the service it references.

**Every check fails open.** When the valid set cannot be established, the check is skipped rather than treated as a mismatch:

| Condition | Behavior |
|-----------|----------|
| Karpenter is not enabled on the rack, or the cluster cannot be queried | The promote and run checks are skipped before any Kubernetes API call, which covers every non-AWS provider |
| The `NodePool` list call returns an error for any reason, including the CRD being absent | The promote and run checks are skipped |
| The `NodePool` list succeeds but no pool carries a `convox.io/nodepool` label | The promote and run checks are skipped |
| The rack has no stored value for a parameter, or a stored or incoming value cannot be read as JSON | That parameter's comparison is skipped |
| An `additional_node_groups_config` or `additional_build_groups_config` entry carries no `label` | That entry is not tracked, since an unlabelled group has no identifier of its own to compare |

No Terraform change, no new rack parameter, and no new API surface ship with this update.

---

### Why is this important?

A node pool name that does not exist on the rack is reported at the moment it is submitted, naming the service and the pool, with the pools that do exist listed alongside it. Removing a pool that workloads are pinned to now takes an explicit `--force`.

**Benefits:**

- **Immediate, specific feedback.** The message names the service, the requested pool, the pools the rack has, and the command that adds a pool, so a typo is correctable from the error alone.
- **One check across three surfaces.** Deploys, `convox run --node-labels`, and the `BuildLabels` app parameter all resolve against the same in-cluster pool list, and the message names the surface that supplied the value.
- **An explicit step before capacity goes away.** `convox rack params set` reports the identifiers a change drops and the label selector that will stop matching, and proceeds only with `--force`.
- **Coverage beyond Karpenter pools for the parameter check.** `additional_node_groups_config` and `additional_build_groups_config` are diffed the same way, on their `convox.io/label` values, on AWS, GCP, and Azure racks.
- **No new failure mode.** Every check is skipped when its source of truth is unavailable, so a Kubernetes API interruption or a rack without Karpenter behaves exactly as it did before.

---

### How to use it?

Pin a service to a Karpenter pool in `convox.yml` as before:

```yaml
services:
  web:
    nodeSelectorLabels:
      convox.io/nodepool: batch
```

Add a pool. The parameter is the full list, so include the pools you are keeping:

    $ convox rack params set additional_karpenter_nodepools_config='[{"name":"batch","instance_families":"c5"},{"name":"analytics","instance_families":"r5"}]' -r rackName

Wait for the rack update to finish, then deploy the service that targets the new pool.

Drop `analytics` from that list, acknowledging that its nodes are drained and deleted:

    $ convox rack params set additional_karpenter_nodepools_config='[{"name":"batch","instance_families":"c5"}]' --force -r rackName

`--force` also accepts the short form `-f` on `convox rack params set`.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this update.

Every existing deploy that targets a pool the rack has continues to promote unchanged, and services with no `convox.io/nodepool` entry are never inspected. The promote check runs only when the release being promoted differs from the app's current release, so `convox apps params set`, `convox apps lock`, and `convox apps unlock`, which re-promote the current release, keep working on an app pinned to a pool that was deliberately removed. `convox deploy --force`, `convox releases promote --force`, and `convox releases rollback --force` skip the promote check. `convox apps import` does not skip it, since importing a release that targets a pool the rack lacks is the case worth catching.

No struct field, route, or method changed and `pkg/structs` is untouched, so Console's parsing of rack responses is unaffected. Older CLIs against a `3.25.4` rack still get the promote and run checks, because those are server side. Newer CLIs against an older rack still get the parameter check, because that ships in the CLI. Downgrading a rack below `3.25.4` removes the server-side checks along with the code.

Three cases to plan for.

A `convox rack params set` call that drops an identifier from `additional_karpenter_nodepools_config`, `additional_node_groups_config`, or `additional_build_groups_config` is rejected. Re-run it with `--force` to proceed. This guard runs in the CLI and returns before any Terraform apply, so it covers `convox rack params set` and not a parameter change made through Console.

The promote check reads every service in the manifest regardless of its replica count, so a service at `scale.count: 0` that pins a pool the rack does not have holds up the whole app, including the healthy services beside it. `convox deploy --force` deploys it.

`convox env set --promote`, `convox env unset --promote`, and `convox env edit --promote` carry no `--force` option, so on an app pinned to a pool the rack does not have they report the same error and leave the app on its previous release. The build still runs and the release is still created, so the change goes out in two commands: run it without `--promote`, then `convox releases promote <release> --force`.

---

### Requirements

This update requires version `3.25.4` or later for the rack.

**Update the Rack:** Run `convox rack update 3.25.4 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
