### PR TITLE
Oracle Cloud (OCI) provider

### DIFF
--- a/assets/provider/oci/params.yaml
+++ b/assets/provider/oci/params.yaml
@@ -1,0 +1,111 @@
+Groups:
+  - name: Immutable
+    order: 1
+    params:
+      - name: high_availability
+        default: "true"
+        type: boolean
+        description: Setting this to false will create a cluster with fewer redundant
+          resources for cost optimization
+      - name: region
+        default: us-ashburn-1
+        type: string
+        regex: ^[a-z]+-[a-z]+-\d+$
+        description: OCI region where the rack will be deployed. See
+          (OCI regions)[https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm]
+          for available options.
+  - name: Security & Compliance
+    order: 2
+    params:
+      - name: cert_duration
+        default: 2160h
+        type: string
+        regex: ^\d+h$
+        description: Certificate renewal period. The default is 90 days (2160h).
+      - name: compartment_ocid
+        default: "null"
+        sideNote: Defaults to the tenancy root
+        optional: true
+        type: string
+        regex: ^ocid1\.(tenancy|compartment)\.oc1\.[a-z0-9-]*\.[a-zA-Z0-9]+$
+        description: OCI compartment where rack resources are created. Leave unset
+          to use the tenancy root compartment.
+      - name: docker_hub_username
+        default: "null"
+        sideNote: Not set by default
+        optional: true
+        type: string
+        description: Docker Hub username for authenticated image pulls. Must be paired
+          with &i docker_hub_password &i to avoid Docker Hub rate limits.
+      - name: docker_hub_password
+        default: "null"
+        sideNote: Not set by default
+        optional: true
+        type: string
+        description: Docker Hub access token for authenticated image pulls. Must be
+          paired with &i docker_hub_username &i. Use a read-only access token rather
+          than your account password.
+  - name: Performance & Scaling
+    order: 4
+    params:
+      - name: node_type
+        default: VM.Standard.E4.Flex
+        type: string
+        regex: ^(VM|BM)\.[A-Za-z0-9]+(\.[A-Za-z0-9]+){1,3}$
+        description: OCI (compute shape)[https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm]
+          used for cluster nodes. Flex shapes let you size &i node_ocpus &i and
+          &i node_memory &i independently.
+      - name: node_ocpus
+        default: "2"
+        type: integer
+        description: Number of OCPUs per node. Only takes effect when &i node_type &i
+          is a Flex shape.
+        allowedMinValue: 1
+      - name: node_memory
+        default: "16"
+        type: integer
+        description: Memory per node in GB. Only takes effect when &i node_type &i
+          is a Flex shape.
+        allowedMinValue: 1
+      - name: node_disk
+        default: "100"
+        type: integer
+        description: Node boot volume size in GB.
+        allowedMinValue: 1
+      - name: node_count
+        default: "2"
+        type: integer
+        description: Number of nodes in the rack's node pool.
+        allowedMinValue: 1
+      - name: gpu_node_type
+        default: "null"
+        sideNote: No GPU node pool by default
+        optional: true
+        type: string
+        regex: ^(VM|BM)\.GPU[A-Za-z0-9]*\.[A-Za-z0-9]+(\.[A-Za-z0-9]+)?$
+        description: OCI GPU (compute shape)[https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm]
+          for an optional tainted GPU node pool, &i e.g. &i - VM.GPU.A10.1. Leave
+          unset to skip creating a GPU pool. &l GPU shapes usually need an OCI
+          service limit increase before nodes will launch. &l
+      - name: gpu_node_count
+        default: "1"
+        type: integer
+        description: Number of nodes in the optional GPU node pool. Only takes
+          effect when &i gpu_node_type &i is set.
+        allowedMinValue: 1
+  - name: Logging & Monitoring
+    order: 5
+    params:
+      - name: syslog
+        default: "null"
+        sideNote: Not forwarded by default
+        type: string
+        regex: ^(tcp|udp|tcp\+tls|udp\+tls)://[a-zA-Z\d._-]+(:\d+)?$
+        description: Forward logs to a syslog endpoint  &l &i e.g. &i - tcp+tls://example.org:1234 &l
+        optional: true
+      - name: fluentd_memory
+        default: 200Mi
+        type: string
+        regex: ^\d+(Mi|Gi)$
+        description: Memory request and limit for the Fluentd DaemonSet. Increase
+          if Fluentd pods are experiencing OOMKills.

--- a/assets/provider/params_test.go
+++ b/assets/provider/params_test.go
@@ -31,7 +31,7 @@ type ParamsFile struct {
 	} `yaml:"Groups"`
 }
 
-var providers = []string{"aws", "gcp", "azure", "do"}
+var providers = []string{"aws", "gcp", "azure", "do", "oci"}
 
 func loadParams(t *testing.T, provider string) ParamsFile {
 	t.Helper()

--- a/cmd/telemetry-gen/main.go
+++ b/cmd/telemetry-gen/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-config-inspect/tfconfig"
 )
 
-var providers = []string{"aws", "azure", "do", "gcp", "local", "metal"}
+var providers = []string{"aws", "azure", "do", "gcp", "local", "metal", "oci"}
 
 // telemetryOmit are params the generator drops from both emitted maps.
 var telemetryOmit = map[string]bool{
@@ -22,6 +22,8 @@ var telemetryOmit = map[string]bool{
 	"token":            true,
 	"private_eks_host": true,
 	"private_eks_user": true,
+	"private_key":      true,
+	"fingerprint":      true,
 }
 
 // telemetryRedact are params kept in the maps and covered by both redaction layers.

--- a/docs/configuration/rack-parameters/README.md
+++ b/docs/configuration/rack-parameters/README.md
@@ -91,5 +91,6 @@ This command sets the specified parameter to the given value.
 - [Google Cloud Platform (GCP)](/configuration/rack-parameters/gcp)
 - [Microsoft Azure](/configuration/rack-parameters/azure)
 - [Digital Ocean](/configuration/rack-parameters/do)
+- [Oracle Cloud (OCI)](/configuration/rack-parameters/oci)
 
 Select your cloud provider to view the available parameters and their configurations.

--- a/docs/configuration/rack-parameters/oci/README.md
+++ b/docs/configuration/rack-parameters/oci/README.md
@@ -1,0 +1,33 @@
+---
+title: "Oracle Cloud Rack Parameters"
+description: "Reference for the rack parameters available when running a Convox rack on Oracle Cloud Infrastructure, covering node shape, disk, GPU node pools, region, and logging."
+slug: oci-rack-parameters
+url: /configuration/rack-parameters/oci
+---
+# Oracle Cloud Rack Parameters
+
+The following parameters are available for configuring your Convox rack on Oracle Cloud Infrastructure (OCI). These parameters allow you to customize and optimize the behavior of your applications and services running on the OCI platform.
+
+> Some parameters can only be set during rack installation and cannot be changed afterwards. These include `region`. See individual parameter pages for details.
+
+## Parameters
+
+| Parameter                            | Description                                                              |
+|:-------------------------------------|:-------------------------------------------------------------------------|
+| [cert_duration](/configuration/rack-parameters/oci/cert_duration)         | Certificate renewal period.                                               |
+| [compartment_ocid](/configuration/rack-parameters/oci/compartment_ocid)   | OCI compartment where rack resources are created.                        |
+| [docker_hub_password](/configuration/rack-parameters/oci/docker_hub_password) | Docker Hub access token for authenticated image pulls. |
+| [docker_hub_username](/configuration/rack-parameters/oci/docker_hub_username) | Docker Hub username for authenticated image pulls. |
+| [fluentd_memory](/configuration/rack-parameters/oci/fluentd_memory)       | Configures memory allocation for the Fluentd log collector DaemonSet.     |
+| [gpu_node_count](/configuration/rack-parameters/oci/gpu_node_count)       | Number of nodes in the optional GPU node pool.                            |
+| [gpu_node_type](/configuration/rack-parameters/oci/gpu_node_type)         | GPU compute shape for an optional tainted GPU node pool.                  |
+| [high_availability](/configuration/rack-parameters/oci/high_availability) | Enable high availability mode with multiple nodes.                        |
+| [node_count](/configuration/rack-parameters/oci/node_count)               | Number of nodes in the rack's node pool.                                  |
+| [node_disk](/configuration/rack-parameters/oci/node_disk)                 | Size of the node boot volume in GB.                                       |
+| [node_memory](/configuration/rack-parameters/oci/node_memory)             | Memory per node in GB, for Flex compute shapes.                           |
+| [node_ocpus](/configuration/rack-parameters/oci/node_ocpus)               | OCPUs per node, for Flex compute shapes.                                  |
+| [node_type](/configuration/rack-parameters/oci/node_type)                 | Specifies the node compute shape.                                         |
+| [region](/configuration/rack-parameters/oci/region)                       | Specifies the OCI region for the rack.                                    |
+| [syslog](/configuration/rack-parameters/oci/syslog)                       | Specifies the endpoint to forward logs to a syslog server.                |
+| [terraform_update_timeout](/configuration/rack-parameters/oci/terraform_update_timeout) | Controls how long Terraform waits for node pool update operations to complete. |
+| [webhook_signing_key](/configuration/rack-parameters/oci/webhook_signing_key) | Per-rack HMAC secret that signs outbound webhook deliveries with a Convox-Signature header. |

--- a/docs/configuration/rack-parameters/oci/cert_duration.md
+++ b/docs/configuration/rack-parameters/oci/cert_duration.md
@@ -1,0 +1,29 @@
+---
+title: "cert_duration"
+description: "The cert_duration Oracle Cloud rack parameter sets the certificate renewal period, controlling how often certificates are renewed, defaulting to 2160h (90 days)."
+slug: cert_duration
+url: /configuration/rack-parameters/oci/cert_duration
+---
+
+# cert_duration
+
+## Description
+The `cert_duration` parameter specifies the certificate renewal period. This determines how often your certificates are renewed, ensuring they remain valid and secure.
+
+## Default Value
+The default value for `cert_duration` is `2160h` (90 days).
+
+## Use Cases
+- **Security Maintenance**: Regularly renewing certificates helps maintain secure communication channels.
+- **Compliance**: Ensuring certificates are renewed within a specific period can help meet compliance requirements.
+
+## Setting Parameters
+To set the `cert_duration` parameter, use the following command:
+```bash
+$ convox rack params set cert_duration=2160h -r rackName
+Updating parameters... OK
+```
+This command sets the `cert_duration` parameter to the specified value.
+
+## Additional Information
+Adjusting the `cert_duration` can help balance between operational convenience and security requirements. Shorter renewal periods increase security but require more frequent updates, while longer periods reduce the maintenance overhead.

--- a/docs/configuration/rack-parameters/oci/compartment_ocid.md
+++ b/docs/configuration/rack-parameters/oci/compartment_ocid.md
@@ -1,0 +1,28 @@
+---
+title: "compartment_ocid"
+description: "The compartment_ocid Oracle Cloud rack parameter sets the OCI compartment where rack resources are created, defaulting to the tenancy root compartment."
+slug: compartment_ocid
+url: /configuration/rack-parameters/oci/compartment_ocid
+---
+
+# compartment_ocid
+
+## Description
+The `compartment_ocid` parameter specifies the OCID of the OCI compartment where the rack's compute, network, and container engine resources are created. OCIR repositories for the rack's images also live in this compartment.
+
+## Default Value
+The default value for `compartment_ocid` is unset, which resolves to your tenancy's root compartment.
+
+## Use Cases
+- **Resource Organization**: Group a rack's resources into a dedicated compartment alongside other workloads managed by the same team.
+- **Access Control**: Scope IAM policies to a compartment narrower than the tenancy root, limiting what the installing user needs tenancy-wide access to.
+- **Cost Tracking**: Attribute OCI spend to a specific compartment for chargeback or budgeting.
+
+## Setting Parameters
+`compartment_ocid` can only be set at install time:
+```bash
+$ convox rack install oci myrack compartment_ocid=ocid1.compartment.oc1..aaaaaaaaexampleuniqueid
+```
+
+## Additional Information
+Rack resources are created directly in this compartment, so changing it after install is not supported; installing into a new compartment requires a new rack. The user or API key installing the rack still needs permission to manage IAM resources at the tenancy level, since the rack creates its own IAM user, group, policy, and auth token for pushing images to OCIR.

--- a/docs/configuration/rack-parameters/oci/docker_hub_password.md
+++ b/docs/configuration/rack-parameters/oci/docker_hub_password.md
@@ -1,0 +1,30 @@
+---
+title: "docker_hub_password"
+description: "The docker_hub_password Oracle Cloud rack parameter sets the Docker Hub authentication token, used with docker_hub_username to enable authenticated image pulls."
+slug: docker_hub_password
+url: /configuration/rack-parameters/oci/docker_hub_password
+---
+
+# docker_hub_password
+
+## Description
+The `docker_hub_password` parameter sets the Docker Hub authentication token for the rack. Must be used alongside `docker_hub_username` to enable authenticated Docker Hub pulls.
+
+## Default Value
+Not set (anonymous Docker Hub access).
+
+## Use Cases
+- **Avoid Rate Limits**: Authenticated Docker Hub pulls have significantly higher rate limits than anonymous pulls.
+- **Private Images**: Access private Docker Hub repositories during builds and deployments.
+
+## Setting Parameters
+Set both `docker_hub_username` and `docker_hub_password` together:
+```bash
+$ convox rack params set docker_hub_username=myuser docker_hub_password=dckr_pat_xxxxx -r rackName
+Updating parameters... OK
+```
+
+Use a read-only access token generated from [Docker Hub Account Settings](https://hub.docker.com/settings/security) rather than your account password.
+
+## Additional Information
+See [docker_hub_username](/configuration/rack-parameters/oci/docker_hub_username) for the companion parameter.

--- a/docs/configuration/rack-parameters/oci/docker_hub_username.md
+++ b/docs/configuration/rack-parameters/oci/docker_hub_username.md
@@ -1,0 +1,32 @@
+---
+title: "docker_hub_username"
+description: "The docker_hub_username Oracle Cloud rack parameter configures Docker Hub authentication, which when set with docker_hub_password avoids anonymous pull rate limits."
+slug: docker_hub_username
+url: /configuration/rack-parameters/oci/docker_hub_username
+---
+
+# docker_hub_username
+
+## Description
+The `docker_hub_username` parameter configures Docker Hub authentication for the rack. When set alongside `docker_hub_password`, all image pulls from Docker Hub are authenticated, avoiding Docker Hub's anonymous pull rate limits.
+
+## Default Value
+Not set (anonymous Docker Hub access).
+
+## Use Cases
+- **Avoid Rate Limits**: Docker Hub enforces rate limits on anonymous image pulls (100 pulls per 6 hours per IP). Authenticated pulls have significantly higher limits.
+- **Private Images**: Pull images from private Docker Hub repositories during builds and deployments.
+
+## Setting Parameters
+Set both `docker_hub_username` and `docker_hub_password` together:
+```bash
+$ convox rack params set docker_hub_username=myuser docker_hub_password=dckr_pat_xxxxx -r rackName
+Updating parameters... OK
+```
+
+Generate a read-only access token from [Docker Hub Account Settings](https://hub.docker.com/settings/security) rather than using your account password.
+
+## Additional Information
+When both credentials are set, the rack creates a Kubernetes image pull secret that authenticates all Docker Hub pulls across the cluster. This applies to both application image pulls and build-time base image pulls.
+
+See [docker_hub_password](/configuration/rack-parameters/oci/docker_hub_password) for the companion parameter.

--- a/docs/configuration/rack-parameters/oci/fluentd_memory.md
+++ b/docs/configuration/rack-parameters/oci/fluentd_memory.md
@@ -1,0 +1,36 @@
+---
+title: "fluentd_memory"
+description: "The fluentd_memory Oracle Cloud rack parameter sets the memory request and limit for the Fluentd log collector DaemonSet, defaulting to 200Mi."
+slug: fluentd_memory
+url: /configuration/rack-parameters/oci/fluentd_memory
+---
+
+# fluentd_memory
+
+## Description
+The `fluentd_memory` parameter configures the memory request and limit for the Fluentd log collector DaemonSet. Fluentd runs on every node in the cluster and forwards application and system logs. Both the Kubernetes memory request and limit are set to the same value, giving the Fluentd pod a Guaranteed QoS class.
+
+## Default Value
+The default value for `fluentd_memory` is `200Mi`.
+
+## Use Cases
+- **High Log Throughput**: Increase memory for racks with many services, verbose application logging, or high request rates to prevent Fluentd OOM restarts and log loss.
+- **GPU / ML Workloads**: Workloads generating large volumes of stdout/stderr may require `512Mi` or `1Gi`.
+- **Resource Optimization**: Reduce memory below `200Mi` on racks with low log volume to reclaim node resources.
+
+## Setting Parameters
+To set the `fluentd_memory` parameter, use the following command:
+```bash
+$ convox rack params set fluentd_memory=512Mi -r rackName
+Updating parameters... OK
+```
+This command sets the Fluentd memory allocation to 512Mi.
+
+## Additional Information
+The value must be a valid Kubernetes memory string matching the pattern `^\d+(Mi|Gi)$` (e.g., `200Mi`, `512Mi`, `1Gi`). When Fluentd is OOM-killed due to high log throughput, in-flight log buffers are lost. Increasing this value prevents gaps in log delivery during high-throughput periods.
+
+The default of `200Mi` matches the previously hardcoded allocation, so existing racks are unaffected.
+
+## See Also
+- [syslog](/configuration/rack-parameters/oci/syslog) for forwarding logs to an external syslog endpoint
+- [Logging](/configuration/logging) for an overview of Convox logging

--- a/docs/configuration/rack-parameters/oci/gpu_node_count.md
+++ b/docs/configuration/rack-parameters/oci/gpu_node_count.md
@@ -1,0 +1,29 @@
+---
+title: "gpu_node_count"
+description: "The gpu_node_count Oracle Cloud rack parameter sets the number of nodes in the optional GPU node pool, defaulting to 1."
+slug: gpu_node_count
+url: /configuration/rack-parameters/oci/gpu_node_count
+---
+
+# gpu_node_count
+
+## Description
+The `gpu_node_count` parameter specifies how many nodes run in the rack's GPU node pool. It only takes effect when [gpu_node_type](/configuration/rack-parameters/oci/gpu_node_type) is set; with no GPU shape configured, no GPU node pool exists and this parameter has no effect.
+
+## Default Value
+The default value for `gpu_node_count` is `1`.
+
+## Use Cases
+- **GPU Capacity Planning**: Add GPU nodes to run more GPU-scheduled Processes concurrently.
+- **Cost Management**: Keep the GPU pool at a single node, or scale it to zero by clearing [gpu_node_type](/configuration/rack-parameters/oci/gpu_node_type), when GPU capacity is not in active use.
+
+## Setting Parameters
+To set the `gpu_node_count` parameter, use the following command:
+```bash
+$ convox rack params set gpu_node_count=2 -r rackName
+Updating parameters... OK
+```
+This command sets the GPU node pool to 2 nodes.
+
+## Additional Information
+Each GPU node is subject to the same tenancy service limits as the shape set in [gpu_node_type](/configuration/rack-parameters/oci/gpu_node_type); increasing this count may require a larger service limit increase.

--- a/docs/configuration/rack-parameters/oci/gpu_node_type.md
+++ b/docs/configuration/rack-parameters/oci/gpu_node_type.md
@@ -1,0 +1,45 @@
+---
+title: "gpu_node_type"
+description: "The gpu_node_type Oracle Cloud rack parameter sets the GPU compute shape for an optional tainted GPU node pool, unset by default."
+slug: gpu_node_type
+url: /configuration/rack-parameters/oci/gpu_node_type
+---
+
+# gpu_node_type
+
+## Description
+The `gpu_node_type` parameter specifies the [GPU compute shape](https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm) (e.g. `VM.GPU.A10.1`) used to create a second, GPU-backed node pool for the rack. Leaving it unset (the default) skips creating a GPU node pool entirely; only the regular node pool controlled by [node_type](/configuration/rack-parameters/oci/node_type) is created.
+
+Nodes in the GPU pool are tainted `nvidia.com/gpu=:NoSchedule`, so only pods that tolerate the taint are scheduled onto them. A service opts in by requesting a GPU with `scale.gpu` in its `convox.yml`:
+```yaml
+services:
+  worker:
+    scale:
+      gpu:
+        count: 1
+```
+
+## Default Value
+The default value for `gpu_node_type` is `""` (no GPU node pool).
+
+## Use Cases
+- **ML/AI Workloads**: Run GPU-accelerated training or inference services alongside regular CPU services on the same rack.
+- **Mixed Workloads**: Keep GPU nodes isolated via the taint so only services that explicitly request a GPU land on the more expensive GPU instances.
+
+## Setting Parameters
+To create a GPU node pool, set the shape:
+```bash
+$ convox rack params set gpu_node_type=VM.GPU.A10.1 -r rackName
+Updating parameters... OK
+```
+
+To remove the GPU node pool, set it back to empty:
+```bash
+$ convox rack params set gpu_node_type="" -r rackName
+Updating parameters... OK
+```
+
+## Additional Information
+OCI GPU shapes are subject to tenancy service limits that default to zero in most tenancies. Before setting this parameter, request a service limit increase for the shape and region you plan to use; approval typically takes 1-3 business days. Without the increase, the GPU node pool is created but nodes fail to launch with an `OutOfHostCapacity` error.
+
+See [gpu_node_count](/configuration/rack-parameters/oci/gpu_node_count) to size the GPU node pool.

--- a/docs/configuration/rack-parameters/oci/high_availability.md
+++ b/docs/configuration/rack-parameters/oci/high_availability.md
@@ -1,0 +1,28 @@
+---
+title: "high_availability"
+description: "The high_availability Oracle Cloud rack parameter runs the rack across multiple nodes when true, or a minimal node configuration when false, defaulting to true."
+slug: high_availability
+url: /configuration/rack-parameters/oci/high_availability
+---
+
+# high_availability
+
+## Description
+The `high_availability` parameter controls whether your Convox rack on Oracle Cloud runs in high availability mode with multiple nodes for redundancy.
+
+## Default Value
+The default value for `high_availability` is `true`.
+
+## Use Cases
+- **Production Environments**: Keep enabled (default) for production workloads that require fault tolerance and zero-downtime deployments.
+- **Development/Testing**: Set to `false` for non-production environments to reduce costs by running fewer nodes.
+
+## Setting Parameters
+To set the `high_availability` parameter, use the following command:
+```bash
+$ convox rack params set high_availability=false -r rackName
+Updating parameters... OK
+```
+
+## Additional Information
+When `high_availability` is enabled, the rack runs multiple replicas of its own system services so they can be rescheduled if a node fails. This is independent of `node_count`, which sets the size of the worker node pool; see [node_count](/configuration/rack-parameters/oci/node_count) to control how many nodes the pool runs.

--- a/docs/configuration/rack-parameters/oci/node_count.md
+++ b/docs/configuration/rack-parameters/oci/node_count.md
@@ -1,0 +1,29 @@
+---
+title: "node_count"
+description: "The node_count Oracle Cloud rack parameter sets the number of nodes in the rack's node pool, defaulting to 2."
+slug: node_count
+url: /configuration/rack-parameters/oci/node_count
+---
+
+# node_count
+
+## Description
+The `node_count` parameter specifies how many nodes run in the rack's node pool. OKE node pools are fixed size, so this parameter is the only way to change how many nodes the pool runs; there is no built-in autoscaler.
+
+## Default Value
+The default value for `node_count` is `2`.
+
+## Use Cases
+- **Capacity Planning**: Add nodes to handle more services or higher load.
+- **Cost Management**: Reduce the node count for smaller workloads or non-production racks.
+
+## Setting Parameters
+To set the `node_count` parameter, use the following command:
+```bash
+$ convox rack params set node_count=4 -r rackName
+Updating parameters... OK
+```
+This command sets the node pool to 4 nodes.
+
+## Additional Information
+Nodes are spread evenly across the availability domains in the region, regardless of [high_availability](/configuration/rack-parameters/oci/high_availability). This parameter only affects the primary node pool; see [gpu_node_count](/configuration/rack-parameters/oci/gpu_node_count) for the optional GPU node pool.

--- a/docs/configuration/rack-parameters/oci/node_disk.md
+++ b/docs/configuration/rack-parameters/oci/node_disk.md
@@ -1,0 +1,29 @@
+---
+title: "node_disk"
+description: "The node_disk Oracle Cloud rack parameter sets the size of the boot volume in GB for each node in the rack, defaulting to 100."
+slug: node_disk
+url: /configuration/rack-parameters/oci/node_disk
+---
+
+# node_disk
+
+## Description
+The `node_disk` parameter specifies the size of the boot volume (in GB) for each node in your Convox rack's node pool.
+
+## Default Value
+The default value for `node_disk` is `100`.
+
+## Use Cases
+- **Storage-Intensive Workloads**: Increase disk size for applications that require more local storage for builds, caches, or temporary data.
+- **Cost Management**: Use the default size when local storage requirements are minimal.
+
+## Setting Parameters
+To set the `node_disk` parameter, use the following command:
+```bash
+$ convox rack params set node_disk=200 -r rackName
+Updating parameters... OK
+```
+This command sets the node boot volume size to 200GB.
+
+## Additional Information
+The disk size is specified in gigabytes (GB). Larger boot volumes provide more space for container images, build caches, and application data stored locally on nodes. Changing this parameter replaces the rack's nodes.

--- a/docs/configuration/rack-parameters/oci/node_memory.md
+++ b/docs/configuration/rack-parameters/oci/node_memory.md
@@ -1,0 +1,29 @@
+---
+title: "node_memory"
+description: "The node_memory Oracle Cloud rack parameter sets the memory in GB per node for Flex compute shapes, defaulting to 16."
+slug: node_memory
+url: /configuration/rack-parameters/oci/node_memory
+---
+
+# node_memory
+
+## Description
+The `node_memory` parameter specifies the amount of memory, in GB, allocated to each node in the rack's node pool. It only takes effect when [node_type](/configuration/rack-parameters/oci/node_type) is a Flex shape (a shape name ending in `.Flex`, such as the default `VM.Standard.E4.Flex`); fixed shapes have a set memory size that this parameter cannot change.
+
+## Default Value
+The default value for `node_memory` is `16`.
+
+## Use Cases
+- **Memory-Bound Workloads**: Increase memory for services that cache heavily or run memory-intensive processes.
+- **Cost Management**: Reduce memory on a Flex shape to right-size nodes for lighter workloads.
+
+## Setting Parameters
+To set the `node_memory` parameter, use the following command:
+```bash
+$ convox rack params set node_memory=32 -r rackName
+Updating parameters... OK
+```
+This command sets the node memory allocation to 32GB.
+
+## Additional Information
+Set alongside [node_ocpus](/configuration/rack-parameters/oci/node_ocpus) to size Flex shape nodes independently for CPU and memory. Changing this parameter replaces the rack's nodes.

--- a/docs/configuration/rack-parameters/oci/node_ocpus.md
+++ b/docs/configuration/rack-parameters/oci/node_ocpus.md
@@ -1,0 +1,29 @@
+---
+title: "node_ocpus"
+description: "The node_ocpus Oracle Cloud rack parameter sets the number of OCPUs per node for Flex compute shapes, defaulting to 2."
+slug: node_ocpus
+url: /configuration/rack-parameters/oci/node_ocpus
+---
+
+# node_ocpus
+
+## Description
+The `node_ocpus` parameter specifies the number of OCPUs allocated to each node in the rack's node pool. It only takes effect when [node_type](/configuration/rack-parameters/oci/node_type) is a Flex shape (a shape name ending in `.Flex`, such as the default `VM.Standard.E4.Flex`); fixed shapes have a set OCPU count that this parameter cannot change.
+
+## Default Value
+The default value for `node_ocpus` is `2`.
+
+## Use Cases
+- **Compute-Bound Workloads**: Increase OCPUs for services that are CPU-limited rather than memory-limited.
+- **Cost Management**: Reduce OCPUs on a Flex shape to right-size nodes for lighter workloads.
+
+## Setting Parameters
+To set the `node_ocpus` parameter, use the following command:
+```bash
+$ convox rack params set node_ocpus=4 -r rackName
+Updating parameters... OK
+```
+This command sets the node OCPU count to 4.
+
+## Additional Information
+Set alongside [node_memory](/configuration/rack-parameters/oci/node_memory) to size Flex shape nodes independently for CPU and memory. Changing this parameter replaces the rack's nodes.

--- a/docs/configuration/rack-parameters/oci/node_type.md
+++ b/docs/configuration/rack-parameters/oci/node_type.md
@@ -1,0 +1,29 @@
+---
+title: "node_type"
+description: "The node_type Oracle Cloud rack parameter sets the compute shape used for rack nodes, defaulting to VM.Standard.E4.Flex."
+slug: node_type
+url: /configuration/rack-parameters/oci/node_type
+---
+
+# node_type
+
+## Description
+The `node_type` parameter specifies the [compute shape](https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm) to use for nodes in your Convox rack's node pool.
+
+## Default Value
+The default value for `node_type` is `VM.Standard.E4.Flex`.
+
+## Use Cases
+- **Performance Optimization**: Select a shape that provides the necessary CPU, memory, and network performance for your application.
+- **Cost Management**: Choose a shape that balances cost with the required performance characteristics.
+
+## Setting Parameters
+To set the `node_type` parameter, use the following command:
+```bash
+$ convox rack params set node_type=VM.Standard.E4.Flex -r rackName
+Updating parameters... OK
+```
+This command sets the `node_type` parameter to the specified value.
+
+## Additional Information
+Flex shapes, such as the default `VM.Standard.E4.Flex`, let you size CPU and memory independently with [node_ocpus](/configuration/rack-parameters/oci/node_ocpus) and [node_memory](/configuration/rack-parameters/oci/node_memory); those two parameters have no effect on fixed (non-Flex) shapes. For more information on OCI compute shapes, refer to the [OCI documentation](https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm).

--- a/docs/configuration/rack-parameters/oci/region.md
+++ b/docs/configuration/rack-parameters/oci/region.md
@@ -1,0 +1,28 @@
+---
+title: "region"
+description: "The region Oracle Cloud rack parameter sets the OCI region where the Convox rack is deployed, affecting latency, availability, and cost, defaulting to us-ashburn-1."
+slug: region
+url: /configuration/rack-parameters/oci/region
+---
+
+# region
+
+## Description
+The `region` parameter specifies the [OCI region](https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm) where your Convox rack will be deployed. Choosing the appropriate region can impact latency, availability, and cost.
+
+## Default Value
+The default value for `region` is `us-ashburn-1`.
+
+## Use Cases
+- **Latency Optimization**: Select a region that is geographically close to your users to reduce latency.
+- **Compliance**: Choose a region that meets data residency and compliance requirements.
+- **Cost Management**: Different regions may have different pricing, so selecting the right region can help manage costs.
+
+## Setting Parameters
+`region` can only be set at install time:
+```bash
+$ convox rack install oci myrack region=us-ashburn-1
+```
+
+## Additional Information
+Selecting the appropriate region is crucial for optimizing the performance and compliance of your applications. For more information on OCI regions, refer to the [OCI documentation on regions and availability domains](https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm).

--- a/docs/configuration/rack-parameters/oci/syslog.md
+++ b/docs/configuration/rack-parameters/oci/syslog.md
@@ -1,0 +1,29 @@
+---
+title: "syslog"
+description: "The syslog Oracle Cloud rack parameter sets the endpoint to forward rack logs to a syslog server, such as tcp+tls://example.org:1234, disabled by default."
+slug: syslog
+url: /configuration/rack-parameters/oci/syslog
+---
+
+# syslog
+
+## Description
+The `syslog` parameter specifies the endpoint to forward logs to a syslog server (e.g. **tcp+tls://example.org:1234**).
+
+## Default Value
+The default value for `syslog` is `""`.
+
+## Use Cases
+- **Centralized Logging**: Forward logs to a central syslog server for easier monitoring and analysis.
+- **Compliance**: Meet compliance requirements by ensuring all logs are collected and stored in a central location.
+
+## Setting Parameters
+To set the `syslog` parameter, use the following command:
+```bash
+$ convox rack params set syslog=tcp+tls://example.org:1234 -r rackName
+Updating parameters... OK
+```
+This command sets the `syslog` parameter to the specified value.
+
+## Additional Information
+When set to `""`, syslog forwarding is not enabled. This parameter is optional and can be configured based on your specific logging needs. Ensure that the syslog endpoint is reachable and properly configured to receive logs from your Convox rack.

--- a/docs/configuration/rack-parameters/oci/terraform_update_timeout.md
+++ b/docs/configuration/rack-parameters/oci/terraform_update_timeout.md
@@ -1,0 +1,33 @@
+---
+title: "terraform_update_timeout"
+description: "The terraform_update_timeout Oracle Cloud rack parameter sets how long Terraform waits for OKE node pool updates to finish, defaulting to 2h."
+slug: terraform_update_timeout
+url: /configuration/rack-parameters/oci/terraform_update_timeout
+---
+
+# terraform_update_timeout
+
+## Description
+The `terraform_update_timeout` parameter controls how long Terraform waits for node pool update operations to complete. On large clusters, node pool updates can take longer than the default timeout.
+
+## Default Value
+The default value for `terraform_update_timeout` is `2h` (2 hours).
+
+## Use Cases
+- **Large Clusters**: Extending the timeout for clusters where node pool updates take longer than 2 hours.
+- **Slow Rolling Updates**: When upgrade settings throttle node replacements, increasing the total update time.
+
+## Setting Parameters
+To set the `terraform_update_timeout` parameter, use the following command:
+```bash
+$ convox rack params set terraform_update_timeout=3h -r rackName
+Updating parameters... OK
+```
+This command sets the Terraform update timeout to 3 hours.
+
+## Additional Information
+The value must be a valid Go duration string (e.g., `2h`, `90m`, `2h30m`). This timeout applies to the OKE node pool update operation. The default value of `2h` matches the previously hardcoded behavior, so existing racks are unaffected.
+
+## See Also
+- [node_type](/configuration/rack-parameters/oci/node_type) for configuring the node compute shape
+- [syslog](/configuration/rack-parameters/oci/syslog) for forwarding logs to an external syslog endpoint

--- a/docs/configuration/rack-parameters/oci/webhook_signing_key.md
+++ b/docs/configuration/rack-parameters/oci/webhook_signing_key.md
@@ -1,0 +1,57 @@
+---
+title: "webhook_signing_key"
+description: "The webhook_signing_key Oracle Cloud rack parameter sets a per-Rack HMAC secret that signs outbound webhook deliveries with a Convox-Signature header, unset by default."
+slug: webhook_signing_key
+url: /configuration/rack-parameters/oci/webhook_signing_key
+---
+
+# webhook_signing_key
+
+## Description
+The `webhook_signing_key` parameter sets a per-Rack HMAC secret that the Rack uses to sign every outbound webhook delivery. With this parameter set, the Rack adds a `Convox-Signature` HTTP header to each webhook POST. The header carries `t=<unix-ts>,v1=<hex1>[,v1=<hex2>]`, where `t` is the Unix timestamp at emit time and each `v1=<hex>` segment is the HMAC-SHA256 of `<t>.<body>` keyed by a configured signing key. Multiple `v1=` segments appear during key rotation; receivers verify against any one. See [Webhook Signing](/console/webhook-signing) for the receiver-side verification example.
+
+When unset (the default), no signature header is emitted, so receivers cannot distinguish authentic Convox webhooks from spoofed payloads. Set this parameter and configure the same secret on your receiver to enable HMAC verification.
+
+The parameter value is treated as a credential. The Rack stores it as a Kubernetes Secret, masks it in interactive `convox rack params` output (pass `--reveal` to display the value; piped output is not masked), and emits only a hash of the value to telemetry, never the key itself.
+
+## Default Value
+The default value for `webhook_signing_key` is `""` (empty string). With an empty value the Rack sends no signature header on outbound webhooks, so receivers cannot HMAC-verify.
+
+## Use Cases
+- **Webhook authenticity verification**: Enable HMAC verification on receivers so a leaked webhook URL cannot be exploited by a third party with crafted payloads.
+- **Compliance with PCI / SOC 2 webhook requirements**: Many compliance frameworks require signed webhook deliveries; this parameter is the Rack-side enabler for that requirement.
+- **Receiver-side replay protection**: The `t=<unix-ts>` segment embedded in `Convox-Signature` lets receivers reject deliveries outside a tolerance window to mitigate replay attacks.
+
+## Setting Parameters
+The key must be lowercase hex, at least 64 hex characters (32 bytes). Generate one with:
+```bash
+$ openssl rand -hex 32
+a3f8c2e19b7d4e605c1f8a2d7e9b3c640d5a8f172c6e9b48d1f7a3e584b0c9f2
+```
+
+To set:
+```bash
+$ convox rack params set webhook_signing_key=a3f8c2e19b7d4e605c1f8a2d7e9b3c640d5a8f172c6e9b48d1f7a3e584b0c9f2 -r rackName
+Updating parameters... OK
+```
+
+To rotate to a new secret without disabling signing, set a comma-separated pair (`newkey,oldkey`) so receivers continue to verify against either segment during the rotation window:
+```bash
+$ convox rack params set webhook_signing_key="$NEW_KEY,$OLD_KEY" -r rackName
+Updating parameters... OK
+```
+Then update receivers to the new key and run `convox rack params set webhook_signing_key="$NEW_KEY"` to retire the old segment. Up to 4 comma-separated keys are supported during rotation.
+
+## Additional Information
+- Available since Rack version 3.24.6.
+- The Rack validates the key at startup. Placeholder values (such as all zeros or repeated patterns), keys shorter than 64 hex characters, uppercase or non-hex characters, and low-entropy values are rejected. A rejected key does not break webhook delivery; the Rack logs a warning and continues delivering webhooks unsigned, so verify your receiver observes the `Convox-Signature` header after setting the parameter.
+- The value is stored as a Kubernetes Secret on the Rack, never in a ConfigMap, and is masked in interactive `convox rack params` output unless `--reveal` is passed. Telemetry receives a hash of the value, never the key itself.
+- Changing the key triggers a rolling restart of the Rack API, so a rotation takes effect within minutes of the parameter update completing.
+- The signature is computed over the Unix timestamp, a literal `.`, then the raw request body. Each configured key produces its own `v1=` segment in the header, which supports zero-downtime key rotation.
+- Signing applies to every outbound webhook the Rack sends. See [Webhooks](/configuration/webhooks) for the event types.
+- If your receiver does not yet support HMAC verification, leaving this parameter unset preserves the default behavior (no signature header). The parameter is purely opt-in.
+
+## See Also
+- [Webhook Signing](/console/webhook-signing): Receiver-side verification, rotation guidance, and code samples.
+- [Webhooks](/configuration/webhooks): The app-level events Racks deliver as webhooks.
+- [docker_hub_password](/configuration/rack-parameters/oci/docker_hub_password): Another Rack-level credential stored as a Kubernetes Secret and masked in parameter output.

--- a/docs/installation/production-rack/README.md
+++ b/docs/installation/production-rack/README.md
@@ -16,6 +16,7 @@ A production Rack runs on a cloud provider and hosts your applications in a real
 - [Digital Ocean](/installation/production-rack/do)
 - [Google Cloud](/installation/production-rack/gcp)
 - [Microsoft Azure](/installation/production-rack/azure)
+- [Oracle Cloud](/installation/production-rack/oci)
 
 ## See Also
 

--- a/docs/installation/production-rack/oci.md
+++ b/docs/installation/production-rack/oci.md
@@ -1,0 +1,103 @@
+---
+title: "Oracle Cloud"
+description: "Install a Convox production Rack on Oracle Cloud Infrastructure via the command line, covering the API signing key, compartment, environment, and install parameters."
+slug: oracle-cloud
+url: /installation/production-rack/oci
+---
+# Oracle Cloud
+> These are instructions for installing a Rack via the command line. The recommended way to install a Rack is with the [Convox Web Console](https://console.convox.com)
+
+## Initial Setup
+
+### OCI CLI
+
+- [Install the OCI CLI](https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/cliinstall.htm)
+
+> The `oci` CLI must stay installed and on `PATH` on any machine that runs `convox rack install oci` or manages the rack afterwards. OKE only issues exec-style kubeconfigs, so every `kubectl`/Terraform connection to the cluster shells out to `oci ce cluster generate-token` to fetch a token. There is no other way to authenticate to the cluster.
+
+### Terraform
+
+- Install [Terraform](https://developer.hashicorp.com/terraform/install)
+
+### Convox CLI
+
+- [Install the Convox CLI](/installation/cli)
+
+## Environment
+
+The following environment variables are required:
+
+- `OCI_TENANCY_OCID`
+- `OCI_USER_OCID`
+- `OCI_FINGERPRINT`
+- `OCI_PRIVATE_KEY`
+- `OCI_REGION`
+
+`OCI_COMPARTMENT_OCID` is optional and defaults to the tenancy root compartment.
+
+### Find your Tenancy and User OCIDs
+
+In the OCI Console, click your profile icon:
+
+- **Tenancy: `<name>`** shows your tenancy OCID. `OCI_TENANCY_OCID` is this value.
+- **User settings** shows your user OCID. `OCI_USER_OCID` is this value.
+
+### Create an API Signing Key
+
+In the OCI Console, go to **User settings > API keys > Add API key**, choose **Generate API Key Pair**, and download the private key.
+
+- `OCI_FINGERPRINT` is the fingerprint shown after the key is added
+- `OCI_PRIVATE_KEY` is the contents of the downloaded PEM file, not a path to it:
+  ```bash
+  $ export OCI_PRIVATE_KEY="$(cat ~/Downloads/oci_api_key.pem)"
+  ```
+
+### Set Region and Compartment
+
+- `OCI_REGION` is the region you want the rack deployed to, e.g. `us-ashburn-1`
+- `OCI_COMPARTMENT_OCID` is the OCID of the compartment to create rack resources in. It defaults to your tenancy root compartment if left unset.
+
+### Permissions
+
+The user creating the rack needs permission to manage IAM resources in the tenancy (the rack creates its own IAM user, group, policy, and auth token for pushing images to OCIR) and to manage compute, network, and container engine resources in the target compartment.
+
+## Install Rack
+```bash
+$ convox rack install oci <name> [param1=value1]...
+```
+### Available Parameters
+
+| Name              | Default                | Description                                                              |
+| ------------------| ------------------------| ------------------------------------------------------------------------ |
+| **cert_duration** | **2160h**               | Certificate renewal period                                               |
+| **node_type**     | **VM.Standard.E4.Flex** | [Node compute shape](https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm) |
+| **node_ocpus**    | **2**                   | OCPUs per node (Flex shapes only)                                        |
+| **node_memory**   | **16**                  | Memory per node in GB (Flex shapes only)                                 |
+| **node_disk**     | **100**                 | Node boot volume size in GB                                              |
+| **node_count**    | **2**                   | Number of nodes in the rack's node pool                                  |
+| **region**        | **us-ashburn-1**        | [OCI region](https://docs.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm) |
+| **gpu_node_type** |                         | GPU compute shape for an optional tainted GPU node pool                  |
+| **syslog**        |                         | Forward logs to a syslog endpoint (e.g. **tcp+tls://example.org:1234**)  |
+
+See [Rack Parameters: Oracle Cloud](/configuration/rack-parameters/oci) for the full list, including GPU node pool parameters.
+
+## Post-Installation
+
+After the install completes, verify your rack is running:
+
+```bash
+$ convox rack
+Name      myrack
+Provider  oci
+Router    router.0a1b2c3d4e5f.convox.cloud
+Status    running
+Version   3.24.11
+```
+
+Installation typically takes 10-20 minutes while OKE provisions the cluster.
+
+## See Also
+
+- [CLI Rack Management](/management/cli-rack-management) for managing and updating your Rack
+- [Deploying an Application](/tutorials/deploying-an-application) to deploy your first app
+- [Rack Parameters: Oracle Cloud](/configuration/rack-parameters/oci) for a full list of configurable parameters

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -30,6 +30,7 @@ var providerKnownParams = map[string]map[string]bool{
 	"gcp":   gcpKnownParams,
 	"azure": azureKnownParams,
 	"do":    doKnownParams,
+	"oci":   ociKnownParams,
 	"metal": metalKnownParams,
 	"local": localKnownParams,
 }
@@ -157,6 +158,21 @@ var doKnownParams = map[string]bool{
 	"settings": true, "sync_tf_now": true, "syslog": true, "telemetry": true,
 	"terraform_update_timeout": true, "token": true, "webhook_signing_key": true,
 	"whitelist": true,
+}
+
+var ociKnownParams = map[string]bool{
+	"cert_duration": true, "compartment_ocid": true,
+	"docker_hub_password": true, "docker_hub_username": true,
+	"fingerprint": true, "fluentd_memory": true,
+	"gpu_node_count": true, "gpu_node_type": true,
+	"high_availability": true, "image": true, "k8s_version": true,
+	"name": true, "node_count": true, "node_disk": true,
+	"node_memory": true, "node_ocpus": true, "node_type": true,
+	"private_key": true, "rack_name": true, "region": true,
+	"release": true, "settings": true, "sync_tf_now": true,
+	"syslog": true, "telemetry": true, "tenancy_ocid": true,
+	"terraform_update_timeout": true, "user_ocid": true,
+	"webhook_signing_key": true, "whitelist": true,
 }
 
 var metalKnownParams = map[string]bool{
@@ -296,6 +312,8 @@ var paramGroups = map[string]map[string]bool{
 		"dcgm_scrape_interval":                  true,
 		"gpu_metrics_max_concurrent":            true,
 		"gpu_metrics_max_pods":                  true,
+		"gpu_node_count":                        true,
+		"gpu_node_type":                         true,
 		"gpu_observability_chart_version":       true,
 		"gpu_observability_enable":              true,
 		"gpu_tag_enable":                        true,
@@ -347,7 +365,12 @@ var paramGroups = map[string]map[string]bool{
 		// v3 native (snake_case)
 		"access_id":                           true,
 		"build_node_minimal_role_enabled":     true, // dual-listed in build
+		"compartment_ocid":                    true,
 		"disable_public_access":               true,
+		"fingerprint":                         true,
+		"private_key":                         true,
+		"tenancy_ocid":                        true,
+		"user_ocid":                           true,
 		"docker_hub_password":                 true,
 		"ebs_volume_encryption_enabled":       true,
 		"ecr_additional_policy_arn":           true,
@@ -415,6 +438,7 @@ var paramGroups = map[string]map[string]bool{
 		"keda_enable":                             true,
 		"max_on_demand_count":                     true,
 		"min_on_demand_count":                     true,
+		"node_count":                              true,
 		"node_max_unavailable_percentage":         true,
 		"pdb_default_min_available_percentage":    true,
 		"schedule_rack_scale_down":                true,
@@ -459,6 +483,8 @@ var paramGroups = map[string]map[string]bool{
 		"node_capacity_type":                   true,
 		"node_disk":                            true,
 		"node_max_unavailable_percentage":      true,
+		"node_memory":                          true,
+		"node_ocpus":                           true,
 		"node_type":                            true,
 		"nvidia_device_plugin_enable":          true,
 		"nvidia_device_time_slicing_replicas":  true,

--- a/pkg/rack/terraform.go
+++ b/pkg/rack/terraform.go
@@ -1049,6 +1049,16 @@ func terraformEnv(provider string) (map[string]string, error) {
 		return requireEnv("DIGITALOCEAN_ACCESS_ID", "DIGITALOCEAN_SECRET_KEY", "DIGITALOCEAN_TOKEN")
 	case "gcp":
 		return requireEnv("GOOGLE_CREDENTIALS", "GOOGLE_PROJECT")
+	case "oci":
+		env, err := requireEnv("OCI_TENANCY_OCID", "OCI_USER_OCID", "OCI_FINGERPRINT", "OCI_PRIVATE_KEY", "OCI_REGION")
+		if err != nil {
+			return nil, err
+		}
+		// defaults to the tenancy root
+		for k, v := range optionalEnv("OCI_COMPARTMENT_OCID") {
+			env[k] = v
+		}
+		return env, nil
 	default:
 		return map[string]string{}, nil
 	}
@@ -1171,6 +1181,16 @@ func terraformProviderVars(provider string) (map[string]string, error) {
 			"access_id":  os.Getenv("DIGITALOCEAN_ACCESS_ID"),
 			"secret_key": os.Getenv("DIGITALOCEAN_SECRET_KEY"),
 			"token":      os.Getenv("DIGITALOCEAN_TOKEN"),
+		}
+		return vars, nil
+	case "oci":
+		vars := map[string]string{
+			"compartment_ocid": os.Getenv("OCI_COMPARTMENT_OCID"),
+			"fingerprint":      os.Getenv("OCI_FINGERPRINT"),
+			"private_key":      os.Getenv("OCI_PRIVATE_KEY"),
+			"region":           os.Getenv("OCI_REGION"),
+			"tenancy_ocid":     os.Getenv("OCI_TENANCY_OCID"),
+			"user_ocid":        os.Getenv("OCI_USER_OCID"),
 		}
 		return vars, nil
 	default:

--- a/provider/oci/build.go
+++ b/provider/oci/build.go
@@ -1,0 +1,43 @@
+package oci
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+
+	"github.com/convox/convox/pkg/structs"
+)
+
+func (p *Provider) BuildExport(app, id string, w io.Writer) error {
+	return p.Provider.BuildExport(app, id, w)
+}
+
+func (p *Provider) BuildImport(app string, r io.Reader) (*structs.Build, error) {
+	return p.Provider.BuildImport(app, r)
+}
+
+func (p *Provider) BuildLogs(app, id string, opts structs.LogsOptions) (io.ReadCloser, error) {
+	b, err := p.BuildGet(app, id)
+	if err != nil {
+		return nil, err
+	}
+
+	opts.Since = nil
+
+	switch b.Status {
+	case "running":
+		return p.ProcessLogs(app, b.Process, opts)
+	default:
+		u, err := url.Parse(b.Logs)
+		if err != nil {
+			return nil, err
+		}
+
+		switch u.Scheme {
+		case "object":
+			return p.ObjectFetch(u.Hostname(), u.Path)
+		default:
+			return nil, fmt.Errorf("unable to read logs for build: %s", id)
+		}
+	}
+}

--- a/provider/oci/deployment.go
+++ b/provider/oci/deployment.go
@@ -1,0 +1,5 @@
+package oci
+
+func (p *Provider) DeploymentTimeout() int {
+	return 1800
+}

--- a/provider/oci/heartbeat.go
+++ b/provider/oci/heartbeat.go
@@ -1,0 +1,10 @@
+package oci
+
+func (p *Provider) Heartbeat() (map[string]interface{}, error) {
+	hs := map[string]interface{}{
+		"instance_type": "unknown",
+		"region":        p.Region,
+	}
+
+	return hs, nil
+}

--- a/provider/oci/ingress.go
+++ b/provider/oci/ingress.go
@@ -1,0 +1,21 @@
+package oci
+
+func (p *Provider) IngressAnnotations(certDuration string) (map[string]string, error) {
+	ans := map[string]string{
+		"cert-manager.io/cluster-issuer": "letsencrypt",
+	}
+
+	if certDuration != "" {
+		ans["cert-manager.io/duration"] = certDuration
+	}
+
+	return ans, nil
+}
+
+func (p *Provider) IngressClass() string {
+	return "nginx"
+}
+
+func (p *Provider) IngressInternalClass() string {
+	return "nginx-internal"
+}

--- a/provider/oci/log.go
+++ b/provider/oci/log.go
@@ -1,0 +1,36 @@
+package oci
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/convox/convox/pkg/structs"
+)
+
+func (p *Provider) Log(app, stream string, ts time.Time, message string) error {
+	index := fmt.Sprintf("convox.%s.%s", p.Name, app)
+
+	tags := map[string]string{
+		"app":    app,
+		"stream": stream,
+	}
+
+	if err := p.elastic.Write(index, ts, message, tags); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *Provider) AppLogs(name string, opts structs.LogsOptions) (io.ReadCloser, error) {
+	r, w := io.Pipe()
+
+	go p.elastic.Stream(p.Context(), w, fmt.Sprintf("convox.%s.%s", p.Name, name), opts)
+
+	return r, nil
+}
+
+func (p *Provider) SystemLogs(opts structs.LogsOptions) (io.ReadCloser, error) {
+	return p.AppLogs("system", opts)
+}

--- a/provider/oci/manifest.go
+++ b/provider/oci/manifest.go
@@ -1,0 +1,9 @@
+package oci
+
+import (
+	"github.com/convox/convox/pkg/manifest"
+)
+
+func (p *Provider) ManifestValidate(m *manifest.Manifest) error {
+	return nil
+}

--- a/provider/oci/object.go
+++ b/provider/oci/object.go
@@ -1,0 +1,140 @@
+package oci
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/convox/convox/pkg/structs"
+)
+
+func (p *Provider) ObjectDelete(app, key string) error {
+	exists, err := p.ObjectExists(app, key)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		return structs.ErrNotFound("object not found: %s", key)
+	}
+
+	_, err = p.s3.DeleteObject(&s3.DeleteObjectInput{
+		Bucket: aws.String(p.Bucket),
+		Key:    aws.String(p.objectKey(app, key)),
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *Provider) ObjectExists(app, key string) (bool, error) {
+	_, err := p.s3.HeadObject(&s3.HeadObjectInput{
+		Bucket: aws.String(p.Bucket),
+		Key:    aws.String(p.objectKey(app, key)),
+	})
+	if err, ok := err.(awserr.Error); ok && err.Code() == "NotFound" {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// ObjectFetch fetches an Object
+func (p *Provider) ObjectFetch(app, key string) (io.ReadCloser, error) {
+	res, err := p.s3.GetObject(&s3.GetObjectInput{
+		Bucket: aws.String(p.Bucket),
+		Key:    aws.String(p.objectKey(app, key)),
+	})
+	if ae, ok := err.(awserr.Error); ok && ae.Code() == "NoSuchKey" {
+		return nil, structs.ErrNotFound("object not found: %s", key)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Body, nil
+}
+
+func (p *Provider) ObjectList(app, prefix string) ([]string, error) {
+	res, err := p.s3.ListObjectsV2(&s3.ListObjectsV2Input{
+		Bucket:    aws.String(p.Bucket),
+		Delimiter: aws.String("/"),
+		Prefix:    aws.String(p.objectKey(app, prefix)),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	objects := []string{}
+
+	for _, item := range res.Contents {
+		objects = append(objects, *item.Key)
+	}
+
+	return objects, nil
+}
+
+// ObjectStore stores an Object
+func (p *Provider) ObjectStore(app, key string, r io.Reader, opts structs.ObjectStoreOptions) (*structs.Object, error) {
+	if key == "" {
+		k, err := generateTempKey()
+		if err != nil {
+			return nil, err
+		}
+		key = k
+	}
+
+	up := s3manager.NewUploaderWithClient(p.s3)
+
+	req := &s3manager.UploadInput{
+		Bucket: aws.String(p.Bucket),
+		Key:    aws.String(p.objectKey(app, key)),
+		Body:   r,
+	}
+
+	if opts.Public != nil && *opts.Public {
+		req.ACL = aws.String("public-read")
+	}
+
+	res, err := up.Upload(req)
+	if err != nil {
+		return nil, err
+	}
+
+	url := fmt.Sprintf("object://%s/%s", app, key)
+
+	if opts.Public != nil && *opts.Public {
+		url = res.Location
+	}
+
+	o := &structs.Object{Url: url}
+
+	return o, nil
+}
+
+func (p *Provider) objectKey(app, key string) string {
+	return fmt.Sprintf("%s/%s", app, key)
+}
+
+func generateTempKey() (string, error) {
+	data := make([]byte, 1024)
+
+	if _, err := rand.Read(data); err != nil {
+		return "", err
+	}
+
+	hash := sha256.Sum256(data)
+
+	return fmt.Sprintf("tmp/%s", hex.EncodeToString(hash[:])[0:30]), nil
+}

--- a/provider/oci/oci.go
+++ b/provider/oci/oci.go
@@ -67,7 +67,9 @@ func (p *Provider) Initialize(opts structs.ProviderOptions) error {
 
 func (p *Provider) WithContext(ctx context.Context) structs.Provider {
 	pp := *p
-	pp.Provider = pp.Provider.WithContext(ctx).(*k8s.Provider)
+	if kp, ok := pp.Provider.WithContext(ctx).(*k8s.Provider); ok {
+		pp.Provider = kp
+	}
 	return &pp
 }
 

--- a/provider/oci/oci.go
+++ b/provider/oci/oci.go
@@ -1,0 +1,98 @@
+package oci
+
+import (
+	"context"
+	"os"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/convox/convox/pkg/elastic"
+	"github.com/convox/convox/pkg/structs"
+	"github.com/convox/convox/provider/k8s"
+)
+
+type Provider struct {
+	*k8s.Provider
+
+	Bucket           string
+	Region           string
+	Registry         string
+	RegistryPassword string
+	RegistryUsername string
+	S3Access         string
+	S3Endpoint       string
+	S3Secret         string
+
+	elastic *elastic.Client
+	s3      s3iface.S3API
+}
+
+func FromEnv() (*Provider, error) {
+	k, err := k8s.FromEnv()
+	if err != nil {
+		return nil, err
+	}
+
+	p := &Provider{
+		Provider:         k,
+		Bucket:           os.Getenv("BUCKET"),
+		Region:           os.Getenv("REGION"),
+		Registry:         os.Getenv("REGISTRY"),
+		RegistryPassword: os.Getenv("REGISTRY_PASSWORD"),
+		RegistryUsername: os.Getenv("REGISTRY_USERNAME"),
+		S3Access:         os.Getenv("S3_ACCESS"),
+		S3Endpoint:       os.Getenv("S3_ENDPOINT"),
+		S3Secret:         os.Getenv("S3_SECRET"),
+	}
+
+	k.Engine = p
+
+	return p, nil
+}
+
+func (p *Provider) Initialize(opts structs.ProviderOptions) error {
+	if err := p.initializeOciServices(); err != nil {
+		return err
+	}
+
+	if err := p.Provider.Initialize(opts); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *Provider) WithContext(ctx context.Context) structs.Provider {
+	pp := *p
+	pp.Provider = pp.Provider.WithContext(ctx).(*k8s.Provider)
+	return &pp
+}
+
+func (p *Provider) initializeOciServices() error {
+	ec, err := elastic.New(os.Getenv("ELASTIC_URL"))
+	if err != nil {
+		return err
+	}
+
+	p.elastic = ec
+
+	s, err := session.NewSession(&aws.Config{
+		Region:      aws.String(p.Region),
+		Credentials: credentials.NewStaticCredentials(p.S3Access, p.S3Secret, ""),
+	})
+	if err != nil {
+		return err
+	}
+
+	// OCI Object Storage speaks the S3 API only at a per-namespace endpoint and
+	// only with path-style addressing.
+	p.s3 = s3.New(s, &aws.Config{
+		Endpoint:         aws.String(p.S3Endpoint),
+		S3ForcePathStyle: aws.Bool(true),
+	})
+
+	return nil
+}

--- a/provider/oci/repository.go
+++ b/provider/oci/repository.go
@@ -1,0 +1,23 @@
+package oci
+
+import (
+	"fmt"
+
+	"github.com/convox/convox/pkg/structs"
+)
+
+func (p *Provider) RepositoryAuth(app string) (string, string, error) {
+	return p.RegistryUsername, p.RegistryPassword, nil
+}
+
+func (p *Provider) RepositoryHost(app string) (string, bool, error) {
+	return fmt.Sprintf("%s/%s", p.Registry, app), true, nil
+}
+
+func (p *Provider) RepositoryPrefix() string {
+	return ""
+}
+
+func (p *Provider) RepositoryImagesBatchDelete(app string, tags []string) error {
+	return structs.ErrNotImplemented("not implemented")
+}

--- a/provider/oci/system.go
+++ b/provider/oci/system.go
@@ -1,0 +1,28 @@
+package oci
+
+import "strings"
+
+func (p *Provider) SystemHost() string {
+	return p.Domain
+}
+
+func (p *Provider) SystemStatus() (string, error) {
+	return "running", nil
+}
+
+// GPUIntanceList returns the subset of the given OCI shapes that have NVIDIA GPUs.
+// OCI GPU shapes are named VM.GPU* and BM.GPU*; the BM.GPU.MI* families are AMD
+// Instinct, so they are excluded.
+func (p *Provider) GPUIntanceList(instanceTypes []string) ([]string, error) {
+	results := []string{}
+	for _, instanceType := range instanceTypes {
+		upper := strings.ToUpper(instanceType)
+		if strings.HasPrefix(upper, "BM.GPU.MI") {
+			continue
+		}
+		if strings.HasPrefix(upper, "VM.GPU") || strings.HasPrefix(upper, "BM.GPU") {
+			results = append(results, instanceType)
+		}
+	}
+	return results, nil
+}

--- a/provider/oci/system_test.go
+++ b/provider/oci/system_test.go
@@ -1,0 +1,37 @@
+package oci
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGPUIntanceList(t *testing.T) {
+	p := &Provider{}
+
+	in := []string{
+		"VM.GPU.A10.1",        // A10
+		"VM.GPU2.1",           // P100
+		"VM.GPU3.4",           // V100
+		"BM.GPU.A100-v2.8",    // A100
+		"BM.GPU.H100.8",       // H100
+		"BM.GPU.B200.8",       // B200
+		"BM.GPU.MI300X.8",     // AMD Instinct, not NVIDIA
+		"BM.GPU.MI355X.8",     // AMD Instinct, not NVIDIA
+		"VM.Standard.E4.Flex", // CPU only
+		"BM.Standard3.64",     // CPU only
+		"vm.gpu.a10.2",        // case-insensitive
+	}
+
+	got, err := p.GPUIntanceList(in)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{
+		"VM.GPU.A10.1",
+		"VM.GPU2.1",
+		"VM.GPU3.4",
+		"BM.GPU.A100-v2.8",
+		"BM.GPU.H100.8",
+		"BM.GPU.B200.8",
+		"vm.gpu.a10.2",
+	}, got)
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -11,6 +11,7 @@ import (
 	"github.com/convox/convox/provider/gcp"
 	"github.com/convox/convox/provider/local"
 	"github.com/convox/convox/provider/metal"
+	"github.com/convox/convox/provider/oci"
 )
 
 var Mock = &structs.MockProvider{}
@@ -31,6 +32,8 @@ func FromEnv() (structs.Provider, error) {
 		return local.FromEnv()
 	case "metal":
 		return metal.FromEnv()
+	case "oci":
+		return oci.FromEnv()
 	case "test":
 		return Mock, nil
 	case "":
@@ -53,6 +56,8 @@ func Valid(slug string) bool {
 	case "local":
 		return true
 	case "metal":
+		return true
+	case "oci":
 		return true
 	default:
 		return false

--- a/terraform/api/oci/identity.tf
+++ b/terraform/api/oci/identity.tf
@@ -1,0 +1,37 @@
+resource "random_string" "suffix" {
+  length  = 12
+  special = false
+  upper   = false
+}
+
+# iam users and groups always live in the tenancy root, not the rack compartment
+resource "oci_identity_user" "api" {
+  compartment_id = var.tenancy_ocid
+  description    = "convox rack ${var.name} api"
+  name           = "${var.name}-api-${random_string.suffix.result}"
+}
+
+resource "oci_identity_group" "api" {
+  compartment_id = var.tenancy_ocid
+  description    = "convox rack ${var.name} api"
+  name           = "${var.name}-api-${random_string.suffix.result}"
+}
+
+resource "oci_identity_user_group_membership" "api" {
+  group_id = oci_identity_group.api.id
+  user_id  = oci_identity_user.api.id
+}
+
+# ocir repositories are created on first push, which needs "manage repos" in the
+# tenancy, so nothing pre-creates oci_artifacts_container_repository here
+resource "oci_identity_policy" "api" {
+  compartment_id = var.tenancy_ocid
+  description    = "convox rack ${var.name} api"
+  name           = "${var.name}-api-${random_string.suffix.result}"
+
+  statements = [
+    "Allow group ${oci_identity_group.api.name} to manage repos in tenancy",
+    "Allow group ${oci_identity_group.api.name} to read buckets in compartment id ${var.compartment_ocid}",
+    "Allow group ${oci_identity_group.api.name} to manage objects in compartment id ${var.compartment_ocid} where target.bucket.name = '${oci_objectstorage_bucket.storage.name}'",
+  ]
+}

--- a/terraform/api/oci/main.tf
+++ b/terraform/api/oci/main.tf
@@ -1,0 +1,70 @@
+module "elasticsearch" {
+  source = "../../elasticsearch/k8s"
+
+  providers = {
+    kubernetes = kubernetes
+  }
+
+  namespace = var.namespace
+  replicas  = var.high_availability ? 2 : 1
+}
+
+module "fluentd" {
+  source = "../../fluentd/elasticsearch"
+
+  providers = {
+    kubernetes = kubernetes
+  }
+
+  cluster        = var.cluster
+  elasticsearch  = module.elasticsearch.host
+  fluentd_memory = var.fluentd_memory
+  namespace      = var.namespace
+  rack           = var.name
+  syslog         = var.syslog
+}
+
+module "k8s" {
+  source = "../k8s"
+
+  depends_on = [
+    oci_objectstorage_bucket.storage
+  ]
+
+  providers = {
+    kubernetes = kubernetes
+  }
+
+  buildkit_enabled          = var.buildkit_enabled
+  docker_hub_authentication = var.docker_hub_authentication
+  domain                    = var.domain
+  image                     = var.image
+  namespace                 = var.namespace
+  rack                      = var.name
+  rack_name                 = var.rack_name
+  release                   = var.release
+  resolver                  = var.resolver
+  replicas                  = var.high_availability ? 2 : 1
+  webhook_signing_key       = var.webhook_signing_key
+
+  annotations = {
+    "cert-manager.io/cluster-issuer" = "letsencrypt"
+  }
+
+  env = {
+    BUCKET            = oci_objectstorage_bucket.storage.name                                                                              # object storage bucket holding builds, releases and logs
+    CERT_MANAGER      = "true"                                                                                                             # certificates come from cert-manager annotations
+    COMPARTMENT       = var.compartment_ocid                                                                                               # compartment every rack resource lives in
+    ELASTIC_URL       = module.elasticsearch.url                                                                                           # in cluster elasticsearch for logs
+    PROVIDER          = "oci"                                                                                                              # selects the oci provider implementation
+    REGION            = var.region                                                                                                         # oci region name, eg us-ashburn-1
+    REGISTRY          = "${local.region_key}.ocir.io/${data.oci_objectstorage_namespace.current.namespace}/${var.name}"                    # ocir base path; the api appends /<app> to make the repo
+    REGISTRY_PASSWORD = oci_identity_auth_token.api.token                                                                                  # ocir docker password (iam auth token)
+    REGISTRY_USERNAME = "${data.oci_objectstorage_namespace.current.namespace}/${oci_identity_user.api.name}"                              # ocir docker username
+    RESOLVER          = var.resolver                                                                                                       # in cluster dns resolver endpoint
+    ROUTER            = var.router                                                                                                         # rack router hostname
+    S3_ACCESS         = oci_identity_customer_secret_key.api.id                                                                            # s3 compatibility access key id
+    S3_ENDPOINT       = "https://${data.oci_objectstorage_namespace.current.namespace}.compat.objectstorage.${var.region}.oraclecloud.com" # s3 compatibility endpoint for BUCKET
+    S3_SECRET         = oci_identity_customer_secret_key.api.key                                                                           # s3 compatibility secret access key
+  }
+}

--- a/terraform/api/oci/outputs.tf
+++ b/terraform/api/oci/outputs.tf
@@ -1,0 +1,3 @@
+output "endpoint" {
+  value = module.k8s.endpoint
+}

--- a/terraform/api/oci/registry.tf
+++ b/terraform/api/oci/registry.tf
@@ -1,0 +1,13 @@
+data "oci_identity_regions" "current" {}
+
+locals {
+  # ocir hostnames use the three letter region key (iad.ocir.io), not the region name
+  region_key = lower([for r in data.oci_identity_regions.current.regions : r.key if r.name == var.region][0])
+}
+
+# an ocir docker password is an iam auth token for the rack user; the matching
+# username is <namespace>/<username>
+resource "oci_identity_auth_token" "api" {
+  description = "convox rack ${var.name} registry"
+  user_id     = oci_identity_user.api.id
+}

--- a/terraform/api/oci/storage.tf
+++ b/terraform/api/oci/storage.tf
@@ -1,0 +1,17 @@
+data "oci_objectstorage_namespace" "current" {
+  compartment_id = var.compartment_ocid
+}
+
+resource "oci_objectstorage_bucket" "storage" {
+  access_type    = "NoPublicAccess"
+  compartment_id = var.compartment_ocid
+  name           = "${var.name}-storage-${random_string.suffix.result}"
+  namespace      = data.oci_objectstorage_namespace.current.namespace
+}
+
+# object storage is reached over its s3 compatibility api, so the api needs an
+# access key / secret pair rather than an oci api key
+resource "oci_identity_customer_secret_key" "api" {
+  display_name = "${var.name}-api"
+  user_id      = oci_identity_user.api.id
+}

--- a/terraform/api/oci/variables.tf
+++ b/terraform/api/oci/variables.tf
@@ -1,0 +1,74 @@
+variable "buildkit_enabled" {
+  default = false
+}
+
+variable "cluster" {
+  type = string
+}
+
+variable "compartment_ocid" {
+  type = string
+}
+
+variable "fluentd_memory" {
+  type    = string
+  default = "200Mi"
+}
+
+variable "docker_hub_authentication" {
+  type = string
+}
+
+variable "domain" {
+  type = string
+}
+
+variable "high_availability" {
+  default = true
+}
+
+variable "image" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
+variable "rack_name" {
+  default = ""
+  type    = string
+}
+
+variable "namespace" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "release" {
+  type = string
+}
+
+variable "resolver" {
+  type = string
+}
+
+variable "router" {
+  type = string
+}
+
+variable "syslog" {
+  default = ""
+}
+
+variable "tenancy_ocid" {
+  type = string
+}
+
+variable "webhook_signing_key" {
+  type    = string
+  default = ""
+}

--- a/terraform/api/oci/versions.tf
+++ b/terraform/api/oci/versions.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 0.12"
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.35.1"
+    }
+    oci = {
+      source  = "oracle/oci"
+      version = "~> 6.0"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
+}

--- a/terraform/cluster/oci/main.tf
+++ b/terraform/cluster/oci/main.tf
@@ -8,9 +8,11 @@ data "oci_containerengine_cluster_option" "rack" {
 }
 
 locals {
-  # oke reports full versions (v1.35.1) but var.k8s_version is major.minor like the other clouds
-  k8s_versions = [for v in data.oci_containerengine_cluster_option.rack.kubernetes_versions : v if length(regexall("^v${var.k8s_version}\\.", v)) > 0]
-  k8s_version  = element(sort(local.k8s_versions), length(local.k8s_versions) - 1)
+  # oke reports full versions (v1.35.1) but var.k8s_version is major.minor like the
+  # other clouds. the patch is compared numerically because sort() would put .10
+  # before .9
+  k8s_patches = [for v in data.oci_containerengine_cluster_option.rack.kubernetes_versions : tonumber(split(".", v)[2]) if length(regexall("^v${var.k8s_version}\\.", v)) > 0]
+  k8s_version = "v${var.k8s_version}.${max(local.k8s_patches...)}"
 }
 
 resource "oci_containerengine_cluster" "rack" {
@@ -36,10 +38,11 @@ data "oci_containerengine_node_pool_option" "rack" {
 }
 
 locals {
-  # oke image names look like Oracle-Linux-8.10-2025.01.31-0-OKE-1.35.1-754, so the
-  # highest sorting name is the newest. "GPU" variants ship the nvidia drivers,
-  # "aarch64" ones are arm.
-  node_images      = { for s in data.oci_containerengine_node_pool_option.rack.sources : s.source_name => s.image_id if s.source_type == "IMAGE" }
+  # oke image names look like Oracle-Linux-8.10-2025.01.31-0-OKE-1.35.1-754. only
+  # images built for the chosen kubernetes version are considered, then the highest
+  # sorting name is the newest since the date is zero padded. "GPU" variants ship
+  # the nvidia drivers, "aarch64" ones are arm.
+  node_images      = { for s in data.oci_containerengine_node_pool_option.rack.sources : s.source_name => s.image_id if s.source_type == "IMAGE" && length(regexall("OKE-${trimprefix(local.k8s_version, "v")}-", s.source_name)) > 0 }
   node_image_names = [for n in keys(local.node_images) : n if length(regexall("GPU|aarch64", n)) == 0]
   gpu_image_names  = [for n in keys(local.node_images) : n if length(regexall("GPU", n)) > 0]
   node_image_id    = local.node_images[element(sort(local.node_image_names), length(local.node_image_names) - 1)]

--- a/terraform/cluster/oci/main.tf
+++ b/terraform/cluster/oci/main.tf
@@ -1,0 +1,122 @@
+data "oci_identity_availability_domains" "rack" {
+  compartment_id = var.compartment_ocid
+}
+
+data "oci_containerengine_cluster_option" "rack" {
+  cluster_option_id = "all"
+  compartment_id    = var.compartment_ocid
+}
+
+locals {
+  # oke reports full versions (v1.35.1) but var.k8s_version is major.minor like the other clouds
+  k8s_versions = [for v in data.oci_containerengine_cluster_option.rack.kubernetes_versions : v if length(regexall("^v${var.k8s_version}\\.", v)) > 0]
+  k8s_version  = element(sort(local.k8s_versions), length(local.k8s_versions) - 1)
+}
+
+resource "oci_containerengine_cluster" "rack" {
+  compartment_id     = var.compartment_ocid
+  kubernetes_version = local.k8s_version
+  name               = var.name
+  type               = "BASIC_CLUSTER"
+  vcn_id             = oci_core_vcn.rack.id
+
+  endpoint_config {
+    is_public_ip_enabled = true
+    subnet_id            = oci_core_subnet.endpoint.id
+  }
+
+  options {
+    service_lb_subnet_ids = [oci_core_subnet.lb.id]
+  }
+}
+
+data "oci_containerengine_node_pool_option" "rack" {
+  compartment_id      = var.compartment_ocid
+  node_pool_option_id = oci_containerengine_cluster.rack.id
+}
+
+locals {
+  # oke image names look like Oracle-Linux-8.10-2025.01.31-0-OKE-1.35.1-754, so the
+  # highest sorting name is the newest. "GPU" variants ship the nvidia drivers,
+  # "aarch64" ones are arm.
+  node_images      = { for s in data.oci_containerengine_node_pool_option.rack.sources : s.source_name => s.image_id if s.source_type == "IMAGE" }
+  node_image_names = [for n in keys(local.node_images) : n if length(regexall("GPU|aarch64", n)) == 0]
+  gpu_image_names  = [for n in keys(local.node_images) : n if length(regexall("GPU", n)) > 0]
+  node_image_id    = local.node_images[element(sort(local.node_image_names), length(local.node_image_names) - 1)]
+  gpu_image_id     = try(local.node_images[element(sort(local.gpu_image_names), length(local.gpu_image_names) - 1)], "")
+}
+
+resource "oci_containerengine_node_pool" "rack" {
+  cluster_id         = oci_containerengine_cluster.rack.id
+  compartment_id     = var.compartment_ocid
+  kubernetes_version = local.k8s_version
+  name               = "${var.name}-node"
+  node_shape         = var.node_type
+
+  # oke node pools are fixed size; scaling them needs the cluster-autoscaler add-on
+  node_config_details {
+    size = var.node_count
+
+    dynamic "placement_configs" {
+      for_each = data.oci_identity_availability_domains.rack.availability_domains
+      content {
+        availability_domain = placement_configs.value.name
+        subnet_id           = oci_core_subnet.workers.id
+      }
+    }
+  }
+
+  dynamic "node_shape_config" {
+    for_each = length(regexall("Flex", var.node_type)) > 0 ? [1] : []
+    content {
+      memory_in_gbs = var.node_memory
+      ocpus         = var.node_ocpus
+    }
+  }
+
+  node_source_details {
+    boot_volume_size_in_gbs = var.node_disk
+    image_id                = local.node_image_id
+    source_type             = "IMAGE"
+  }
+
+  timeouts {
+    update = var.terraform_update_timeout
+  }
+}
+
+# oke only issues exec kubeconfigs (token_version 2.0.0), so the kubernetes and helm
+# providers authenticate by shelling out to `oci ce cluster generate-token`. there is
+# no data source that returns a bearer token, so the oci cli must be on the machine
+# running terraform. the ca and server are read out of the same kubeconfig because
+# oci_containerengine_cluster does not export them.
+data "oci_containerengine_cluster_kube_config" "rack" {
+  cluster_id    = oci_containerengine_cluster.rack.id
+  token_version = "2.0.0"
+}
+
+locals {
+  kube_config = yamldecode(data.oci_containerengine_cluster_kube_config.rack.content)
+  kube_ca     = base64decode(local.kube_config["clusters"][0]["cluster"]["certificate-authority-data"])
+  kube_host   = local.kube_config["clusters"][0]["cluster"]["server"]
+}
+
+resource "local_file" "kubeconfig" {
+  depends_on = [oci_containerengine_node_pool.rack]
+
+  filename = pathexpand("~/.kube/config.oci.${var.name}")
+  content  = data.oci_containerengine_cluster_kube_config.rack.content
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = local.kube_host
+    cluster_ca_certificate = local.kube_ca
+
+    exec {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "oci"
+      args        = ["ce", "cluster", "generate-token", "--cluster-id", oci_containerengine_cluster.rack.id, "--region", var.region]
+    }
+  }
+}

--- a/terraform/cluster/oci/network.tf
+++ b/terraform/cluster/oci/network.tf
@@ -1,0 +1,185 @@
+locals {
+  vcn_cidr = "10.0.0.0/16"
+
+  # the service gateway needs the "All <region> Services" cidr, not the object storage only one
+  services = [for s in data.oci_core_services.rack.services : s if length(regexall("All .* Services In Oracle Services Network", s.name)) > 0]
+}
+
+data "oci_core_services" "rack" {}
+
+resource "oci_core_vcn" "rack" {
+  compartment_id = var.compartment_ocid
+  cidr_blocks    = [local.vcn_cidr]
+  display_name   = var.name
+  dns_label      = substr(replace(lower(var.name), "/[^a-z0-9]/", ""), 0, 15)
+}
+
+resource "oci_core_internet_gateway" "rack" {
+  compartment_id = var.compartment_ocid
+  display_name   = "${var.name}-internet"
+  vcn_id         = oci_core_vcn.rack.id
+}
+
+resource "oci_core_nat_gateway" "rack" {
+  compartment_id = var.compartment_ocid
+  display_name   = "${var.name}-nat"
+  vcn_id         = oci_core_vcn.rack.id
+}
+
+resource "oci_core_service_gateway" "rack" {
+  compartment_id = var.compartment_ocid
+  display_name   = "${var.name}-services"
+  vcn_id         = oci_core_vcn.rack.id
+
+  services {
+    service_id = local.services[0].id
+  }
+}
+
+resource "oci_core_route_table" "public" {
+  compartment_id = var.compartment_ocid
+  display_name   = "${var.name}-public"
+  vcn_id         = oci_core_vcn.rack.id
+
+  route_rules {
+    destination       = "0.0.0.0/0"
+    destination_type  = "CIDR_BLOCK"
+    network_entity_id = oci_core_internet_gateway.rack.id
+  }
+}
+
+resource "oci_core_route_table" "private" {
+  compartment_id = var.compartment_ocid
+  display_name   = "${var.name}-private"
+  vcn_id         = oci_core_vcn.rack.id
+
+  route_rules {
+    destination       = "0.0.0.0/0"
+    destination_type  = "CIDR_BLOCK"
+    network_entity_id = oci_core_nat_gateway.rack.id
+  }
+
+  route_rules {
+    destination       = local.services[0].cidr_block
+    destination_type  = "SERVICE_CIDR_BLOCK"
+    network_entity_id = oci_core_service_gateway.rack.id
+  }
+}
+
+resource "oci_core_security_list" "endpoint" {
+  compartment_id = var.compartment_ocid
+  display_name   = "${var.name}-endpoint"
+  vcn_id         = oci_core_vcn.rack.id
+
+  egress_security_rules {
+    destination = "0.0.0.0/0"
+    protocol    = "all"
+  }
+
+  # kubectl and the terraform kubernetes provider
+  ingress_security_rules {
+    protocol = "6"
+    source   = "0.0.0.0/0"
+
+    tcp_options {
+      min = 6443
+      max = 6443
+    }
+  }
+
+  # workers to control plane (6443 and 12250)
+  ingress_security_rules {
+    protocol = "all"
+    source   = local.vcn_cidr
+  }
+}
+
+resource "oci_core_security_list" "workers" {
+  compartment_id = var.compartment_ocid
+  display_name   = "${var.name}-workers"
+  vcn_id         = oci_core_vcn.rack.id
+
+  egress_security_rules {
+    destination = "0.0.0.0/0"
+    protocol    = "all"
+  }
+
+  # control plane, other workers, and load balancer health checks / nodeports
+  ingress_security_rules {
+    protocol = "all"
+    source   = local.vcn_cidr
+  }
+
+  # path mtu discovery
+  ingress_security_rules {
+    protocol = "1"
+    source   = "0.0.0.0/0"
+
+    icmp_options {
+      type = 3
+      code = 4
+    }
+  }
+}
+
+resource "oci_core_security_list" "lb" {
+  compartment_id = var.compartment_ocid
+  display_name   = "${var.name}-lb"
+  vcn_id         = oci_core_vcn.rack.id
+
+  egress_security_rules {
+    destination = "0.0.0.0/0"
+    protocol    = "all"
+  }
+
+  ingress_security_rules {
+    protocol = "6"
+    source   = "0.0.0.0/0"
+
+    tcp_options {
+      min = 80
+      max = 80
+    }
+  }
+
+  ingress_security_rules {
+    protocol = "6"
+    source   = "0.0.0.0/0"
+
+    tcp_options {
+      min = 443
+      max = 443
+    }
+  }
+}
+
+resource "oci_core_subnet" "endpoint" {
+  cidr_block        = cidrsubnet(local.vcn_cidr, 12, 0)
+  compartment_id    = var.compartment_ocid
+  display_name      = "${var.name}-endpoint"
+  dns_label         = "endpoint"
+  route_table_id    = oci_core_route_table.public.id
+  security_list_ids = [oci_core_security_list.endpoint.id]
+  vcn_id            = oci_core_vcn.rack.id
+}
+
+resource "oci_core_subnet" "workers" {
+  cidr_block                 = cidrsubnet(local.vcn_cidr, 8, 1)
+  compartment_id             = var.compartment_ocid
+  display_name               = "${var.name}-workers"
+  dns_label                  = "workers"
+  prohibit_public_ip_on_vnic = true
+  route_table_id             = oci_core_route_table.private.id
+  security_list_ids          = [oci_core_security_list.workers.id]
+  vcn_id                     = oci_core_vcn.rack.id
+}
+
+resource "oci_core_subnet" "lb" {
+  cidr_block        = cidrsubnet(local.vcn_cidr, 8, 2)
+  compartment_id    = var.compartment_ocid
+  display_name      = "${var.name}-lb"
+  dns_label         = "lb"
+  route_table_id    = oci_core_route_table.public.id
+  security_list_ids = [oci_core_security_list.lb.id]
+  vcn_id            = oci_core_vcn.rack.id
+}

--- a/terraform/cluster/oci/node_pools.tf
+++ b/terraform/cluster/oci/node_pools.tf
@@ -1,0 +1,50 @@
+locals {
+  # oke node pools have no taints argument, so the taint is registered by a custom
+  # cloud-init that re-runs the oke bootstrap script with extra kubelet flags.
+  gpu_user_data = <<-EOF
+    #!/bin/bash
+    curl --fail -H "Authorization: Bearer Oracle" -L0 http://169.254.169.254/opc/v2/instance/metadata/oke_init_script | base64 --decode >/var/run/oke-init.sh
+    bash /var/run/oke-init.sh --kubelet-extra-args "--register-with-taints=nvidia.com/gpu=:NoSchedule"
+  EOF
+}
+
+resource "oci_containerengine_node_pool" "gpu" {
+  count = var.gpu_node_type != "" ? 1 : 0
+
+  cluster_id         = oci_containerengine_cluster.rack.id
+  compartment_id     = var.compartment_ocid
+  kubernetes_version = local.k8s_version
+  name               = "${var.name}-gpu"
+  node_shape         = var.gpu_node_type
+
+  initial_node_labels {
+    key   = "convox.io/gpu-vendor"
+    value = "nvidia"
+  }
+
+  node_config_details {
+    size = var.gpu_node_count
+
+    dynamic "placement_configs" {
+      for_each = data.oci_identity_availability_domains.rack.availability_domains
+      content {
+        availability_domain = placement_configs.value.name
+        subnet_id           = oci_core_subnet.workers.id
+      }
+    }
+  }
+
+  node_metadata = {
+    user_data = base64encode(local.gpu_user_data)
+  }
+
+  node_source_details {
+    boot_volume_size_in_gbs = var.node_disk
+    image_id                = local.gpu_image_id
+    source_type             = "IMAGE"
+  }
+
+  timeouts {
+    update = var.terraform_update_timeout
+  }
+}

--- a/terraform/cluster/oci/nvidia.tf
+++ b/terraform/cluster/oci/nvidia.tf
@@ -1,0 +1,51 @@
+resource "helm_release" "nvidia_device_plugin" {
+  depends_on = [
+    oci_containerengine_node_pool.gpu,
+  ]
+
+  count = var.gpu_node_type != "" ? 1 : 0
+
+  name       = "nvidia-device-plugin"
+  repository = "https://nvidia.github.io/k8s-device-plugin"
+  chart      = "nvidia-device-plugin"
+  version    = "0.17.1"
+  namespace  = "kube-system"
+
+  values = [
+    yamlencode({
+      affinity = {
+        nodeAffinity = {
+          requiredDuringSchedulingIgnoredDuringExecution = {
+            nodeSelectorTerms = [
+              {
+                matchExpressions = [
+                  {
+                    key      = "convox.io/gpu-vendor"
+                    operator = "In"
+                    values   = ["nvidia"]
+                  }
+                ]
+              },
+            ]
+          }
+        }
+      }
+      tolerations = [
+        {
+          key      = "CriticalAddonsOnly"
+          operator = "Exists"
+        },
+        {
+          key      = "nvidia.com/gpu"
+          operator = "Exists"
+          effect   = "NoSchedule"
+        },
+        {
+          key      = "dedicated-node"
+          operator = "Exists"
+          effect   = "NoSchedule"
+        },
+      ]
+    })
+  ]
+}

--- a/terraform/cluster/oci/outputs.tf
+++ b/terraform/cluster/oci/outputs.tf
@@ -1,0 +1,18 @@
+output "ca" {
+  depends_on = [oci_containerengine_node_pool.rack]
+  value      = local.kube_ca
+}
+
+output "endpoint" {
+  depends_on = [oci_containerengine_node_pool.rack]
+  value      = local.kube_host
+}
+
+output "id" {
+  depends_on = [oci_containerengine_node_pool.rack]
+  value      = oci_containerengine_cluster.rack.id
+}
+
+output "name" {
+  value = oci_containerengine_cluster.rack.name
+}

--- a/terraform/cluster/oci/variables.tf
+++ b/terraform/cluster/oci/variables.tf
@@ -1,0 +1,51 @@
+variable "compartment_ocid" {
+  type = string
+}
+
+variable "gpu_node_count" {
+  default = 1
+}
+
+# empty disables the gpu node pool and the nvidia device plugin
+variable "gpu_node_type" {
+  default = ""
+  type    = string
+}
+
+variable "k8s_version" {
+  type    = string
+  default = "1.35"
+}
+
+variable "name" {
+  type = string
+}
+
+variable "node_count" {
+  default = 2
+}
+
+variable "node_disk" {
+  default = 100
+}
+
+variable "node_memory" {
+  default = 16
+}
+
+variable "node_ocpus" {
+  default = 2
+}
+
+variable "node_type" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "terraform_update_timeout" {
+  type    = string
+  default = "2h"
+}

--- a/terraform/cluster/oci/versions.tf
+++ b/terraform/cluster/oci/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 0.12"
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "2.12.1"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.5"
+    }
+    oci = {
+      source  = "oracle/oci"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/terraform/rack/oci/main.tf
+++ b/terraform/rack/oci/main.tf
@@ -1,0 +1,77 @@
+module "k8s" {
+  source = "../k8s"
+
+  providers = {
+    kubernetes = kubernetes
+  }
+
+  docker_hub_username   = var.docker_hub_username
+  docker_hub_password   = var.docker_hub_password
+  domain                = module.router.endpoint
+  name                  = var.name
+  release               = var.release
+  telemetry             = var.telemetry
+  telemetry_map         = var.telemetry_map
+  telemetry_default_map = var.telemetry_default_map
+}
+
+module "api" {
+  source = "../../api/oci"
+
+  providers = {
+    oci        = oci
+    kubernetes = kubernetes
+  }
+
+  buildkit_enabled          = var.buildkit_enabled
+  cluster                   = var.cluster
+  compartment_ocid          = var.compartment_ocid
+  docker_hub_authentication = module.k8s.docker_hub_authentication
+  fluentd_memory            = var.fluentd_memory
+  domain                    = module.router.endpoint
+  high_availability         = var.high_availability
+  image                     = var.image
+  name                      = var.name
+  rack_name                 = var.rack_name
+  namespace                 = module.k8s.namespace
+  region                    = var.region
+  release                   = var.release
+  resolver                  = module.resolver.endpoint
+  router                    = module.router.endpoint
+  syslog                    = var.syslog
+  tenancy_ocid              = var.tenancy_ocid
+  webhook_signing_key       = var.webhook_signing_key
+}
+
+module "resolver" {
+  source = "../../resolver/oci"
+
+  providers = {
+    oci        = oci
+    kubernetes = kubernetes
+  }
+
+  docker_hub_authentication = module.k8s.docker_hub_authentication
+  high_availability         = var.high_availability
+  image                     = var.image
+  namespace                 = module.k8s.namespace
+  rack                      = var.name
+  release                   = var.release
+}
+
+module "router" {
+  source = "../../router/oci"
+
+  providers = {
+    oci        = oci
+    kubernetes = kubernetes
+  }
+
+  docker_hub_authentication = module.k8s.docker_hub_authentication
+  high_availability         = var.high_availability
+  name                      = var.name
+  namespace                 = module.k8s.namespace
+  region                    = var.region
+  release                   = var.release
+  whitelist                 = var.whitelist
+}

--- a/terraform/rack/oci/outputs.tf
+++ b/terraform/rack/oci/outputs.tf
@@ -1,0 +1,7 @@
+output "api" {
+  value = module.api.endpoint
+}
+
+output "endpoint" {
+  value = module.router.endpoint
+}

--- a/terraform/rack/oci/variables.tf
+++ b/terraform/rack/oci/variables.tf
@@ -1,0 +1,78 @@
+variable "buildkit_enabled" {
+  default = false
+}
+
+variable "cluster" {
+  type = string
+}
+
+variable "compartment_ocid" {
+  type = string
+}
+
+variable "fluentd_memory" {
+  type    = string
+  default = "200Mi"
+}
+
+variable "docker_hub_username" {
+  default = ""
+}
+
+variable "docker_hub_password" {
+  default = ""
+}
+
+variable "high_availability" {
+  default = true
+}
+
+variable "image" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
+variable "rack_name" {
+  default = ""
+  type    = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "release" {
+  type = string
+}
+
+variable "syslog" {
+  default = ""
+}
+
+variable "telemetry" {
+  type = bool
+}
+
+variable "telemetry_map" {
+  type = any
+}
+
+variable "telemetry_default_map" {
+  type = any
+}
+
+variable "tenancy_ocid" {
+  type = string
+}
+
+variable "webhook_signing_key" {
+  type    = string
+  default = ""
+}
+
+variable "whitelist" {
+  default = ["0.0.0.0/0"]
+}

--- a/terraform/rack/oci/versions.tf
+++ b/terraform/rack/oci/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 0.12"
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.35.1"
+    }
+    oci = {
+      source  = "oracle/oci"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/terraform/resolver/oci/main.tf
+++ b/terraform/resolver/oci/main.tf
@@ -1,0 +1,15 @@
+module "k8s" {
+  source = "../k8s"
+
+  providers = {
+    kubernetes = kubernetes
+  }
+
+  docker_hub_authentication = var.docker_hub_authentication
+  image                     = var.image
+  namespace                 = var.namespace
+  rack                      = var.rack
+  release                   = var.release
+  replicas                  = var.high_availability ? 2 : 1
+
+}

--- a/terraform/resolver/oci/outputs.tf
+++ b/terraform/resolver/oci/outputs.tf
@@ -1,0 +1,3 @@
+output "endpoint" {
+  value = module.k8s.endpoint
+}

--- a/terraform/resolver/oci/variables.tf
+++ b/terraform/resolver/oci/variables.tf
@@ -1,0 +1,23 @@
+variable "docker_hub_authentication" {
+  type = string
+}
+
+variable "high_availability" {
+  default = true
+}
+
+variable "image" {
+  type = string
+}
+
+variable "namespace" {
+  type = string
+}
+
+variable "rack" {
+  type = string
+}
+
+variable "release" {
+  type = string
+}

--- a/terraform/resolver/oci/versions.tf
+++ b/terraform/resolver/oci/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 0.12"
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.35.1"
+    }
+    oci = {
+      source  = "oracle/oci"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/terraform/router/oci/main.tf
+++ b/terraform/router/oci/main.tf
@@ -1,0 +1,59 @@
+module "nginx" {
+  source = "../nginx"
+
+  providers = {
+    kubernetes = kubernetes
+  }
+
+  docker_hub_authentication = var.docker_hub_authentication
+  namespace                 = var.namespace
+  rack                      = var.name
+  replicas_max              = var.high_availability ? 10 : 1
+  replicas_min              = var.high_availability ? 2 : 1
+}
+
+resource "kubernetes_service" "router" {
+  metadata {
+    namespace = var.namespace
+    name      = "router"
+
+    annotations = {
+      # the oci cloud controller manager also rewrites the load balancer subnet
+      # security list unless it is told to leave it alone
+      "service.beta.kubernetes.io/oci-load-balancer-security-list-management-mode" = "None"
+      "service.beta.kubernetes.io/oci-load-balancer-shape"                         = "flexible"
+      "service.beta.kubernetes.io/oci-load-balancer-shape-flex-min"                = var.lb_bandwidth_min
+      "service.beta.kubernetes.io/oci-load-balancer-shape-flex-max"                = var.lb_bandwidth_max
+    }
+  }
+
+  spec {
+    type = "LoadBalancer"
+
+    load_balancer_source_ranges = var.whitelist
+
+    port {
+      name        = "http"
+      port        = 80
+      protocol    = "TCP"
+      target_port = "http"
+    }
+
+    port {
+      name        = "https"
+      port        = 443
+      protocol    = "TCP"
+      target_port = "https"
+    }
+
+    selector = module.nginx.selector
+  }
+
+  lifecycle {
+    ignore_changes = [metadata[0].annotations]
+  }
+}
+
+data "http" "alias" {
+  url = "https://alias.convox.com/alias/${length(kubernetes_service.router.status.0.load_balancer.0.ingress) > 0 ? kubernetes_service.router.status.0.load_balancer.0.ingress.0.ip : ""}"
+}

--- a/terraform/router/oci/outputs.tf
+++ b/terraform/router/oci/outputs.tf
@@ -1,0 +1,3 @@
+output "endpoint" {
+  value = data.http.alias.response_body
+}

--- a/terraform/router/oci/variables.tf
+++ b/terraform/router/oci/variables.tf
@@ -1,0 +1,38 @@
+variable "docker_hub_authentication" {
+  type    = string
+  default = null
+}
+
+variable "high_availability" {
+  default = true
+}
+
+variable "lb_bandwidth_max" {
+  default = "100"
+  type    = string
+}
+
+variable "lb_bandwidth_min" {
+  default = "10"
+  type    = string
+}
+
+variable "name" {
+  type = string
+}
+
+variable "namespace" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "release" {
+  type = string
+}
+
+variable "whitelist" {
+  default = ["0.0.0.0/0"]
+}

--- a/terraform/router/oci/versions.tf
+++ b/terraform/router/oci/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 0.12"
+  required_providers {
+    http = {
+      source  = "hashicorp/http"
+      version = "~> 2.1"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.35.1"
+    }
+    oci = {
+      source  = "oracle/oci"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/terraform/system/oci/main.tf
+++ b/terraform/system/oci/main.tf
@@ -1,0 +1,82 @@
+provider "oci" {
+  fingerprint  = var.fingerprint
+  private_key  = var.private_key
+  region       = var.region
+  tenancy_ocid = var.tenancy_ocid
+  user_ocid    = var.user_ocid
+}
+
+# oke only issues exec kubeconfigs, so the oci cli must be installed and able to
+# read the same credentials as the provider above
+provider "kubernetes" {
+  cluster_ca_certificate = module.cluster.ca
+  host                   = module.cluster.endpoint
+
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "oci"
+    args        = ["ce", "cluster", "generate-token", "--cluster-id", module.cluster.id, "--region", var.region]
+  }
+}
+
+data "http" "releases" {
+  url = "https://api.github.com/repos/${var.image}/releases/latest"
+}
+
+locals {
+  name             = lower(var.name)
+  rack_name        = lower(var.rack_name)
+  current          = jsondecode(data.http.releases.response_body).tag_name
+  release          = coalesce(var.release, local.current)
+  compartment_ocid = var.compartment_ocid != "" ? var.compartment_ocid : var.tenancy_ocid
+}
+
+module "cluster" {
+  source = "../../cluster/oci"
+
+  providers = {
+    oci = oci
+  }
+
+  compartment_ocid         = local.compartment_ocid
+  gpu_node_count           = var.gpu_node_count
+  gpu_node_type            = var.gpu_node_type
+  k8s_version              = var.k8s_version
+  name                     = local.name
+  node_count               = var.node_count
+  node_disk                = var.node_disk
+  node_memory              = var.node_memory
+  node_ocpus               = var.node_ocpus
+  node_type                = var.node_type
+  region                   = var.region
+  terraform_update_timeout = var.terraform_update_timeout
+}
+
+module "rack" {
+  source = "../../rack/oci"
+
+  providers = {
+    oci        = oci
+    kubernetes = kubernetes
+  }
+
+  buildkit_enabled      = var.buildkit_enabled
+  cluster               = module.cluster.id
+  compartment_ocid      = local.compartment_ocid
+  docker_hub_username   = var.docker_hub_username
+  docker_hub_password   = var.docker_hub_password
+  fluentd_memory        = var.fluentd_memory
+  high_availability     = var.high_availability
+  image                 = var.image
+  name                  = local.name
+  rack_name             = local.rack_name
+  region                = var.region
+  release               = local.release
+  syslog                = var.syslog
+  telemetry             = var.telemetry
+  telemetry_map         = local.telemetry_map
+  telemetry_default_map = local.telemetry_default_map
+  tenancy_ocid          = var.tenancy_ocid
+  webhook_signing_key   = var.webhook_signing_key
+  whitelist             = split(",", var.whitelist)
+}

--- a/terraform/system/oci/outputs.tf
+++ b/terraform/system/oci/outputs.tf
@@ -1,0 +1,15 @@
+output "api" {
+  value = module.rack.api
+}
+
+output "cluster" {
+  value = module.cluster
+}
+
+output "endpoint" {
+  value = module.rack.endpoint
+}
+
+output "release" {
+  value = local.release
+}

--- a/terraform/system/oci/telemetry.tf
+++ b/terraform/system/oci/telemetry.tf
@@ -1,0 +1,66 @@
+
+// this is auto generated(do not edit manually): go run cmd/telemetry-gen/main.go oci
+
+locals {
+  telemetry_map = {
+    buildkit_enabled         = var.buildkit_enabled
+    cert_duration            = var.cert_duration
+    compartment_ocid         = var.compartment_ocid
+    docker_hub_password      = var.docker_hub_password
+    docker_hub_username      = var.docker_hub_username
+    fluentd_memory           = var.fluentd_memory
+    gpu_node_count           = var.gpu_node_count
+    gpu_node_type            = var.gpu_node_type
+    high_availability        = var.high_availability
+    image                    = var.image
+    k8s_version              = var.k8s_version
+    name                     = var.name
+    node_count               = var.node_count
+    node_disk                = var.node_disk
+    node_memory              = var.node_memory
+    node_ocpus               = var.node_ocpus
+    node_type                = var.node_type
+    rack_name                = var.rack_name
+    region                   = var.region
+    release                  = var.release
+    settings                 = var.settings
+    syslog                   = var.syslog
+    telemetry                = var.telemetry
+    tenancy_ocid             = var.tenancy_ocid
+    terraform_update_timeout = var.terraform_update_timeout
+    user_ocid                = var.user_ocid
+    webhook_signing_key      = var.webhook_signing_key
+    whitelist                = var.whitelist
+  }
+
+  telemetry_default_map = {
+    buildkit_enabled         = "false"
+    cert_duration            = "2160h"
+    compartment_ocid         = ""
+    docker_hub_password      = ""
+    docker_hub_username      = ""
+    fluentd_memory           = "200Mi"
+    gpu_node_count           = "1"
+    gpu_node_type            = ""
+    high_availability        = "true"
+    image                    = "convox/convox"
+    k8s_version              = "1.35"
+    name                     = ""
+    node_count               = "2"
+    node_disk                = "100"
+    node_memory              = "16"
+    node_ocpus               = "2"
+    node_type                = "VM.Standard.E4.Flex"
+    rack_name                = ""
+    region                   = "us-ashburn-1"
+    release                  = ""
+    settings                 = ""
+    syslog                   = ""
+    telemetry                = "false"
+    tenancy_ocid             = ""
+    terraform_update_timeout = "2h"
+    user_ocid                = ""
+    webhook_signing_key      = ""
+    whitelist                = "0.0.0.0/0"
+  }
+}

--- a/terraform/system/oci/variables.tf
+++ b/terraform/system/oci/variables.tf
@@ -1,0 +1,130 @@
+variable "buildkit_enabled" {
+  default = false
+}
+
+variable "cert_duration" {
+  default = "2160h"
+  type    = string
+}
+
+# defaults to the tenancy root, which is also where ocir repositories live
+variable "compartment_ocid" {
+  default = ""
+  type    = string
+}
+
+variable "docker_hub_username" {
+  default = ""
+}
+
+variable "docker_hub_password" {
+  default = ""
+}
+
+variable "fingerprint" {
+  type = string
+}
+
+variable "fluentd_memory" {
+  type    = string
+  default = "200Mi"
+}
+
+variable "gpu_node_count" {
+  default = 1
+}
+
+variable "gpu_node_type" {
+  default = ""
+  type    = string
+}
+
+variable "high_availability" {
+  default = true
+}
+
+variable "image" {
+  default = "convox/convox"
+}
+
+variable "k8s_version" {
+  type    = string
+  default = "1.35"
+}
+
+variable "name" {
+  type = string
+}
+
+variable "node_count" {
+  default = 2
+}
+
+variable "node_disk" {
+  default = 100
+}
+
+variable "node_memory" {
+  default = 16
+}
+
+variable "node_ocpus" {
+  default = 2
+}
+
+variable "node_type" {
+  default = "VM.Standard.E4.Flex"
+}
+
+variable "private_key" {
+  type = string
+}
+
+variable "rack_name" {
+  default = ""
+  type    = string
+}
+
+variable "region" {
+  default = "us-ashburn-1"
+}
+
+variable "release" {
+  default = ""
+}
+
+variable "settings" {
+  default = ""
+}
+
+variable "syslog" {
+  default = ""
+}
+
+variable "telemetry" {
+  type    = bool
+  default = false
+}
+
+variable "tenancy_ocid" {
+  type = string
+}
+
+variable "terraform_update_timeout" {
+  type    = string
+  default = "2h"
+}
+
+variable "user_ocid" {
+  type = string
+}
+
+variable "webhook_signing_key" {
+  type        = string
+  default     = ""
+  description = "Optional HMAC-SHA256 key(s) for signing outbound webhook payloads. Hex-encoded; comma-separated for rotation (max 2). When set, emits Convox-Signature header. Empty preserves 3.24.5 behavior (unsigned)."
+}
+
+variable "whitelist" {
+  default = "0.0.0.0/0"
+}

--- a/terraform/system/oci/versions.tf
+++ b/terraform/system/oci/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 0.12"
+  required_providers {
+    http = {
+      source  = "hashicorp/http"
+      version = "~> 2.1"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.35.1"
+    }
+    oci = {
+      source  = "oracle/oci"
+      version = "~> 6.0"
+    }
+  }
+}


### PR DESCRIPTION
### What is the feature/fix?

We're interested in running Convox on Oracle cloud, so this extends the Convox terraform scripts and provider code to install and run racks on OCI — with GPU-based workloads supported from the start, since that was the main question mark going in.

The rack is an OKE cluster with its own VCN, OCIR for images, OCI Object Storage over its S3 compatibility API, and an optional GPU node pool.

- Terraform (`terraform/*/oci`, ~1,300 lines, six modules) follows the do/azure module shape: `system` wires `cluster` and `rack`, which composes the shared k8s modules with thin oci wrappers for api, resolver and router.
- Go (`provider/oci`, ~450 lines) mirrors `provider/do`: embeds `k8s.Provider`, implements the engine, and reuses the aws-sdk-go S3 client against the OCI compatibility endpoint with path-style addressing forced.
- OKE only issues exec kubeconfigs, so the kubernetes and helm providers shell out to `oci ce cluster generate-token`; the `oci` CLI must be on PATH for installs.
- OKE node pools have no taints argument, so the GPU pool registers `nvidia.com/gpu=:NoSchedule` through kubelet extra args in cloud-init, per Oracle's documented `oke_init_script` pattern. `nvidia.tf` installs the device plugin the same way aws/azure do, and `GPUIntanceList` matches `VM.GPU`/`BM.GPU` shapes (AMD `BM.GPU.MI*` excluded).
- Images push to OCIR at `<region-key>.ocir.io/<namespace>/<rack>/<app>`; repositories auto-create on first push under a rack-owned IAM user, group, policy and auth token created by terraform.
- `OCI_COMPARTMENT_OCID` is optional at install and defaults to the tenancy root. `private_key` and `fingerprint` are omitted from telemetry.

### Add screenshot or video (optional)

None.

### Does it has a breaking change?

No. All changes are additive: a new provider slug, new terraform modules, and new docs. Existing providers are untouched apart from adding `oci` to shared registration lists.

### How to use/test it?

```
export OCI_TENANCY_OCID=... OCI_USER_OCID=... OCI_FINGERPRINT=...
export OCI_PRIVATE_KEY="$(cat oci_api_key.pem)" OCI_REGION=us-ashburn-1
convox rack install oci dev
```

The `oci` CLI and terraform must be installed. For GPU workloads, set `gpu_node_type` (e.g. `VM.GPU.A10.1`) after requesting a service limit increase for the shape, then use `scale.gpu` in `convox.yml`. Install docs are at `docs/installation/production-rack/oci.md`.

This is a draft because no rack has been installed against a real tenancy yet. What passed: `go build ./...`, `go test` on `provider/oci`, `pkg/rack`, `pkg/cli` and `assets/provider`, `terraform validate` on all six modules, and `telemetry-gen verify`. What a first real install still needs to prove: security list sufficiency for the load balancer path, OCIR push with the auto-created user, the exec token auth flow, and the GPU cloud-init taint.

### Checklist
- [x] New coverage tests
- [x] Unit tests passing
- [ ] E2E tests passing
- [ ] E2E downgrade/update test passing
- [x] Documentation updated
- [ ] No warnings or errors on Deepsource/Codecov

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YUhi2NY2AXakyEmbWxtrA
