### PR TITLE
add liveness.grpcService for grpc liveness probe

### DIFF
--- a/docs/configuration/health-checks.md
+++ b/docs/configuration/health-checks.md
@@ -100,7 +100,7 @@ services:
 
 ### Important Considerations
 
-- **Path is Required**: Unlike health checks, you must specify a `path` to enable liveness checks. Setting `liveness.port` without `liveness.path` is a silent no-op, so no liveness probe is generated
+- **Path is Required**: Unlike health checks, an HTTP service must specify a `path` to enable liveness checks. Setting `liveness.port` without `liveness.path` is a silent no-op, so no liveness probe is generated. A gRPC service using `grpcHealthEnabled` is the exception, see [gRPC Health Checks](#grpc-health-checks)
 - **`port` is optional**: If unset, the liveness probe targets the main service port, mirroring the `health.port` behavior. Startup probes ignore `liveness.port` and continue to target the main service port. If you need the liveness probe to use a specific scheme (for example, HTTPS), set `liveness.port.scheme` explicitly. Unlike readiness, liveness does not auto-inherit the main service scheme
 - **Conservative Configuration**: Liveness checks should be configured conservatively to avoid unnecessary restarts. False positives can cause service disruption
 - **Separate Endpoints**: Consider using different endpoints for health checks and liveness checks to monitor different aspects of your application
@@ -284,7 +284,7 @@ services:
 
 ### Advanced Configuration
 
-A subset of the `health` attributes applies to gRPC health checks. See the table below.
+A subset of the `health` attributes applies to gRPC health checks, along with two `liveness` attributes. See the tables below.
 
 ```yaml
 services:
@@ -297,6 +297,8 @@ services:
       interval: 5
       grpcService: myapp.v1.Greeter
       timeout: 2
+    liveness:
+      grpcService: myapp.v1.Liveness
 ```
 
 | Attribute  | Default | Description                                                                      |
@@ -309,9 +311,22 @@ services:
 | **timeout**  | `interval - 1` | The number of seconds to wait for a valid response. Defaults to `interval` minus one |
 | **disable**  | false   | Set to `true` to disable the gRPC readiness and liveness probes. Requires rack version 3.25.4 or later |
 
-`grpcService` takes a gRPC service name such as `myapp.v1.Greeter`. It is not a URL path: a value beginning with `/` is rejected when your app is built, so moving an old `path: /` value into this key fails fast rather than at rollout. Beyond that the value is passed through as written, and the name must be registered on your server. `Check` returns `NOT_FOUND` for a name your server does not know, so readiness never passes and the deploy does not converge.
+These two `liveness` attributes apply as well.
 
-`grpcService` changes the readiness probe only. The automatic liveness probe keeps sending the empty service name, so your server must report `SERVING` for both the empty name and the name you set. Go's `health.NewServer()` registers the empty name for you. A hand-written `Check` method, or a health registry you populate yourself, must handle an empty `req.Service` as well, or the liveness probe fails and the container restarts. If `liveness.port` points at a separate health listener, only that listener needs the empty name; it does not need the name you set in `grpcService`.
+| Attribute  | Default | Description                                                                      |
+| ---------- | ------- | -------------------------------------------------------------------------------- |
+| **grpcService** | empty | The gRPC health service name placed in the liveness probe's `HealthCheckRequest`. Empty means overall server health. Requires rack version 3.25.5 or later. An earlier rack accepts the key without error and ignores it, leaving the liveness probe on the empty name |
+| **port**     | Main service port | Moves the gRPC liveness probe to another port |
+
+No other `liveness` attribute reaches the gRPC probes. The `liveness.*` timing fields are still the fallback timings for a [startup probe](#startup-probes).
+
+`grpcService` takes a gRPC service name such as `myapp.v1.Greeter`. It is not a URL path: a value beginning with `/` is rejected when your app is built, so moving an old `path: /` value into this key fails fast rather than at rollout. Beyond that the value is passed through as written, and the name must be registered on your server. `Check` returns `NOT_FOUND` for a name your server does not know. In `health.grpcService` that means readiness never passes and the deploy does not converge; in `liveness.grpcService` it means the liveness probe fails and the kubelet restarts the container.
+
+`health.grpcService` changes the readiness probe only. The liveness probe sends the empty service name unless you also set `liveness.grpcService`, so by default your server must report `SERVING` for both the empty name and the name you set. Go's `health.NewServer()` registers the empty name for you. A hand-written `Check` method, or a health registry you populate yourself, must handle an empty `req.Service` as well, or the liveness probe fails and the container restarts. Registering the empty name is one line and is safe to drain against, so prefer it whenever you control the server.
+
+`liveness.grpcService` is for the cases where you cannot: a server you do not build, or one that deliberately exposes a separate liveness service. Point it at a name you never flip to `NOT_SERVING`. Setting it to the same name as `health.grpcService` means a drain fails liveness as well, and the container is restarted after five failed checks instead of being taken out of rotation, which is the opposite of what a drain is for. Your build prints a warning to the deploy output when the two names match.
+
+If `liveness.port` points at a separate health listener, only that listener has to answer the name the liveness probe sends.
 
 Before rack version 3.25.4, `health.disable: true` was ignored on a gRPC service and both probes rendered anyway. Updating a rack to 3.25.4 with `health.disable: true` already set on a gRPC service removes both of its probes.
 
@@ -335,6 +350,8 @@ Readiness now checks `myapp.v1.Greeter` on port 50051 and liveness checks the em
 
 Unlike an HTTP service, a gRPC service needs no `liveness.path` for this: the liveness probe is generated by `grpcHealthEnabled` and `liveness.port` moves it.
 
+From rack version 3.25.5 you can separate the two checks on a single port by giving each one its own name, with `health.grpcService` for readiness and `liveness.grpcService` for liveness. A second listener is still the better answer when the checks need to be independent of the main port itself, for example when that port can saturate.
+
 ### Implementation Requirements
 
 Services using gRPC health checks must implement the gRPC Health Checking Protocol, which is defined in the [gRPC health checking protocol repository](https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
@@ -356,7 +373,7 @@ Both probes use `health.grace`, `health.interval` and `health.timeout`. They do 
 
 `grpcHealthEnabled: true` is inert on a service whose main port is not gRPC, unless you also set `health.port.scheme: grpc`. That activates the gRPC probes, giving you a gRPC readiness probe on `health.port` and a gRPC liveness probe on `liveness.port`, which defaults to the main port. If `liveness.path` is also set, that HTTP liveness probe is replaced by the gRPC one. Set `liveness.port` to match, or leave `health.port.scheme` unset.
 
-For the gRPC probes, only `liveness.port` has any effect; the `liveness.*` timing fields and `liveness.path` do not. Those timings are still used as the fallback timings for a [startup probe](#startup-probes), including the automatic startup probe added to GPU services.
+For the gRPC probes, only `liveness.port` and `liveness.grpcService` have any effect; the `liveness.*` timing fields and `liveness.path` do not. Those timings are still used as the fallback timings for a [startup probe](#startup-probes), including the automatic startup probe added to GPU services.
 
 `startupProbe.path` renders a plain HTTP GET against the gRPC port and fails unless your server also answers HTTP/1.1 there. Use `startupProbe.tcpSocketPort` on a gRPC service.
 
@@ -385,13 +402,16 @@ func main() {
 	healthServer := health.NewServer()
 	healthpb.RegisterHealthServer(server, healthServer)
 	
-	// The liveness probe always checks the empty service name
+	// The liveness probe checks the empty service name unless you set liveness.grpcService
 	healthServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
 	
 	// Only needed when you set health.grpcService, which the readiness probe checks.
 	// Flip this to NOT_SERVING to drain traffic without restarting the container.
 	healthServer.SetServingStatus("myapp.v1.Greeter", healthpb.HealthCheckResponse_SERVING)
 	
+	// Only needed when you set liveness.grpcService. Never flip this one to NOT_SERVING.
+	healthServer.SetServingStatus("myapp.v1.Liveness", healthpb.HealthCheckResponse_SERVING)
+
 	// Continue with server initialization...
 }
 ```

--- a/docs/reference/primitives/app/service.md
+++ b/docs/reference/primitives/app/service.md
@@ -437,6 +437,7 @@ See [Health Checks](/configuration/health-checks) for configuring readiness, liv
 | Attribute  | Type   | Default | Description                                                                                      |
 | ---------- | ------ | ------- | ------------------------------------------------------------------------------------------------ |
 | **grace**    | number | 10       | The number of seconds to wait for a [Process](/reference/primitives/app/process) to start before starting liveness checks |
+| **grpcService** | string |      | The gRPC health service name placed in the liveness probe's `HealthCheckRequest`, for services using `grpcHealthEnabled`. Empty means overall server health. Ignored unless the gRPC probes are active. Requires rack version 3.25.5 or later. See [gRPC Health Checks](/configuration/health-checks#grpc-health-checks) |
 | **interval** | number | 5       | The number of seconds between health checks                                                      |
 | **path**     | string |        | The path to request for health checks                                                            |
 | **port**     | number or map | Main service port | The port the liveness probe connects to. Same form as `health.port`. Unlike readiness, liveness does **not** auto-inherit the main service scheme. Set `scheme` explicitly when the probe needs HTTPS. See [Separate Health Port](/configuration/health-checks#separate-health-port) |
@@ -444,7 +445,7 @@ See [Health Checks](/configuration/health-checks) for configuring readiness, liv
 | **successThreshold**  | number | 1      | The number of consecutive successful checks required to consider the probe successful             |
 | **failureThreshold**  | number | 3      | The number of consecutive failed checks required before restarting the container                  |
 
-> If you want to enable liveness check, you have to specify **path** and others are optional
+> On an HTTP service you have to specify **path** to enable the liveness check, and the others are optional. A gRPC service using `grpcHealthEnabled` gets a liveness probe without **path**, unless `health.disable` is set, and only **port** and **grpcService** change that probe. The timing fields still apply to a `startupProbe`.
 
 ### scale
 

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -170,6 +170,7 @@ func (m *Manifest) ApplyDefaults() error {
 		}
 
 		m.Services[i].Health.GrpcService = strings.TrimSpace(s.Health.GrpcService)
+		m.Services[i].Liveness.GrpcService = strings.TrimSpace(s.Liveness.GrpcService)
 
 		s.Liveness.Path = strings.TrimSpace(s.Liveness.Path)
 		if s.Liveness.Path != "" {

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -792,6 +792,7 @@ func TestManifestValidate(t *testing.T) {
 		"service name serviceF invalid, must contain only lowercase alphanumeric and dashes",
 		"service serviceF references a resource that does not exist: foo",
 		"service grpc-path-invalid health grpcService must be a grpc service name such as myapp.v1.Greeter, not a path",
+		"service grpc-liveness-path-invalid liveness grpcService must be a grpc service name such as myapp.v1.Greeter, not a path",
 		"timer name timer_1 invalid, must contain only lowercase alphanumeric and dashes",
 		"timer timer_1 references a service that does not exist: someservice",
 	}
@@ -999,7 +1000,7 @@ func TestManifestStartupProbeGpu_NoPortService_NoFailureThresholdSet(t *testing.
 func TestManifestGrpcHealthService(t *testing.T) {
 	m, err := testdataManifest("grpc-health", map[string]string{})
 	require.NoError(t, err)
-	require.Equal(t, 4, len(m.Services))
+	require.Equal(t, 7, len(m.Services))
 
 	named, err := m.Service("named")
 	require.NoError(t, err)
@@ -1018,6 +1019,55 @@ func TestManifestGrpcHealthService(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "/ready", shorthand.Health.Path)
 	require.Equal(t, "", shorthand.Health.GrpcService)
+
+	require.Equal(t, "", plain.Liveness.GrpcService, "liveness grpcService must stay empty when unset")
+
+	livenessNamed, err := m.Service("liveness-named")
+	require.NoError(t, err)
+	require.Equal(t, "myapp.v1.Liveness", livenessNamed.Liveness.GrpcService)
+	require.Equal(t, "", livenessNamed.Health.GrpcService)
+	require.Equal(t, 0, livenessNamed.Liveness.Grace, "liveness grpcService alone must not activate the liveness defaults")
+	require.Equal(t, 0, livenessNamed.Liveness.FailureThreshold)
+
+	livenessPadded, err := m.Service("liveness-padded")
+	require.NoError(t, err)
+	require.Equal(t, "myapp.v1.Liveness", livenessPadded.Liveness.GrpcService)
+
+	both, err := m.Service("both")
+	require.NoError(t, err)
+	require.Equal(t, "myapp.v1.Greeter", both.Health.GrpcService)
+	require.Equal(t, "myapp.v1.Liveness", both.Liveness.GrpcService)
+}
+
+func TestManifestGrpcServiceSharedNameWarning(t *testing.T) {
+	validate := func(health, liveness string) string {
+		m, err := manifest.Load([]byte(fmt.Sprintf(`services:
+  api:
+    build: .
+    port: grpc:50051
+    grpcHealthEnabled: true
+    health:
+      grpcService: %q
+    liveness:
+      grpcService: %q
+`, health, liveness)), map[string]string{})
+		require.NoError(t, err)
+
+		var verr error
+		out := captureStderr(t, func() { verr = m.Validate() })
+		require.NoError(t, verr)
+
+		return out
+	}
+
+	shared := validate("myapp.v1.Greeter", "myapp.v1.Greeter")
+	require.Contains(t, shared, `WARNING: service "api": liveness grpcService matches health grpcService`)
+	require.Equal(t, 1, strings.Count(shared, "WARNING"))
+
+	require.Empty(t, validate("myapp.v1.Greeter", "myapp.v1.Liveness"))
+	require.Empty(t, validate("", "myapp.v1.Liveness"))
+	require.Empty(t, validate("myapp.v1.Greeter", ""))
+	require.Empty(t, validate("", ""), "both unset must not warn")
 }
 
 func TestManifestKeda(t *testing.T) {

--- a/pkg/manifest/service.go
+++ b/pkg/manifest/service.go
@@ -356,6 +356,7 @@ type ServiceHealth struct {
 
 type ServiceLiveness struct {
 	Grace            int               `yaml:"grace,omitempty"`
+	GrpcService      string            `yaml:"grpcService,omitempty"`
 	Interval         int               `yaml:"interval,omitempty"`
 	Path             string            `yaml:"path,omitempty"`
 	Port             ServicePortScheme `yaml:"port,omitempty"`

--- a/pkg/manifest/testdata/grpc-health.yml
+++ b/pkg/manifest/testdata/grpc-health.yml
@@ -20,3 +20,23 @@ services:
     port: grpc:50054
     grpcHealthEnabled: true
     health: /ready
+  liveness-named:
+    build: .
+    port: grpc:50055
+    grpcHealthEnabled: true
+    liveness:
+      grpcService: myapp.v1.Liveness
+  liveness-padded:
+    build: .
+    port: grpc:50056
+    grpcHealthEnabled: true
+    liveness:
+      grpcService: "  myapp.v1.Liveness  "
+  both:
+    build: .
+    port: grpc:50057
+    grpcHealthEnabled: true
+    health:
+      grpcService: myapp.v1.Greeter
+    liveness:
+      grpcService: myapp.v1.Liveness

--- a/pkg/manifest/testdata/validate.yml
+++ b/pkg/manifest/testdata/validate.yml
@@ -30,6 +30,12 @@ services:
     grpcHealthEnabled: true
     health:
       grpcService: /ready
+  grpc-liveness-path-invalid:
+    build: .
+    port: grpc:50052
+    grpcHealthEnabled: true
+    liveness:
+      grpcService: "  /ready"
 timers:
   timer_1:
     service: someservice

--- a/pkg/manifest/validate.go
+++ b/pkg/manifest/validate.go
@@ -150,6 +150,16 @@ func (m *Manifest) validateServices() []error {
 			errs = append(errs, fmt.Errorf("service %s health grpcService must be a grpc service name such as myapp.v1.Greeter, not a path", s.Name))
 		}
 
+		if strings.HasPrefix(s.Liveness.GrpcService, "/") {
+			errs = append(errs, fmt.Errorf("service %s liveness grpcService must be a grpc service name such as myapp.v1.Greeter, not a path", s.Name))
+		}
+
+		if s.Liveness.GrpcService != "" && s.Liveness.GrpcService == s.Health.GrpcService {
+			fmt.Fprintf(os.Stderr,
+				"WARNING: service %q: liveness grpcService matches health grpcService; setting that name NOT_SERVING fails the liveness probe and restarts the container instead of draining it\n",
+				s.Name)
+		}
+
 		if s.Agent.Enabled && s.SpreadAcrossZones {
 			errs = append(errs, fmt.Errorf("service %s can not set spreadAcrossZones when agent is enabled", s.Name))
 		}

--- a/provider/k8s/template/app/service.yml.tmpl
+++ b/provider/k8s/template/app/service.yml.tmpl
@@ -359,6 +359,9 @@ spec:
         livenessProbe:
           grpc:
             port: {{ if gt $.Service.Liveness.Port.Port 0 }}{{ $.Service.Liveness.Port.Port }}{{ else }}{{.}}{{ end }}
+            {{ if not (eq $.Service.Liveness.GrpcService "") }}
+            service: "{{$.Service.Liveness.GrpcService}}"
+            {{ end }}
           initialDelaySeconds: {{$.Service.Health.Grace}}
           periodSeconds: {{$.Service.Health.Interval}}
           timeoutSeconds: {{$.Service.Health.Timeout}}

--- a/provider/k8s/template_test.go
+++ b/provider/k8s/template_test.go
@@ -264,6 +264,18 @@ func gpuTemplateFixture(t *testing.T, src string) (*Provider, map[string]interfa
 	return p, params
 }
 
+// splitProbes returns the livenessProbe and readinessProbe blocks of a rendered
+// service. FormatYAML sorts keys, so livenessProbe always precedes readinessProbe.
+func splitProbes(t *testing.T, rendered string) (string, string) {
+	t.Helper()
+	livenessIdx := strings.Index(rendered, "livenessProbe:")
+	readinessIdx := strings.Index(rendered, "readinessProbe:")
+	if livenessIdx < 0 || readinessIdx < 0 || livenessIdx > readinessIdx {
+		t.Fatalf("unexpected probe layout: %s", rendered)
+	}
+	return rendered[livenessIdx:readinessIdx], rendered[readinessIdx:]
+}
+
 // countKey returns the number of lines in rendered that contain key when
 // leading/trailing whitespace is stripped (guards against duplicate YAML keys).
 func countKey(rendered, key string) int {
@@ -1040,6 +1052,7 @@ func TestRenderTemplateServiceHealthPort(t *testing.T) {
 		assertNotContains("no grpc service name", out, grpcProbeService)
 		// Pins the bytes: port is the only key inside grpc, so the next key is the probe's.
 		assertContains("grpc block unchanged", out, "grpc:\n            port: 50051\n          initialDelaySeconds: 5")
+		assertContains("liveness block unchanged", out, "livenessProbe:\n          failureThreshold: 5\n          grpc:\n            port: 50051\n          initialDelaySeconds: 5")
 	})
 
 	t.Run("health.grpcService renders in the grpc readinessProbe only", func(t *testing.T) {
@@ -1057,6 +1070,7 @@ func TestRenderTemplateServiceHealthPort(t *testing.T) {
 		svc.Health.GrpcService = "myapp.v1.Greeter"
 		svc.Health.Port = manifest.ServicePortScheme{Port: 50052}
 		svc.Liveness = manifest.ServiceLiveness{
+			GrpcService:      "myapp.v1.Liveness",
 			Port:             manifest.ServicePortScheme{Port: 50053},
 			SuccessThreshold: 1,
 			FailureThreshold: 5,
@@ -1070,8 +1084,8 @@ func TestRenderTemplateServiceHealthPort(t *testing.T) {
 		livenessBlock := out[livenessIdx:readinessIdx]
 		readinessBlock := out[readinessIdx:]
 		assertContains("readiness keeps health.port and the service name", readinessBlock, "grpc:\n            port: 50052\n            service: myapp.v1.Greeter")
-		assertContains("liveness keeps liveness.port", livenessBlock, "port: 50053")
-		assertNotContains("liveness has no service name", livenessBlock, grpcProbeService)
+		assertContains("liveness keeps liveness.port and its own service name", livenessBlock, "grpc:\n            port: 50053\n            service: myapp.v1.Liveness")
+		assertNotContains("liveness does not take the readiness name", livenessBlock, "service: myapp.v1.Greeter")
 	})
 
 	t.Run("health.path never becomes the grpc service name", func(t *testing.T) {
@@ -1100,6 +1114,7 @@ func TestRenderTemplateServiceHealthPort(t *testing.T) {
 	t.Run("health.disable removes both grpc probes", func(t *testing.T) {
 		svc := grpcService("disabledgrpc")
 		svc.Health.Disable = true
+		svc.Liveness.GrpcService = "myapp.v1.Liveness"
 		out := render(svc)
 		assertNotContains("no readinessProbe", out, "readinessProbe:")
 		assertNotContains("no livenessProbe", out, "livenessProbe:")
@@ -1144,10 +1159,68 @@ func TestRenderTemplateServiceHealthPort(t *testing.T) {
 		assertNotContains("no readinessProbe", out, "readinessProbe:")
 	})
 
+	t.Run("liveness.grpcService renders in the grpc livenessProbe only", func(t *testing.T) {
+		svc := grpcService("namedliveness")
+		svc.Liveness.GrpcService = "myapp.v1.Liveness"
+		out := render(svc)
+		livenessBlock, readinessBlock := splitProbes(t, out)
+		assertContains("liveness service name", livenessBlock, "grpc:\n            port: 50051\n            service: myapp.v1.Liveness")
+		assertNotContains("readiness has no service name", readinessBlock, grpcProbeService)
+		if n := countKey(out, "service: myapp.v1.Liveness"); n != 1 {
+			t.Errorf("expected the service name exactly once (liveness only); got %d:\n%s", n, out)
+		}
+	})
+
+	t.Run("health and liveness grpcService render independently", func(t *testing.T) {
+		svc := grpcService("bothnames")
+		svc.Health.GrpcService = "myapp.v1.Greeter"
+		svc.Liveness.GrpcService = "myapp.v1.Liveness"
+		out := render(svc)
+		livenessBlock, readinessBlock := splitProbes(t, out)
+		assertContains("readiness keeps its own name", readinessBlock, "service: myapp.v1.Greeter")
+		assertNotContains("readiness does not take the liveness name", readinessBlock, "service: myapp.v1.Liveness")
+		assertContains("liveness keeps its own name", livenessBlock, "service: myapp.v1.Liveness")
+		assertNotContains("liveness does not take the readiness name", livenessBlock, "service: myapp.v1.Greeter")
+	})
+
+	t.Run("the same name on both probes renders on both", func(t *testing.T) {
+		svc := grpcService("samename")
+		svc.Health.GrpcService = "myapp.v1.Greeter"
+		svc.Liveness.GrpcService = "myapp.v1.Greeter"
+		out := render(svc)
+		if n := countKey(out, "service: myapp.v1.Greeter"); n != 2 {
+			t.Errorf("expected the service name on both probes; got %d:\n%s", n, out)
+		}
+	})
+
+	t.Run("http service ignores liveness.grpcService", func(t *testing.T) {
+		svc := manifest.Service{
+			Name: "httpliveness",
+			Port: manifest.ServicePortScheme{Port: 8080, Scheme: "http"},
+			Health: manifest.ServiceHealth{
+				Path: "/health", Grace: 5, Interval: 5, Timeout: 4,
+			},
+			Liveness: manifest.ServiceLiveness{
+				GrpcService:      "myapp.v1.Liveness",
+				Path:             "/live",
+				Grace:            10,
+				Interval:         5,
+				Timeout:          5,
+				SuccessThreshold: 1,
+				FailureThreshold: 3,
+			},
+		}
+		out := render(svc)
+		assertContains("httpGet keeps the liveness path", out, "path: /live")
+		assertNotContains("no grpc block", out, "grpc:")
+		assertNotContains("no grpc service name", out, "service: myapp.v1.Liveness")
+	})
+
 	t.Run("grpc port without grpcHealthEnabled renders no probes", func(t *testing.T) {
 		svc := grpcService("optedout")
 		svc.GrpcHealthEnabled = false
 		svc.Liveness = manifest.ServiceLiveness{
+			GrpcService:      "myapp.v1.Liveness",
 			Path:             "/live",
 			Grace:            10,
 			Interval:         5,


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: `liveness.grpcService` for gRPC Services**

A gRPC service can now select which gRPC health service name Convox places in the liveness probe's `HealthCheckRequest`. A new `convox.yml` attribute, `services.<name>.liveness.grpcService`, is passed through to the automatic gRPC liveness probe as its `service` field. It mirrors `health.grpcService`, which `3.25.4` added for the readiness probe, and the two names are independent.

**New Service Attribute:**

| Attribute | Type | Default | Effect |
|-----------|------|---------|--------|
| `services.<name>.liveness.grpcService` | string | empty | The gRPC health service name sent in the liveness probe's `HealthCheckRequest`. Empty means overall server health. Ignored on a non-gRPC service. |

Unset renders exactly as it does today: the liveness probe emits no `service` key and the kubelet asks for the empty name, which is overall server health. Whitespace around a value is trimmed, and a value beginning with `/` is rejected at build time with `service <name> liveness grpcService must be a grpc service name such as myapp.v1.Greeter, not a path`, so a `path:` value moved into the wrong key fails the build instead of surfacing at rollout.

A build prints a warning when `liveness.grpcService` matches `health.grpcService`:

```
WARNING: service "api": liveness grpcService matches health grpcService; setting that name NOT_SERVING fails the liveness probe and restarts the container instead of draining it
```

It is a warning rather than an error, and the build continues. A server that registers exactly one name has no other option, and a server that never drains by status is unaffected.

`health.disable` still removes both gRPC probes. The gRPC probe's `successThreshold` of 1 and `failureThreshold` of 5 are unchanged, the gRPC probes continue to take their timings from the `health` block, and `grpcHealthEnabled: true` still turns them on.

---

### Why is this important?

The recommended behavior for a gRPC server is still to report `SERVING` for the empty service name, which `grpc-go`'s `health.NewServer()` does on its own. This attribute is for the servers where that is not available: a hand-implemented `Health` service that registers only named services returns `NOT_FOUND` for the empty name, and a server that deliberately exposes a separate liveness service has no way to point the probe at it.

**Benefits:**

- **Name each probe independently.** Readiness and liveness can check different gRPC health service names, so a drain that flips the readiness name to `NOT_SERVING` takes the pod out of rotation without restarting the container.
- **No server change required.** A server you do not control, or cannot easily change, can be probed on the names it actually registers.
- **Caught at build time.** A value that looks like a path is rejected when the app is built, and a configuration that would turn a drain into a restart prints a warning naming the service.
- **Unchanged by default.** The attribute is empty by default and every existing manifest renders a byte-identical pod spec.

---

### How to use it?

Set the attribute alongside `health.grpcService` on a gRPC service in `convox.yml`:

```yaml
services:
  api:
    port: grpc:50051
    grpcHealthEnabled: true
    health:
      grpcService: myapp.v1.Greeter
    liveness:
      grpcService: myapp.v1.Liveness
```

Deploy the app to apply it:

    $ convox deploy -a my-app -r rackName

Readiness checks `myapp.v1.Greeter` and liveness checks `myapp.v1.Liveness`. Flipping the readiness name to `NOT_SERVING` drains the pod without restarting it.

If your server controls its own health registration, `SetServingStatus("", SERVING)` is still the simplest option and needs no `convox.yml` change at all.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this feature.

The attribute is purely additive with an inert default, so no existing deployment changes on upgrade. On a rack older than `3.25.5` the key parses without error and is ignored, leaving the liveness probe on the empty service name, which is how every new manifest key behaves. The same applies in reverse: on a rack downgraded below `3.25.5` the next app update re-renders the workload without the key and the liveness probe returns to the empty name.

---

### Requirements

This feature requires version `3.25.5` or later for the rack.

**Update the Rack:** Run `convox rack update 3.25.5 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
