### PR TITLE
open a stderr stream for non-tty execs

### DIFF
--- a/provider/k8s/process.go
+++ b/provider/k8s/process.go
@@ -110,29 +110,7 @@ func (p *Provider) ProcessExec(app, pid, command string, rw io.ReadWriter, opts 
 		return 0, errors.WithStack(err)
 	}
 
-	sopts := remotecommand.StreamOptions{
-		Stdout: rw,
-		Stderr: rw,
-		Tty:    true,
-	}
-
-	if !eo.Stdin && !eo.TTY {
-		sopts.Tty = false
-	} else {
-		if eo.Stdin {
-			inr, inw := io.Pipe()
-			go io.Copy(inw, rw)
-
-			sopts.Stdin = inr
-		}
-
-		if opts.Height != nil && opts.Width != nil {
-			sopts.TerminalSizeQueue = &terminalSize{Height: *opts.Height, Width: *opts.Width}
-		}
-
-	}
-
-	err = e.StreamWithContext(p.ctx, sopts)
+	err = e.StreamWithContext(p.ctx, execStreamOptions(eo, rw, opts))
 	if ee, ok := err.(exec.ExitError); ok {
 		return ee.ExitStatus(), nil
 	}
@@ -1369,6 +1347,30 @@ func (p *Provider) processFromPod(pd ac.Pod) (*structs.Process, error) {
 	}
 
 	return ps, nil
+}
+
+func execStreamOptions(eo *ac.PodExecOptions, rw io.ReadWriter, opts structs.ProcessExecOptions) remotecommand.StreamOptions {
+	sopts := remotecommand.StreamOptions{
+		Stdout: rw,
+		Stderr: rw,
+		Tty:    eo.TTY,
+	}
+
+	if eo.Stdin {
+		inr, inw := io.Pipe()
+
+		go func() {
+			_, _ = io.Copy(inw, rw)
+		}()
+
+		sopts.Stdin = inr
+	}
+
+	if opts.Height != nil && opts.Width != nil {
+		sopts.TerminalSizeQueue = &terminalSize{Height: *opts.Height, Width: *opts.Width}
+	}
+
+	return sopts
 }
 
 type terminalSize struct {

--- a/provider/k8s/process_stream_options_test.go
+++ b/provider/k8s/process_stream_options_test.go
@@ -1,0 +1,53 @@
+package k8s
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/convox/convox/pkg/options"
+	"github.com/convox/convox/pkg/structs"
+	"github.com/stretchr/testify/require"
+	ac "k8s.io/api/core/v1"
+)
+
+func TestExecStreamOptionsTty(t *testing.T) {
+	for _, c := range []struct {
+		name  string
+		stdin bool
+		tty   bool
+	}{
+		{"interactive", true, true},
+		{"piped", true, false},
+		{"no stdin no tty", false, false},
+		{"no stdin with tty", false, true},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			rw := &bytes.Buffer{}
+
+			sopts := execStreamOptions(
+				&ac.PodExecOptions{Stdin: c.stdin, TTY: c.tty},
+				rw,
+				structs.ProcessExecOptions{Height: options.Int(24), Width: options.Int(80)},
+			)
+
+			require.Equal(t, c.tty, sopts.Tty)
+			require.Equal(t, c.stdin, sopts.Stdin != nil)
+			require.Same(t, rw, sopts.Stdout)
+			require.Same(t, rw, sopts.Stderr)
+			require.NotNil(t, sopts.TerminalSizeQueue)
+		})
+	}
+}
+
+func TestExecStreamOptionsTerminalSize(t *testing.T) {
+	eo := &ac.PodExecOptions{Stdin: true, TTY: true}
+
+	sopts := execStreamOptions(eo, &bytes.Buffer{}, structs.ProcessExecOptions{Height: options.Int(24), Width: options.Int(80)})
+	require.NotNil(t, sopts.TerminalSizeQueue)
+
+	sopts = execStreamOptions(eo, &bytes.Buffer{}, structs.ProcessExecOptions{Height: options.Int(24)})
+	require.Nil(t, sopts.TerminalSizeQueue)
+
+	sopts = execStreamOptions(eo, &bytes.Buffer{}, structs.ProcessExecOptions{})
+	require.Nil(t, sopts.TerminalSizeQueue)
+}


### PR DESCRIPTION
### What is the feature/update/fix?

**Fix: Commands Run Without a Terminal Return Their Error Output**

A command run through `convox exec`, `convox run`, or `convox test` without a terminal now returns its error output along with its normal output. The rack opens a stderr stream for those commands, matching what it already tells the Kubernetes API server to expect.

| Case | Before | After |
|-------|--------|-------|
| `convox run` in CI | stdout only | stdout and stderr, interleaved |
| Non-terminal `convox exec` | stdout only | stdout and stderr, interleaved |
| `convox test` | stdout only | stdout and stderr, interleaved |
| Interactive `convox exec <pid> bash` | unchanged | unchanged |
| An exec that disables stdin | unchanged | unchanged |

A non-terminal exec now opens error, stdin, stdout, and stderr streams and no resize stream, the same streams a non-terminal `kubectl exec` opens. An interactive session is unchanged: a real terminal merges the two output streams by design.

The two streams share one connection, so their lines can interleave and are not synchronized line by line. A terminal already behaves that way.

---

### Why is this important?

Most programs report failures on stderr, and a command run without a terminal now returns that output in the CI log alongside its normal output.

**Benefits:**

- **Error output reaches the CI log.** A migration, a build script, or a test that writes its error to stderr now has that output in the CI log.
- **Nothing to change.** No flag, no option, no manifest key. Stderr just appears in the output.
- **Every provider, no CLI upgrade.** The change is in the shared rack code path, so it applies on AWS, GCP, Azure, DigitalOcean, Metal, and Local, and any supported CLI gets it.
- **Interactive sessions unaffected.** A terminal session behaves exactly as before, including terminal resizing.

This ships with the fix that gives piped commands their end-of-input signal, so a command that reads to end of input both runs to completion and reports why it failed.

---

### How to use it?

Nothing to configure:

    $ convox exec 7b6bccfd9fdf "sh -c 'echo working; echo failed >&2'"
    working
    failed

---

### Does it have a breaking change?

**No breaking changes** are introduced with this fix, but output that was previously dropped now shows up.

No command changes its exit status and nothing that worked stops working. Anything doing an exact match on the output of `convox run`, `convox exec`, or `convox test` should expect stderr lines to appear in it now, in an order that is not guaranteed relative to stdout.

One struct field expression, a removed branch, and a helper extraction changed on the rack. There is no new field, no new option, no Terraform change, and no API surface change. An older CLI needs no change and nothing about it breaks, since the behavior is derived from the terminal option every supported CLI already sends the same way.

---

### Requirements

This fix requires version `3.25.5` or later for the rack. It is a rack-side change, so it applies to any CLI version.

**Update the Rack:** Run `convox rack update 3.25.5 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
