### PR TITLE
fix doubled name in system log groups

### DIFF
--- a/provider/k8s/controller_atom.go
+++ b/provider/k8s/controller_atom.go
@@ -190,8 +190,10 @@ func (a *AtomController) processDependency(obj *atomv1.Atom) {
 	}, v1.PatchOptions{})
 	if err != nil {
 		a.logger.Logf("%s", err.Error())
-		a.provider.systemLog(a.provider.parseTidFromNamespace(obj.Namespace),
-			a.provider.parseAppFromNamespace(obj.Namespace), "state", time.Now(), fmt.Sprintf("failed to patch atom dependency: %s", err))
+		if len(obj.Spec.Dependencies) > 0 {
+			rs := parseResourceSubstitutionId(obj.Spec.Dependencies[0])
+			_ = a.provider.systemLog(rs.Tid, rs.App, "state", time.Now(), fmt.Sprintf("failed to patch atom dependency: %s", err))
+		}
 		return
 	}
 }

--- a/provider/k8s/controller_event.go
+++ b/provider/k8s/controller_event.go
@@ -94,7 +94,7 @@ func (c *EventController) Add(obj interface{}) error {
 			return errors.WithStack(err)
 		}
 
-		if err := c.Provider.systemLog(c.Provider.parseTidFromNamespace(o.Namespace), app, o.Name, e.LastTimestamp.Time, e.Message); err != nil {
+		if err := c.Provider.systemLog(c.Provider.namespaceTid(o.Namespace, app), app, o.Name, e.LastTimestamp.Time, e.Message); err != nil {
 			return errors.WithStack(err)
 		}
 	case "apps/v1/ReplicaSet":
@@ -106,7 +106,7 @@ func (c *EventController) Add(obj interface{}) error {
 			return errors.WithStack(err)
 		}
 
-		if err := c.Provider.systemLog(c.Provider.parseTidFromNamespace(o.Namespace), app, o.Name, e.LastTimestamp.Time, e.Message); err != nil {
+		if err := c.Provider.systemLog(c.Provider.namespaceTid(o.Namespace, app), app, o.Name, e.LastTimestamp.Time, e.Message); err != nil {
 			return errors.WithStack(err)
 		}
 	case "atom.convox.com/v1/Atom":
@@ -118,7 +118,7 @@ func (c *EventController) Add(obj interface{}) error {
 			return errors.WithStack(err)
 		}
 
-		if err := c.Provider.systemLog(c.Provider.parseTidFromNamespace(o.Namespace), app, fmt.Sprintf("atom/%s", strings.ReplaceAll(e.InvolvedObject.Name, ".", "/")), e.LastTimestamp.Time, fmt.Sprintf("%s: %s", e.Reason, e.Message)); err != nil {
+		if err := c.Provider.systemLog(c.Provider.namespaceTid(o.Namespace, app), app, fmt.Sprintf("atom/%s", strings.ReplaceAll(e.InvolvedObject.Name, ".", "/")), e.LastTimestamp.Time, fmt.Sprintf("%s: %s", e.Reason, e.Message)); err != nil {
 			return errors.WithStack(err)
 		}
 	case "autoscaling/v2beta2/HorizontalPodAutoscaler":
@@ -130,7 +130,7 @@ func (c *EventController) Add(obj interface{}) error {
 			return errors.WithStack(err)
 		}
 
-		if err := c.Provider.systemLog(c.Provider.parseTidFromNamespace(o.Namespace), app, o.Name, e.LastTimestamp.Time, e.Message); err != nil {
+		if err := c.Provider.systemLog(c.Provider.namespaceTid(o.Namespace, app), app, o.Name, e.LastTimestamp.Time, e.Message); err != nil {
 			return errors.WithStack(err)
 		}
 	case "autoscaling/v2/HorizontalPodAutoscaler":
@@ -142,7 +142,7 @@ func (c *EventController) Add(obj interface{}) error {
 			return errors.WithStack(err)
 		}
 
-		if err := c.Provider.systemLog(c.Provider.parseTidFromNamespace(o.Namespace), app, o.Name, e.LastTimestamp.Time, e.Message); err != nil {
+		if err := c.Provider.systemLog(c.Provider.namespaceTid(o.Namespace, app), app, o.Name, e.LastTimestamp.Time, e.Message); err != nil {
 			return errors.WithStack(err)
 		}
 	case "v1/ConfigMap":
@@ -158,7 +158,7 @@ func (c *EventController) Add(obj interface{}) error {
 				return errors.WithStack(err)
 			}
 
-			if err := c.Provider.systemLog(c.Provider.parseTidFromNamespace(o.Namespace), app, o.Name, e.LastTimestamp.Time, e.Message); err != nil {
+			if err := c.Provider.systemLog(c.Provider.namespaceTid(o.Namespace, app), app, o.Name, e.LastTimestamp.Time, e.Message); err != nil {
 				return errors.WithStack(err)
 			}
 		}

--- a/provider/k8s/helpers.go
+++ b/provider/k8s/helpers.go
@@ -180,22 +180,13 @@ func (p *Provider) volumeSources(app, service string, vs []string) []string {
 	return vsu
 }
 
-func (p *Provider) parseTidFromNamespace(ns string) string {
-	ns = strings.TrimPrefix(ns, p.Name+"-")
-	parts := strings.SplitN(ns, "-", 2)
-	if len(parts) == 2 {
-		return parts[0]
+// namespaceTid returns the tenant segment of an app namespace, or "" when it has none.
+func (p *Provider) namespaceTid(ns, app string) string {
+	rest := strings.TrimPrefix(ns, p.Name+"-")
+	if rest == ns || !strings.HasSuffix(rest, "-"+app) {
+		return ""
 	}
-	return ""
-}
-
-func (p *Provider) parseAppFromNamespace(ns string) string {
-	ns = strings.TrimPrefix(ns, p.Name+"-")
-	parts := strings.SplitN(ns, "-", 2)
-	if len(parts) == 2 {
-		return parts[1]
-	}
-	return ns
+	return strings.TrimSuffix(rest, "-"+app)
 }
 
 func nameFilter(name string) string {

--- a/provider/k8s/log_test.go
+++ b/provider/k8s/log_test.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -38,5 +39,39 @@ func TestSystemLogStream(t *testing.T) {
 
 		require.NoError(t, p.systemLog(tc.tid, "app1", "state", time.Now(), "hello"))
 		require.Equal(t, []string{tc.want}, e.calls)
+	}
+}
+
+func TestNamespaceTid(t *testing.T) {
+	p := &Provider{Name: "rack1"}
+
+	for _, tc := range []struct {
+		name string
+		ns   string
+		app  string
+		want string
+	}{
+		{name: "hyphenated app, no tenant", ns: "rack1-amzn-advertising-staging", app: "amzn-advertising-staging"},
+		{name: "hyphenated app, tenant", ns: "rack1-ab12-amzn-advertising-staging", app: "amzn-advertising-staging", want: "ab12"},
+		{name: "single token app, no tenant", ns: "rack1-app1", app: "app1"},
+		{name: "single token app, tenant", ns: "rack1-ab12-app1", app: "app1", want: "ab12"},
+		{name: "same namespace, app named for the leading segment", ns: "rack1-ab12-app1", app: "ab12-app1"},
+		{name: "rack system namespace", ns: "rack1-system", app: "system"},
+		{name: "namespace without the rack prefix", ns: "kube-system", app: "system"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tid := p.namespaceTid(tc.ns, tc.app)
+			require.Equal(t, tc.want, tid)
+
+			if !strings.HasPrefix(tc.ns, p.Name+"-") {
+				return
+			}
+
+			name := tc.app
+			if tid != "" {
+				name = fmt.Sprintf("%s-%s", tid, tc.app)
+			}
+			require.Equal(t, strings.TrimPrefix(tc.ns, p.Name+"-"), name)
+		})
 	}
 }


### PR DESCRIPTION
### What is the feature/update/fix?

**Fix: System Log Destinations Use the App Name Exactly**

The rack controller writes Kubernetes events for an app, covering deployments, replica sets, pods, autoscalers, and atoms, to a per-app log destination. That destination is now named from the namespace and the app name together, so it matches the destination `convox logs -a <app>` reads.

The tenant segment of a namespace is now whatever remains after the rack prefix and the app name, rather than being taken as the first hyphen-separated segment:

| Namespace | App | Destination |
|-----------|-----|-------------|
| `<rack>-foo-bar-baz` | `foo-bar-baz` | `/convox/<rack>/foo-bar-baz` |
| `<rack>-api` | `api` | `/convox/<rack>/api` |
| `<rack>-t1-foo-bar-baz` | `foo-bar-baz` | `/convox/<rack>/t1-foo-bar-baz` |
| `<rack>-system` | `system` | `/convox/<rack>/system` |

Apps whose names contain no hyphen were already named this way, and racks that serve multiple tenants are unaffected. The correction applies on every provider, since each one builds its log destination from the same value; on AWS that value is the CloudWatch log group name.

---

### Why is this important?

`convox logs -a <app>` reads `/convox/<rack>/<app>`. For an app whose name contains a hyphen, the controller's event lines were written under a different name, so they did not appear in the output `convox logs` returns.

**Benefits:**

- **Events where you look for them.** `convox logs -a <app>` now includes the controller's `system/k8s/*` lines for apps with hyphenated names, the same way it always has for single-word names.
- **One destination per app.** An app has a single log destination rather than one that Fluentd writes and another the controller writes.
- **Every provider.** The name is built in shared code, so the correction is not AWS specific.
- **No configuration.** The naming is derived, so there is nothing to set or migrate.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this fix.

No parameter, Terraform, state, or API surface changes, and the log writer itself is untouched. Racks that serve multiple tenants resolve the same names before and after.

On AWS, log groups created under the earlier naming stop receiving writes once this ships and can be removed out of band when convenient. Select them by name, a leading segment repeated immediately after itself under `/convox/<rack>/`, rather than by size: on a rack that keeps CloudWatch enabled they still hold events, and a size-based selector would instead match quiet legitimate app groups and discard their configured retention. Confirm each candidate against `convox apps` before deleting it, since an app whose own name starts with a repeated segment has a live group that matches the same pattern.

---

### Requirements

This fix requires version `3.25.5` or later for the rack.

**Update the Rack:** Run `convox rack update 3.25.5 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
