### PR TITLE
pass fake clientset by pointer in test

### DIFF
--- a/provider/k8s/task_release_cleanup_test.go
+++ b/provider/k8s/task_release_cleanup_test.go
@@ -119,7 +119,7 @@ func (m *MockEngine) SystemStatus() (string, error) {
 func createReleaseCleaner(
 	provider providerForReleaseCleaner,
 	engine Engine,
-	convox cvfake.Clientset,
+	convox *cvfake.Clientset,
 	cluster *fake.Clientset,
 	systemNamespace string,
 	releasesToRetainAfterActive int,
@@ -129,7 +129,7 @@ func createReleaseCleaner(
 	return &releaseCleaner{
 		provider:                    provider,
 		engine:                      engine,
-		convox:                      &convox,
+		convox:                      convox,
 		logger:                      log,
 		cluster:                     cluster,
 		systemNamespace:             systemNamespace,
@@ -232,7 +232,7 @@ func TestWaitUntilScheduledForCleanup(t *testing.T) {
 			require.NoError(t, err)
 
 			// Create the cleaner
-			cleaner := createReleaseCleaner(provider, engine, *convox, cluster, systemNamespace, 3)
+			cleaner := createReleaseCleaner(provider, engine, convox, cluster, systemNamespace, 3)
 
 			// Override the context with a canceled one to avoid long sleeps in tests
 			cancelCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
@@ -387,7 +387,7 @@ func TestAppReleaseAndBuildCleanup(t *testing.T) {
 			}
 
 			// Create the cleaner
-			cleaner := createReleaseCleaner(mockProvider, mockEngine, *convox, cluster, "test-namespace", tc.releasesToRetainAfterActive)
+			cleaner := createReleaseCleaner(mockProvider, mockEngine, convox, cluster, "test-namespace", tc.releasesToRetainAfterActive)
 
 			// Call the method
 			err := cleaner.appReleaseAndBuildCleanup(&tc.app)


### PR DESCRIPTION
## Summary

`createReleaseCleaner` in `provider/k8s/task_release_cleanup_test.go` took its fake Convox clientset by value while taking the fake Kubernetes clientset next to it by pointer:

```go
convox  cvfake.Clientset
cluster *fake.Clientset
```

`cvfake.Clientset` embeds `testing.Fake`, which embeds a `sync.RWMutex`, so every call copied a mutex. The helper then stored `&convox`, the address of its own local copy, which means the cleaner under test operated on a different clientset object than the one the test held. Both call sites dereferenced a pointer just to pass a copy.

`go vet ./provider/k8s/` reported three `copylocks` diagnostics for it, and golangci-lint's govet reported two. They were the only govet findings in the package.
