### PR TITLE
close exec stdin when client input ends

### DIFF
--- a/provider/k8s/process.go
+++ b/provider/k8s/process.go
@@ -120,10 +120,7 @@ func (p *Provider) ProcessExec(app, pid, command string, rw io.ReadWriter, opts 
 		sopts.Tty = false
 	} else {
 		if eo.Stdin {
-			inr, inw := io.Pipe()
-			go io.Copy(inw, rw)
-
-			sopts.Stdin = inr
+			sopts.Stdin = stdinPipe(rw)
 		}
 
 		if opts.Height != nil && opts.Width != nil {
@@ -1369,6 +1366,18 @@ func (p *Provider) processFromPod(pd ac.Pod) (*structs.Process, error) {
 	}
 
 	return ps, nil
+}
+
+func stdinPipe(r io.Reader) io.Reader {
+	pr, pw := io.Pipe()
+
+	go func() {
+		if _, err := io.Copy(pw, r); err == nil {
+			pw.Close()
+		}
+	}()
+
+	return pr
 }
 
 type terminalSize struct {

--- a/provider/k8s/process_stdin_test.go
+++ b/provider/k8s/process_stdin_test.go
@@ -1,0 +1,53 @@
+package k8s
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"testing/iotest"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStdinPipeEndsOnCleanEnd(t *testing.T) {
+	read := make(chan []byte, 1)
+
+	r := stdinPipe(strings.NewReader("hello\n"))
+
+	go func() {
+		b, _ := io.ReadAll(r)
+		read <- b
+	}()
+
+	select {
+	case b := <-read:
+		require.Equal(t, "hello\n", string(b))
+	case <-time.After(5 * time.Second):
+		t.Fatal("stdin never reached end of input")
+	}
+}
+
+func TestStdinPipeStaysOpenOnReadError(t *testing.T) {
+	r := stdinPipe(io.MultiReader(strings.NewReader("partial"), iotest.ErrReader(errors.New("boom"))))
+
+	b := make([]byte, len("partial"))
+	_, err := io.ReadFull(r, b)
+	require.NoError(t, err)
+	require.Equal(t, "partial", string(b))
+
+	returned := make(chan struct{})
+
+	go func() {
+		var next [1]byte
+		_, _ = r.Read(next[:])
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+		t.Fatal("stdin reached end of input after a failed read")
+	case <-time.After(500 * time.Millisecond):
+	}
+}


### PR DESCRIPTION
### What is the feature/update/fix?

**Fix: Piped and Redirected Input Signals End of Input**

A command run through `convox exec` or `convox run` with piped or redirected stdin now receives end of input when the client's stdin is exhausted. Commands that read until end of input, such as `cat`, `psql -f -`, `mysql`, `sh -s`, and `xargs`, finish rather than waiting.

The rack builds a pipe to carry client input into the exec stream, and the writing half is now closed when the copy from the client ends. The client-go stream protocol half-closes the container's stdin as soon as its copy finishes, so a non-interactive exec terminates.

The writing half is closed only when the copy from the client ends cleanly. A connection that drops mid-stream leaves it open, so a command that acts at end of input does not get a normal end of input for input that was cut off in transit. `psql -1 -f -`, `xargs`, `sh -s`, and `cat > tmp && mv tmp dest` would otherwise act on a partial script.

The stream protocol has an end-of-input signal and no error signal, so a producer killed mid-stream on your side, as in `producer | convox exec ... "psql -1 -f -"`, still delivers a clean end of input. The rack cannot distinguish that case.

Interactive sessions are unaffected. A terminal never reaches end of input, so the signal is never sent while the session is open, and Ctrl-D on an interactive exec is a byte interpreted by the container's line discipline rather than a client-side end of input. Exit status, `--timeout`, and terminal resizing are unchanged. `convox resources console` connects to a pseudo-terminal, which has no half-close, and is not covered by this change.

---

### Why is this important?

Feeding a script or a file to a command in a running process is how you run a migration, load a schema, or process a batch. Without an end-of-input signal, those commands read to the end of the data and then wait, so the operator had to interrupt them and could not tell whether the work had committed.

**Benefits:**

- **Commands that read to end of input finish.** A piped or redirected command completes and returns its status instead of waiting.
- **Partial input is not treated as complete.** A dropped connection does not give a command a clean end of input, so a single-transaction script does not commit a script it only partly received.
- **Every provider, no CLI upgrade.** The change is in the shared rack code path, so it applies on AWS, GCP, Azure, DigitalOcean, Metal, and Local, and every CLI back to `3.18.11` already sends the signal.
- **Interactive sessions untouched.** A terminal session behaves exactly as before.

---

### How to use it?

Nothing to configure. Pipe or redirect as you would locally:

    $ printf 'hello\n' | convox exec 7b6bccfd9fdf cat
    hello

    $ convox exec 7b6bccfd9fdf "psql -1 -f -" < schema.sql

The command runs without a shell, so anything relying on shell syntax inside the container, such as a pipe or a redirect, needs its own `sh -c` wrapper:

    $ convox exec 7b6bccfd9fdf "sh -c 'wc -l > /tmp/count'" < input.txt

---

### Does it have a breaking change?

**No breaking changes** are introduced with this fix.

One function and one call site changed on the rack. There is no new field, no new option, no Terraform change, and no API surface change. Execs that disable stdin never build the pipe and are unaffected. A newer CLI against an older rack behaves exactly as it does today, and no version skew breaks in either direction.

---

### Requirements

This fix requires version `3.25.5` or later for the rack. It is a rack-side change, so it applies to any CLI version.

On a rack reached through Convox Console, the end-of-input signal also passes through Console, and the change that forwards it is deployed on Convox-hosted Console. A self-hosted Console older than that change closes the session on that signal regardless of rack version.

**Update the Rack:** Run `convox rack update 3.25.5 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
