### PR TITLE
add app_cloudwatch_disable rack parameter

### DIFF
--- a/assets/provider/aws/params.yaml
+++ b/assets/provider/aws/params.yaml
@@ -496,6 +496,10 @@ Groups:
         default: "false"
         type: boolean
         description: "Stops shipping your logs to CloudWatch. &l Enable this if you use another logging service. &l"
+      - name: app_cloudwatch_disable
+        default: "false"
+        type: boolean
+        description: "Stops CloudWatch log groups for your apps, one per app, while keeping the rack's own log group so rack logs stay visible. &l Turn this on if you route app logs elsewhere and still want the rack view. &l &l Note: convox logs returns empty for an app while this is on, and Kubernetes event and deploy state lines for apps stop being recorded. Use convox logs --service to read a service directly. &l &l If &i cloudwatch_disable &i is also on, it covers the rack log group too and rack logs stay hidden until you turn it off. &l"
       - name: cloudwatch_disable
         default: "false"
         type: boolean

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -37,7 +37,7 @@ var providerKnownParams = map[string]map[string]bool{
 var awsKnownParams = map[string]bool{
 	"access_log_retention_in_days": true, "additional_build_groups_config": true,
 	"additional_karpenter_nodepools_config": true, "additional_node_groups_config": true,
-	"api_feature_gates": true, "availability_zones": true,
+	"api_feature_gates": true, "app_cloudwatch_disable": true, "availability_zones": true,
 	"aws_ebs_csi_driver_version": true, "build_disable_convox_resolver": true,
 	"build_node_enabled": true, "build_node_minimal_role_enabled": true, "build_node_min_count": true,
 	"build_node_type": true, "buildkit_host_path_cache_enable": true,
@@ -185,6 +185,7 @@ var managedParams = map[string]bool{
 // boolParams lists type=bool TF variables that require ParseBool validation.
 // Maintain in sync with terraform/{system,rack}/<provider>/variables.tf.
 var boolParams = map[string]bool{
+	"app_cloudwatch_disable":          true,
 	"azure_files_enable":              true,
 	"build_disable_convox_resolver":   true,
 	"build_node_enabled":              true,
@@ -538,6 +539,7 @@ var paramGroups = map[string]map[string]bool{
 	"logging": {
 		// v3 native (snake_case)
 		"access_log_retention_in_days":    true,
+		"app_cloudwatch_disable":          true,
 		"cloudwatch_disable":              true,
 		"cost_tracking_enable":            true,
 		"eks_log_types":                   true,
@@ -2019,11 +2021,19 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 		if effectiveCloudwatch == "" {
 			effectiveCloudwatch = currentParams["cloudwatch_disable"]
 		}
-		if params["cloudwatch_disable"] == "true" && effectiveFluentd != "true" {
+		effectiveAppCloudwatch := params["app_cloudwatch_disable"]
+		if effectiveAppCloudwatch == "" {
+			effectiveAppCloudwatch = currentParams["app_cloudwatch_disable"]
+		}
+		if params["cloudwatch_disable"] == "true" && effectiveFluentd != "true" && effectiveAppCloudwatch != "true" {
 			fmt.Fprintf(os.Stderr, "WARNING: cloudwatch_disable stops Convox rack-side CloudWatch writes and makes 'convox logs' return empty, but fluentd is still enabled and will keep shipping application logs to CloudWatch and creating /convox/<rack>/<app> groups. To stop CloudWatch entirely, also set fluentd_disable=true.\n")
 		}
-		if params["fluentd_disable"] == "true" && effectiveCloudwatch != "true" {
-			fmt.Fprintf(os.Stderr, "WARNING: disabling fluentd stops application logs, but the rack still creates an empty CloudWatch log group per app (/convox/<rack>/<app>). Set cloudwatch_disable=true to prevent them.\n")
+		if params["fluentd_disable"] == "true" && effectiveCloudwatch != "true" && effectiveAppCloudwatch != "true" {
+			fmt.Fprintf(os.Stderr, "WARNING: disabling fluentd stops application logs, but the rack still creates an empty CloudWatch log group per app (/convox/<rack>/<app>). Set app_cloudwatch_disable=true to prevent them while keeping 'convox rack logs', or cloudwatch_disable=true to stop all rack CloudWatch.\n")
+		}
+		if (params["app_cloudwatch_disable"] == "true" && effectiveCloudwatch == "true") ||
+			(params["cloudwatch_disable"] == "true" && effectiveAppCloudwatch == "true") {
+			fmt.Fprintf(os.Stderr, "WARNING: cloudwatch_disable also covers the rack system log group, so 'convox rack logs' stays empty while it is set. Set cloudwatch_disable=false to get the rack view back.\n")
 		}
 	}
 

--- a/pkg/cli/rack_validate_test.go
+++ b/pkg/cli/rack_validate_test.go
@@ -784,6 +784,7 @@ func TestAdditionalNodeGroupsConfigTpuValidation(t *testing.T) {
 func TestValidateAndMutateParams_CloudwatchDisableWarnings(t *testing.T) {
 	const warnA = "cloudwatch_disable stops Convox"
 	const warnB = "disabling fluentd stops application logs"
+	const warnC = "cloudwatch_disable also covers the rack system log group"
 
 	cases := []struct {
 		name         string
@@ -837,6 +838,43 @@ func TestValidateAndMutateParams_CloudwatchDisableWarnings(t *testing.T) {
 			params:     map[string]string{"cost_tracking_enable": "true"},
 			wantAbsent: []string{warnA, warnB},
 		},
+		{
+			name:         "C fires: app_cloudwatch_disable=true while cloudwatch already disabled",
+			params:       map[string]string{"app_cloudwatch_disable": "true"},
+			current:      map[string]string{"cloudwatch_disable": "true"},
+			wantContains: []string{warnC},
+			wantAbsent:   []string{warnA, warnB},
+		},
+		{
+			name:       "C absent when cloudwatch enabled",
+			params:     map[string]string{"app_cloudwatch_disable": "true"},
+			wantAbsent: []string{warnA, warnB, warnC},
+		},
+		{
+			name:         "C fires the other way: cloudwatch_disable=true while app_cloudwatch_disable already set",
+			params:       map[string]string{"cloudwatch_disable": "true"},
+			current:      map[string]string{"app_cloudwatch_disable": "true"},
+			wantContains: []string{warnC},
+			wantAbsent:   []string{warnA, warnB},
+		},
+		{
+			name:         "C fires when both are set in one call",
+			params:       map[string]string{"app_cloudwatch_disable": "true", "cloudwatch_disable": "true"},
+			wantContains: []string{warnC},
+			wantAbsent:   []string{warnA, warnB},
+		},
+		{
+			name:       "B suppressed when app_cloudwatch_disable already set",
+			params:     map[string]string{"fluentd_disable": "true"},
+			current:    map[string]string{"app_cloudwatch_disable": "true"},
+			wantAbsent: []string{warnA, warnB, warnC},
+		},
+		{
+			name:       "no warning on unrelated param set with both already disabled",
+			params:     map[string]string{"cost_tracking_enable": "true"},
+			current:    map[string]string{"cloudwatch_disable": "true", "app_cloudwatch_disable": "true"},
+			wantAbsent: []string{warnA, warnB, warnC},
+		},
 	}
 
 	for _, tc := range cases {
@@ -865,15 +903,17 @@ func TestValidateAndMutateParams_CloudwatchDisableWarnings(t *testing.T) {
 }
 
 func TestValidateAndMutateParams_CloudwatchDisableBoolValidation(t *testing.T) {
-	captureStderr(t, func() {
-		for _, v := range []string{"true", "false", "1", "0", "t", "F"} {
-			if err := validateAndMutateParams(map[string]string{"cloudwatch_disable": v}, "aws", map[string]string{}, false); err != nil {
-				t.Errorf("cloudwatch_disable=%q: unexpected error: %v", v, err)
+	for _, param := range []string{"cloudwatch_disable", "app_cloudwatch_disable"} {
+		captureStderr(t, func() {
+			for _, v := range []string{"true", "false", "1", "0", "t", "F"} {
+				if err := validateAndMutateParams(map[string]string{param: v}, "aws", map[string]string{}, false); err != nil {
+					t.Errorf("%s=%q: unexpected error: %v", param, v, err)
+				}
 			}
+		})
+		if err := validateAndMutateParams(map[string]string{param: "maybe"}, "aws", map[string]string{}, false); err == nil {
+			t.Errorf("%s=maybe: expected error, got nil", param)
 		}
-	})
-	if err := validateAndMutateParams(map[string]string{"cloudwatch_disable": "maybe"}, "aws", map[string]string{}, false); err == nil {
-		t.Error("cloudwatch_disable=maybe: expected error, got nil")
 	}
 }
 

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -38,6 +38,7 @@ type Provider struct {
 	EcrScanOnPushEnable     bool
 	EcrImmutableTagsEnabled bool
 	CloudwatchDisable       bool
+	AppCloudwatchDisable    bool
 
 	Ec2 *ec2.EC2
 
@@ -74,6 +75,7 @@ func FromEnv() (*Provider, error) {
 		EcrScanOnPushEnable:     ecrScanOnPushEnable,
 		EcrImmutableTagsEnabled: ecrImmutableTagsEnabled,
 		CloudwatchDisable:       os.Getenv("CLOUDWATCH_DISABLE") == "true",
+		AppCloudwatchDisable:    os.Getenv("APP_CLOUDWATCH_DISABLE") == "true",
 	}
 
 	k.Engine = p

--- a/provider/aws/log.go
+++ b/provider/aws/log.go
@@ -27,6 +27,10 @@ func (p *Provider) Log(name, stream string, ts time.Time, message string) error 
 		return nil
 	}
 
+	if p.AppCloudwatchDisable && name != "system" {
+		return nil
+	}
+
 	group := p.appLogGroup(name)
 
 	req := &cloudwatchlogs.PutLogEventsInput{
@@ -78,7 +82,7 @@ func (p *Provider) Log(name, stream string, ts time.Time, message string) error 
 }
 
 func (p *Provider) AppLogs(name string, opts structs.LogsOptions) (io.ReadCloser, error) {
-	if p.CloudwatchDisable {
+	if p.CloudwatchDisable || p.AppCloudwatchDisable {
 		return io.NopCloser(strings.NewReader("")), nil
 	}
 	if p.ContextTID() != "" {
@@ -123,7 +127,7 @@ func (p *Provider) createLogGroup(app string) error {
 }
 
 func (p *Provider) UpdateOrDisableLogGroupRetention(app string, retentionDays int, disableRetention bool) error {
-	if p.CloudwatchDisable {
+	if p.CloudwatchDisable || p.AppCloudwatchDisable {
 		return nil
 	}
 

--- a/provider/aws/log_internal_test.go
+++ b/provider/aws/log_internal_test.go
@@ -2,7 +2,9 @@ package aws
 
 import (
 	"context"
+	"fmt"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	mocks "github.com/convox/convox/pkg/mock/aws"
 	"github.com/convox/convox/pkg/structs"
+	"github.com/convox/convox/provider/k8s"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -207,4 +210,134 @@ func TestStreamLogsThrottlingNotBounded(t *testing.T) {
 	}
 	// 5 throttles (not bounded by the cap of 3) + 1 success = 6 calls.
 	m.AssertNumberOfCalls(t, "FilterLogEvents", 6)
+}
+
+// app_cloudwatch_disable must gate app traffic and leave the rack system group
+// reachable. "system" is the discriminator every write funnels through, so the
+// two flags are pinned in both directions on that name.
+func TestLogAppCloudwatchDisable(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		appDisable bool
+		app        string
+		wantGroup  string
+	}{
+		{name: "off, app writes", app: "myapp", wantGroup: "/convox/rack/myapp"},
+		{name: "on, app gated", appDisable: true, app: "myapp"},
+		{name: "on, system reachable", appDisable: true, app: "system", wantGroup: "/convox/rack/system"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &mocks.CloudWatchLogsAPI{}
+			m.On("PutLogEvents", mock.Anything).Return(&cloudwatchlogs.PutLogEventsOutput{
+				NextSequenceToken: aws.String("token"),
+			}, nil)
+			p := &Provider{Provider: &k8s.Provider{Name: "rack"}, CloudWatchLogs: m, AppCloudwatchDisable: tc.appDisable}
+
+			stream := fmt.Sprintf("stream/%s", tc.name)
+			t.Cleanup(func() { sequenceTokens.Delete(fmt.Sprintf("%s/%s", tc.wantGroup, stream)) })
+
+			if err := p.Log(tc.app, stream, time.Now(), "msg"); err != nil {
+				t.Fatalf("expected nil, got %v", err)
+			}
+			m.AssertNumberOfCalls(t, "CreateLogGroup", 0)
+
+			if tc.wantGroup == "" {
+				m.AssertNumberOfCalls(t, "PutLogEvents", 0)
+				return
+			}
+			m.AssertNumberOfCalls(t, "PutLogEvents", 1)
+			in, ok := m.Calls[0].Arguments.Get(0).(*cloudwatchlogs.PutLogEventsInput)
+			if !ok {
+				t.Fatalf("unexpected PutLogEvents input type %T", m.Calls[0].Arguments.Get(0))
+			}
+			if got := aws.StringValue(in.LogGroupName); got != tc.wantGroup {
+				t.Errorf("log group: got %q, want %q", got, tc.wantGroup)
+			}
+		})
+	}
+}
+
+// cloudwatch_disable keeps covering the system group. Collapsing the two flags
+// into one derived boolean passes every other case here while silently
+// re-enabling rack system writes on racks that already opted out.
+func TestLogCloudwatchDisableStillGatesSystem(t *testing.T) {
+	for _, appDisable := range []bool{false, true} {
+		m := &mocks.CloudWatchLogsAPI{}
+		p := &Provider{CloudWatchLogs: m, CloudwatchDisable: true, AppCloudwatchDisable: appDisable}
+
+		if err := p.Log("system", "stream", time.Now(), "msg"); err != nil {
+			t.Fatalf("app_cloudwatch_disable=%v: expected nil, got %v", appDisable, err)
+		}
+		m.AssertNumberOfCalls(t, "PutLogEvents", 0)
+		m.AssertNumberOfCalls(t, "CreateLogGroup", 0)
+	}
+}
+
+// The bare struct literal is deliberate: the embedded provider is nil, so this
+// only passes while the guard sits above the ContextTID block.
+func TestAppLogsAppCloudwatchDisableReturnsEmpty(t *testing.T) {
+	m := &mocks.CloudWatchLogsAPI{}
+	p := &Provider{CloudWatchLogs: m, AppCloudwatchDisable: true}
+
+	r, err := p.AppLogs("app", structs.LogsOptions{})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	b, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(b) != 0 {
+		t.Fatalf("expected empty reader, got %q", b)
+	}
+	m.AssertNumberOfCalls(t, "FilterLogEvents", 0)
+}
+
+func TestSystemLogsAppCloudwatchDisableStillReads(t *testing.T) {
+	m := &mocks.CloudWatchLogsAPI{}
+	m.On("FilterLogEvents", mock.Anything).Return(&cloudwatchlogs.FilterLogEventsOutput{
+		Events: []*cloudwatchlogs.FilteredLogEvent{
+			{EventId: aws.String("e1"), Timestamp: aws.Int64(1), Message: aws.String("hi")},
+		},
+	}, nil)
+	p, ok := (&Provider{Provider: &k8s.Provider{Name: "rack"}, CloudWatchLogs: m, AppCloudwatchDisable: true}).
+		WithContext(context.Background()).(*Provider)
+	if !ok {
+		t.Fatal("WithContext did not return an aws provider")
+	}
+
+	follow := false
+	r, err := p.SystemLogs(structs.LogsOptions{Follow: &follow})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	b, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(b), "hi") {
+		t.Fatalf("expected system logs to stream, got %q", b)
+	}
+
+	in, ok := m.Calls[0].Arguments.Get(0).(*cloudwatchlogs.FilterLogEventsInput)
+	if !ok {
+		t.Fatalf("unexpected FilterLogEvents input type %T", m.Calls[0].Arguments.Get(0))
+	}
+	if got := aws.StringValue(in.LogGroupName); got != "/convox/rack/system" {
+		t.Errorf("log group: got %q, want %q", got, "/convox/rack/system")
+	}
+}
+
+func TestUpdateOrDisableLogGroupRetentionAppCloudwatchDisable(t *testing.T) {
+	m := &mocks.CloudWatchLogsAPI{}
+	p := &Provider{CloudWatchLogs: m, AppCloudwatchDisable: true}
+
+	if err := p.UpdateOrDisableLogGroupRetention("app", 30, false); err != nil {
+		t.Fatalf("set retention: expected nil, got %v", err)
+	}
+	if err := p.UpdateOrDisableLogGroupRetention("app", 0, true); err != nil {
+		t.Fatalf("disable retention: expected nil, got %v", err)
+	}
+	m.AssertNumberOfCalls(t, "PutRetentionPolicy", 0)
+	m.AssertNumberOfCalls(t, "DeleteRetentionPolicy", 0)
 }

--- a/terraform/api/aws/main.tf
+++ b/terraform/api/aws/main.tf
@@ -66,6 +66,7 @@ module "k8s" {
     SOCKET                                    = "/var/run/docker.sock"
     ECR_IMMUTABLE_TAGS_ENABLED                = var.ecr_immutable_tags_enabled
     ECR_SCAN_ON_PUSH_ENABLE                   = var.ecr_scan_on_push_enable
+    APP_CLOUDWATCH_DISABLE                    = var.app_cloudwatch_disable
     CLOUDWATCH_DISABLE                        = var.cloudwatch_disable
     SUBNET_IDS                                = join(",", var.subnets)
     VPC_ID                                    = var.vpc_id

--- a/terraform/api/aws/variables.tf
+++ b/terraform/api/aws/variables.tf
@@ -98,6 +98,11 @@ variable "ecr_scan_on_push_enable" {
   default = false
 }
 
+variable "app_cloudwatch_disable" {
+  type    = bool
+  default = false
+}
+
 variable "cloudwatch_disable" {
   type    = bool
   default = false

--- a/terraform/fluentd/aws/main.tf
+++ b/terraform/fluentd/aws/main.tf
@@ -24,10 +24,11 @@ module "k8s" {
   rack      = var.rack
 
   target = templatefile("${path.module}/target.conf.tpl", {
-    access_log_retention = var.access_log_retention_in_days,
-    rack                 = var.rack,
-    region               = data.aws_region.current.name,
-    syslog               = compact(split(",", var.syslog))
+    access_log_retention   = var.access_log_retention_in_days,
+    app_cloudwatch_disable = var.app_cloudwatch_disable,
+    rack                   = var.rack,
+    region                 = data.aws_region.current.name,
+    syslog                 = compact(split(",", var.syslog))
   })
 
   annotations = {

--- a/terraform/fluentd/aws/target.conf.tpl
+++ b/terraform/fluentd/aws/target.conf.tpl
@@ -39,7 +39,7 @@
       </store>
     </match>
 
-	<match **>
+	<match ${app_cloudwatch_disable ? "rack.*.app.system.**" : "**"}>
 		@type copy
 
 		<store>
@@ -73,4 +73,26 @@
 			</store>
 		%{ endfor ~}
 	</match>
+%{ if app_cloudwatch_disable ~}
+
+	<match **>
+%{ if length(syslog) > 0 ~}
+		@type copy
+
+%{ for endpoint in syslog ~}
+		<store>
+			@type syslog
+			url ${endpoint}
+			facility user
+			severity info
+			hostname_key hostname
+			tag_key program
+			payload_key log
+		</store>
+%{ endfor ~}
+%{ else ~}
+		@type null
+%{ endif ~}
+	</match>
+%{ endif ~}
 </label>

--- a/terraform/fluentd/aws/variables.tf
+++ b/terraform/fluentd/aws/variables.tf
@@ -7,6 +7,11 @@ variable "cluster" {
   type = string
 }
 
+variable "app_cloudwatch_disable" {
+  type    = bool
+  default = false
+}
+
 variable "fluentd_disable" {
   type    = bool
   default = false

--- a/terraform/rack/aws/main.tf
+++ b/terraform/rack/aws/main.tf
@@ -42,6 +42,7 @@ module "api" {
   ecr_full_access                           = var.ecr_full_access
   ecr_immutable_tags_enabled                = var.ecr_immutable_tags_enabled
   ecr_scan_on_push_enable                   = var.ecr_scan_on_push_enable
+  app_cloudwatch_disable                    = var.app_cloudwatch_disable
   cloudwatch_disable                        = var.cloudwatch_disable
   ecr_docker_hub_cache_prefix               = var.ecr_docker_hub_cache_prefix
   efs_csi_driver_enable                     = var.efs_csi_driver_enable

--- a/terraform/rack/aws/variables.tf
+++ b/terraform/rack/aws/variables.tf
@@ -88,6 +88,11 @@ variable "ecr_scan_on_push_enable" {
   default = false
 }
 
+variable "app_cloudwatch_disable" {
+  type    = bool
+  default = false
+}
+
 variable "cloudwatch_disable" {
   type    = bool
   default = false

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -249,6 +249,7 @@ module "fluentd" {
   ]
 
   access_log_retention_in_days = var.access_log_retention_in_days
+  app_cloudwatch_disable       = var.app_cloudwatch_disable
   cluster                      = module.cluster.id
   eks_addons                   = module.cluster.eks_addons
   fluentd_disable              = var.fluentd_disable
@@ -332,6 +333,7 @@ module "rack" {
   ecr_full_access                           = var.ecr_full_access
   ecr_immutable_tags_enabled                = var.ecr_immutable_tags_enabled
   ecr_scan_on_push_enable                   = var.ecr_scan_on_push_enable
+  app_cloudwatch_disable                    = var.app_cloudwatch_disable
   cloudwatch_disable                        = var.cloudwatch_disable
   ecr_docker_hub_cache_prefix               = module.cluster.ecr_docker_hub_cache_prefix
   vpc_id                                    = module.cluster.vpc

--- a/terraform/system/aws/telemetry.tf
+++ b/terraform/system/aws/telemetry.tf
@@ -8,6 +8,7 @@ locals {
     additional_karpenter_nodepools_config     = var.additional_karpenter_nodepools_config
     additional_node_groups_config             = var.additional_node_groups_config
     api_feature_gates                         = var.api_feature_gates
+    app_cloudwatch_disable                    = var.app_cloudwatch_disable
     availability_zones                        = var.availability_zones
     aws_ebs_csi_driver_version                = var.aws_ebs_csi_driver_version
     build_disable_convox_resolver             = var.build_disable_convox_resolver
@@ -164,6 +165,7 @@ locals {
     additional_karpenter_nodepools_config     = ""
     additional_node_groups_config             = ""
     api_feature_gates                         = ""
+    app_cloudwatch_disable                    = "false"
     availability_zones                        = ""
     aws_ebs_csi_driver_version                = "v1.62.0-eksbuild.1"
     build_disable_convox_resolver             = "false"

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -112,6 +112,11 @@ variable "ecr_docker_hub_cache" {
   default = false
 }
 
+variable "app_cloudwatch_disable" {
+  type    = bool
+  default = false
+}
+
 variable "cloudwatch_disable" {
   type    = bool
   default = false


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: `app_cloudwatch_disable` Rack Parameter for AWS Racks**

AWS racks gain a new parameter, `app_cloudwatch_disable`, that stops CloudWatch for apps while leaving the rack's own log group in place. With it set to `true` the rack stops creating, writing, reading, and setting retention on the per-app groups `/convox/<rack>/<app>`, and Fluentd stops shipping app container output to CloudWatch. The rack system group `/convox/<rack>/system` is untouched, so `convox rack logs` and the Console Rack Logs view keep working. The default is `false`, so behavior is unchanged unless the parameter is set.

**New Rack Parameter:**

| Parameter | Type | Default | Effect |
|-----------|------|---------|--------|
| `app_cloudwatch_disable` | bool | `false` | AWS racks stop creating, writing, reading, and setting retention on `/convox/<rack>/<app>`, and Fluentd stops sending app container output to CloudWatch. The rack system group is unaffected. |

`/convox/<rack>/<app>` has two independent writers, and the parameter covers both:

| Writer | What it sends | Covered |
|--------|---------------|---------|
| Fluentd DaemonSet | App container stdout | Yes, the CloudWatch store is dropped from the app branch of the Fluentd routing config |
| Rack controller | Kubernetes events, deploy state, AWS resource provisioning state | Yes, the log call returns early for any app name other than `system` |

**What changes while it is on:**

| Command | Result |
|---------|--------|
| `convox logs -a my-app` | Empty |
| `convox logs -a my-app --service web` | Unchanged, per-service logs read pod logs directly |
| `convox rack logs` | Unchanged |
| `convox builds logs` | Unchanged |
| `convox ps` | Unchanged |
| `convox deploy`, `convox releases promote` | Tail output keeps process state lines, and loses Kubernetes event and deploy state lines |

Controller-written app lines have no destination other than CloudWatch, so Kubernetes event, deploy state, and AWS provisioning lines for apps stop being recorded while the parameter is on. `cloudwatch_disable=true` already drops the same lines. Use per-service logs to read app output.

`app_cloudwatch_disable` is not a subset of `cloudwatch_disable`. `cloudwatch_disable` never reaches Fluentd, so on a rack with Fluentd running the new parameter stops per-app groups that `cloudwatch_disable` alone leaves in place.

Existing `/convox/<rack>/<app>` groups are not deleted or migrated. Creation and writes stop going forward, and the groups keep their contents and retention.

---

### Why is this important?

`cloudwatch_disable` takes an AWS rack off CloudWatch entirely, including the rack system group that `convox rack logs` and the Console Rack Logs view read, and `fluentd_disable` leaves the rack controller creating and writing per-app groups. Neither one covers the common request: send app logs to your own aggregator and keep the rack view working.

**Benefits:**

- **App groups off, rack view still works.** One parameter covers both writers of the per-app groups and leaves the rack system group alone.
- **Works with your own destination.** Any configured `syslog` endpoint keeps receiving app container output, so the parameter drops the CloudWatch copy and nothing else.
- **CloudWatch spend and retention.** No new per-app groups are created, and retention calls for app groups stop being made.
- **Off by default.** With the default, the Fluentd routing config renders exactly as it does today, so the DaemonSet does not roll on upgrade.

---

### How to use it?

    $ convox rack params set app_cloudwatch_disable=true -r rackName

To route app logs to your own aggregator and keep the rack view, pair it with a `syslog` endpoint:

    $ convox rack params set app_cloudwatch_disable=true syslog=tcp+tls://logs.example.com:1234 -r rackName

#### New Rack Parameters

| Parameter | Default | Description |
|-----------|---------|-------------|
| `app_cloudwatch_disable` | `false` | Stops CloudWatch log groups for apps while keeping the rack system group and `convox rack logs`. AWS racks. |

**Interactions:**

- **With no `syslog` endpoint configured,** app container output has no remaining destination and is dropped entirely, not just kept out of CloudWatch. Set a `syslog` endpoint first if you want to keep that output.
- **With `fluentd_disable=true` as well,** nothing reaches the per-app groups from either writer, and the rack system group still carries rack-namespace Kubernetes events.
- **With `cloudwatch_disable=true` as well,** `cloudwatch_disable` covers the rack system group too, so `convox rack logs` returns empty until it goes back to `false`. This combination is not redundant: with Fluentd running, `app_cloudwatch_disable` still stops Fluentd creating and writing the per-app groups.
- **`syslog` is unaffected.** App container output keeps reaching the configured endpoints.

`convox rack params set` prints a warning for the `cloudwatch_disable` pairing in either order, so you find out about the empty rack view when you set the parameters rather than later.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this feature.

The parameter is purely additive, defaults to `false`, and is AWS only. With the default, the rack controller keeps writing app log lines and the Fluentd routing config renders byte for byte as it does today, so the Fluentd DaemonSet does not roll on upgrade. No resource is created or destroyed by the parameter.

Turning it on is a deliberate behavior change on that rack: `convox logs -a my-app` returns empty, and app Kubernetes event and deploy state lines stop being recorded.

On a downgrade below `3.25.5` the rack's parameter reconciler removes the variable, the Fluentd routing config reverts, the DaemonSet rolls once, and the API deployment loses the environment variable. A Console-managed rack keeps the stored value and re-supplies it on a later upgrade; a self-managed Terraform rack has to set it again.

---

### Requirements

This feature requires version `3.25.5` or later for the rack.

**Update the Rack:** Run `convox rack update 3.25.5 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
