### PR TITLE
fix local rack in-cluster hostname resolution

### DIFF
--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -235,6 +235,7 @@ func (r *Resolver) setupRouter() error {
 		fmt.Printf("ns=resolver fn=setupRouter using ROUTER_IP_OVERRIDE=%s\n", override)
 		r.routerInternal = override
 		r.routerExternal = override
+		r.routerExternalClusterIP = override
 		return nil
 	}
 

--- a/pkg/resolver/resolver_test.go
+++ b/pkg/resolver/resolver_test.go
@@ -21,6 +21,7 @@ func TestSetupRouterOverrideUsed(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "10.96.100.50", r.routerInternal)
 	require.Equal(t, "10.96.100.50", r.routerExternal)
+	require.Equal(t, "10.96.100.50", r.routerExternalClusterIP)
 }
 
 func TestSetupRouterOverrideEmptyStringIgnored(t *testing.T) {
@@ -100,6 +101,7 @@ func TestSetupRouterFallbackWithLoadBalancer(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "10.96.0.100", r.routerInternal)
 	require.Equal(t, "203.0.113.50", r.routerExternal)
+	require.Equal(t, "10.96.0.100", r.routerExternalClusterIP)
 }
 
 func TestSetupRouterOverrideTakesPrecedenceOverService(t *testing.T) {
@@ -132,6 +134,7 @@ func TestSetupRouterOverrideTakesPrecedenceOverService(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "10.96.100.99", r.routerInternal)
 	require.Equal(t, "10.96.100.99", r.routerExternal)
+	require.Equal(t, "10.96.100.99", r.routerExternalClusterIP)
 }
 
 func TestSetupRouterNoOverrideNoService(t *testing.T) {
@@ -197,4 +200,106 @@ func TestSetupRouterOverrideTrimmedWhitespace(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "10.96.0.1", r.routerInternal)
 	require.Equal(t, "10.96.0.1", r.routerExternal)
+	require.Equal(t, "10.96.0.1", r.routerExternalClusterIP)
+}
+
+func TestSetupRouterInternalRouterService(t *testing.T) {
+	t.Setenv("ROUTER_IP_OVERRIDE", "")
+
+	router := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "router",
+			Namespace: "test-ns",
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.96.0.100",
+		},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{
+					{IP: "203.0.113.50"},
+				},
+			},
+		},
+	}
+
+	internal := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "router-internal",
+			Namespace: "test-ns",
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.96.0.200",
+		},
+	}
+
+	r := &Resolver{
+		namespace:  "test-ns",
+		kubernetes: fake.NewSimpleClientset(router, internal),
+	}
+
+	err := r.setupRouter()
+	require.NoError(t, err)
+	require.Equal(t, "10.96.0.200", r.routerInternal)
+	require.Equal(t, "203.0.113.50", r.routerExternal)
+	require.Equal(t, "10.96.0.100", r.routerExternalClusterIP)
+}
+
+func TestResolveInternalOverrideResolvesExternalIngressHost(t *testing.T) {
+	t.Setenv("ROUTER_IP_OVERRIDE", "10.96.100.50")
+
+	r := &Resolver{
+		namespace:  "test-ns",
+		kubernetes: fake.NewSimpleClientset(),
+		ingress: &Ingress{
+			hosts:         map[string]bool{"registry.dev.localdev.convox.cloud": true},
+			internalHosts: map[string]bool{},
+		},
+		service: &Service{},
+	}
+
+	err := r.setupRouter()
+	require.NoError(t, err)
+
+	ip, ok := r.resolveInternal("A", "registry.dev.localdev.convox.cloud")
+	require.True(t, ok)
+	require.Equal(t, "10.96.100.50", ip)
+}
+
+func TestResolveInternalServiceLookupUsesClusterIP(t *testing.T) {
+	t.Setenv("ROUTER_IP_OVERRIDE", "")
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "router",
+			Namespace: "test-ns",
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.96.0.100",
+		},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{
+					{IP: "203.0.113.50"},
+				},
+			},
+		},
+	}
+
+	r := &Resolver{
+		namespace:  "test-ns",
+		kubernetes: fake.NewSimpleClientset(svc),
+		ingress: &Ingress{
+			hosts:         map[string]bool{"web.app.example.com": true},
+			internalHosts: map[string]bool{},
+		},
+		service: &Service{},
+	}
+
+	err := r.setupRouter()
+	require.NoError(t, err)
+
+	ip, ok := r.resolveInternal("A", "web.app.example.com")
+	require.True(t, ok)
+	require.Equal(t, "10.96.0.100", ip)
 }


### PR DESCRIPTION
### What is the feature/update/fix?

**Fix: Local Racks Resolve Rack Hostnames From Inside the Cluster**

On a local rack, in-cluster lookups of a hostname served by a non-internal Ingress now answer with the ingress controller's cluster IP. Builds push to the rack registry by hostname, and an app reaches another app's public hostname from inside the cluster.

On the override path that only local racks take, the resolver's cluster-IP router address now gets the same validated address as the other two router fields. All three are correctly the same address on a local rack, because the local router module creates no load balancer and no internal ingress class.

Local racks answer these queries the way they did before `3.24.2`. Service names of the form `<service>.<app>.<rack>.local` were answered from a different source and were unaffected.

---

### Why is this important?

Developers run the whole platform on a local rack, and a build that cannot reach the registry by hostname fails at the first step.

**Benefits:**

- **Builds complete.** The registry push step resolves the rack hostname from inside the cluster.
- **App to app calls by public hostname work.** An app can reach another app on the same local rack through its hostname.
- **Local only.** The change is inside the override branch that only local racks take, so the resolution path every cloud rack uses is unchanged.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this fix.

A rack that does not set the router IP override never reaches the changed line, and the Service-lookup path every cloud provider takes is unchanged. There is no Terraform variable, rack parameter, API, SDK, or CLI change. The answer-or-forward decision is unchanged, so nothing that was forwarded upstream is now answered locally, and non-A queries, `.local` service names, and internal-class Ingress hosts behave as before.

---

### Requirements

This fix requires version `3.25.5` or later for the rack, and applies to local racks.

**Update the Rack:** Run `convox rack update 3.25.5 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
