### PR TITLE
require admin role on kubernetes api proxy

### DIFF
--- a/provider/k8s/api.go
+++ b/provider/k8s/api.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"crypto/subtle"
 	"fmt"
 	"net"
 	"net/http"
@@ -8,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/convox/convox/pkg/structs"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/proxy"
 	"k8s.io/client-go/rest"
@@ -62,13 +64,17 @@ func (p *Provider) apiProxyAuthenticate(handler http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		username, password, _ := r.BasicAuth()
 		if username == "jwt" && p.JwtMngr != nil {
-			_, err := p.JwtMngr.Verify(password)
+			data, err := p.JwtMngr.Verify(password)
 			if err != nil {
 				http.Error(w, "Unauthorized", http.StatusUnauthorized)
 				return
 			}
+			if data.Role != structs.ConvoxRoleAdmin {
+				http.Error(w, "admin role required for kubernetes api access", http.StatusForbidden)
+				return
+			}
 		} else {
-			if password != p.Password {
+			if p.Password == "" || subtle.ConstantTimeCompare([]byte(p.Password), []byte(password)) != 1 {
 				http.Error(w, "Unauthorized", http.StatusUnauthorized)
 				return
 			}

--- a/provider/k8s/api_authenticate_test.go
+++ b/provider/k8s/api_authenticate_test.go
@@ -1,0 +1,205 @@
+package k8s
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/convox/convox/pkg/jwt"
+	"github.com/convox/convox/pkg/structs"
+	gojwt "github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/require"
+)
+
+const testProxySignKey = "testkey"
+
+type proxyAuthResult struct {
+	code       int
+	ran        bool
+	authHeader string
+	body       string
+}
+
+func serveProxyAuth(p *Provider, creds ...string) proxyAuthResult {
+	res := proxyAuthResult{}
+
+	stub := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		res.ran = true
+		res.authHeader = r.Header.Get("Authorization")
+	})
+
+	req := httptest.NewRequest("GET", "/api/v1/namespaces", nil)
+	if len(creds) == 2 {
+		req.SetBasicAuth(creds[0], creds[1])
+	}
+
+	w := httptest.NewRecorder()
+	p.apiProxyAuthenticate(stub)(w, req)
+
+	res.code = w.Code
+	res.body = w.Body.String()
+
+	return res
+}
+
+func mintTokenWithRole(t *testing.T, signKey, role string, expires time.Time) string {
+	t.Helper()
+
+	tk := gojwt.NewWithClaims(gojwt.SigningMethodHS256, gojwt.MapClaims{
+		"user":      "test-user",
+		"role":      role,
+		"expiresAt": expires.UTC().Unix(),
+	})
+
+	s, err := tk.SignedString([]byte(signKey))
+	require.NoError(t, err)
+
+	return s
+}
+
+func mintTokenWithoutRole(t *testing.T, signKey string) string {
+	t.Helper()
+
+	tk := gojwt.NewWithClaims(gojwt.SigningMethodHS256, gojwt.MapClaims{
+		"user":      "test-user",
+		"expiresAt": time.Now().UTC().Add(time.Hour).Unix(),
+	})
+
+	s, err := tk.SignedString([]byte(signKey))
+	require.NoError(t, err)
+
+	return s
+}
+
+func testProxyProvider(password string) *Provider {
+	return &Provider{
+		Password: password,
+		JwtMngr:  jwt.NewJwtManager(testProxySignKey),
+	}
+}
+
+func TestApiProxyAuthenticateJwtRoles(t *testing.T) {
+	p := testProxyProvider("rackpassword")
+
+	admin, err := p.JwtMngr.AdminToken(time.Hour)
+	require.NoError(t, err)
+	read, err := p.JwtMngr.ReadToken(time.Hour)
+	require.NoError(t, err)
+	write, err := p.JwtMngr.WriteToken(time.Hour)
+	require.NoError(t, err)
+
+	res := serveProxyAuth(p, "jwt", admin)
+	require.True(t, res.ran)
+	require.Equal(t, http.StatusOK, res.code)
+	require.Empty(t, res.authHeader)
+
+	for name, token := range map[string]string{"read": read, "write": write} {
+		t.Run(name, func(t *testing.T) {
+			res := serveProxyAuth(p, "jwt", token)
+			require.False(t, res.ran)
+			require.Equal(t, http.StatusForbidden, res.code)
+			require.Equal(t, "admin role required for kubernetes api access\n", res.body)
+		})
+	}
+}
+
+// Roles containing "a" but not equal to "rwa" separate the exact-role check
+// from a substring match, which pkg/jwt's three tokens cannot distinguish.
+func TestApiProxyAuthenticateNonAdminRoleVariants(t *testing.T) {
+	p := testProxyProvider("rackpassword")
+
+	for _, role := range []string{"ra", "admin", "a", "rw", structs.ConvoxRoleRead} {
+		t.Run(role, func(t *testing.T) {
+			res := serveProxyAuth(p, "jwt", mintTokenWithRole(t, testProxySignKey, role, time.Now().Add(time.Hour)))
+			require.False(t, res.ran)
+			require.Equal(t, http.StatusForbidden, res.code)
+		})
+	}
+}
+
+func TestApiProxyAuthenticateInvalidTokens(t *testing.T) {
+	p := testProxyProvider("rackpassword")
+
+	tokens := map[string]string{
+		"malformed": "not-a-token",
+		"wrong-key": mintTokenWithRole(t, "otherkey", structs.ConvoxRoleAdmin, time.Now().Add(time.Hour)),
+		"expired":   mintTokenWithRole(t, testProxySignKey, structs.ConvoxRoleAdmin, time.Now().Add(-time.Hour)),
+		"empty":     "",
+		"no-role":   mintTokenWithoutRole(t, testProxySignKey),
+	}
+
+	for name, token := range tokens {
+		t.Run(name, func(t *testing.T) {
+			res := serveProxyAuth(p, "jwt", token)
+			require.False(t, res.ran)
+			require.Equal(t, http.StatusUnauthorized, res.code)
+		})
+	}
+}
+
+func TestApiProxyAuthenticateJwtManagerNil(t *testing.T) {
+	p := &Provider{Password: "rackpassword"}
+
+	admin, err := jwt.NewJwtManager(testProxySignKey).AdminToken(time.Hour)
+	require.NoError(t, err)
+
+	res := serveProxyAuth(p, "jwt", admin)
+	require.False(t, res.ran)
+	require.Equal(t, http.StatusUnauthorized, res.code)
+}
+
+func TestApiProxyAuthenticatePassword(t *testing.T) {
+	p := testProxyProvider("rackpassword")
+
+	for _, username := range []string{"convox", "anything", "jwt-but-not-exact", ""} {
+		t.Run("correct-"+username, func(t *testing.T) {
+			res := serveProxyAuth(p, username, "rackpassword")
+			require.True(t, res.ran)
+			require.Equal(t, http.StatusOK, res.code)
+			require.Empty(t, res.authHeader)
+		})
+	}
+
+	for _, password := range []string{"wrongpassword", "", "rackpassword2", "rackpasswor"} {
+		t.Run("wrong-"+password, func(t *testing.T) {
+			res := serveProxyAuth(p, "convox", password)
+			require.False(t, res.ran)
+			require.Equal(t, http.StatusUnauthorized, res.code)
+		})
+	}
+
+	t.Run("no-credentials", func(t *testing.T) {
+		res := serveProxyAuth(p)
+		require.False(t, res.ran)
+		require.Equal(t, http.StatusUnauthorized, res.code)
+	})
+}
+
+func TestApiProxyAuthenticateEmptyRackPassword(t *testing.T) {
+	p := testProxyProvider("")
+
+	for _, password := range []string{"", "anything"} {
+		t.Run("password-"+password, func(t *testing.T) {
+			res := serveProxyAuth(p, "convox", password)
+			require.False(t, res.ran)
+			require.Equal(t, http.StatusUnauthorized, res.code)
+		})
+	}
+
+	t.Run("no-credentials", func(t *testing.T) {
+		res := serveProxyAuth(p)
+		require.False(t, res.ran)
+		require.Equal(t, http.StatusUnauthorized, res.code)
+	})
+
+	t.Run("admin-token-still-works", func(t *testing.T) {
+		admin, err := p.JwtMngr.AdminToken(time.Hour)
+		require.NoError(t, err)
+
+		res := serveProxyAuth(p, "jwt", admin)
+		require.True(t, res.ran)
+		require.Equal(t, http.StatusOK, res.code)
+		require.Empty(t, res.authHeader)
+	})
+}


### PR DESCRIPTION
# Require the admin role on the rack Kubernetes API proxy

The rack runs a listener on port 8001 that reverse-proxies to the Kubernetes API server, mounted under `/kubernetes/` and exposed through its own ingress. It is what `convox rack kubeconfig` points `kubectl` at. Authentication happens in `apiProxyAuthenticate` (`provider/k8s/api.go`), which accepts either a rack access token or the rack password.

This makes the admin role a requirement on the token path, and tightens two details of the password path while the file is open.

## What changed

All three changes are inside `apiProxyAuthenticate`. Nothing else in the file, the package, or the repo is touched.

**Role requirement on the token branch.** `apiProxyAuthenticate` now binds the `*jwt.TokenData` returned by `JwtMngr.Verify` and requires `data.Role == structs.ConvoxRoleAdmin`, returning 403 otherwise. This listener proxies to the cluster API and has no per-route authorization of its own, so admin is the appropriate bar for it.

The test is exact equality against `structs.ConvoxRoleAdmin` rather than the substring convention in `pkg/api.CanAdmin`. `provider/k8s` cannot import `pkg/api` (the cycle runs `pkg/api` to `provider` to `provider/aws` to `provider/k8s`), and copying a substring rule into a second package would duplicate the role vocabulary with no shared definition behind it. Exact equality covers every role `pkg/jwt` mints (`r`, `rw`, `rwa`) and fails closed if that vocabulary ever grows. If a future role should be admin-equivalent, the predicate belongs in `pkg/structs` with `pkg/api.CanAdmin` delegating to it, not as a second copy of the rule.

**Require a configured rack password.** The password branch now rejects when `p.Password` is empty, before comparing. The empty-`PASSWORD` state is not reachable through any supported install or params path (`variable "authentication"` defaults to `true`, no rack parameter maps to it, and the env is a required `secret_key_ref`, so a missing Secret stops the container rather than emptying the value). This makes that state deny rather than fall through, which is the behavior this listener should have if a module ever reaches it.

**Constant-time password comparison.** `subtle.ConstantTimeCompare` replaces `!=`, matching the main API listener (`pkg/api/api.go`). Low severity on its own behind TLS and an ingress; included for parity now that the file is open.

The 403 body carries no `Forbidden:` prefix on purpose. `client-go` promotes a text/plain error body into the `StatusError` message and `kubectl` prints the status reason itself, so a prefixed body would render as `Error from server (Forbidden): Forbidden: ...`.

## Behavior change

| Caller | After this change | Changed |
|--------|-------------------|---------|
| `admin` rack access token on `/kubernetes/` | proxied, full surface as before | no |
| `read` or `write` rack access token on `/kubernetes/` | 403, `admin role required for kubernetes api access` | **yes** |
| Rack password on `/kubernetes/`, any username | proxied | no |
| Any credential when no rack password is configured | 401 | **yes** |
| Rack access tokens on the main API (`:5443`) | role-gated per route, as before | no |

One change reaches users: holders of `read` and `write` rack access tokens can no longer use `/kubernetes/`. The affected flow is `convox rack access --role read|write` followed by `convox rack kubeconfig` with `RACK_URL` set. To use the proxy, mint an `admin` token, or use a kubeconfig that authenticates with the rack password. Requesting an `admin` token requires the caller to already hold admin, and the rack password authenticates as admin on the main API.

The empty-password rejection applies to the password branch only. An `admin` token still works when `PASSWORD` is empty, because `JwtMngr` is built from the signing-key Secret independently of `PASSWORD`. That preserves an operator recovery path into `/kubernetes/` on a rack whose password Secret is gone.

There is no role-scoped `kubectl` here, before or after: access through this listener is admin or nothing. Preserving scoped `kubectl` as a product feature would need per-request `rest.Config.Impersonate` with real ClusterRoles per role, a pattern that appears nowhere in first-party code today and that needs its own Terraform resources. That is a separate change and does not gate this one.