### PR TITLE
report runs whose exit status never arrives

### DIFF
--- a/pkg/api/controllers.go
+++ b/pkg/api/controllers.go
@@ -1334,7 +1334,11 @@ func (s *Server) ProcessExec(c *stdapi.Context) error {
 
 	v, err := s.provider(c).WithContext(contextFrom(c)).ProcessExec(app, pid, command, stdsdk.NewAdapterWs(c.Websocket()), opts)
 	if err != nil {
-		renderStatusCode(c, v)
+		// a zero here means the command never ran, so sending it as the exit
+		// status would report success for a failure
+		if v != 0 {
+			_ = renderStatusCode(c, v)
+		}
 		return err
 	}
 

--- a/pkg/api/process_test.go
+++ b/pkg/api/process_test.go
@@ -90,7 +90,36 @@ func TestProcessExecError(t *testing.T) {
 		require.NoError(t, err)
 		d, err := io.ReadAll(r)
 		require.NoError(t, err)
-		require.Equal(t, []byte("F1E49A85-0AD7-4AEF-A618-C249C6E6568D:0\nERROR: err1\n"), d)
+		require.Equal(t, []byte("ERROR: err1\n"), d, "a command that never ran must not be given an exit status of 0")
+	})
+}
+
+func TestProcessExecErrorWithStatus(t *testing.T) {
+	testServer(t, func(c *stdsdk.Client, p *structs.MockProvider) {
+		a1 := fxApp
+		p.On("AppGet", "app1").Return(&a1, nil)
+		opts := structs.ProcessExecOptions{
+			Entrypoint: options.Bool(true),
+			Height:     options.Int(1),
+			Tty:        options.Bool(false),
+			Width:      options.Int(2),
+		}
+		ro := stdsdk.RequestOptions{
+			Body: strings.NewReader("in"),
+			Headers: stdsdk.Headers{
+				"Command":    "command",
+				"Entrypoint": "true",
+				"Height":     "1",
+				"Tty":        "false",
+				"Width":      "2",
+			},
+		}
+		p.On("ProcessExec", "app1", "pid1", "command", mock.Anything, opts).Return(1, fmt.Errorf("err1"))
+		r, err := c.Websocket("/apps/app1/processes/pid1/exec", ro)
+		require.NoError(t, err)
+		d, err := io.ReadAll(r)
+		require.NoError(t, err)
+		require.Equal(t, []byte("F1E49A85-0AD7-4AEF-A618-C249C6E6568D:1\nERROR: err1\n"), d, "a real status must still reach clients that only read the marker")
 	})
 }
 

--- a/pkg/cli/exec.go
+++ b/pkg/cli/exec.go
@@ -38,7 +38,7 @@ func Exec(rack sdk.Interface, c *stdcli.Context) error {
 
 	code, err := rack.ProcessExec(app(c), pid, command, c, opts)
 	if err != nil {
-		return err
+		return execExitError(err, "The command may still be running in the target process, so retrying could run it twice.")
 	}
 
 	return stdcli.Exit(code)

--- a/pkg/cli/exec_test.go
+++ b/pkg/cli/exec_test.go
@@ -10,6 +10,7 @@ import (
 	mocksdk "github.com/convox/convox/pkg/mock/sdk"
 	"github.com/convox/convox/pkg/options"
 	"github.com/convox/convox/pkg/structs"
+	"github.com/convox/convox/sdk"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -29,6 +30,19 @@ func TestExec(t *testing.T) {
 		require.Equal(t, 4, res.Code)
 		res.RequireStderr(t, []string{""})
 		require.Equal(t, "out", res.Stdout)
+	})
+}
+
+func TestExecStreamIncomplete(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		opts := structs.ProcessExecOptions{Tty: options.Bool(false)}
+		i.On("ProcessExec", "app1", "0123456789", "bash", mock.Anything, opts).Return(0, sdk.ErrExecIncomplete)
+
+		res, err := testExecute(e, "exec 0123456789 bash -a app1", strings.NewReader("in"))
+		require.NoError(t, err)
+		require.Equal(t, 1, res.Code)
+		require.Contains(t, res.Stderr, "the rack did not report an exit status for this command")
+		require.Contains(t, res.Stderr, "retrying could run it twice")
 	})
 }
 

--- a/pkg/cli/helpers.go
+++ b/pkg/cli/helpers.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -67,6 +68,16 @@ func executableName() string {
 	default:
 		return "convox"
 	}
+}
+
+// execExitError expands a missing exit status. Many things can cause one and the
+// client cannot tell them apart, so it points at the output instead of guessing.
+func execExitError(err error, detail string) error {
+	if !errors.Is(err, sdk.ErrExecIncomplete) {
+		return err
+	}
+
+	return fmt.Errorf("%w, so it may not have finished.\n       Check the output above for a reason. %s\n       A command that must gate a deploy should write its own success marker to the output for the caller to check", err, detail)
 }
 
 func generateTempKey() (string, error) {

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -53,9 +53,6 @@ func Run(rack sdk.Interface, c *stdcli.Context) error {
 		opts.Width = options.Int(w)
 	}
 
-	restore := c.TerminalRaw()
-	defer restore()
-
 	if c.Bool("detach") {
 		c.Startf("Running detached process")
 
@@ -64,8 +61,17 @@ func Run(rack sdk.Interface, c *stdcli.Context) error {
 			return err
 		}
 
-		return c.OK(ps.Id)
+		if err := c.OK(ps.Id); err != nil {
+			return err
+		}
+
+		fmt.Fprintf(c.Writer().Stderr, "  convox logs -a %s\n  convox ps stop %s -a %s\n", app(c), ps.Id, app(c))
+
+		return nil
 	}
+
+	restore := c.TerminalRaw()
+	defer restore()
 
 	opts.Command = options.String(fmt.Sprintf("sleep %d", timeout))
 
@@ -92,7 +98,7 @@ func Run(rack sdk.Interface, c *stdcli.Context) error {
 
 	code, err := rack.ProcessExec(app(c), ps.Id, command, c, eopts)
 	if err != nil {
-		return err
+		return execExitError(err, "This run's process has been stopped.")
 	}
 
 	return stdcli.Exit(code)

--- a/pkg/cli/run_test.go
+++ b/pkg/cli/run_test.go
@@ -10,6 +10,7 @@ import (
 	mocksdk "github.com/convox/convox/pkg/mock/sdk"
 	"github.com/convox/convox/pkg/options"
 	"github.com/convox/convox/pkg/structs"
+	"github.com/convox/convox/sdk"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -55,7 +56,24 @@ func TestRunDetached(t *testing.T) {
 		res, err := testExecute(e, "run web bash -a app1 -d", nil)
 		require.NoError(t, err)
 		require.Equal(t, 0, res.Code)
-		res.RequireStderr(t, []string{""})
+		res.RequireStderr(t, []string{"  convox logs -a app1", "  convox ps stop pid1 -a app1"})
 		res.RequireStdout(t, []string{"Running detached process... OK, pid1"})
+	})
+}
+
+func TestRunStreamIncomplete(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("ProcessRun", "app1", "web", structs.ProcessRunOptions{Command: options.String("sleep 7200")}).Return(fxProcess(), nil)
+		i.On("ProcessGet", "app1", "pid1").Return(fxProcess(), nil)
+		opts := structs.ProcessExecOptions{Entrypoint: options.Bool(true), Tty: options.Bool(false)}
+		i.On("ProcessExec", "app1", "pid1", "bash", mock.Anything, opts).Return(0, sdk.ErrExecIncomplete)
+		i.On("ProcessStop", "app1", "pid1").Return(nil)
+
+		res, err := testExecute(e, "run web bash -a app1 -t 7200", strings.NewReader("in"))
+		require.NoError(t, err)
+		require.Equal(t, 1, res.Code)
+		require.Contains(t, res.Stderr, "the rack did not report an exit status for this command")
+		require.Contains(t, res.Stderr, "This run's process has been stopped.")
+		require.Contains(t, res.Stderr, "write its own success marker")
 	})
 }

--- a/pkg/cli/test.go
+++ b/pkg/cli/test.go
@@ -87,7 +87,7 @@ func Test(rack sdk.Interface, c *stdcli.Context) error {
 
 		code, err := rack.ProcessExec(app(c), ps.Id, s.Test, c, eopts)
 		if err != nil {
-			return err
+			return execExitError(err, "This test's process has been stopped.")
 		}
 
 		if code != 0 {

--- a/pkg/cli/test_test.go
+++ b/pkg/cli/test_test.go
@@ -9,6 +9,7 @@ import (
 	mocksdk "github.com/convox/convox/pkg/mock/sdk"
 	"github.com/convox/convox/pkg/options"
 	"github.com/convox/convox/pkg/structs"
+	"github.com/convox/convox/sdk"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -94,5 +95,32 @@ func TestTestFail(t *testing.T) {
 			"Running make test on web",
 			"out",
 		})
+	})
+}
+
+func TestTestStreamIncomplete(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("AppGet", "app1").Return(fxApp(), nil).Once()
+		i.On("ReleaseList", "app1", structs.ReleaseListOptions{Limit: options.Int(1)}).Return(structs.Releases{*fxRelease()}, nil).Once()
+		i.On("SystemGet").Return(fxSystem(), nil)
+		i.On("ObjectStore", "app1", mock.AnythingOfType("string"), mock.Anything, structs.ObjectStoreOptions{}).Return(&fxObject, nil)
+		i.On("BuildCreate", "app1", "object://test", structs.BuildCreateOptions{Development: options.Bool(true), Description: options.String("foo")}).Return(fxBuild(), nil)
+		i.On("BuildLogs", "app1", "build1", structs.LogsOptions{}).Return(testLogs(fxLogs()), nil)
+		i.On("BuildGet", "app1", "build1").Return(fxBuildRunning(), nil).Once()
+		i.On("BuildGet", "app1", "build1").Return(fxBuild(), nil)
+		i.On("BuildGet", "app1", "build4").Return(fxBuild(), nil)
+		i.On("ReleaseGet", "app1", "release1").Return(fxRelease(), nil)
+		i.On("ProcessRun", "app1", "web", structs.ProcessRunOptions{Command: options.String("sleep 7200"), Release: options.String("release1")}).Return(fxProcess(), nil)
+		i.On("ProcessGet", "app1", "pid1").Return(fxProcessPending(), nil).Twice()
+		i.On("ProcessGet", "app1", "pid1").Return(fxProcess(), nil)
+		opts := structs.ProcessExecOptions{Entrypoint: options.Bool(true), Tty: options.Bool(false)}
+		i.On("ProcessExec", "app1", "pid1", "make test", mock.Anything, opts).Return(0, sdk.ErrExecIncomplete)
+		i.On("ProcessStop", "app1", "pid1").Return(nil)
+
+		res, err := testExecute(e, "test ./testdata/httpd -a app1 -d foo -t 7200", strings.NewReader("in"))
+		require.NoError(t, err)
+		require.Equal(t, 1, res.Code)
+		require.Contains(t, res.Stderr, "the rack did not report an exit status for this command")
+		require.Contains(t, res.Stderr, "This test's process has been stopped.")
 	})
 }

--- a/sdk/exec_test.go
+++ b/sdk/exec_test.go
@@ -2,10 +2,13 @@ package sdk
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"io"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -119,18 +122,151 @@ func TestExecStreamECSSessionTruncated(t *testing.T) {
 
 	code, err := execStream(&framesReader{frames: frames}, out)
 	require.Error(t, err)
+	require.False(t, errors.Is(err, ErrExecIncomplete), "the ECS branch keeps its own error")
 	require.Equal(t, -1, code)
 	require.Equal(t, 0, *calls)
 	require.Empty(t, out.String())
 }
 
+func TestExecStreamNoMarker(t *testing.T) {
+	// The defect: a stream that ends before the marker was indistinguishable from
+	// a clean exit 0.
+	stubPlugin(t)
+	out := &bytes.Buffer{}
+
+	code, err := execStream(bytes.NewReader([]byte("hello world")), out)
+	require.ErrorIs(t, err, ErrExecIncomplete)
+	require.Equal(t, 0, code)
+	require.Equal(t, "hello world", out.String())
+}
+
+// requireOutput asserts that every byte of real output arrived. A marker that
+// straddles a read is recognized only once its last byte lands, so the bytes of
+// it that were already written can trail the output; nothing else may.
+func requireOutput(t *testing.T, want, got string, msg ...interface{}) {
+	t.Helper()
+	require.True(t, strings.HasPrefix(got, want), msg...)
+	require.True(t, strings.HasPrefix(statusCodePrefix, strings.TrimPrefix(got, want)),
+		"only marker bytes may trail the output, got %q", got)
+}
+
+func TestExecStreamMarkerSplitAtEveryOffset(t *testing.T) {
+	// The transport delivers at most 1024 bytes per read and a short read can land
+	// anywhere inside the marker. A split must never cost the code or invent a
+	// failure on a run that succeeded.
+	for _, code := range []int{0, 7, 137, -1} {
+		stream := []byte(fmt.Sprintf("hello world%s%d\n", statusCodePrefix, code))
+
+		for split := 1; split < len(stream); split++ {
+			stubPlugin(t)
+			out := &bytes.Buffer{}
+			frames := [][]byte{stream[:split], stream[split:]}
+
+			got, err := execStream(&framesReader{frames: frames}, out)
+			require.NoError(t, err, "code %d split at %d", code, split)
+			require.Equal(t, code, got, "code %d split at %d", code, split)
+			requireOutput(t, "hello world", out.String(), "code %d split at %d", code, split)
+		}
+	}
+}
+
+func TestExecStreamMarkerOneBytePerRead(t *testing.T) {
+	stubPlugin(t)
+	stream := []byte("hi" + statusCodePrefix + "42\n")
+
+	var frames [][]byte
+	for i := range stream {
+		frames = append(frames, stream[i:i+1])
+	}
+	out := &bytes.Buffer{}
+
+	code, err := execStream(&framesReader{frames: frames}, out)
+	require.NoError(t, err)
+	require.Equal(t, 42, code)
+	requireOutput(t, "hi", out.String())
+}
+
+func TestExecStreamMarkerCutBeforeNewline(t *testing.T) {
+	// The code arrived, the newline did not. Pre-existing behavior is to trust it.
+	stubPlugin(t)
+	out := &bytes.Buffer{}
+
+	code, err := execStream(bytes.NewReader([]byte("out"+statusCodePrefix+"3")), out)
+	require.NoError(t, err)
+	require.Equal(t, 3, code)
+	require.Equal(t, "out", out.String())
+}
+
+func TestExecStreamMarkerCutBeforeCode(t *testing.T) {
+	stubPlugin(t)
+	out := &bytes.Buffer{}
+
+	code, err := execStream(bytes.NewReader([]byte("out"+statusCodePrefix)), out)
+	require.ErrorIs(t, err, ErrExecIncomplete)
+	require.Equal(t, 0, code)
+	require.Equal(t, "out", out.String())
+}
+
+func TestExecStreamPrefixInOutput(t *testing.T) {
+	// Output that happens to carry the sentinel must not be swallowed, and must not
+	// blackhole the rest of the stream waiting for a code that never comes.
+	stubPlugin(t)
+	noise := statusCodePrefix + strings.Repeat("x", 64)
+	out := &bytes.Buffer{}
+
+	code, err := execStream(bytes.NewReader([]byte(noise+statusCodePrefix+"9\n")), out)
+	require.NoError(t, err)
+	require.Equal(t, 9, code)
+	require.Equal(t, noise, out.String())
+}
+
+func TestWebsocketExitStreamNoMarker(t *testing.T) {
+	// Deliberately unchanged: the endpoints behind WebsocketExit are interactive
+	// shells, not deploy gates, and two of them have no readable server source.
+	out := &bytes.Buffer{}
+
+	code, err := websocketExitStream(bytes.NewReader([]byte("hello world")), out)
+	require.NoError(t, err)
+	require.Equal(t, 0, code)
+	require.Equal(t, "hello world", out.String())
+}
+
+func TestExecBodyHoldsEOFUntilClose(t *testing.T) {
+	// stdsdk sends an empty binary frame when the request body ends, and a
+	// Console-proxied rack reads that as a closed stream and kills the command.
+	b := newExecBody(strings.NewReader("in"))
+	p := make([]byte, 8)
+
+	n, err := b.Read(p)
+	require.NoError(t, err)
+	require.Equal(t, "in", string(p[:n]))
+
+	blocked := make(chan error, 1)
+	go func() {
+		_, rerr := b.Read(p)
+		blocked <- rerr
+	}()
+
+	select {
+	case <-blocked:
+		require.Fail(t, "the body reported EOF before the exec finished")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	b.close()
+	require.Equal(t, io.EOF, <-blocked)
+}
+
 // methods.go is generated; ProcessExec is hand-maintained to relay the ECS Exec
-// protocol via execStream. A regen would revert it to a plain WebsocketExit call
-// and silently break ECS Exec (the unused linter would not notice, because these
-// tests reference execStream directly). This guard fails loudly if that happens.
+// protocol via execStream and to hold the request body open via newExecBody. A
+// regen would revert it to a plain WebsocketExit call and silently break ECS Exec
+// (the unused linter would not notice, because these tests reference execStream
+// directly). This guard fails loudly if that happens.
 func TestProcessExecWiredToExecStream(t *testing.T) {
 	src, err := os.ReadFile("methods.go")
 	require.NoError(t, err)
 	require.Contains(t, string(src), "return execStream(ws, rw)",
 		"sdk/methods.go ProcessExec must relay via execStream; if methods.go was regenerated, reapply the ECS Exec wrapper")
+	require.Contains(t, string(src), "newExecBody(rw)",
+		"sdk/methods.go ProcessExec must wrap the request body with newExecBody; if methods.go was regenerated, reapply it")
 }

--- a/sdk/exec_test.go
+++ b/sdk/exec_test.go
@@ -310,6 +310,14 @@ func TestExecBodyForwardsEOFWithoutProxy(t *testing.T) {
 	}
 }
 
+func TestProxied(t *testing.T) {
+	// A cloud machine reaches its target through the same Console relay but carries
+	// no rack name, so keying only on Rack would leave it uncovered.
+	require.False(t, (&Client{}).proxied())
+	require.True(t, (&Client{Rack: "rack1"}).proxied())
+	require.True(t, (&Client{MachineID: "m1"}).proxied())
+}
+
 func TestExecBodyReturnsDataWithEOF(t *testing.T) {
 	// A reader is allowed to return its last bytes together with io.EOF; those
 	// bytes must not wait on the exec.
@@ -335,6 +343,6 @@ func TestProcessExecWiredToExecStream(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(src), "return execStream(ws, rw)",
 		"sdk/methods.go ProcessExec must relay via execStream; if methods.go was regenerated, reapply the ECS Exec wrapper")
-	require.Contains(t, string(src), "newExecBody(rw, c.Rack",
+	require.Contains(t, string(src), "newExecBody(rw, c.proxied())",
 		"sdk/methods.go ProcessExec must wrap the request body with newExecBody; if methods.go was regenerated, reapply it")
 }

--- a/sdk/exec_test.go
+++ b/sdk/exec_test.go
@@ -30,6 +30,19 @@ func (f *framesReader) Read(p []byte) (int, error) {
 	return n, nil
 }
 
+type dataWithEOFReader struct {
+	data string
+	done bool
+}
+
+func (r *dataWithEOFReader) Read(p []byte) (int, error) {
+	if r.done {
+		return 0, io.EOF
+	}
+	r.done = true
+	return copy(p, r.data), io.EOF
+}
+
 func stubPlugin(t *testing.T) (*int, *ecsExecSession) {
 	t.Helper()
 	orig := runSessionManagerPlugin
@@ -234,12 +247,8 @@ func TestWebsocketExitStreamNoMarker(t *testing.T) {
 func TestExecBodyHoldsEOFUntilClose(t *testing.T) {
 	// stdsdk sends an empty binary frame when the request body ends, and a
 	// Console-proxied rack reads that as a closed stream and kills the command.
-	b := newExecBody(strings.NewReader("in"))
+	b := newExecBody(strings.NewReader(""), true)
 	p := make([]byte, 8)
-
-	n, err := b.Read(p)
-	require.NoError(t, err)
-	require.Equal(t, "in", string(p[:n]))
 
 	blocked := make(chan error, 1)
 	go func() {
@@ -257,6 +266,65 @@ func TestExecBodyHoldsEOFUntilClose(t *testing.T) {
 	require.Equal(t, io.EOF, <-blocked)
 }
 
+func TestExecBodyForwardsEOFAfterInput(t *testing.T) {
+	// A v2 rack half-closes the command's own stdin on that frame, so a caller
+	// that piped something in still needs it.
+	b := newExecBody(strings.NewReader("in"), true)
+	p := make([]byte, 8)
+
+	n, err := b.Read(p)
+	require.NoError(t, err)
+	require.Equal(t, "in", string(p[:n]))
+
+	done := make(chan error, 1)
+	go func() {
+		_, rerr := b.Read(p)
+		done <- rerr
+	}()
+
+	select {
+	case rerr := <-done:
+		require.Equal(t, io.EOF, rerr)
+	case <-time.After(time.Second):
+		require.Fail(t, "input was sent, so the body must report EOF without waiting")
+	}
+}
+
+func TestExecBodyForwardsEOFWithoutProxy(t *testing.T) {
+	// A rack reached directly is not torn down by the frame, and a v2 rack needs
+	// it to half-close the command's own stdin.
+	b := newExecBody(strings.NewReader(""), false)
+	p := make([]byte, 8)
+
+	done := make(chan error, 1)
+	go func() {
+		_, rerr := b.Read(p)
+		done <- rerr
+	}()
+
+	select {
+	case rerr := <-done:
+		require.Equal(t, io.EOF, rerr)
+	case <-time.After(time.Second):
+		require.Fail(t, "an unproxied client must report EOF without waiting")
+	}
+}
+
+func TestExecBodyReturnsDataWithEOF(t *testing.T) {
+	// A reader is allowed to return its last bytes together with io.EOF; those
+	// bytes must not wait on the exec.
+	b := newExecBody(&dataWithEOFReader{data: "in"}, true)
+	p := make([]byte, 8)
+
+	n, err := b.Read(p)
+	require.NoError(t, err)
+	require.Equal(t, "in", string(p[:n]))
+
+	n, err = b.Read(p)
+	require.Equal(t, io.EOF, err)
+	require.Equal(t, 0, n)
+}
+
 // methods.go is generated; ProcessExec is hand-maintained to relay the ECS Exec
 // protocol via execStream and to hold the request body open via newExecBody. A
 // regen would revert it to a plain WebsocketExit call and silently break ECS Exec
@@ -267,6 +335,6 @@ func TestProcessExecWiredToExecStream(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(src), "return execStream(ws, rw)",
 		"sdk/methods.go ProcessExec must relay via execStream; if methods.go was regenerated, reapply the ECS Exec wrapper")
-	require.Contains(t, string(src), "newExecBody(rw)",
+	require.Contains(t, string(src), "newExecBody(rw, c.Rack",
 		"sdk/methods.go ProcessExec must wrap the request body with newExecBody; if methods.go was regenerated, reapply it")
 }

--- a/sdk/methods.go
+++ b/sdk/methods.go
@@ -756,7 +756,7 @@ func (c *Client) ProcessExec(app, pid, command string, rw io.ReadWriter, opts st
 		return 0, err
 	}
 
-	body := newExecBody(rw, c.Rack != "")
+	body := newExecBody(rw, c.proxied())
 	defer body.close()
 
 	ro.Headers["command"] = command

--- a/sdk/methods.go
+++ b/sdk/methods.go
@@ -756,7 +756,7 @@ func (c *Client) ProcessExec(app, pid, command string, rw io.ReadWriter, opts st
 		return 0, err
 	}
 
-	body := newExecBody(rw)
+	body := newExecBody(rw, c.Rack != "")
 	defer body.close()
 
 	ro.Headers["command"] = command

--- a/sdk/methods.go
+++ b/sdk/methods.go
@@ -748,16 +748,19 @@ func (c *Client) ObjectStore(app, key string, r io.Reader, opts structs.ObjectSt
 }
 
 // NOTE: this file is generated, but ProcessExec is hand-maintained to relay the
-// v2 ECS Exec session protocol via execStream (in sdk.go). Preserve it if you
-// regenerate sdk/methods.go.
+// v2 ECS Exec session protocol via execStream and to hold the request body open
+// via newExecBody (both in sdk.go). Preserve them if you regenerate sdk/methods.go.
 func (c *Client) ProcessExec(app, pid, command string, rw io.ReadWriter, opts structs.ProcessExecOptions) (int, error) {
 	ro, err := stdsdk.MarshalOptions(opts)
 	if err != nil {
 		return 0, err
 	}
 
+	body := newExecBody(rw)
+	defer body.close()
+
 	ro.Headers["command"] = command
-	ro.Body = rw
+	ro.Body = body
 
 	ws, err := c.Websocket(fmt.Sprintf("/apps/%s/processes/%s/exec", app, pid), ro)
 	if err != nil {

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -432,24 +432,32 @@ func statusCodeFromMarker(marker []byte) (int, bool) {
 
 type execBody struct {
 	r    io.Reader
+	hold bool
+	sent bool
 	done chan struct{}
 }
 
-// newExecBody holds the stdin EOF until the exec is over. The empty binary frame
-// stdsdk sends on that EOF reads as a closed stream at a Console-proxied rack,
-// which then kills the running command.
-func newExecBody(r io.Reader) *execBody {
-	return &execBody{r: r, done: make(chan struct{})}
+// newExecBody optionally holds the EOF of a caller that never sends anything: the
+// empty binary frame stdsdk emits there reads as a closed stream at a Console
+// proxy, which kills the command. Held only for a proxied client and only until
+// the first byte, since a rack reached directly uses that frame to half-close the
+// command's own stdin.
+func newExecBody(r io.Reader, hold bool) *execBody {
+	return &execBody{r: r, hold: hold, done: make(chan struct{})}
 }
 
 func (b *execBody) Read(p []byte) (int, error) {
 	n, err := b.r.Read(p)
 
-	if err == io.EOF {
-		if n > 0 {
+	if n > 0 {
+		b.sent = true
+
+		if err == io.EOF {
 			return n, nil
 		}
+	}
 
+	if err == io.EOF && b.hold && !b.sent {
 		<-b.done
 	}
 

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -1,9 +1,11 @@
 package sdk
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -22,11 +24,15 @@ import (
 const (
 	sortableTime       = "20060102.150405.000000000"
 	statusCodePrefix   = "F1E49A85-0AD7-4AEF-A618-C249C6E6568D:"
+	statusCodeMaxLen   = len(statusCodePrefix) + 16
 	ecsExecSessionByte = '\x00'
 )
 
 var (
 	Version = "dev"
+
+	// ErrExecIncomplete reports a stream that ended without the exit-code marker.
+	ErrExecIncomplete = errors.New("the rack did not report an exit status for this command")
 )
 
 type Client struct {
@@ -192,6 +198,12 @@ func (c *Client) WebsocketExit(path string, ro stdsdk.RequestOptions, rw io.Read
 		return 0, err
 	}
 
+	return websocketExitStream(ws, rw)
+}
+
+// websocketExitStream still reports a markerless end as exit 0, unlike
+// execStream: the endpoints behind it are interactive shells, not deploy gates.
+func websocketExitStream(ws io.Reader, rw io.ReadWriter) (int, error) {
 	buf := make([]byte, 10*1024)
 	code := 0
 
@@ -274,18 +286,28 @@ var runSessionManagerPlugin = func(session ecsExecSession) (int, error) {
 // execStream relays an exec websocket. A v2 rack with ECSExec enabled signals an
 // ECS Exec session by prefixing the FIRST payload with ecsExecSessionByte and a
 // JSON session blob (handed to session-manager-plugin); any other rack streams
-// the process output and the exit-code marker, which we forward unchanged.
+// the process output and the exit-code marker, which we strip. The marker can
+// straddle a read, so the scan window carries the tail of what was already
+// written and the code accumulates until its newline.
 func execStream(ws io.Reader, rw io.ReadWriter) (int, error) {
 	buf := make([]byte, 10*1024)
 	code := 0
+	sawExit := false
 	first := true
 	var ecsSessionData []byte
+	var tail, marker []byte
 
 	for {
 		n, err := ws.Read(buf)
 		if err == io.EOF {
 			if ecsSessionData != nil {
 				return -1, fmt.Errorf("ECS Exec session ended before it was established; please retry")
+			}
+			if c, ok := statusCodeFromMarker(marker); ok {
+				return c, nil
+			}
+			if !sawExit {
+				return code, ErrExecIncomplete
 			}
 			return code, nil
 		}
@@ -314,25 +336,128 @@ func execStream(ws io.Reader, rw io.ReadWriter) (int, error) {
 			}
 		}
 
-		if i := strings.Index(string(buf[0:n]), statusCodePrefix); i > -1 {
-			if _, err := rw.Write(buf[0:i]); err != nil {
-				return 0, err
+		chunk := buf[0:n]
+
+		for len(chunk) > 0 {
+			if marker != nil {
+				seek := chunk
+				if room := statusCodeMaxLen - len(marker); len(seek) > room {
+					seek = seek[0:room]
+				}
+
+				if j := bytes.IndexByte(seek, '\n'); j > -1 {
+					marker = append(marker, chunk[0:j]...)
+					chunk = chunk[j+1:]
+
+					if c, ok := statusCodeFromMarker(marker); ok {
+						code = c
+						sawExit = true
+					} else if _, err := rw.Write(append(marker, '\n')); err != nil {
+						return 0, err
+					}
+
+					marker = nil
+					tail = nil
+
+					continue
+				}
+
+				marker = append(marker, seek...)
+				chunk = chunk[len(seek):]
+
+				if len(marker) >= statusCodeMaxLen {
+					if _, err := rw.Write(marker); err != nil {
+						return 0, err
+					}
+					tail = appendTail(tail, marker)
+					marker = nil
+				}
+
+				continue
 			}
 
-			m := i + len(statusCodePrefix)
+			win := append(append([]byte(nil), tail...), chunk...)
 
-			code, err = strconv.Atoi(strings.TrimSpace(string(buf[m:n])))
-			if err != nil {
-				return 0, fmt.Errorf("unable to read exit code")
+			i := bytes.Index(win, []byte(statusCodePrefix))
+			if i < 0 {
+				if _, err := rw.Write(chunk); err != nil {
+					return 0, err
+				}
+				tail = appendTail(tail, chunk)
+
+				break
 			}
 
-			continue
-		}
+			if i > len(tail) {
+				if _, err := rw.Write(chunk[0 : i-len(tail)]); err != nil {
+					return 0, err
+				}
+			}
 
-		if _, err := rw.Write(buf[0:n]); err != nil {
-			return 0, err
+			marker = append([]byte(nil), statusCodePrefix...)
+			chunk = chunk[i+len(statusCodePrefix)-len(tail):]
+			tail = nil
 		}
 	}
+}
+
+func appendTail(tail, b []byte) []byte {
+	keep := len(statusCodePrefix) - 1
+
+	if len(b) >= keep {
+		return append(tail[:0], b[len(b)-keep:]...)
+	}
+
+	tail = append(tail, b...)
+
+	if len(tail) > keep {
+		tail = append(tail[:0], tail[len(tail)-keep:]...)
+	}
+
+	return tail
+}
+
+func statusCodeFromMarker(marker []byte) (int, bool) {
+	if len(marker) <= len(statusCodePrefix) {
+		return 0, false
+	}
+
+	code, err := strconv.Atoi(strings.TrimSpace(string(marker[len(statusCodePrefix):])))
+	if err != nil {
+		return 0, false
+	}
+
+	return code, true
+}
+
+type execBody struct {
+	r    io.Reader
+	done chan struct{}
+}
+
+// newExecBody holds the stdin EOF until the exec is over. The empty binary frame
+// stdsdk sends on that EOF reads as a closed stream at a Console-proxied rack,
+// which then kills the running command.
+func newExecBody(r io.Reader) *execBody {
+	return &execBody{r: r, done: make(chan struct{})}
+}
+
+func (b *execBody) Read(p []byte) (int, error) {
+	n, err := b.r.Read(p)
+
+	if err == io.EOF {
+		if n > 0 {
+			return n, nil
+		}
+
+		<-b.done
+	}
+
+	return n, err
+}
+
+func (b *execBody) close() {
+	close(b.done)
 }
 
 func (c *Client) WithContext(ctx context.Context) structs.Provider {

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -468,6 +468,12 @@ func (b *execBody) close() {
 	close(b.done)
 }
 
+// proxied reports whether this client reaches its target through the Console,
+// which is where an end-of-input frame is read as the end of the whole session.
+func (c *Client) proxied() bool {
+	return c.Rack != "" || c.MachineID != ""
+}
+
 func (c *Client) WithContext(ctx context.Context) structs.Provider {
 	cc := *c
 	cc.Client = cc.Client.WithContext(ctx)


### PR DESCRIPTION
### What is the feature/update/fix?

**Fix: `convox run`, `convox exec`, and `convox test` Report a Missing Exit Status**

These three commands carry the command's exit status back in band, at the end of the exec stream. A stream that ends before that status arrives is now reported as a failure instead of being treated as an exit of 0. The CLI exits 1 and prints:

```
ERROR: the rack did not report an exit status for this command, so it may not have finished.
       Check the output above for a reason. This run's process has been stopped.
       A command that must gate a deploy should write its own success marker to the output for the caller to check
```

Each command says what happened to the process, since that decides whether a retry is safe:

| Command | Second line |
|---------|-------------|
| `convox run` | `This run's process has been stopped.` |
| `convox test` | `This test's process has been stopped.` |
| `convox exec` | `The command may still be running in the target process, so retrying could run it twice.` |

The message does not name a cause. A lost connection, a rejected token, a validation failure, and a proxy restart all look the same from the client, so it points at the output above, where the rack's own error message is already printed if it sent one.

**A non-interactive run stays connected.** The exec request body is the client's stdin, and when stdin is not a terminal it reaches end of input immediately. That end of input is now held until the exec returns, so a command run from CI, from cron, or with `< /dev/null` stays connected for the life of the command. This applies to a client that reaches its rack through Convox Console and sends nothing on stdin. A rack reached directly is unaffected either way, and an interactive session never reaches end of input, so nothing changes there.

**A command the rack rejects before it starts sends no exit status.** On that path the status marker is written only when the value is non-zero, so a real status still reaches every client and a command that never started sends none at all, which the CLI reports as above.

**`convox run --detach` prints the follow-up commands for the process it started.**

```
  convox logs -a my-app
  convox ps stop 7b6bccfd9fdf -a my-app
```

Both lines go to stderr, so a caller reading the process id from stdout is unaffected.

A command that gates a deploy should still emit output periodically so the stream is never silent for long, and write an explicit success marker as its last line for the caller to check. The exit code is trustworthy when it is reported, and an explicit marker survives every failure mode.

`convox instances shell` and `convox instances ssh` are interactive shells rather than deploy gates and are deliberately unchanged. On a V2 rack with ECS Exec, the exit code has always reflected the session rather than the command, and that is unchanged.

---

### Why is this important?

A CI step that gates a deploy on `convox run` needs the exit code to mean something, and a stream that ends before the status arrives is now reported rather than read as an exit of 0.

**Benefits:**

- **The exit code can be trusted.** A run reports success only when the rack reported a real status for it.
- **A named outcome.** When the status is missing, the CLI says so, points at the output above, and states whether the process was stopped, so you know whether retrying is safe.
- **Long CI commands stay connected.** A non-interactive run against a Console-managed rack stays connected until the command finishes rather than being cut shortly after it starts.
- **No false failures.** The status marker is reassembled across read boundaries, so a status that arrives split across two reads is still read correctly.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this fix, and one behavior change to plan for.

A caller that today passes on a truncated stream will start failing. Nothing about the command itself changed, only what the CLI reports when it cannot tell how the command ended. `convox test` is affected the same way, since it treats an exit of 0 as a pass.

There is no change to the wire format, no route change, no struct field change, and no required parameter. An older CLI against a rack on this release is unchanged, because a real non-zero status is still written to the marker. Piping input into a command behaves exactly as it does today on every rack. The one case that now waits rather than being cut is a command that blocks reading stdin while being given no input.

---

### Requirements

What you get depends on which side you upgrade.

| Change | Requires |
|--------|----------|
| A stream that ends without a status is reported as a failure, and a non-interactive run stays connected | The CLI at `3.25.5` or later, against any supported rack |
| A command that the rack rejected before it started sends no status at all | The rack at `3.25.5` or later |

**Update the Rack:** Run `convox rack update 3.25.5 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
