### PR TITLE
report detached run outcomes

### DIFF
--- a/pkg/cli/engine.go
+++ b/pkg/cli/engine.go
@@ -14,6 +14,16 @@ type Engine struct {
 	Client sdk.Interface
 }
 
+func hasFlag(flags []stdcli.Flag, name string) bool {
+	for _, f := range flags {
+		if f.Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (e *Engine) Command(command, description string, fn HandlerFunc, opts stdcli.CommandOptions) {
 	wfn := func(c *stdcli.Context) error {
 		r, err := rack.Current(c)
@@ -35,9 +45,12 @@ func (e *Engine) Command(command, description string, fn HandlerFunc, opts stdcl
 		return err
 	}
 
-	// the wait command flag is added for making the cli tool v2 backwards compatible
-	flagWait.SkipHelpCommand = true
-	opts.Flags = append(opts.Flags, flagWait)
+	// the wait command flag is added for making the cli tool v2 backwards compatible,
+	// unless the command declares its own, in which case a second one would panic pflag
+	if !hasFlag(opts.Flags, flagWait.Name) {
+		flagWait.SkipHelpCommand = true
+		opts.Flags = append(opts.Flags, flagWait)
+	}
 
 	e.Engine.Command(command, description, wfn, opts)
 }
@@ -67,9 +80,12 @@ func (e *Engine) CommandWithoutProvider(command, description string, fn HandlerF
 		return fn(nil, c)
 	}
 
-	// the wait command flag is added for making the cli tool v2 backwards compatible
-	flagWait.SkipHelpCommand = true
-	opts.Flags = append(opts.Flags, flagWait)
+	// the wait command flag is added for making the cli tool v2 backwards compatible,
+	// unless the command declares its own, in which case a second one would panic pflag
+	if !hasFlag(opts.Flags, flagWait.Name) {
+		flagWait.SkipHelpCommand = true
+		opts.Flags = append(opts.Flags, flagWait)
+	}
 
 	e.Engine.Command(command, description, wfn, opts)
 }

--- a/pkg/cli/fixtures_test.go
+++ b/pkg/cli/fixtures_test.go
@@ -183,6 +183,14 @@ func fxProcess() *structs.Process {
 	}
 }
 
+func fxProcessExited(status string, code *int) *structs.Process {
+	ps := fxProcess()
+	ps.Status = status
+	ps.ExitCode = code
+
+	return ps
+}
+
 func fxProcessPending() *structs.Process {
 	return &structs.Process{
 		Id:       "pid1",

--- a/pkg/cli/ps.go
+++ b/pkg/cli/ps.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"strconv"
+
 	"github.com/convox/convox/pkg/common"
 	"github.com/convox/convox/pkg/structs"
 	"github.com/convox/convox/sdk"
@@ -65,6 +67,10 @@ func PsInfo(rack sdk.Interface, c *stdcli.Context) error {
 	i.Add("Service", ps.Name)
 	i.Add("Started", common.Ago(ps.Started))
 	i.Add("Status", ps.Status)
+
+	if ps.ExitCode != nil {
+		i.Add("Exit", strconv.Itoa(*ps.ExitCode))
+	}
 
 	return i.Print()
 }

--- a/pkg/cli/ps_test.go
+++ b/pkg/cli/ps_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/convox/convox/pkg/cli"
 	mocksdk "github.com/convox/convox/pkg/mock/sdk"
+	"github.com/convox/convox/pkg/options"
 	"github.com/convox/convox/pkg/structs"
 	"github.com/stretchr/testify/require"
 )
@@ -93,5 +94,27 @@ func TestPsStopError(t *testing.T) {
 		require.Equal(t, 1, res.Code)
 		res.RequireStderr(t, []string{"ERROR: err1"})
 		res.RequireStdout(t, []string{"Stopping pid1... "})
+	})
+}
+
+func TestPsInfoExitCode(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("ProcessGet", "app1", "pid1").Return(fxProcessExited("failed", options.Int(3)), nil)
+
+		res, err := testExecute(e, "ps info pid1 -a app1", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		res.RequireStderr(t, []string{""})
+		res.RequireStdout(t, []string{
+			"Id        pid1",
+			"App       app1",
+			"Command   command",
+			"Instance  instance",
+			"Release   release1",
+			"Service   name",
+			"Started   2 days ago",
+			"Status    failed",
+			"Exit      3",
+		})
 	})
 }

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -2,8 +2,10 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/convox/convox/pkg/common"
 	"github.com/convox/convox/pkg/options"
@@ -11,6 +13,8 @@ import (
 	"github.com/convox/convox/sdk"
 	"github.com/convox/stdcli"
 )
+
+const waitRetainSeconds = 60
 
 func init() {
 	entrypoint := stdcli.BoolFlag("entrypoint", "e", "set to false to disable the original entrypoint in your container")
@@ -21,8 +25,11 @@ func init() {
 			stdcli.OptionFlags(structs.ProcessRunOptions{}),
 			flagRack,
 			flagApp,
+			flagId,
 			stdcli.BoolFlag("detach", "d", "run process in the background"),
 			stdcli.IntFlag("timeout", "t", "timeout"),
+			stdcli.IntFlag("retain", "", "with --detach, seconds to keep the finished process readable by ps info"),
+			stdcli.BoolFlag("wait", "w", "with --detach, wait for the process to finish and exit with its status"),
 			entrypoint,
 		),
 		Usage:    "<service> <command>",
@@ -53,19 +60,18 @@ func Run(rack sdk.Interface, c *stdcli.Context) error {
 		opts.Width = options.Int(w)
 	}
 
+	if c.Bool("detach") {
+		return runDetached(rack, c, service, &opts, timeout)
+	}
+
+	if c.Int("retain") > 0 {
+		return fmt.Errorf("--retain is only valid with --detach")
+	}
+
+	// raw mode belongs only to the attached path, which is the one that reads stdin;
+	// setting it around a --wait would clear ISIG and swallow the caller's ctrl-c
 	restore := c.TerminalRaw()
 	defer restore()
-
-	if c.Bool("detach") {
-		c.Startf("Running detached process")
-
-		ps, err := rack.ProcessRun(app(c), service, opts)
-		if err != nil {
-			return err
-		}
-
-		return c.OK(ps.Id)
-	}
 
 	opts.Command = options.String(fmt.Sprintf("sleep %d", timeout))
 
@@ -96,4 +102,81 @@ func Run(rack sdk.Interface, c *stdcli.Context) error {
 	}
 
 	return stdcli.Exit(code)
+}
+
+func runDetached(rack sdk.Interface, c *stdcli.Context, service string, opts *structs.ProcessRunOptions, timeout int) error {
+	wait := c.Bool("wait")
+
+	// divert before anything is printed so the id lands on stdout by itself
+	var stdout io.Writer
+
+	if c.Bool("id") {
+		stdout = c.Writer().Stdout
+		c.Writer().Stdout = c.Writer().Stderr
+	}
+
+	retain := c.Int("retain")
+
+	// --wait has to read the record back, so the record must outlive a poll
+	if wait && retain < waitRetainSeconds {
+		retain = waitRetainSeconds
+	}
+
+	if retain > 0 {
+		opts.Retain = options.Int(retain)
+	}
+
+	c.Startf("Running detached process")
+
+	ps, err := rack.ProcessRun(app(c), service, *opts)
+	if err != nil {
+		return err
+	}
+
+	if err := c.OK(ps.Id); err != nil {
+		return err
+	}
+
+	if stdout != nil {
+		fmt.Fprintf(stdout, "%s", ps.Id)
+	}
+
+	if !wait {
+		return nil
+	}
+
+	return waitForProcessExit(rack, c, ps.Id, timeout)
+}
+
+func waitForProcessExit(rack sdk.Interface, c *stdcli.Context, pid string, timeout int) error {
+	var done *structs.Process
+
+	// common.Wait wants two consecutive successes; latch so the second never races cleanup
+	err := common.Wait(WaitDuration, time.Duration(timeout)*time.Second, 2, func() (bool, error) {
+		if done != nil {
+			return true, nil
+		}
+
+		ps, err := rack.ProcessGet(app(c), pid)
+		if err != nil {
+			return false, err
+		}
+
+		if !ps.Terminal() {
+			return false, nil
+		}
+
+		done = ps
+
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("could not confirm the outcome of process %s: %s\n       convox ps info %s -a %s", pid, err, pid, app(c))
+	}
+
+	if done.ExitCode == nil {
+		return fmt.Errorf("process %s ended with status %s but the rack did not report an exit status.\n       It may have been stopped before its command ran, or the rack may predate the release that reports one", pid, done.Status)
+	}
+
+	return stdcli.Exit(*done.ExitCode)
 }

--- a/pkg/cli/run_test.go
+++ b/pkg/cli/run_test.go
@@ -59,3 +59,115 @@ func TestRunDetached(t *testing.T) {
 		res.RequireStdout(t, []string{"Running detached process... OK, pid1"})
 	})
 }
+
+func TestRunDetachedRetain(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("ProcessRun", "app1", "web", structs.ProcessRunOptions{
+			Command: options.String("bash"),
+			Retain:  options.Int(120),
+		}).Return(fxProcess(), nil)
+
+		res, err := testExecute(e, "run web bash -a app1 -d --retain 120", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		res.RequireStderr(t, []string{""})
+		res.RequireStdout(t, []string{"Running detached process... OK, pid1"})
+	})
+}
+
+func TestRunRetainRequiresDetach(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		res, err := testExecute(e, "run web bash -a app1 --retain 120", nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, res.Code)
+		res.RequireStderr(t, []string{"ERROR: --retain is only valid with --detach"})
+		res.RequireStdout(t, []string{""})
+		i.AssertNotCalled(t, "ProcessRun", mock.Anything, mock.Anything, mock.Anything)
+	})
+}
+
+func TestRunDetachedWait(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("ProcessRun", "app1", "web", structs.ProcessRunOptions{
+			Command: options.String("bash"),
+			Retain:  options.Int(60),
+		}).Return(fxProcess(), nil)
+		i.On("ProcessGet", "app1", "pid1").Return(fxProcessExited("failed", options.Int(3)), nil)
+
+		res, err := testExecute(e, "run web bash -a app1 -d -w", nil)
+		require.NoError(t, err)
+		require.Equal(t, 3, res.Code)
+		res.RequireStderr(t, []string{""})
+		res.RequireStdout(t, []string{"Running detached process... OK, pid1"})
+	})
+}
+
+func TestRunDetachedWaitSuccess(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("ProcessRun", "app1", "web", structs.ProcessRunOptions{
+			Command: options.String("bash"),
+			Retain:  options.Int(300),
+		}).Return(fxProcess(), nil)
+		i.On("ProcessGet", "app1", "pid1").Return(fxProcessExited("complete", options.Int(0)), nil)
+
+		res, err := testExecute(e, "run web bash -a app1 -d -w --retain 300", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+	})
+}
+
+func TestRunDetachedWaitWithoutExitStatus(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("ProcessRun", "app1", "web", structs.ProcessRunOptions{
+			Command: options.String("bash"),
+			Retain:  options.Int(60),
+		}).Return(fxProcess(), nil)
+		i.On("ProcessGet", "app1", "pid1").Return(fxProcessExited("failed", nil), nil)
+
+		res, err := testExecute(e, "run web bash -a app1 -d -w", nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, res.Code)
+		require.Contains(t, res.Stderr, "did not report an exit status")
+	})
+}
+
+func TestRunDetachedWaitUnconfirmed(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("ProcessRun", "app1", "web", structs.ProcessRunOptions{
+			Command: options.String("bash"),
+			Retain:  options.Int(60),
+		}).Return(fxProcess(), nil)
+		i.On("ProcessGet", "app1", "pid1").Return(nil, fmt.Errorf("err1"))
+
+		res, err := testExecute(e, "run web bash -a app1 -d -w", nil)
+		require.NoError(t, err)
+		require.Equal(t, 1, res.Code)
+		require.Contains(t, res.Stderr, "could not confirm the outcome of process pid1")
+	})
+}
+
+func TestRunDetachedId(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("ProcessRun", "app1", "web", structs.ProcessRunOptions{Command: options.String("bash")}).Return(fxProcess(), nil)
+
+		res, err := testExecute(e, "run web bash -a app1 -d --id", nil)
+		require.NoError(t, err)
+		require.Equal(t, 0, res.Code)
+		res.RequireStdout(t, []string{"pid1"})
+		res.RequireStderr(t, []string{"Running detached process... OK, pid1"})
+	})
+}
+
+func TestRunWaitWithoutDetachIsStillANoOp(t *testing.T) {
+	testClient(t, func(e *cli.Engine, i *mocksdk.Interface) {
+		i.On("ProcessRun", "app1", "web", structs.ProcessRunOptions{Command: options.String("sleep 7200")}).Return(fxProcess(), nil)
+		i.On("ProcessGet", "app1", "pid1").Return(fxProcess(), nil)
+		opts := structs.ProcessExecOptions{Entrypoint: options.Bool(true), Tty: options.Bool(false)}
+		i.On("ProcessExec", "app1", "pid1", "bash", mock.Anything, opts).Return(4, nil)
+		i.On("ProcessStop", "app1", "pid1").Return(nil)
+
+		res, err := testExecute(e, "run web bash -a app1 -t 7200 -w", strings.NewReader("in"))
+		require.NoError(t, err)
+		require.Equal(t, 4, res.Code)
+	})
+}

--- a/pkg/structs/process.go
+++ b/pkg/structs/process.go
@@ -37,6 +37,9 @@ type Process struct {
 	GpuFp16Active   *float64 `json:"gpu-fp16-active,omitempty"`   // percent 0-100
 	GpuFp32Active   *float64 `json:"gpu-fp32-active,omitempty"`   // percent 0-100
 	GpuPowerW       *float64 `json:"gpu-power-w,omitempty"`       // watts
+
+	// ExitCode is the primary container's terminated exit status; nil while running or unknown.
+	ExitCode *int `json:"exit-code,omitempty"`
 }
 
 type Processes []Process
@@ -79,9 +82,15 @@ type ProcessRunOptions struct {
 	UseServiceLifecycle *bool   `flag:"use-service-lifecycle" header:"Use-Service-Lifecycle"`
 	NodeAffinity        *string `flag:"node-affinity" header:"Node-Affinity"`
 	Tolerations         *string `flag:"tolerations" header:"Run-Tolerations"`
+	Retain              *int    `header:"Retain"`
 
 	IsBuild   bool
 	BuildArch *string
+}
+
+// Terminal reports whether the process has stopped and will not run again.
+func (p *Process) Terminal() bool {
+	return p.Status == "complete" || p.Status == "failed"
 }
 
 func (p *Process) sortKey() string {

--- a/pkg/structs/process_test.go
+++ b/pkg/structs/process_test.go
@@ -144,3 +144,31 @@ func TestProcessGpuFields_RoundTrip(t *testing.T) {
 	assert.Equal(t, memTotal, *got.GpuMemTotal)
 	assert.Equal(t, "inference", got.Service)
 }
+
+// TestProcess_ExitCode_OmitEmpty: a nil ExitCode must be stripped from JSON so
+// an older Console parsing a newer rack sees the same shape it does today, and a
+// real exit of 0 must still serialize rather than being mistaken for absence.
+func TestProcess_ExitCode_OmitEmpty(t *testing.T) {
+	b, err := json.Marshal(Process{Id: "abc", App: "myapp"})
+	require.NoError(t, err)
+	assert.NotContains(t, string(b), `"exit-code"`)
+
+	code := 0
+	b, err = json.Marshal(Process{Id: "abc", App: "myapp", ExitCode: &code})
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"exit-code":0`)
+}
+
+func TestProcess_Terminal(t *testing.T) {
+	for status, want := range map[string]bool{
+		"complete": true,
+		"failed":   true,
+		"running":  false,
+		"pending":  false,
+		"starting": false,
+		"crashed":  false,
+		"":         false,
+	} {
+		assert.Equal(t, want, (&Process{Status: status}).Terminal(), "status %q", status)
+	}
+}

--- a/provider/k8s/capacity.go
+++ b/provider/k8s/capacity.go
@@ -38,6 +38,11 @@ func (p *Provider) CapacityGet() (*structs.Capacity, error) {
 	}
 
 	for _, p := range ps.Items {
+		// a pod that has exited still carries its requests but reserves nothing
+		if p.Status.Phase == corev1.PodSucceeded || p.Status.Phase == corev1.PodFailed {
+			continue
+		}
+
 		c.ProcessCount += 1
 
 		for _, pc := range p.Spec.Containers {

--- a/provider/k8s/capacity_test.go
+++ b/provider/k8s/capacity_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/convox/convox/provider/k8s"
 	"github.com/stretchr/testify/require"
+	ac "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -27,5 +28,24 @@ func TestCapacityGet(t *testing.T) {
 		require.Equal(t, int64(949), c.ProcessCPU)
 		require.Equal(t, int64(5236), c.ProcessMemory)
 		require.Equal(t, int64(3), c.ProcessCount)
+	})
+}
+
+func TestCapacityGetExcludesTerminalProcesses(t *testing.T) {
+	testProvider(t, func(p *k8s.Provider) {
+		kk, ok := p.Cluster.(*fake.Clientset)
+		require.True(t, ok)
+
+		require.NoError(t, nodeCreateResources(kk, "node1", "2000m", "3000M"))
+		require.NoError(t, appCreate(kk, "rack1", "app1"))
+		require.NoError(t, processCreateResources(kk, "rack1-app1", "process1", "system=convox,rack=rack1,app=app1,service=service1,type=service", "128m", "256M"))
+		require.NoError(t, processCreatePhase(kk, "rack1-app1", "process2", "system=convox,rack=rack1,app=app1,service=service2,type=process", "228m", "592M", ac.PodSucceeded))
+		require.NoError(t, processCreatePhase(kk, "rack1-app1", "process3", "system=convox,rack=rack1,app=app1,service=service2,type=process", "593m", "4388M", ac.PodFailed))
+
+		c, err := p.CapacityGet()
+		require.NoError(t, err)
+		require.Equal(t, int64(128), c.ProcessCPU)
+		require.Equal(t, int64(256), c.ProcessMemory)
+		require.Equal(t, int64(1), c.ProcessCount)
 	})
 }

--- a/provider/k8s/controller_pod.go
+++ b/provider/k8s/controller_pod.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strconv"
 	"time"
 
 	"github.com/convox/convox/pkg/kctl"
@@ -14,6 +15,13 @@ import (
 	ic "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	AnnotationProcessRetain = "convox.com/retain"
+
+	podCleanupDelay     = 5 * time.Second
+	podRetainMaxSeconds = 600
 )
 
 type PodController struct {
@@ -129,8 +137,34 @@ func (c *PodController) Update(prev, cur interface{}) error {
 	return nil
 }
 
+func cleanupDelay(p *ac.Pod, now time.Time) time.Duration {
+	retain, err := strconv.Atoi(p.Annotations[AnnotationProcessRetain])
+	if err != nil || retain <= 0 {
+		return podCleanupDelay
+	}
+
+	if retain > podRetainMaxSeconds {
+		retain = podRetainMaxSeconds
+	}
+
+	// a rack api restart replays Add for pods that are already terminal, so the
+	// window has to run from the container's exit rather than from this observation
+	from := now
+	if css := p.Status.ContainerStatuses; len(css) > 0 && css[0].State.Terminated != nil {
+		if t := css[0].State.Terminated.FinishedAt.Time; !t.IsZero() {
+			from = t
+		}
+	}
+
+	if d := from.Add(time.Duration(retain) * time.Second).Sub(now); d > podCleanupDelay {
+		return d
+	}
+
+	return podCleanupDelay
+}
+
 func (c *PodController) cleanupPod(p *ac.Pod) error {
-	time.Sleep(5 * time.Second)
+	time.Sleep(cleanupDelay(p, time.Now().UTC()))
 
 	// the pod observed here may already have been replaced by one reusing its
 	// name, which statefulsets do, so delete only this exact object

--- a/provider/k8s/controller_pod_retain_test.go
+++ b/provider/k8s/controller_pod_retain_test.go
@@ -1,0 +1,58 @@
+package k8s
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	ac "k8s.io/api/core/v1"
+	am "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func retainPod(annotation string, finished time.Time) *ac.Pod {
+	p := &ac.Pod{ObjectMeta: am.ObjectMeta{Name: "web-abc", Namespace: "ns1"}}
+
+	if annotation != "" {
+		p.Annotations = map[string]string{AnnotationProcessRetain: annotation}
+	}
+
+	if !finished.IsZero() {
+		p.Status.ContainerStatuses = []ac.ContainerStatus{
+			{
+				Name:  "app1",
+				State: ac.ContainerState{Terminated: &ac.ContainerStateTerminated{FinishedAt: am.NewTime(finished)}},
+			},
+		}
+	}
+
+	return p
+}
+
+func TestCleanupDelay(t *testing.T) {
+	now := time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name       string
+		annotation string
+		finished   time.Time
+		want       time.Duration
+	}{
+		{name: "no annotation keeps today's grace", want: podCleanupDelay},
+		{name: "unparseable falls back", annotation: "soon", finished: now, want: podCleanupDelay},
+		{name: "zero falls back", annotation: "0", finished: now, want: podCleanupDelay},
+		{name: "negative falls back", annotation: "-30", finished: now, want: podCleanupDelay},
+		{name: "overflow falls back", annotation: "999999999999999999999", finished: now, want: podCleanupDelay},
+		{name: "in range runs from the container exit", annotation: "120", finished: now.Add(-30 * time.Second), want: 90 * time.Second},
+		{name: "clamped to the ceiling", annotation: "99999", finished: now, want: podRetainMaxSeconds * time.Second},
+		{name: "elapsed window still gets the grace", annotation: "60", finished: now.Add(-10 * time.Minute), want: podCleanupDelay},
+		{name: "no container status runs from now", annotation: "120", want: 120 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.want, cleanupDelay(retainPod(tt.annotation, tt.finished), now))
+		})
+	}
+}

--- a/provider/k8s/diagnose.go
+++ b/provider/k8s/diagnose.go
@@ -409,6 +409,12 @@ func (p *Provider) diagnosePods(namespace string, opts structs.AppDiagnoseOption
 			continue
 		}
 
+		// a one-off run that finished is not a service health problem; a failed one
+		// still is, so it stays
+		if pod.Labels["type"] == "process" && pod.Status.Phase == ac.PodSucceeded {
+			continue
+		}
+
 		classification, stateDetail := classifyPod(&pod, ageThreshold)
 
 		switch classification {

--- a/provider/k8s/diagnose_process_test.go
+++ b/provider/k8s/diagnose_process_test.go
@@ -1,0 +1,52 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	"github.com/convox/convox/pkg/structs"
+	"github.com/stretchr/testify/require"
+	ac "k8s.io/api/core/v1"
+	am "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func diagnosePod(t *testing.T, kk *fake.Clientset, name, podType string, phase ac.PodPhase) {
+	t.Helper()
+
+	_, err := kk.CoreV1().Pods("rack1-app1").Create(context.TODO(), &ac.Pod{
+		ObjectMeta: am.ObjectMeta{
+			Name:      name,
+			Namespace: "rack1-app1",
+			Labels:    map[string]string{"system": "convox", "app": "app1", "service": "web", "type": podType},
+		},
+		Spec:   ac.PodSpec{Containers: []ac.Container{{Name: "app1"}}},
+		Status: ac.PodStatus{Phase: phase},
+	}, am.CreateOptions{})
+	require.NoError(t, err)
+}
+
+func TestDiagnosePodsSkipsCompletedRuns(t *testing.T) {
+	p, kk, _ := minimalProvider(t)
+
+	diagnosePod(t, kk, "web-done", "process", ac.PodSucceeded)
+
+	pods, summary, err := p.diagnosePods("rack1-app1", structs.AppDiagnoseOptions{})
+	require.NoError(t, err)
+	require.Empty(t, pods)
+	require.Equal(t, 0, summary.Total)
+	require.Equal(t, 0, summary.Unhealthy)
+}
+
+func TestDiagnosePodsKeepsFailedRunsAndServices(t *testing.T) {
+	p, kk, _ := minimalProvider(t)
+
+	diagnosePod(t, kk, "web-failed", "process", ac.PodFailed)
+	diagnosePod(t, kk, "web-stopped", "service", ac.PodSucceeded)
+
+	pods, summary, err := p.diagnosePods("rack1-app1", structs.AppDiagnoseOptions{})
+	require.NoError(t, err)
+	require.Len(t, pods, 2)
+	require.Equal(t, 2, summary.Total)
+	require.Equal(t, 2, summary.Unhealthy)
+}

--- a/provider/k8s/process.go
+++ b/provider/k8s/process.go
@@ -158,11 +158,15 @@ func (p *Provider) processGet(ns, app, pid string) (*structs.Process, error) {
 		return nil, errors.WithStack(err)
 	}
 
-	m, err := p.MetricsClient.MetricsV1beta1().PodMetricses(ns).Get(context.TODO(), pid, am.GetOptions{})
-	if err != nil {
-		p.logger.Errorf("failed to fetch pod metrics: %s", err)
-	} else if m != nil && len(m.Containers) > 0 {
-		ps.Cpu, ps.Memory = calculatePodCpuAndMem(m)
+	// metrics-server serves nothing for a pod that has already exited, so asking
+	// would only log an error on every poll of a retained process
+	if !ps.Terminal() {
+		m, err := p.MetricsClient.MetricsV1beta1().PodMetricses(ns).Get(context.TODO(), pid, am.GetOptions{})
+		if err != nil {
+			_ = p.logger.Errorf("failed to fetch pod metrics: %s", err)
+		} else if m != nil && len(m.Containers) > 0 {
+			ps.Cpu, ps.Memory = calculatePodCpuAndMem(m)
+		}
 	}
 
 	// GPU runtime telemetry — best-effort enrichment from the rack's
@@ -528,6 +532,11 @@ func (p *Provider) ProcessRun(app, service string, opts structs.ProcessRunOption
 
 	if opts.IsBuild {
 		labels["service-type"] = "build"
+	}
+
+	// set ahead of the caller's annotations so the merge below leaves this one alone
+	if opts.Retain != nil {
+		ans[AnnotationProcessRetain] = strconv.Itoa(*opts.Retain)
 	}
 
 	if opts.Annotations != nil {
@@ -1324,12 +1333,18 @@ func (p *Provider) processFromPod(pd ac.Pod) (*structs.Process, error) {
 		}
 	}
 
+	var exitCode *int
+
 	if css := pd.Status.ContainerStatuses; len(css) > 0 && css[0].Name == app {
 		if cs := css[0]; cs.State.Waiting != nil {
 			switch cs.State.Waiting.Reason {
 			case "CrashLoopBackOff":
 				status = "crashed"
 			}
+		}
+
+		if t := css[0].State.Terminated; t != nil {
+			exitCode = options.Int(int(t.ExitCode))
 		}
 	}
 
@@ -1355,6 +1370,7 @@ func (p *Provider) processFromPod(pd ac.Pod) (*structs.Process, error) {
 		Release:  pd.ObjectMeta.Labels["release"],
 		Started:  pd.CreationTimestamp.Time,
 		Status:   status,
+		ExitCode: exitCode,
 	}
 
 	for key := range gpuKeyToVendor {

--- a/provider/k8s/process_exit_code_test.go
+++ b/provider/k8s/process_exit_code_test.go
@@ -1,0 +1,89 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	ac "k8s.io/api/core/v1"
+	am "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func podWithContainerState(phase ac.PodPhase, state ac.ContainerState) ac.Pod {
+	return ac.Pod{
+		ObjectMeta: am.ObjectMeta{
+			Name:   "web-abc",
+			Labels: map[string]string{"app": "app1", "service": "web"},
+		},
+		Spec:   ac.PodSpec{Containers: []ac.Container{{Name: "app1"}}},
+		Status: ac.PodStatus{Phase: phase, ContainerStatuses: []ac.ContainerStatus{{Name: "app1", State: state}}},
+	}
+}
+
+func TestProcessFromPod_ExitCode(t *testing.T) {
+	p := &Provider{Name: "rack1"}
+
+	tests := []struct {
+		name  string
+		pod   ac.Pod
+		want  *int
+		state string
+	}{
+		{
+			name:  "terminated container reports its code",
+			pod:   podWithContainerState(ac.PodFailed, ac.ContainerState{Terminated: &ac.ContainerStateTerminated{ExitCode: 3}}),
+			want:  intp(3),
+			state: "failed",
+		},
+		{
+			name:  "clean exit reports zero rather than nil",
+			pod:   podWithContainerState(ac.PodSucceeded, ac.ContainerState{Terminated: &ac.ContainerStateTerminated{ExitCode: 0}}),
+			want:  intp(0),
+			state: "complete",
+		},
+		{
+			name:  "running container has none",
+			pod:   podWithContainerState(ac.PodRunning, ac.ContainerState{Running: &ac.ContainerStateRunning{}}),
+			state: "running",
+		},
+		{
+			name:  "crash looping container has none",
+			pod:   podWithContainerState(ac.PodRunning, ac.ContainerState{Waiting: &ac.ContainerStateWaiting{Reason: "CrashLoopBackOff"}}),
+			state: "crashed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ps, err := p.processFromPod(tt.pod)
+			require.NoError(t, err)
+			require.Equal(t, tt.state, ps.Status)
+
+			if tt.want == nil {
+				require.Nil(t, ps.ExitCode)
+				return
+			}
+
+			require.NotNil(t, ps.ExitCode)
+			require.Equal(t, *tt.want, *ps.ExitCode)
+		})
+	}
+}
+
+func TestProcessFromPod_ExitCodeAbsentWithoutContainerStatus(t *testing.T) {
+	p := &Provider{Name: "rack1"}
+
+	pod := ac.Pod{
+		ObjectMeta: am.ObjectMeta{Name: "web-abc", Labels: map[string]string{"app": "app1", "service": "web"}},
+		Spec:       ac.PodSpec{Containers: []ac.Container{{Name: "app1"}}},
+		Status:     ac.PodStatus{Phase: ac.PodFailed},
+	}
+
+	ps, err := p.processFromPod(pod)
+	require.NoError(t, err)
+	require.Equal(t, "failed", ps.Status)
+	require.Nil(t, ps.ExitCode)
+}
+
+func intp(i int) *int {
+	return &i
+}

--- a/provider/k8s/process_run_flags_test.go
+++ b/provider/k8s/process_run_flags_test.go
@@ -369,3 +369,31 @@ func TestProcessRun_OrderingWithNodeLabels(t *testing.T) {
 	}
 	require.True(t, found, "user toleration must survive the --node-labels reset")
 }
+
+func TestProcessRun_Retain(t *testing.T) {
+	p, kk := runFlagsProvider(t)
+	pod := runAndGetPod(t, p, kk, "app1", "plain", structs.ProcessRunOptions{
+		Release: options.String("rel1"),
+		Retain:  options.Int(120),
+	})
+	require.Equal(t, "120", pod.Annotations[AnnotationProcessRetain])
+}
+
+func TestProcessRun_RetainUnsetLeavesNoAnnotation(t *testing.T) {
+	p, kk := runFlagsProvider(t)
+	pod := runAndGetPod(t, p, kk, "app1", "plain", structs.ProcessRunOptions{
+		Release: options.String("rel1"),
+	})
+	_, ok := pod.Annotations[AnnotationProcessRetain]
+	require.False(t, ok)
+}
+
+func TestProcessRun_RetainBeatsCollidingAnnotation(t *testing.T) {
+	p, kk := runFlagsProvider(t)
+	pod := runAndGetPod(t, p, kk, "app1", "plain", structs.ProcessRunOptions{
+		Release:     options.String("rel1"),
+		Retain:      options.Int(120),
+		Annotations: options.String(AnnotationProcessRetain + "=99999"),
+	})
+	require.Equal(t, "120", pod.Annotations[AnnotationProcessRetain])
+}

--- a/provider/k8s/process_test.go
+++ b/provider/k8s/process_test.go
@@ -110,6 +110,19 @@ func processCreateResources(c kubernetes.Interface, ns, name, labels, cpu, mem s
 	})
 }
 
+func processCreatePhase(c kubernetes.Interface, ns, name, labels, cpu, mem string, phase ac.PodPhase) error {
+	return processCreator(c, ns, name, labels, func(p *ac.Pod) {
+		p.Status = ac.PodStatus{Phase: phase}
+
+		for i := range p.Spec.Containers {
+			p.Spec.Containers[i].Resources.Requests = ac.ResourceList{
+				ac.ResourceCPU:    resource.MustParse(cpu),
+				ac.ResourceMemory: resource.MustParse(mem),
+			}
+		}
+	})
+}
+
 func processCreateGpu(c kubernetes.Interface, ns, name, labels, gpuKey string, gpuCount int) error {
 	return processCreator(c, ns, name, labels, func(p *ac.Pod) {
 		for i := range p.Spec.Containers {


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: Outcome Reporting for a Detached `convox run`**

A detached process now reports how it ended. `convox run --detach` gains `--wait`, which polls for the process to finish and exits with its status, and `--retain`, which keeps a finished process readable by `convox ps info` after it exits. `convox run` also gains `--id`, matching `convox deploy --id`, and `convox ps info` gains an `Exit` row.

**New flags:**

| Flag | Applies to | Effect |
|------|------------|--------|
| `--wait` | `convox run --detach` | Polls for the process to finish and exits with its exit status. `--timeout` bounds the wait. |
| `--retain <seconds>` | `convox run --detach` | Keeps the finished process readable by `convox ps info` for up to 600 seconds. |
| `--id` | `convox run --detach` | Puts the process id alone on stdout with everything else on stderr. |

So a long command run from a pipeline becomes one line, with no stream to lose and no output to parse:

```
convox run web "bin/migrate" --detach --wait -a my-app
```

`--wait` is a client-side poll rather than a held connection, so a dropped connection means one failed poll instead of a failed run. The CLI exits non-zero unless it observed a real exit status:

| Observed | Result |
|----------|--------|
| Finished, exit status reported | Exits with that status |
| Finished, no exit status reported | Non-zero, listing the possible reasons without picking one |
| Wait deadline reached, or two consecutive poll errors | Non-zero, printing the process id and the follow-up command |

`--wait` finishes on a `complete` or `failed` process. A process that is crash-looping or unhealthy keeps being polled until the `--timeout` deadline, which defaults to one hour.

**`convox ps info` now reports an exit status:**

```
Status    failed
Exit      3
```

The `Exit` row appears for any process whose main container has terminated, so a finished timer or a crashed service process shows one too. It is absent on a process that never reached a container exit, an eviction for example. A `failed` status with no `Exit` means the command did not run to completion.

---

### Why is this important?

A long command run from a pipeline had two bad options: hold a websocket open for as long as the command runs, or detach it and give up any signal about how it ended. Detaching makes sense for a database index build or a migration, and it is now observable.

**Benefits:**

- **One step, real exit status.** `--detach --wait` is a normal pipeline step that passes or fails on the command's own status, with no connection held open while it runs.
- **Nothing to lose mid-run.** Each poll is a fresh short request, so a network blip fails one poll rather than the whole run.
- **Check later, in another step.** `--id` plus `--retain` lets one step start the command and a later step read its outcome with `convox ps info`.
- **Never a false pass.** A wait that cannot confirm an outcome exits non-zero. A rack that reports no exit status produces a non-zero exit rather than a pass.
- **No noise from retained processes.** A retained one-off process no longer counts toward rack capacity, a retained process that finished successfully is no longer reported as a service health problem by `convox apps diagnose`, and neither one produces a metrics lookup error on each poll. A retained process that failed still appears in `convox apps diagnose`, which is where you want it.

---

### How to use it?

Wait on the command in one step:

    $ convox run web "bin/migrate" --detach --wait -a my-app

Start it in one step and check it in another:

    $ pid=$(convox run web "bin/migrate" --detach --id --retain 600 -a my-app)
    $ convox ps info "$pid" -a my-app

The second step needs `--retain`. A finished one-off process is otherwise cleaned up within a few seconds. The retention window is measured from the moment the container finished, is capped at 600 seconds, and is a best-effort upper bound: if the node the process ran on is drained or reclaimed first, the record disappears with it. A poller that can no longer find a process should treat that as an unknown outcome and fail rather than pass.

`--detach --wait` sets a retention floor of 60 seconds on its own, so you only need both flags when the wait deadline and the retention window have to differ.

Three behaviors to plan around:

- A retained process appears in `convox ps` as `complete` or `failed` for the length of the window. That means the process is still readable, not that it is stuck.
- `--timeout` has never bounded a detached run and still does not. Nothing stops a detached process other than the command finishing or `convox ps stop`. With `--wait` it bounds how long the CLI waits.
- `--id` writes the process id to stdout with no trailing newline, so `pid=$(...)` captures it cleanly.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this feature.

The new flags are default off, so `convox run` behaves exactly as before without them. `--wait` on an attached run remains a no-op, because that path already waits and already returns the real status. `--retain` outside `--detach` is rejected with `--retain is only valid with --detach`.

Two output changes take effect with no flag to opt into:

- `convox ps info` prints an `Exit` row for any process whose main container has terminated, not only for one started with `--retain`. A caller that reads that output by line position should read it by label instead.
- Rack capacity totals no longer count pods that have exited, and `convox apps diagnose` no longer reports a one-off process that finished successfully. Both apply to every process on the rack.

`structs.Process` gains an `exit-code` field marked `omitempty`, and the run options gain a `Retain` header, both additive. All four version-skew combinations degrade to current behavior: an older CLI sends no retention header and gets the current few-second cleanup, and a newer CLI against an older rack sends flags the rack ignores, so `--wait` reports a truthful non-zero rather than a false pass. Downgrading is clean in both directions; older code ignores the retention annotation, and its controller reaps every terminal pod as it does today.

---

### Requirements

This feature requires version `3.25.5` or later for the rack, and a CLI carrying the new flags.

`--wait`, `--retain`, and the `Exit` row all need the rack on this release, because the rack reports the exit status and honors retention. Against an older rack the flags are accepted and ignored, so `--wait` exits non-zero rather than reporting a false pass.

**Update the Rack:** Run `convox rack update 3.25.5 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
