### PR TITLE
fix release watch cleanup

### DIFF
--- a/provider/k8s/export_test.go
+++ b/provider/k8s/export_test.go
@@ -549,7 +549,21 @@ func AcquireAppBudgetLockForTest(app string) {
 func RunReleasePromoteWatcherForTest(p *Provider, ctx context.Context, app string, state *structs.ReleasePromoteWatchState) {
 	// Acquire slot (mirror production flow); the watcher's defer releases it.
 	_, release := tryAcquireWatchSlot(app, state.ReleaseID)
-	p.runReleasePromoteWatcher(ctx, app, state, release)
+	p.runReleasePromoteWatcher(ctx, p.AppNamespace(app), app, state, release)
+}
+
+// LaunchReleasePromoteWatcherForTest exposes the promote-path launch so tests
+// can assert the watcher outlives the request context it was started from.
+// Test-only.
+func LaunchReleasePromoteWatcherForTest(p *Provider, app string, state *structs.ReleasePromoteWatchState) {
+	p.launchReleasePromoteWatcher(app, state)
+}
+
+// WithContextForTest returns the request-scoped provider copy as a concrete
+// *Provider so tests can drive request-path code. Test-only.
+func WithContextForTest(p *Provider, ctx context.Context) *Provider {
+	pp, _ := p.WithContext(ctx).(*Provider)
+	return pp
 }
 
 // ReleaseTemplateServicesForTest exposes the unexported releaseTemplateServices
@@ -576,7 +590,7 @@ func WriteReleasePromoteWatchAnnotationForTest(p *Provider, ctx context.Context,
 // DeleteReleasePromoteWatchAnnotationForTest exposes the delete path so
 // tests can clean up between scenarios. Test-only.
 func DeleteReleasePromoteWatchAnnotationForTest(p *Provider, ctx context.Context, app string) error {
-	return p.deleteReleasePromoteWatchAnnotation(ctx, app)
+	return p.deleteReleasePromoteWatchAnnotation(ctx, p.AppNamespace(app))
 }
 
 // EmitReleasePromoteResultForTest exposes the emitter so tests can pin
@@ -662,8 +676,8 @@ func SetReleasePromoteCleanupDeferPanicHookForTest(hook func(app, releaseID stri
 // supersession-aware delete variant so unit tests can assert the
 // read-before-delete invariant directly without driving the full
 // watcher lifecycle. Test-only.
-func DeleteReleasePromoteWatchAnnotationIfMatchesForTest(p *Provider, ctx context.Context, app, expectedReleaseID string) error {
-	return p.deleteReleasePromoteWatchAnnotationIfMatches(ctx, app, expectedReleaseID)
+func DeleteReleasePromoteWatchAnnotationIfMatchesForTest(p *Provider, ctx context.Context, app, expectedReleaseID string) (bool, error) {
+	return p.deleteReleasePromoteWatchAnnotationIfMatches(ctx, p.AppNamespace(app), expectedReleaseID)
 }
 
 // HashParamValueForTest exposes the per-Provider hashParamValue method so

--- a/provider/k8s/karpenter_test.go
+++ b/provider/k8s/karpenter_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/convox/convox/pkg/atom"
 	"github.com/convox/convox/pkg/manifest"
@@ -304,13 +305,12 @@ func releasePromoteNodePoolProvider(t *testing.T, badManifestRelease string) *Pr
 	require.NoError(t, err)
 	require.NoError(t, p.Initialize(structs.ProviderOptions{}))
 
-	// A promote that reaches Apply spawns runReleasePromoteWatcher, which polls
-	// until its context is done and holds a package-global watch slot meanwhile.
-	ctx, cancel := context.WithCancel(context.Background())
-	p.ctx = ctx
-	t.Cleanup(cancel)
-
 	createAppNamespace(t, kk, "rack1", "app1")
+	// A promote that reaches Apply spawns a watcher holding a package-global
+	// slot. A terminal app-status plus a short tick retire it immediately
+	// instead of leaving it to poll to its deadline.
+	t.Cleanup(SetReleasePromoteWatchPollIntervalForTest(20 * time.Millisecond))
+	setAppStatus(t, kk, "rack1-app1", "Running")
 	createBuild(t, kc, "rack1-app1", "build1")
 	createRelease(t, kc, "rack1-app1", "rel1", manifestWithNodeSelectors)
 	createRelease(t, kc, "rack1-app1", badManifestRelease, manifestWithNodeSelectors)
@@ -358,4 +358,28 @@ func TestReleasePromote_SkipsNodePoolCheckOnForce(t *testing.T) {
 	if err != nil {
 		require.NotContains(t, err.Error(), nodePoolRejection)
 	}
+}
+
+// TestReleasePromote_StartsTheWatcher pins the launch call site: a promote must
+// still start a watcher, and that watcher clears the annotation the promote wrote.
+func TestReleasePromote_StartsTheWatcher(t *testing.T) {
+	p := releasePromoteNodePoolProvider(t, "rel2")
+	kk, ok := p.Cluster.(*fake.Clientset)
+	require.True(t, ok)
+
+	// The watch slot is package-global, so an earlier test's watcher for this
+	// same pair would make the launch a no-op and mask the assertion.
+	require.Eventually(t, func() bool {
+		return !releasePromoteWatchSlotHeldForTest("app1", "rel1")
+	}, 5*time.Second, 10*time.Millisecond, "watch slot still held by an earlier test")
+
+	if err := p.ReleasePromote("app1", "rel1", structs.ReleasePromoteOptions{}); err != nil {
+		require.NotContains(t, err.Error(), nodePoolRejection)
+	}
+
+	require.Eventually(t, func() bool {
+		ns, err := kk.CoreV1().Namespaces().Get(context.TODO(), "rack1-app1", am.GetOptions{})
+		return err == nil && ns.Annotations[structs.ReleasePromoteWatchAnnotation] == ""
+	}, 3*time.Second, 20*time.Millisecond,
+		"the promote path must start a watcher that resolves and clears its annotation")
 }

--- a/provider/k8s/process_nodeselector_test.go
+++ b/provider/k8s/process_nodeselector_test.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"testing"
 
@@ -17,6 +18,7 @@ import (
 	am "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
 	metricfake "k8s.io/metrics/pkg/client/clientset/versioned/fake"
@@ -62,6 +64,13 @@ func createAppNamespace(t *testing.T, kk *fake.Clientset, rack, app string) {
 			},
 		},
 	}, am.CreateOptions{})
+	require.NoError(t, err)
+}
+
+func setAppStatus(t *testing.T, kk *fake.Clientset, ns, status string) {
+	t.Helper()
+	patch := fmt.Sprintf(`{"metadata":{"annotations":{"convox.com/app-status":%q}}}`, status)
+	_, err := kk.CoreV1().Namespaces().Patch(context.TODO(), ns, types.MergePatchType, []byte(patch), am.PatchOptions{})
 	require.NoError(t, err)
 }
 

--- a/provider/k8s/release.go
+++ b/provider/k8s/release.go
@@ -371,15 +371,7 @@ func (p *Provider) ReleasePromote(app, id string, opts structs.ReleasePromoteOpt
 
 	p.FlushStateLog(p.ContextTID(), app)
 
-	// Per-(app, release-id) lock — sync.Map.LoadOrStore is the atomic
-	// check-and-set primitive. If a watcher is already in-flight for
-	// this exact pair, the second promote skips the goroutine launch
-	// (the existing watcher continues; it will see the supersession
-	// via the release annotation mismatch on its next tick).
-	if acquired, release := tryAcquireWatchSlot(app, id); acquired {
-		s := state // own a heap copy so the goroutine doesn't alias
-		go p.runReleasePromoteWatcher(p.ctx, app, &s, release)
-	}
+	p.launchReleasePromoteWatcher(app, &state)
 
 	return nil
 }

--- a/provider/k8s/release_watcher.go
+++ b/provider/k8s/release_watcher.go
@@ -45,8 +45,22 @@ func releasePromoteWatchSlotHeldForTest(app, releaseID string) bool {
 var releasePromoteWatcherPanicHookForTest func(app, releaseID string)
 var releasePromoteCleanupDeferPanicHookForTest func(app, releaseID string)
 
+// launchReleasePromoteWatcher starts the post-promote watcher unless one is
+// already in flight for this exact (app, release-id): that watcher stays, and
+// sees the supersession via the release annotation on its next tick.
+func (p *Provider) launchReleasePromoteWatcher(app string, state *structs.ReleasePromoteWatchState) {
+	acquired, release := tryAcquireWatchSlot(app, state.ReleaseID)
+	if !acquired {
+		return
+	}
+	s := *state // own a heap copy so the goroutine doesn't alias
+	// p.ctx is the request context and dies when this handler returns.
+	go p.runReleasePromoteWatcher(context.WithoutCancel(p.ctx), p.AppNamespace(app), app, &s, release)
+}
+
 func (p *Provider) runReleasePromoteWatcher(
 	ctx context.Context,
+	namespace string,
 	app string,
 	state *structs.ReleasePromoteWatchState,
 	release func(),
@@ -66,8 +80,8 @@ func (p *Provider) runReleasePromoteWatcher(
 		if hook := releasePromoteCleanupDeferPanicHookForTest; hook != nil {
 			hook(app, state.ReleaseID)
 		}
-		if err := p.deleteReleasePromoteWatchAnnotationIfMatches(ctx, app, state.ReleaseID); err != nil {
-			fmt.Printf("ns=release_watcher at=warn kind=annotation_delete app=%s err=%q\n", app, err)
+		if _, err := p.deleteReleasePromoteWatchAnnotationIfMatches(ctx, namespace, state.ReleaseID); err != nil {
+			fmt.Printf("ns=release_watcher at=warn kind=annotation_delete namespace=%s app=%s err=%q\n", namespace, app, err)
 		}
 		release()
 	}()
@@ -85,7 +99,7 @@ func (p *Provider) runReleasePromoteWatcher(
 			if hook := releasePromoteWatcherPanicHookForTest; hook != nil {
 				hook(app, state.ReleaseID)
 			}
-			ns, err := p.GetNamespaceFromInformer(p.AppNamespace(app))
+			ns, err := p.GetNamespaceFromInformer(namespace)
 			if err != nil {
 				if kerr.IsNotFound(err) {
 					resultStatus = ""
@@ -183,55 +197,56 @@ func (p *Provider) writeReleasePromoteWatchAnnotation(ctx context.Context, app s
 
 // deleteReleasePromoteWatchAnnotationIfMatches only deletes if the annotation's
 // release-id still matches ours. Uses JSON-Patch test op for atomic check-and-delete.
-func (p *Provider) deleteReleasePromoteWatchAnnotationIfMatches(ctx context.Context, app, expectedReleaseID string) error {
-	ns, err := p.Cluster.CoreV1().Namespaces().Get(ctx, p.AppNamespace(app), am.GetOptions{})
+// Reports whether this caller is the one that removed it.
+func (p *Provider) deleteReleasePromoteWatchAnnotationIfMatches(ctx context.Context, namespace, expectedReleaseID string) (bool, error) {
+	ns, err := p.Cluster.CoreV1().Namespaces().Get(ctx, namespace, am.GetOptions{})
 	if err != nil {
 		if kerr.IsNotFound(err) {
-			return nil
+			return false, nil
 		}
-		return errors.WithStack(err)
+		return false, errors.WithStack(err)
 	}
 	raw := ns.Annotations[structs.ReleasePromoteWatchAnnotation]
 	if raw == "" {
-		return nil
+		return false, nil
 	}
 	var state structs.ReleasePromoteWatchState
 	if jerr := json.Unmarshal([]byte(raw), &state); jerr != nil {
-		fmt.Printf("ns=release_watcher at=warn kind=cleanup_corrupt_json app=%s err=%q\n", app, jerr)
-		return nil
+		fmt.Printf("ns=release_watcher at=warn kind=cleanup_corrupt_json namespace=%s err=%q\n", namespace, jerr)
+		return false, nil
 	}
 	if state.ReleaseID != expectedReleaseID {
-		fmt.Printf("ns=release_watcher at=info kind=cleanup_supersession_skip app=%s mine=%s current=%s\n",
-			app, expectedReleaseID, state.ReleaseID)
-		return nil
+		fmt.Printf("ns=release_watcher at=info kind=cleanup_supersession_skip namespace=%s mine=%s current=%s\n",
+			namespace, expectedReleaseID, state.ReleaseID)
+		return false, nil
 	}
 	rawJSON, jerr := json.Marshal(raw)
 	if jerr != nil {
-		return errors.WithStack(jerr)
+		return false, errors.WithStack(jerr)
 	}
 	patch := []byte(fmt.Sprintf(
 		`[{"op":"test","path":"/metadata/annotations/convox.com~1release-promote-watch","value":%s},{"op":"remove","path":"/metadata/annotations/convox.com~1release-promote-watch"}]`,
 		rawJSON,
 	))
-	_, perr := p.Cluster.CoreV1().Namespaces().Patch(ctx, p.AppNamespace(app), types.JSONPatchType, patch, am.PatchOptions{})
+	_, perr := p.Cluster.CoreV1().Namespaces().Patch(ctx, namespace, types.JSONPatchType, patch, am.PatchOptions{})
 	if perr != nil {
 		if kerr.IsNotFound(perr) {
-			return nil
+			return false, nil
 		}
 		if kerr.IsConflict(perr) || kerr.IsInvalid(perr) {
 			// test op failed — annotation was overwritten concurrently.
-			fmt.Printf("ns=release_watcher at=info kind=cleanup_supersession_skip_toctou app=%s mine=%s err=%q\n",
-				app, expectedReleaseID, perr)
-			return nil
+			fmt.Printf("ns=release_watcher at=info kind=cleanup_supersession_skip_toctou namespace=%s mine=%s err=%q\n",
+				namespace, expectedReleaseID, perr)
+			return false, nil
 		}
-		return errors.WithStack(perr)
+		return false, errors.WithStack(perr)
 	}
-	return nil
+	return true, nil
 }
 
-func (p *Provider) deleteReleasePromoteWatchAnnotation(ctx context.Context, app string) error {
+func (p *Provider) deleteReleasePromoteWatchAnnotation(ctx context.Context, namespace string) error {
 	patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":{%q:null}}}`, structs.ReleasePromoteWatchAnnotation))
-	_, err := p.Cluster.CoreV1().Namespaces().Patch(ctx, p.AppNamespace(app), types.MergePatchType, patch, am.PatchOptions{})
+	_, err := p.Cluster.CoreV1().Namespaces().Patch(ctx, namespace, types.MergePatchType, patch, am.PatchOptions{})
 	if kerr.IsNotFound(err) {
 		return nil
 	}
@@ -277,31 +292,30 @@ func (p *Provider) scanReleasePromoteAnnotations(ctx context.Context) {
 		}
 		var state structs.ReleasePromoteWatchState
 		if err := json.Unmarshal([]byte(raw), &state); err != nil {
-			fmt.Printf("ns=release_watcher at=warn kind=corrupt_json app=%s err=%q\n", app, err)
-			_ = p.deleteReleasePromoteWatchAnnotation(ctx, app)
+			fmt.Printf("ns=release_watcher at=warn kind=corrupt_json namespace=%s err=%q\n", ns.Name, err)
+			if derr := p.deleteReleasePromoteWatchAnnotation(ctx, ns.Name); derr != nil {
+				fmt.Printf("ns=release_watcher at=warn kind=gc_cleanup_failed namespace=%s err=%q\n", ns.Name, derr)
+			}
 			continue
 		}
 		if state.SchemaVersion != 1 {
 			// unknown schemaVersion — skip, don't delete (may belong to a newer api-pod during rolling upgrade).
 			fmt.Printf("ns=release_watcher at=warn kind=unknown_schema_version app=%s schemaVersion=%d release_id=%s actor=%s expires_at=%q recovery=\"kubectl annotate ns %s convox.com/release-promote-watch-\"\n",
-				app, state.SchemaVersion, state.ReleaseID, state.Actor, state.ExpiresAt.Format(time.RFC3339), p.AppNamespace(app))
+				app, state.SchemaVersion, state.ReleaseID, state.Actor, state.ExpiresAt.Format(time.RFC3339), ns.Name)
 			continue
 		}
 		if state.ExpiresAt.Before(now) {
 			// consult app-status before assuming timeout — AtomController may have already written a terminal status.
-			atomStatus := ns.Annotations["convox.com/app-status"]
-			if status, errMsg, terminal := mapAppStatusToWatchResult(atomStatus); terminal {
-				p.emitReleasePromoteResult(app, &state, status, errMsg)
-			} else {
-				p.emitReleasePromoteResult(app, &state, "error", "watcher-timeout")
+			status, errMsg, terminal := mapAppStatusToWatchResult(ns.Annotations["convox.com/app-status"])
+			if !terminal {
+				status, errMsg = "error", "watcher-timeout"
 			}
-			_ = p.deleteReleasePromoteWatchAnnotationIfMatches(ctx, app, state.ReleaseID)
+			p.cleanupAndEmitReleasePromoteResult(ctx, ns.Name, app, &state, status, errMsg)
 			continue
 		}
 		currentRelease := ns.Annotations["convox.com/app-release"]
 		if currentRelease != "" && state.AtomVersion != "" && currentRelease != state.AtomVersion {
-			p.emitReleasePromoteResult(app, &state, "cancelled", "superseded-by-newer-promote")
-			_ = p.deleteReleasePromoteWatchAnnotationIfMatches(ctx, app, state.ReleaseID)
+			p.cleanupAndEmitReleasePromoteResult(ctx, ns.Name, app, &state, "cancelled", "superseded-by-newer-promote")
 			continue
 		}
 		acquired, release := tryAcquireWatchSlot(app, state.ReleaseID)
@@ -309,8 +323,27 @@ func (p *Provider) scanReleasePromoteAnnotations(ctx context.Context) {
 			continue
 		}
 		s := state
-		go p.runReleasePromoteWatcher(ctx, app, &s, release)
+		go p.runReleasePromoteWatcher(ctx, ns.Name, app, &s, release)
 	}
+}
+
+// cleanupAndEmitReleasePromoteResult gates the emit on the compare-and-swap so
+// racing api replicas notify once between them.
+func (p *Provider) cleanupAndEmitReleasePromoteResult(ctx context.Context, namespace, app string, state *structs.ReleasePromoteWatchState, status, errMsg string) {
+	removed, err := p.deleteReleasePromoteWatchAnnotationIfMatches(ctx, namespace, state.ReleaseID)
+	if err != nil {
+		fmt.Printf("ns=release_watcher at=warn kind=gc_cleanup_failed namespace=%s release_id=%s err=%q\n",
+			namespace, state.ReleaseID, err)
+		return
+	}
+	if !removed {
+		fmt.Printf("ns=release_watcher at=info kind=gc_cleanup_skip namespace=%s release_id=%s\n",
+			namespace, state.ReleaseID)
+		return
+	}
+	fmt.Printf("ns=release_watcher at=info kind=gc_cleanup namespace=%s release_id=%s status=%s\n",
+		namespace, state.ReleaseID, status)
+	p.emitReleasePromoteResult(app, state, status, errMsg)
 }
 
 const (

--- a/provider/k8s/release_watcher_test.go
+++ b/provider/k8s/release_watcher_test.go
@@ -856,8 +856,9 @@ func TestReleasePromoteWatcher_SupersessionAware_CleanupSkips(t *testing.T) {
 		// A's cleanup reads + skips: A's cleanup defer calls
 		// the supersession-aware variant with its own release-id (R1).
 		// It should see R2 in the annotation and SKIP the delete.
-		err := k8s.DeleteReleasePromoteWatchAnnotationIfMatchesForTest(p, context.Background(), app, "R1")
+		removed, err := k8s.DeleteReleasePromoteWatchAnnotationIfMatchesForTest(p, context.Background(), app, "R1")
 		require.NoError(t, err, "supersession-aware delete must succeed (no-op skip)")
+		assert.False(t, removed, "a superseded cleanup MUST NOT report a removal")
 
 		// Verify: annotation must still hold B's payload.
 		ns, _ := p.Cluster.CoreV1().Namespaces().Get(context.TODO(),
@@ -871,8 +872,9 @@ func TestReleasePromoteWatcher_SupersessionAware_CleanupSkips(t *testing.T) {
 
 		// When B's own cleanup runs (with releaseID=R2), the
 		// delete proceeds because the stored release-id matches B's.
-		err = k8s.DeleteReleasePromoteWatchAnnotationIfMatchesForTest(p, context.Background(), app, "R2")
+		removed, err = k8s.DeleteReleasePromoteWatchAnnotationIfMatchesForTest(p, context.Background(), app, "R2")
 		require.NoError(t, err, "matching-release cleanup must proceed normally")
+		assert.True(t, removed, "matching-release cleanup MUST report the removal")
 		ns2, _ := p.Cluster.CoreV1().Namespaces().Get(context.TODO(),
 			fmt.Sprintf("%s-%s", p.Name, app), am.GetOptions{})
 		assert.Empty(t, ns2.Annotations[structs.ReleasePromoteWatchAnnotation],
@@ -985,9 +987,10 @@ func TestReleasePromoteWatcher_SupersessionAware_CleanupSkips_TOCTOU_PatchTestOp
 func TestDeleteReleasePromoteWatchAnnotationIfMatches_NotFound(t *testing.T) {
 	testProvider(t, func(p *k8s.Provider) {
 		// Do NOT seed the namespace — Get returns NotFound.
-		err := k8s.DeleteReleasePromoteWatchAnnotationIfMatchesForTest(
+		removed, err := k8s.DeleteReleasePromoteWatchAnnotationIfMatchesForTest(
 			p, context.Background(), "appNotFound", "R-NF-1")
 		require.NoError(t, err, "namespace-not-found MUST be a silent no-op")
+		assert.False(t, removed, "namespace-not-found MUST NOT report a removal")
 	})
 }
 
@@ -1002,9 +1005,10 @@ func TestDeleteReleasePromoteWatchAnnotationIfMatches_EmptyAnnotation(t *testing
 		// only writes app-status / app-release annotations.
 		seedAppNamespaceWithStatus(t, p, "appEmpty", "Updating", "R-EMPTY-1")
 
-		err := k8s.DeleteReleasePromoteWatchAnnotationIfMatchesForTest(
+		removed, err := k8s.DeleteReleasePromoteWatchAnnotationIfMatchesForTest(
 			p, context.Background(), "appEmpty", "R-EMPTY-1")
 		require.NoError(t, err, "empty annotation MUST be a silent no-op")
+		assert.False(t, removed, "empty annotation MUST NOT report a removal")
 
 		// Confirm seed annotations are untouched.
 		ns, _ := p.Cluster.CoreV1().Namespaces().Get(context.TODO(),
@@ -1036,9 +1040,10 @@ func TestDeleteReleasePromoteWatchAnnotationIfMatches_CorruptJSON(t *testing.T) 
 			fmt.Sprintf("%s-appCorrupt", p.Name), types.MergePatchType, body, am.PatchOptions{})
 		require.NoError(t, err)
 
-		derr := k8s.DeleteReleasePromoteWatchAnnotationIfMatchesForTest(
+		removed, derr := k8s.DeleteReleasePromoteWatchAnnotationIfMatchesForTest(
 			p, context.Background(), "appCorrupt", "R-CORRUPT-1")
 		require.NoError(t, derr, "corrupt-JSON MUST be a silent no-op (deferred to GC scan)")
+		assert.False(t, removed, "corrupt-JSON MUST NOT report a removal")
 
 		// Confirm the corrupt annotation persists — the supersession-aware
 		// variant does NOT delete corrupt JSON (no payload to attribute).

--- a/provider/k8s/release_watcher_tid_test.go
+++ b/provider/k8s/release_watcher_tid_test.go
@@ -1,0 +1,431 @@
+package k8s_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/convox/convox/pkg/structs"
+	"github.com/convox/convox/provider/k8s"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ac "k8s.io/api/core/v1"
+	kerr "k8s.io/apimachinery/pkg/api/errors"
+	am "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// The GC loop runs on the provider's background context, so ContextTID() is
+// empty while tenant namespaces carry a tid segment. These fixtures reproduce
+// that pairing: the provider has no tenant context, the namespace is
+// <rack>-<tid>-<app>. A fixture that gave the provider a tenant context would
+// resolve AppNamespace correctly and pass against the broken code.
+func seedWatchNamespace(t *testing.T, p *k8s.Provider, namespace, tid, app, atomStatus, releaseID, watchAnnotation string) {
+	t.Helper()
+	kk, ok := p.Cluster.(*fake.Clientset)
+	require.True(t, ok)
+
+	annotations := map[string]string{}
+	if atomStatus != "" {
+		annotations["convox.com/app-status"] = atomStatus
+	}
+	if releaseID != "" {
+		annotations["convox.com/app-release"] = releaseID
+	}
+	if watchAnnotation != "" {
+		annotations[structs.ReleasePromoteWatchAnnotation] = watchAnnotation
+	}
+	labels := map[string]string{
+		"app":    app,
+		"name":   app,
+		"rack":   p.Name,
+		"system": "convox",
+		"type":   "app",
+	}
+	if tid != "" {
+		labels["tid"] = tid
+	}
+
+	_, err := kk.CoreV1().Namespaces().Create(context.TODO(), &ac.Namespace{
+		ObjectMeta: am.ObjectMeta{
+			Name:        namespace,
+			Annotations: annotations,
+			Labels:      labels,
+		},
+	}, am.CreateOptions{})
+	require.NoError(t, err)
+}
+
+func watchStateJSON(t *testing.T, releaseID string, expiresIn time.Duration) string {
+	t.Helper()
+	raw, err := json.Marshal(structs.ReleasePromoteWatchState{
+		SchemaVersion: 1,
+		ReleaseID:     releaseID,
+		AtomVersion:   releaseID,
+		StartedAt:     time.Now().UTC().Add(-time.Minute),
+		ExpiresAt:     time.Now().UTC().Add(expiresIn),
+		Actor:         "deploy-key:test",
+	})
+	require.NoError(t, err)
+	return string(raw)
+}
+
+func watchAnnotationOf(t *testing.T, p *k8s.Provider, namespace string) string {
+	t.Helper()
+	ns, err := p.Cluster.CoreV1().Namespaces().Get(context.TODO(), namespace, am.GetOptions{})
+	require.NoError(t, err)
+	return ns.Annotations[structs.ReleasePromoteWatchAnnotation]
+}
+
+// TestReleasePromoteWatchGC_TenantNamespace_ExpiredEmitsOnceThenSilent is the
+// regression test. Before the fix the cleanup rebuilt the namespace from an
+// empty tenant context, the delete hit <rack>-<app>, NotFound read as
+// already-clean, and every later tick re-emitted the same promote.
+func TestReleasePromoteWatchGC_TenantNamespace_ExpiredEmitsOnceThenSilent(t *testing.T) {
+	testProvider(t, func(p *k8s.Provider) {
+		namespace := fmt.Sprintf("%s-2bzcs9-tenantapp", p.Name)
+		seedWatchNamespace(t, p, namespace, "2bzcs9", "tenantapp", "Running", "R-TID-1",
+			watchStateJSON(t, "R-TID-1", -time.Hour))
+
+		events := captureReleaseWatcherEvents(t, p, func() {
+			k8s.ScanReleasePromoteAnnotationsForTest(p, context.Background())
+		}, 2, 500*time.Millisecond)
+
+		require.Len(t, events, 1, "expired tenant watch MUST emit exactly once; got %v", events)
+		assert.Equal(t, "app:promote:completed", events[0]["action"])
+		assert.Empty(t, watchAnnotationOf(t, p, namespace),
+			"cleanup MUST clear the annotation on the tenant namespace it read")
+
+		repeat := captureReleaseWatcherEvents(t, p, func() {
+			k8s.ScanReleasePromoteAnnotationsForTest(p, context.Background())
+		}, 1, 200*time.Millisecond)
+
+		assert.Empty(t, repeat, "a second GC pass MUST be silent; got %v", repeat)
+	})
+}
+
+// TestReleasePromoteWatchGC_RackNamespace_ExpiredEmitsOnceThenSilent proves the
+// ordinary non-tenant path is unchanged.
+func TestReleasePromoteWatchGC_RackNamespace_ExpiredEmitsOnceThenSilent(t *testing.T) {
+	testProvider(t, func(p *k8s.Provider) {
+		namespace := fmt.Sprintf("%s-rackapp", p.Name)
+		seedWatchNamespace(t, p, namespace, "", "rackapp", "Running", "R-RACK-1",
+			watchStateJSON(t, "R-RACK-1", -time.Hour))
+
+		events := captureReleaseWatcherEvents(t, p, func() {
+			k8s.ScanReleasePromoteAnnotationsForTest(p, context.Background())
+		}, 2, 500*time.Millisecond)
+
+		require.Len(t, events, 1, "expired watch MUST emit exactly once; got %v", events)
+		assert.Equal(t, "app:promote:completed", events[0]["action"])
+		assert.Empty(t, watchAnnotationOf(t, p, namespace))
+
+		repeat := captureReleaseWatcherEvents(t, p, func() {
+			k8s.ScanReleasePromoteAnnotationsForTest(p, context.Background())
+		}, 1, 200*time.Millisecond)
+
+		assert.Empty(t, repeat, "a second GC pass MUST be silent; got %v", repeat)
+	})
+}
+
+// TestReleasePromoteWatchGC_TenantNamespace_ResumesLiveWatch covers the watcher
+// the GC spawns for a still-live annotation, which is how a promote in flight
+// across an api-pod restart gets its result. It saw the wrong namespace, read
+// NotFound and exited silently on every tick.
+func TestReleasePromoteWatchGC_TenantNamespace_ResumesLiveWatch(t *testing.T) {
+	defer k8s.SetReleasePromoteWatchPollIntervalForTest(20 * time.Millisecond)()
+
+	testProvider(t, func(p *k8s.Provider) {
+		namespace := fmt.Sprintf("%s-2bzcs9-liveapp", p.Name)
+		seedWatchNamespace(t, p, namespace, "2bzcs9", "liveapp", "Running", "R-TID-2",
+			watchStateJSON(t, "R-TID-2", time.Minute))
+
+		events := captureReleaseWatcherEvents(t, p, func() {
+			k8s.ScanReleasePromoteAnnotationsForTest(p, context.Background())
+		}, 1, 2*time.Second)
+
+		ev := findEventByAction(events, "app:promote:completed")
+		require.NotNil(t, ev, "GC MUST resume a live tenant watch; got %v", events)
+		assert.Equal(t, "success", ev["status"])
+
+		assert.Eventually(t, func() bool {
+			return watchAnnotationOf(t, p, namespace) == ""
+		}, 2*time.Second, 20*time.Millisecond,
+			"the resumed watcher MUST clear the annotation it was resumed from")
+	})
+}
+
+// TestReleasePromoteWatchGC_CorruptJSON_LeavesRackNamespaceAlone pins the
+// unguarded branch: the corrupt-JSON delete carries no release-id compare, so a
+// derived namespace let a tenant's corrupt annotation strip a same-named rack
+// app's live one.
+func TestReleasePromoteWatchGC_CorruptJSON_LeavesRackNamespaceAlone(t *testing.T) {
+	testProvider(t, func(p *k8s.Provider) {
+		tenantNamespace := fmt.Sprintf("%s-2bzcs9-shared", p.Name)
+		rackNamespace := fmt.Sprintf("%s-shared", p.Name)
+		// schemaVersion 2 is an annotation the scan must leave untouched, so
+		// anything missing from it afterwards came from the tenant's branch.
+		rackWatch := `{"schemaVersion":2,"releaseId":"R-RACK-2","atomVersion":"R-RACK-2","actor":"future@convox.com"}`
+
+		seedWatchNamespace(t, p, tenantNamespace, "2bzcs9", "shared", "Running", "R-TID-3", "{not-valid-json")
+		seedWatchNamespace(t, p, rackNamespace, "", "shared", "Running", "R-RACK-2", rackWatch)
+
+		events := captureReleaseWatcherEvents(t, p, func() {
+			k8s.ScanReleasePromoteAnnotationsForTest(p, context.Background())
+		}, 1, 200*time.Millisecond)
+
+		assert.Empty(t, events, "corrupt JSON MUST NOT emit; got %v", events)
+		assert.Empty(t, watchAnnotationOf(t, p, tenantNamespace),
+			"corrupt annotation MUST be cleared on the namespace it was read from")
+		assert.Equal(t, rackWatch, watchAnnotationOf(t, p, rackNamespace),
+			"a same-named rack app's annotation MUST NOT be touched")
+	})
+}
+
+// TestReleasePromoteWatchGC_CleanupFailureIsLogged: a cleanup error that is not
+// NotFound has no observable trace in the namespace, so a surviving annotation
+// is indistinguishable from the loop this patch fixes. It has to reach the log,
+// and it must not emit, so the next tick can retry.
+func TestReleasePromoteWatchGC_CleanupFailureIsLogged(t *testing.T) {
+	testProvider(t, func(p *k8s.Provider) {
+		namespace := fmt.Sprintf("%s-2bzcs9-failapp", p.Name)
+		seedWatchNamespace(t, p, namespace, "2bzcs9", "failapp", "Running", "R-TID-4",
+			watchStateJSON(t, "R-TID-4", -time.Hour))
+
+		kk, ok := p.Cluster.(*fake.Clientset)
+		require.True(t, ok)
+		kk.PrependReactor("get", "namespaces", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, kerr.NewInternalError(fmt.Errorf("etcd unavailable"))
+		})
+
+		readStdout := captureStdout(t)
+		events := captureReleaseWatcherEvents(t, p, func() {
+			k8s.ScanReleasePromoteAnnotationsForTest(p, context.Background())
+		}, 1, 200*time.Millisecond)
+		out := readStdout()
+
+		assert.Empty(t, events, "a failed cleanup MUST NOT emit; got %v", events)
+		assert.Contains(t, out, fmt.Sprintf("kind=gc_cleanup_failed namespace=%s", namespace))
+	})
+}
+
+// TestReleasePromoteWatchGC_TenantNamespace_RecoveryCommandNamesRealNamespace:
+// the operator remedy printed for an unrecognized schemaVersion has to name a
+// namespace that exists, or running it verbatim fails.
+func TestReleasePromoteWatchGC_TenantNamespace_RecoveryCommandNamesRealNamespace(t *testing.T) {
+	testProvider(t, func(p *k8s.Provider) {
+		namespace := fmt.Sprintf("%s-2bzcs9-futureapp", p.Name)
+		raw := `{"schemaVersion":2,"releaseId":"R-TID-5","atomVersion":"R-TID-5","actor":"future@convox.com"}`
+		seedWatchNamespace(t, p, namespace, "2bzcs9", "futureapp", "Running", "R-TID-5", raw)
+
+		readStdout := captureStdout(t)
+		events := captureReleaseWatcherEvents(t, p, func() {
+			k8s.ScanReleasePromoteAnnotationsForTest(p, context.Background())
+		}, 1, 200*time.Millisecond)
+		out := readStdout()
+
+		assert.Empty(t, events, "unknown schemaVersion MUST NOT emit; got %v", events)
+		assert.Equal(t, raw, watchAnnotationOf(t, p, namespace),
+			"unknown schemaVersion MUST NOT be deleted")
+		assert.Contains(t, out,
+			fmt.Sprintf(`recovery="kubectl annotate ns %s convox.com/release-promote-watch-"`, namespace))
+	})
+}
+
+// TestReleasePromoteWatchGC_EmitFollowsTheCompareAndSwap: the GC runs unelected
+// in every api pod, so the swap is what decides which replica notifies. A
+// caller that loses it must stay quiet.
+func TestReleasePromoteWatchGC_EmitFollowsTheCompareAndSwap(t *testing.T) {
+	testProvider(t, func(p *k8s.Provider) {
+		namespace := fmt.Sprintf("%s-2bzcs9-raceapp", p.Name)
+		seedWatchNamespace(t, p, namespace, "2bzcs9", "raceapp", "Running", "R-TID-6",
+			watchStateJSON(t, "R-TID-6", -time.Hour))
+
+		kk, ok := p.Cluster.(*fake.Clientset)
+		require.True(t, ok)
+		kk.PrependReactor("patch", "namespaces", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, kerr.NewConflict(
+				schema.GroupResource{Resource: "namespaces"}, namespace, fmt.Errorf("test op rejected"))
+		})
+
+		readStdout := captureStdout(t)
+		events := captureReleaseWatcherEvents(t, p, func() {
+			k8s.ScanReleasePromoteAnnotationsForTest(p, context.Background())
+		}, 1, 200*time.Millisecond)
+		out := readStdout()
+
+		assert.Empty(t, events, "losing the swap MUST NOT emit; got %v", events)
+		assert.Contains(t, out, fmt.Sprintf("kind=gc_cleanup_skip namespace=%s release_id=R-TID-6", namespace),
+			"the branch must be reached and its suppression recorded")
+		assert.NotContains(t, out, "kind=gc_cleanup namespace=")
+		assert.NotEmpty(t, watchAnnotationOf(t, p, namespace),
+			"a rejected swap MUST leave the annotation for the next tick")
+	})
+}
+
+// TestReleasePromoteWatchGC_TenantNamespace_SupersededEmitsOnceThenSilent: the
+// superseded branch shares the cleanup path, so it carried the same loop.
+func TestReleasePromoteWatchGC_TenantNamespace_SupersededEmitsOnceThenSilent(t *testing.T) {
+	testProvider(t, func(p *k8s.Provider) {
+		namespace := fmt.Sprintf("%s-2bzcs9-supersededapp", p.Name)
+		seedWatchNamespace(t, p, namespace, "2bzcs9", "supersededapp", "Updating", "R-TID-7-NEW",
+			watchStateJSON(t, "R-TID-7-OLD", time.Minute))
+
+		readStdout := captureStdout(t)
+		events := captureReleaseWatcherEvents(t, p, func() {
+			k8s.ScanReleasePromoteAnnotationsForTest(p, context.Background())
+		}, 2, 500*time.Millisecond)
+		out := readStdout()
+
+		require.Len(t, events, 1, "superseded watch MUST emit exactly once; got %v", events)
+		assert.Equal(t, "app:promote:cancelled", events[0]["action"])
+		assert.Contains(t, out, fmt.Sprintf("kind=gc_cleanup namespace=%s release_id=R-TID-7-OLD status=cancelled", namespace),
+			"the GC branch MUST be what emitted, not a spawned watcher")
+		assert.Empty(t, watchAnnotationOf(t, p, namespace))
+
+		repeat := captureReleaseWatcherEvents(t, p, func() {
+			k8s.ScanReleasePromoteAnnotationsForTest(p, context.Background())
+		}, 1, 200*time.Millisecond)
+
+		assert.Empty(t, repeat, "a second GC pass MUST be silent; got %v", repeat)
+	})
+}
+
+// TestReleasePromoteWatchGC_TenantNamespace_TimeoutWhenStatusNotTerminal: an
+// expired watch over a namespace the AtomController never reached a terminal
+// status for still resolves once, as an error, rather than repeating.
+func TestReleasePromoteWatchGC_TenantNamespace_TimeoutWhenStatusNotTerminal(t *testing.T) {
+	testProvider(t, func(p *k8s.Provider) {
+		namespace := fmt.Sprintf("%s-2bzcs9-stuckapp", p.Name)
+		seedWatchNamespace(t, p, namespace, "2bzcs9", "stuckapp", "", "R-TID-8",
+			watchStateJSON(t, "R-TID-8", -time.Hour))
+
+		events := captureReleaseWatcherEvents(t, p, func() {
+			k8s.ScanReleasePromoteAnnotationsForTest(p, context.Background())
+		}, 2, 500*time.Millisecond)
+
+		require.Len(t, events, 1, "expired watch MUST emit exactly once; got %v", events)
+		assert.Equal(t, "app:promote:errored", events[0]["action"])
+		data, _ := events[0]["data"].(map[string]any)
+		assert.Equal(t, "watcher-timeout", data["message"])
+		assert.Empty(t, watchAnnotationOf(t, p, namespace))
+
+		repeat := captureReleaseWatcherEvents(t, p, func() {
+			k8s.ScanReleasePromoteAnnotationsForTest(p, context.Background())
+		}, 1, 200*time.Millisecond)
+
+		assert.Empty(t, repeat, "a second GC pass MUST be silent; got %v", repeat)
+	})
+}
+
+// TestReleasePromoteWatchGC_TenantAndRackAppsShareAName: two apps with the same
+// name in different namespaces each resolve against their own object.
+func TestReleasePromoteWatchGC_TenantAndRackAppsShareAName(t *testing.T) {
+	testProvider(t, func(p *k8s.Provider) {
+		tenantNamespace := fmt.Sprintf("%s-2bzcs9-web", p.Name)
+		rackNamespace := fmt.Sprintf("%s-web", p.Name)
+
+		seedWatchNamespace(t, p, tenantNamespace, "2bzcs9", "web", "Running", "R-TENANT",
+			watchStateJSON(t, "R-TENANT", -time.Hour))
+		seedWatchNamespace(t, p, rackNamespace, "", "web", "Running", "R-RACK",
+			watchStateJSON(t, "R-RACK", -time.Hour))
+
+		events := captureReleaseWatcherEvents(t, p, func() {
+			k8s.ScanReleasePromoteAnnotationsForTest(p, context.Background())
+		}, 3, 500*time.Millisecond)
+
+		require.Len(t, events, 2, "each namespace MUST resolve once; got %v", events)
+		ids := []string{}
+		for _, ev := range events {
+			data, _ := ev["data"].(map[string]any)
+			id, _ := data["id"].(string)
+			ids = append(ids, id)
+		}
+		assert.ElementsMatch(t, []string{"R-TENANT", "R-RACK"}, ids)
+		assert.Empty(t, watchAnnotationOf(t, p, tenantNamespace))
+		assert.Empty(t, watchAnnotationOf(t, p, rackNamespace))
+	})
+}
+
+// TestReleasePromoteWatchGC_LogsEachCleanup: a loop that emits user-visible
+// notifications had no log line at all, which is why it ran unnoticed.
+func TestReleasePromoteWatchGC_LogsEachCleanup(t *testing.T) {
+	testProvider(t, func(p *k8s.Provider) {
+		namespace := fmt.Sprintf("%s-2bzcs9-loggedapp", p.Name)
+		seedWatchNamespace(t, p, namespace, "2bzcs9", "loggedapp", "Running", "R-TID-9",
+			watchStateJSON(t, "R-TID-9", -time.Hour))
+
+		readStdout := captureStdout(t)
+		captureReleaseWatcherEvents(t, p, func() {
+			k8s.ScanReleasePromoteAnnotationsForTest(p, context.Background())
+		}, 1, 500*time.Millisecond)
+		out := readStdout()
+
+		assert.Contains(t, out, fmt.Sprintf("kind=gc_cleanup namespace=%s release_id=R-TID-9", namespace),
+			"a successful GC cleanup MUST leave a log line")
+	})
+}
+
+// TestReleasePromoteWatchGC_CorruptJSONCleanupFailureIsLogged: the corrupt-JSON
+// branch deletes without a compare-and-swap, so a failure there has no other
+// trace at all.
+func TestReleasePromoteWatchGC_CorruptJSONCleanupFailureIsLogged(t *testing.T) {
+	testProvider(t, func(p *k8s.Provider) {
+		namespace := fmt.Sprintf("%s-2bzcs9-corruptapp", p.Name)
+		seedWatchNamespace(t, p, namespace, "2bzcs9", "corruptapp", "Running", "R-TID-10", "{not-valid-json")
+
+		kk, ok := p.Cluster.(*fake.Clientset)
+		require.True(t, ok)
+		kk.PrependReactor("patch", "namespaces", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, kerr.NewInternalError(fmt.Errorf("etcd unavailable"))
+		})
+
+		readStdout := captureStdout(t)
+		k8s.ScanReleasePromoteAnnotationsForTest(p, context.Background())
+		out := readStdout()
+
+		assert.Contains(t, out, fmt.Sprintf("kind=gc_cleanup_failed namespace=%s", namespace))
+		assert.Equal(t, "{not-valid-json", watchAnnotationOf(t, p, namespace),
+			"a failed cleanup MUST leave the annotation for the next tick")
+	})
+}
+
+// TestReleasePromoteWatcher_OutlivesTheRequestContext: the promote handler's
+// context is cancelled the moment it returns, which left the watcher it starts
+// dead on arrival on every rack.
+func TestReleasePromoteWatcher_OutlivesTheRequestContext(t *testing.T) {
+	defer k8s.SetReleasePromoteWatchPollIntervalForTest(20 * time.Millisecond)()
+
+	testProvider(t, func(p *k8s.Provider) {
+		namespace := fmt.Sprintf("%s-detachedapp", p.Name)
+		seedWatchNamespace(t, p, namespace, "", "detachedapp", "Running", "R-CTX-1",
+			watchStateJSON(t, "R-CTX-1", time.Minute))
+
+		state := structs.ReleasePromoteWatchState{
+			SchemaVersion: 1,
+			ReleaseID:     "R-CTX-1",
+			AtomVersion:   "R-CTX-1",
+			StartedAt:     time.Now().UTC(),
+			ExpiresAt:     time.Now().UTC().Add(time.Minute),
+			Actor:         "deploy-key:test",
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		request := k8s.WithContextForTest(p, ctx)
+		require.NotNil(t, request)
+		cancel()
+
+		events := captureReleaseWatcherEvents(t, request, func() {
+			k8s.LaunchReleasePromoteWatcherForTest(request, "detachedapp", &state)
+		}, 1, 2*time.Second)
+
+		ev := findEventByAction(events, "app:promote:completed")
+		require.NotNil(t, ev, "the watcher MUST survive the request context; got %v", events)
+		assert.Equal(t, "success", ev["status"])
+	})
+}


### PR DESCRIPTION
### What is the feature/update/fix?

**Fix: Promote Result Notifications Arrive on Time and Once**

A promote's outcome event, and the Slack and Discord notifications it drives, are now sent when the rollout reaches its terminal status, a few seconds after it settles.

Three changes produce that:

| Change | Effect |
|--------|--------|
| The rollout watcher a promote starts now runs on a context that outlives the request | The watcher observes the rollout for its full window rather than exiting shortly after the promote call returns |
| The watch cleanup uses the namespace it read rather than rebuilding one | Cleanup finds the object it is cleaning up, on racks that serve multiple tenants as well as ordinary racks |
| The watch annotation delete reports whether this replica removed it | The cleanup pass sends a promote result only from the replica that removed the annotation, so two rack API replicas that adopt the same leftover watch notify once between them |

A promote whose rollout has not reached a terminal status within its timeout plus a thirty second grace period now reports `watcher-timeout` at that point. The timeout window and its behavior are unchanged; the watcher is now alive to observe it.

Cleanup of a corrupt watch annotation is now scoped to the namespace the annotation was read from, so it cannot reach a same-named app in another namespace.

---

### Why is this important?

A pipeline, a Slack channel, or a Discord channel learns a deploy's result from the promote outcome event. It is now sent when the rollout reaches a terminal status, within seconds of the rollout settling.

**Benefits:**

- **Notifications arrive when the rollout finishes.** A promote result is sent within seconds of the rollout reaching a terminal status.
- **One notification per recovered watch.** Only the replica whose delete removed the annotation sends the notification, so two rack API replicas cannot both notify for the same recovered promote.
- **A named timeout.** A promote that never settles reports `watcher-timeout` at its deadline rather than reporting whatever the app status happened to be much later.
- **Correctly scoped cleanup.** A watch annotation is only ever cleared from the namespace it was read from.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this fix.

No Terraform variable, rack parameter, API route, or struct field changes, and the annotation format and every other piece of persisted state are unchanged.

The first cleanup pass after the rack API starts, fifteen seconds in rather than at the five minute tick, clears any watch annotation left over from an earlier promote and sends its final notification. On a rack where promotes had accumulated them, that arrives as one notification per affected app, all at once, shortly after the update completes. An app whose namespace no longer carries a terminal status reports `watcher-timeout` rather than a promote result.

Ordinary racks also stop logging a `context canceled` warning that appeared on every promote.

---

### Requirements

This fix requires version `3.25.5` or later for the rack.

**Update the Rack:** Run `convox rack update 3.25.5 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
