### PR TITLE
upgrade aws load balancer controller to 3.5.0

### DIFF
--- a/terraform/cluster/aws/files/lbc-crds/albtargetcontrolconfigs.elbv2.k8s.aws.yaml
+++ b/terraform/cluster/aws/files/lbc-crds/albtargetcontrolconfigs.elbv2.k8s.aws.yaml
@@ -1,0 +1,186 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: albtargetcontrolconfigs.elbv2.k8s.aws
+spec:
+  group: elbv2.k8s.aws
+  names:
+    kind: ALBTargetControlConfig
+    listKind: ALBTargetControlConfigList
+    plural: albtargetcontrolconfigs
+    singular: albtargetcontrolconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The ALB target control agent sidecar image
+      jsonPath: .spec.image
+      name: IMAGE
+      type: string
+    - description: Application destination address
+      jsonPath: .spec.destinationAddress
+      name: DESTINATION
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ALBTargetControlConfig is the Schema for the albtargetcontrolconfigs
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ALBTargetControlConfigSpec defines the desired state of ALBTargetControlConfig
+            properties:
+              controlAddress:
+                description: |-
+                  ControlAddress specifies the socket (IP:port) where the load balancer exchanges management traffic with agents.
+                  The port in the socket is the target control port you configure for the target group.
+                pattern: ^.+:[0-9]+$
+                type: string
+              dataAddress:
+                description: |-
+                  DataAddress specifies the socket (IP:port) where the agent receives application traffic from the load balancer.
+                  The port in this socket is the application traffic port you configure for your target group.
+                pattern: ^.+:[0-9]+$
+                type: string
+              destinationAddress:
+                description: |-
+                  DestinationAddress specifies the socket (IP:port) where the agent proxies application traffic.
+                  Your application should be listening on this port.
+                pattern: ^.+:[0-9]+$
+                type: string
+              image:
+                description: |-
+                  Image specifies the container image for the ALB target control agent sidecar.
+                  The agent is available as a Docker image at: public.ecr.aws/aws-elb/target-optimizer/target-control-agent:latest
+                type: string
+              maxConcurrency:
+                default: 1
+                description: MaxConcurrency specifies the maximum number of concurrent
+                  requests that the target receives from the load balancer.
+                format: int32
+                maximum: 1000
+                minimum: 0
+                type: integer
+              protocolVersion:
+                description: |-
+                  ProtocolVersion specifies the protocol through which the load balancer communicates with the agent.
+                  Possible values are HTTP1, HTTP2, GRPC.
+                enum:
+                - HTTP1
+                - HTTP2
+                - GRPC
+                type: string
+              resources:
+                description: Resources specifies the resource requirements for the
+                  ALB target control agent sidecar
+                properties:
+                  claims:
+                    description: |-
+                      Claims lists the names of resources, defined in spec.resourceClaims,
+                      that are used by this container.
+
+                      This field depends on the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable. It can only be set for containers.
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: |-
+                            Name must match the name of one entry in pod.spec.resourceClaims of
+                            the Pod where this field is used. It makes that resource available
+                            inside a container.
+                          type: string
+                        request:
+                          description: |-
+                            Request is the name chosen for a request in the referenced claim.
+                            If empty, everything from the claim is made available, otherwise
+                            only the result of this request.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Limits describes the maximum amount of compute resources allowed.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Requests describes the minimum amount of compute resources required.
+                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                type: object
+              rustLog:
+                description: |-
+                  RustLog specifies the log level of the agent process. The agent software is written in Rust.
+                  Possible values are debug, info, and error.
+                enum:
+                - debug
+                - info
+                - error
+                type: string
+              tlsCertPath:
+                description: |-
+                  TLSCertPath specifies the location of the TLS certificate that the agent provides to the load balancer during TLS handshake.
+                  By default, the agent generates a self-signed certificate in-memory.
+                type: string
+              tlsKeyPath:
+                description: |-
+                  TLSKeyPath specifies the location of the private key corresponding to the TLS certificate that the agent provides to the load balancer during TLS handshake.
+                  By default, the agent generates a private key in memory.
+                type: string
+              tlsSecurityPolicy:
+                description: TLSSecurityPolicy specifies the ELB security policy that
+                  you configure for the target group.
+                type: string
+            required:
+            - controlAddress
+            - dataAddress
+            - destinationAddress
+            - image
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/terraform/cluster/aws/files/lbc-crds/globalaccelerators.aga.k8s.aws.yaml
+++ b/terraform/cluster/aws/files/lbc-crds/globalaccelerators.aga.k8s.aws.yaml
@@ -1,0 +1,402 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: globalaccelerators.aga.k8s.aws
+spec:
+  group: aga.k8s.aws
+  names:
+    kind: GlobalAccelerator
+    listKind: GlobalAcceleratorList
+    plural: globalaccelerators
+    singular: globalaccelerator
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The Global Accelerator name
+      jsonPath: .spec.name
+      name: ACCELERATOR-NAME
+      type: string
+    - description: The Global Accelerator DNS name
+      jsonPath: .status.dnsName
+      name: DNS-NAME
+      type: string
+    - description: The Global Accelerator type
+      jsonPath: .spec.type
+      name: TYPE
+      type: string
+    - description: The Global Accelerator status
+      jsonPath: .status.status
+      name: STATUS
+      type: string
+    - description: The Global Accelerator ARN
+      jsonPath: .status.acceleratorARN
+      name: ARN
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: GlobalAccelerator is the Schema for the GlobalAccelerator API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GlobalAcceleratorSpec defines the desired state of GlobalAccelerator
+            properties:
+              ipAddressType:
+                default: IPV4
+                description: IPAddressType is the value for the address type.
+                enum:
+                - IPV4
+                - DUAL_STACK
+                type: string
+              ipAddresses:
+                description: |-
+                  IpAddresses optionally specifies the IP addresses from your own IP address pool (BYOIP) to use for the accelerator's static IP addresses.
+                  You can specify one or two addresses. Do not include the /32 suffix.
+                  If you bring your own IP address pool to Global Accelerator (BYOIP), you can choose an IPv4 address from your own pool to use for the accelerator's static IPv4 address.
+                  After you bring an address range to AWS, it appears in your account as an address pool. When you create an accelerator, you can assign one IPv4 address from your range to it.
+                  Global Accelerator assigns you a second static IPv4 address from an Amazon IP address range. If you bring two IPv4 address ranges to AWS, you can assign one IPv4 address from each range to your accelerator.
+                  Note that you can't update IP addresses for an existing accelerator. To change them, you must create a new accelerator with the new addresses.
+                  For more information, see Bring your own IP addresses (BYOIP) in the AWS Global Accelerator Developer Guide.
+                  https://docs.aws.amazon.com/global-accelerator/latest/dg/using-byoip.html
+                items:
+                  type: string
+                maxItems: 2
+                minItems: 1
+                type: array
+              listeners:
+                description: Listeners defines the listeners for the Global Accelerator.
+                items:
+                  description: GlobalAcceleratorListener defines a listener for the
+                    Global Accelerator.
+                  properties:
+                    clientAffinity:
+                      default: NONE
+                      description: |-
+                        ClientAffinity lets you direct all requests from a user to the same endpoint, if you have stateful applications, regardless of the port and protocol of the client request.
+                        Client affinity gives you control over whether to always route each client to the same specific endpoint.
+                        AWS Global Accelerator uses a consistent-flow hashing algorithm to choose the optimal endpoint for a connection.
+                        If client affinity is NONE, Global Accelerator uses the "five-tuple" (5-tuple) properties—source IP address, source port, destination IP address, destination port, and protocol—to select the hash value, and then chooses the best endpoint.
+                        However, with this setting, if someone uses different ports to connect to Global Accelerator, their connections might not be always routed to the same endpoint because the hash value changes.
+                        If you want a given client to always be routed to the same endpoint, set client affinity to SOURCE_IP instead.
+                        When you use the SOURCE_IP setting, Global Accelerator uses the "two-tuple" (2-tuple) properties— source (client) IP address and destination IP address—to select the hash value.
+                        The default value is NONE.
+                      enum:
+                      - SOURCE_IP
+                      - NONE
+                      type: string
+                    endpointGroups:
+                      description: EndpointGroups defines a list of endpoint groups
+                        for a Global Accelerator listener.
+                      items:
+                        description: GlobalAcceleratorEndpointGroup defines an endpoint
+                          group for a Global Accelerator listener.
+                        properties:
+                          endpoints:
+                            description: Endpoints is the list of endpoint configurations
+                              for this endpoint group.
+                            items:
+                              description: GlobalAcceleratorEndpoint defines an endpoint
+                                for a Global Accelerator endpoint group.
+                              properties:
+                                clientIPPreservationEnabled:
+                                  default: true
+                                  description: |-
+                                    ClientIPPreservationEnabled indicates whether client IP address preservation is enabled for an Application Load Balancer endpoint.
+                                    The value is true or false. The default value is true for new accelerators.
+                                    If the value is set to true, the client's IP address is preserved in the X-Forwarded-For request header as traffic travels to applications on the Application Load Balancer endpoint fronted by the accelerator.
+                                    For more information, see Preserve Client IP Addresses in the AWS Global Accelerator Developer Guide:
+                                    https://docs.aws.amazon.com/global-accelerator/latest/dg/preserve-client-ip-address.html
+                                  type: boolean
+                                endpointID:
+                                  description: |-
+                                    EndpointID is the ID of the endpoint when type is EndpointID.
+                                    If the endpoint is a Network Load Balancer or Application Load Balancer, this is the Amazon Resource Name (ARN) of the resource.
+                                    A resource must be valid and active when you add it as an endpoint.
+                                    Mandatory for remote regions.
+                                  maxLength: 255
+                                  type: string
+                                name:
+                                  description: Name is the name of the Kubernetes
+                                    resource when type is Service, Ingress, or Gateway.
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace is the namespace of the Kubernetes resource when type is Service, Ingress, or Gateway.
+                                    If not specified, defaults to the same namespace as the GlobalAccelerator resource.
+                                  type: string
+                                type:
+                                  description: Type specifies the type of endpoint
+                                    reference.
+                                  enum:
+                                  - EndpointID
+                                  - Service
+                                  - Ingress
+                                  - Gateway
+                                  type: string
+                                weight:
+                                  default: 128
+                                  description: |-
+                                    Weight is the weight associated with the endpoint. When you add weights to endpoints, you configure Global Accelerator to route traffic based on proportions that you specify.
+                                    For example, you might specify endpoint weights of 4, 5, 5, and 6 (sum=20). The result is that 4/20 of your traffic, on average, is routed to the first endpoint,
+                                    5/20 is routed both to the second and third endpoints, and 6/20 is routed to the last endpoint.
+                                    For more information, see Endpoint Weights in the AWS Global Accelerator Developer Guide:
+                                    https://docs.aws.amazon.com/global-accelerator/latest/dg/about-endpoints-endpoint-weights.html
+                                  format: int32
+                                  maximum: 255
+                                  minimum: 0
+                                  type: integer
+                              required:
+                              - type
+                              type: object
+                              x-kubernetes-validations:
+                              - message: endpointID is required and name must not
+                                  be set when type is EndpointID
+                                rule: self.type != 'EndpointID' || (has(self.endpointID)
+                                  && !has(self.name))
+                              - message: name is required and endpointID must not
+                                  be set when type is Service/Ingress/Gateway
+                                rule: self.type == 'EndpointID' || (has(self.name)
+                                  && !has(self.endpointID))
+                            type: array
+                          portOverrides:
+                            description: PortOverrides is a list of endpoint port
+                              overrides. Allows you to override the destination ports
+                              used to route traffic to an endpoint. Using a port override
+                              lets you map a list of external destination ports (that
+                              your users send traffic to) to a list of internal destination
+                              ports that you want an application endpoint to receive
+                              traffic on.
+                            items:
+                              description: |-
+                                PortOverride defines a port override for an endpoint group.
+                                Override specific listener ports used to route traffic to endpoints that are part of an endpoint group.
+                                For example, you can create a port override in which the listener receives user traffic on ports 80 and 443,
+                                but your accelerator routes that traffic to ports 1080 and 1443, respectively, on the endpoints.
+
+                                For more information, see Port overrides in the AWS Global Accelerator Developer Guide:
+                                https://docs.aws.amazon.com/global-accelerator/latest/dg/about-endpoint-groups-port-override.html
+                              properties:
+                                endpointPort:
+                                  description: |-
+                                    EndpointPort is the endpoint port that you want traffic to be routed to.
+                                    This is the port on the endpoint, such as the Application Load Balancer or Amazon EC2 instance.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 1
+                                  type: integer
+                                listenerPort:
+                                  description: |-
+                                    ListenerPort is the listener port that you want to map to a specific endpoint port.
+                                    This is the port that user traffic arrives to the Global Accelerator on.
+                                  format: int32
+                                  maximum: 65535
+                                  minimum: 1
+                                  type: integer
+                              required:
+                              - endpointPort
+                              - listenerPort
+                              type: object
+                            type: array
+                          region:
+                            description: |-
+                              Region is the AWS Region where the endpoint group is located.
+                              If unspecified, defaults to the current cluster region.
+                            maxLength: 255
+                            type: string
+                          trafficDialPercentage:
+                            default: 100
+                            description: |-
+                              TrafficDialPercentage is the percentage of traffic to send to an AWS Regions. Additional traffic is distributed to other endpoint groups for this listener
+                              Use this action to increase (dial up) or decrease (dial down) traffic to a specific Region. The percentage is applied to the traffic that would otherwise have been routed to the Region based on optimal routing.
+                            format: int32
+                            maximum: 100
+                            minimum: 0
+                            type: integer
+                        type: object
+                      type: array
+                    portRanges:
+                      description: |-
+                        PortRanges is the list of port ranges for the connections from clients to the accelerator.
+                        When not specified, the controller will automatically determine the port ranges by inspecting
+                        the referenced Kubernetes resources (Service, Ingress, or Gateway) in the endpoint groups.
+                      items:
+                        description: PortRange defines the port range for Global Accelerator
+                          listeners.
+                        properties:
+                          fromPort:
+                            description: FromPort is the first port in the range of
+                              ports, inclusive.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          toPort:
+                            description: ToPort is the last port in the range of ports,
+                              inclusive.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                        required:
+                        - fromPort
+                        - toPort
+                        type: object
+                        x-kubernetes-validations:
+                        - message: FromPort must be less than or equal to ToPort
+                          rule: self.fromPort <= self.toPort
+                      maxItems: 10
+                      minItems: 1
+                      type: array
+                    protocol:
+                      description: |-
+                        Protocol is the protocol for the connections from clients to the accelerator.
+                        When not specified, the controller will automatically determine the protocol by inspecting
+                        the referenced Kubernetes resources (Service, Ingress, or Gateway) in the endpoint groups.
+                      enum:
+                      - TCP
+                      - UDP
+                      type: string
+                  type: object
+                type: array
+              name:
+                description: |-
+                  Name is the name of the Global Accelerator.
+                  The name must contain only alphanumeric characters or hyphens (-), and must not begin or end with a hyphen.
+                maxLength: 64
+                minLength: 1
+                pattern: ^[a-zA-Z0-9_-]{1,64}$
+                type: string
+              tags:
+                additionalProperties:
+                  type: string
+                description: Tags defines list of Tags on the Global Accelerator.
+                type: object
+            type: object
+          status:
+            description: GlobalAcceleratorStatus defines the observed state of GlobalAccelerator
+            properties:
+              acceleratorARN:
+                description: AcceleratorARN is the Amazon Resource Name (ARN) of the
+                  accelerator.
+                type: string
+              conditions:
+                description: Conditions represent the current conditions of the GlobalAccelerator.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              dnsName:
+                description: DNSName The Domain Name System (DNS) name that Global
+                  Accelerator creates that points to an accelerator's static IPv4
+                  addresses.
+                type: string
+              dualStackDnsName:
+                description: 'DualStackDnsName is the Domain Name System (DNS) name
+                  that Global Accelerator creates that points to a dual-stack accelerator''s
+                  four static IP addresses: two IPv4 addresses and two IPv6 addresses.'
+                type: string
+              ipSets:
+                description: IPSets is the static IP addresses that Global Accelerator
+                  associates with the accelerator.
+                items:
+                  description: IPSet is the static IP addresses that Global Accelerator
+                    associates with the accelerator.
+                  properties:
+                    ipAddressFamily:
+                      description: IpAddressFamily is the types of IP addresses included
+                        in this IP set.
+                      type: string
+                    ipAddresses:
+                      description: IpAddresses is the array of IP addresses in the
+                        IP address set.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: array
+              observedGeneration:
+                description: The generation observed by the GlobalAccelerator controller.
+                format: int64
+                type: integer
+              status:
+                description: Status is the current status of the accelerator.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/terraform/cluster/aws/files/lbc-crds/ingressclassparams.elbv2.k8s.aws.yaml
+++ b/terraform/cluster/aws/files/lbc-crds/ingressclassparams.elbv2.k8s.aws.yaml
@@ -1,0 +1,298 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: ingressclassparams.elbv2.k8s.aws
+spec:
+  group: elbv2.k8s.aws
+  names:
+    kind: IngressClassParams
+    listKind: IngressClassParamsList
+    plural: ingressclassparams
+    singular: ingressclassparam
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: The Ingress Group name
+      jsonPath: .spec.group.name
+      name: GROUP-NAME
+      type: string
+    - description: The AWS Load Balancer scheme
+      jsonPath: .spec.scheme
+      name: SCHEME
+      type: string
+    - description: The AWS Load Balancer ipAddressType
+      jsonPath: .spec.ipAddressType
+      name: IP-ADDRESS-TYPE
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: IngressClassParams is the Schema for the IngressClassParams API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IngressClassParamsSpec defines the desired state of IngressClassParams
+            properties:
+              PrefixListsIDs:
+                description: |-
+                  PrefixListsIDsLegacy defines the security group prefix lists for all Ingresses that belong to IngressClass with this IngressClassParams.
+                  Not Recommended, Use PrefixListsIDs (prefixListsIDs in JSON) instead
+                items:
+                  type: string
+                type: array
+              certificateArn:
+                description: CertificateArn specifies the ARN of the certificates
+                  for all Ingresses that belong to IngressClass with this IngressClassParams.
+                items:
+                  type: string
+                type: array
+              group:
+                description: Group defines the IngressGroup for all Ingresses that
+                  belong to IngressClass with this IngressClassParams.
+                properties:
+                  name:
+                    description: Name is the name of IngressGroup.
+                    type: string
+                required:
+                - name
+                type: object
+              inboundCIDRs:
+                description: InboundCIDRs specifies the CIDRs that are allowed to
+                  access the Ingresses that belong to IngressClass with this IngressClassParams.
+                items:
+                  type: string
+                type: array
+              ipAddressType:
+                description: IPAddressType defines the ip address type for all Ingresses
+                  that belong to IngressClass with this IngressClassParams.
+                enum:
+                - ipv4
+                - dualstack
+                - dualstack-without-public-ipv4
+                type: string
+              ipamConfiguration:
+                description: IPAMConfiguration defines the IPAM settings for a Load
+                  Balancer.
+                properties:
+                  ipv4IPAMPoolId:
+                    description: IPv4IPAMPoolId defines the IPAM pool ID used for
+                      IPv4 Addresses on the ALB.
+                    type: string
+                type: object
+              listeners:
+                description: Listeners define a list of listeners with their protocol,
+                  port and attributes.
+                items:
+                  properties:
+                    listenerAttributes:
+                      description: The attributes of the listener
+                      items:
+                        description: Attributes defines custom attributes on resources.
+                        properties:
+                          key:
+                            description: The key of the attribute.
+                            type: string
+                          value:
+                            description: The value of the attribute.
+                            type: string
+                        required:
+                        - key
+                        - value
+                        type: object
+                      type: array
+                    port:
+                      description: The port of the listener
+                      format: int32
+                      type: integer
+                    protocol:
+                      description: The protocol of the listener
+                      type: string
+                  type: object
+                type: array
+              loadBalancerAttributes:
+                description: LoadBalancerAttributes define the custom attributes to
+                  LoadBalancers for all Ingress that that belong to IngressClass with
+                  this IngressClassParams.
+                items:
+                  description: Attributes defines custom attributes on resources.
+                  properties:
+                    key:
+                      description: The key of the attribute.
+                      type: string
+                    value:
+                      description: The value of the attribute.
+                      type: string
+                  required:
+                  - key
+                  - value
+                  type: object
+                type: array
+              loadBalancerName:
+                description: LoadBalancerName defines the name of the load balancer
+                  that will be created with this IngressClassParams.
+                type: string
+              minimumLoadBalancerCapacity:
+                description: MinimumLoadBalancerCapacity define the capacity reservation
+                  for LoadBalancers for all Ingress that belong to IngressClass with
+                  this IngressClassParams.
+                properties:
+                  capacityUnits:
+                    description: The Capacity Units Value.
+                    format: int32
+                    type: integer
+                required:
+                - capacityUnits
+                type: object
+              namespaceSelector:
+                description: |-
+                  NamespaceSelector restrict the namespaces of Ingresses that are allowed to specify the IngressClass with this IngressClassParams.
+                  * if absent or present but empty, it selects all namespaces.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              prefixListsIDs:
+                description: PrefixListsIDs defines the security group prefix lists
+                  for all Ingresses that belong to IngressClass with this IngressClassParams.
+                items:
+                  type: string
+                type: array
+              scheme:
+                description: Scheme defines the scheme for all Ingresses that belong
+                  to IngressClass with this IngressClassParams.
+                enum:
+                - internal
+                - internet-facing
+                type: string
+              sslPolicy:
+                description: SSLPolicy specifies the SSL Policy for all Ingresses
+                  that belong to IngressClass with this IngressClassParams.
+                type: string
+              sslRedirectPort:
+                description: SSLRedirectPort specifies the SSL Redirect Port for all
+                  Ingresses that belong to IngressClass with this IngressClassParams.
+                type: string
+              subnets:
+                description: Subnets defines the subnets for all Ingresses that belong
+                  to IngressClass with this IngressClassParams.
+                properties:
+                  ids:
+                    description: IDs specify the resource IDs of subnets. Exactly
+                      one of this or `tags` must be specified.
+                    items:
+                      description: SubnetID specifies a subnet ID.
+                      pattern: subnet-[0-9a-f]+
+                      type: string
+                    minItems: 1
+                    type: array
+                  tags:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: |-
+                      Tags specifies subnets in the load balancer's VPC where each
+                      tag specified in the map key contains one of the values in the corresponding
+                      value list.
+                      Exactly one of this or `ids` must be specified.
+                    type: object
+                type: object
+              tags:
+                description: Tags defines list of Tags on AWS resources provisioned
+                  for Ingresses that belong to IngressClass with this IngressClassParams.
+                items:
+                  description: Tag defines a AWS Tag on resources.
+                  properties:
+                    key:
+                      description: The key of the tag.
+                      type: string
+                    value:
+                      description: The value of the tag.
+                      type: string
+                  required:
+                  - key
+                  - value
+                  type: object
+                type: array
+              targetType:
+                description: TargetType defines the target type of target groups for
+                  all Ingresses that belong to IngressClass with this IngressClassParams.
+                enum:
+                - instance
+                - ip
+                type: string
+              wafv2AclArn:
+                description: WAFv2ACLArn specifies ARN for the Amazon WAFv2 web ACL.
+                type: string
+              wafv2AclName:
+                description: WAFv2ACLName specifies name of the Amazon WAFv2 web ACL.
+                type: string
+            type: object
+            x-kubernetes-validations:
+            - message: cannot specify both 'prefixListsIDs' and 'PrefixListsIDs' fields
+              rule: '!(has(self.prefixListsIDs) && has(self.PrefixListsIDs))'
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/terraform/cluster/aws/files/lbc-crds/targetgroupbindings.elbv2.k8s.aws.yaml
+++ b/terraform/cluster/aws/files/lbc-crds/targetgroupbindings.elbv2.k8s.aws.yaml
@@ -1,0 +1,519 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: targetgroupbindings.elbv2.k8s.aws
+spec:
+  group: elbv2.k8s.aws
+  names:
+    kind: TargetGroupBinding
+    listKind: TargetGroupBindingList
+    plural: targetgroupbindings
+    singular: targetgroupbinding
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The Kubernetes Service's name
+      jsonPath: .spec.serviceRef.name
+      name: SERVICE-NAME
+      type: string
+    - description: The Kubernetes Service's port
+      jsonPath: .spec.serviceRef.port
+      name: SERVICE-PORT
+      type: string
+    - description: The AWS TargetGroup's TargetType
+      jsonPath: .spec.targetType
+      name: TARGET-TYPE
+      type: string
+    - description: The AWS TargetGroup's Amazon Resource Name
+      jsonPath: .spec.targetGroupARN
+      name: ARN
+      priority: 1
+      type: string
+    - description: The AWS TargetGroup's Name
+      jsonPath: .spec.targetGroupName
+      name: NAME
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TargetGroupBinding is the Schema for the TargetGroupBinding API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TargetGroupBindingSpec defines the desired state of TargetGroupBinding
+            properties:
+              assumeRoleExternalId:
+                description: IAM Role ARN to assume when calling AWS APIs. Needed
+                  to assume a role in another account and prevent the confused deputy
+                  problem. https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html
+                type: string
+              iamRoleArnToAssume:
+                description: IAM Role ARN to assume when calling AWS APIs. Useful
+                  if the target group is in a different AWS account
+                type: string
+              multiClusterTargetGroup:
+                description: MultiClusterTargetGroup Denotes if the TargetGroup is
+                  shared among multiple clusters
+                type: boolean
+              networking:
+                description: networking provides the networking setup for ELBV2 LoadBalancer
+                  to access targets in TargetGroup.
+                properties:
+                  ingress:
+                    description: List of ingress rules to allow ELBV2 LoadBalancer
+                      to access targets in TargetGroup.
+                    items:
+                      properties:
+                        from:
+                          description: |-
+                            List of peers which should be able to access the targets in TargetGroup.
+                            At least one NetworkingPeer should be specified.
+                          items:
+                            description: NetworkingPeer defines the source/destination
+                              peer for networking rules.
+                            properties:
+                              ipBlock:
+                                description: |-
+                                  IPBlock defines an IPBlock peer.
+                                  If specified, none of the other fields can be set.
+                                properties:
+                                  cidr:
+                                    description: |-
+                                      CIDR is the network CIDR.
+                                      Both IPV4 or IPV6 CIDR are accepted.
+                                    type: string
+                                required:
+                                - cidr
+                                type: object
+                              securityGroup:
+                                description: |-
+                                  SecurityGroup defines a SecurityGroup peer.
+                                  If specified, none of the other fields can be set.
+                                properties:
+                                  groupID:
+                                    description: GroupID is the EC2 SecurityGroupID.
+                                    type: string
+                                required:
+                                - groupID
+                                type: object
+                            type: object
+                          type: array
+                        ports:
+                          description: |-
+                            List of ports which should be made accessible on the targets in TargetGroup.
+                            If ports is empty or unspecified, it defaults to all ports with TCP.
+                          items:
+                            properties:
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  The port which traffic must match.
+                                  When NodePort endpoints(instance TargetType) is used, this must be a numerical port.
+                                  When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods.
+                                  if port is unspecified, it defaults to all ports.
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                description: |-
+                                  The protocol which traffic must match.
+                                  If protocol is unspecified, it defaults to TCP.
+                                enum:
+                                - TCP
+                                - UDP
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - from
+                      - ports
+                      type: object
+                    type: array
+                type: object
+              serviceRef:
+                description: serviceRef is a reference to a Kubernetes Service and
+                  ServicePort.
+                properties:
+                  name:
+                    description: Name is the name of the Service.
+                    type: string
+                  port:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Port is the port of the ServicePort.
+                    x-kubernetes-int-or-string: true
+                required:
+                - name
+                - port
+                type: object
+              targetGroupARN:
+                description: targetGroupARN is the Amazon Resource Name (ARN) for
+                  the TargetGroup.
+                type: string
+              targetGroupName:
+                description: targetGroupName is the Name of the TargetGroup.
+                type: string
+              targetType:
+                description: targetType is the TargetType of TargetGroup. If unspecified,
+                  it will be automatically inferred.
+                enum:
+                - instance
+                - ip
+                type: string
+            required:
+            - serviceRef
+            type: object
+          status:
+            description: TargetGroupBindingStatus defines the observed state of TargetGroupBinding
+            properties:
+              observedGeneration:
+                description: The generation observed by the TargetGroupBinding controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: The Kubernetes Service's name
+      jsonPath: .spec.serviceRef.name
+      name: SERVICE-NAME
+      type: string
+    - description: The Kubernetes Service's port
+      jsonPath: .spec.serviceRef.port
+      name: SERVICE-PORT
+      type: string
+    - description: The AWS TargetGroup's TargetType
+      jsonPath: .spec.targetType
+      name: TARGET-TYPE
+      type: string
+    - description: The AWS TargetGroup's Amazon Resource Name
+      jsonPath: .spec.targetGroupARN
+      name: ARN
+      priority: 1
+      type: string
+    - description: The AWS TargetGroup's Name
+      jsonPath: .spec.targetGroupName
+      name: NAME
+      priority: 2
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: TargetGroupBinding is the Schema for the TargetGroupBinding API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TargetGroupBindingSpec defines the desired state of TargetGroupBinding
+            properties:
+              assumeRoleExternalId:
+                description: IAM Role ARN to assume when calling AWS APIs. Needed
+                  to assume a role in another account and prevent the confused deputy
+                  problem. https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html
+                type: string
+              iamRoleArnToAssume:
+                description: IAM Role ARN to assume when calling AWS APIs. Useful
+                  if the target group is in a different AWS account
+                type: string
+              ipAddressType:
+                description: ipAddressType specifies whether the target group is of
+                  type IPv4 or IPv6. If unspecified, it will be automatically inferred.
+                enum:
+                - ipv4
+                - ipv6
+                type: string
+              multiClusterTargetGroup:
+                description: MultiClusterTargetGroup Denotes if the TargetGroup is
+                  shared among multiple clusters
+                type: boolean
+              networking:
+                description: networking defines the networking rules to allow ELBV2
+                  LoadBalancer to access targets in TargetGroup.
+                properties:
+                  ingress:
+                    description: List of ingress rules to allow ELBV2 LoadBalancer
+                      to access targets in TargetGroup.
+                    items:
+                      description: NetworkingIngressRule defines a particular set
+                        of traffic that is allowed to access TargetGroup's targets.
+                      properties:
+                        from:
+                          description: |-
+                            List of peers which should be able to access the targets in TargetGroup.
+                            At least one NetworkingPeer should be specified.
+                          items:
+                            description: NetworkingPeer defines the source/destination
+                              peer for networking rules.
+                            properties:
+                              ipBlock:
+                                description: |-
+                                  IPBlock defines an IPBlock peer.
+                                  If specified, none of the other fields can be set.
+                                properties:
+                                  cidr:
+                                    description: |-
+                                      CIDR is the network CIDR.
+                                      Both IPV4 or IPV6 CIDR are accepted.
+                                    type: string
+                                required:
+                                - cidr
+                                type: object
+                              securityGroup:
+                                description: |-
+                                  SecurityGroup defines a SecurityGroup peer.
+                                  If specified, none of the other fields can be set.
+                                properties:
+                                  groupID:
+                                    description: GroupID is the EC2 SecurityGroupID.
+                                    type: string
+                                required:
+                                - groupID
+                                type: object
+                            type: object
+                          type: array
+                        ports:
+                          description: |-
+                            List of ports which should be made accessible on the targets in TargetGroup.
+                            If ports is empty or unspecified, it defaults to all ports with TCP.
+                          items:
+                            description: NetworkingPort defines the port and protocol
+                              for networking rules.
+                            properties:
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  The port which traffic must match.
+                                  When NodePort endpoints(instance TargetType) is used, this must be a numerical port.
+                                  When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods.
+                                  if port is unspecified, it defaults to all ports.
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                description: |-
+                                  The protocol which traffic must match.
+                                  If protocol is unspecified, it defaults to TCP.
+                                enum:
+                                - TCP
+                                - UDP
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - from
+                      - ports
+                      type: object
+                    type: array
+                type: object
+              nodeSelector:
+                description: node selector for instance type target groups to only
+                  register certain nodes
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              serviceRef:
+                description: serviceRef is a reference to a Kubernetes Service and
+                  ServicePort.
+                properties:
+                  name:
+                    description: Name is the name of the Service.
+                    type: string
+                  port:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Port is the port of the ServicePort.
+                    x-kubernetes-int-or-string: true
+                required:
+                - name
+                - port
+                type: object
+              targetGroupARN:
+                description: targetGroupARN is the Amazon Resource Name (ARN) for
+                  the TargetGroup.
+                type: string
+              targetGroupName:
+                description: targetGroupName is the Name of the TargetGroup.
+                type: string
+              targetGroupProtocol:
+                description: targetGroupProtocol is the Protocol of the TargetGroup.
+                  If unspecified, it will be automatically inferred.
+                enum:
+                - HTTP
+                - HTTPS
+                - TCP
+                - TLS
+                - UDP
+                - TCP_UDP
+                - QUIC
+                - TCP_QUIC
+                type: string
+              targetType:
+                description: targetType is the TargetType of TargetGroup. If unspecified,
+                  it will be automatically inferred.
+                enum:
+                - instance
+                - ip
+                type: string
+              vpcID:
+                description: VpcID is the VPC of the TargetGroup. If unspecified,
+                  it will be automatically inferred.
+                type: string
+            required:
+            - serviceRef
+            type: object
+          status:
+            description: TargetGroupBindingStatus defines the observed state of TargetGroupBinding
+            properties:
+              conditions:
+                description: Conditions describe the current conditions of the TargetGroupBinding.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: The generation observed by the TargetGroupBinding controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/terraform/cluster/aws/files/lbc_policy.json
+++ b/terraform/cluster/aws/files/lbc_policy.json
@@ -29,6 +29,9 @@
                 "ec2:DescribeTags",
                 "ec2:GetCoipPoolUsage",
                 "ec2:DescribeCoipPools",
+                "ec2:GetSecurityGroupsForVpc",
+                "ec2:DescribeIpamPools",
+                "ec2:DescribeRouteTables",
                 "elasticloadbalancing:DescribeLoadBalancers",
                 "elasticloadbalancing:DescribeLoadBalancerAttributes",
                 "elasticloadbalancing:DescribeListeners",
@@ -39,7 +42,9 @@
                 "elasticloadbalancing:DescribeTargetGroupAttributes",
                 "elasticloadbalancing:DescribeTargetHealth",
                 "elasticloadbalancing:DescribeTags",
-                "elasticloadbalancing:DescribeTrustStores"
+                "elasticloadbalancing:DescribeTrustStores",
+                "elasticloadbalancing:DescribeListenerAttributes",
+                "elasticloadbalancing:DescribeCapacityReservation"
             ],
             "Resource": "*"
         },
@@ -188,7 +193,10 @@
                 "elasticloadbalancing:DeleteLoadBalancer",
                 "elasticloadbalancing:ModifyTargetGroup",
                 "elasticloadbalancing:ModifyTargetGroupAttributes",
-                "elasticloadbalancing:DeleteTargetGroup"
+                "elasticloadbalancing:DeleteTargetGroup",
+                "elasticloadbalancing:ModifyListenerAttributes",
+                "elasticloadbalancing:ModifyCapacityReservation",
+                "elasticloadbalancing:ModifyIpPools"
             ],
             "Resource": "*",
             "Condition": {
@@ -234,7 +242,8 @@
                 "elasticloadbalancing:ModifyListener",
                 "elasticloadbalancing:AddListenerCertificates",
                 "elasticloadbalancing:RemoveListenerCertificates",
-                "elasticloadbalancing:ModifyRule"
+                "elasticloadbalancing:ModifyRule",
+                "elasticloadbalancing:SetRulePriorities"
             ],
             "Resource": "*"
         }

--- a/terraform/cluster/aws/lbc.tf
+++ b/terraform/cluster/aws/lbc.tf
@@ -56,18 +56,34 @@ resource "kubernetes_service_account" "lbc" {
 }
 
 
+# One document per file from the chart's crds/crds.yaml, tracking the chart
+# version below. Helm installs CRDs only on a first install. Never deleted:
+# dropping the TargetGroupBinding CRD cascades to every binding in the cluster.
+resource "kubectl_manifest" "lbc_crds" {
+  for_each = fileset("${path.module}/files/lbc-crds", "*.yaml")
+
+  depends_on = [null_resource.wait_eks_addons]
+
+  yaml_body         = file("${path.module}/files/lbc-crds/${each.value}")
+  server_side_apply = true
+  force_conflicts   = true
+  apply_only        = true
+}
+
+
 resource "helm_release" "aws_lbc" {
   depends_on = [
     null_resource.wait_eks_addons,
     aws_iam_role.lbc,
     aws_iam_role_policy.lbc_policy,
     aws_eks_node_group.cluster,
+    kubectl_manifest.lbc_crds,
   ]
 
   name       = "aws-lbc"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-load-balancer-controller"
-  version    = "1.7.2"
+  version    = "3.5.0"
   namespace  = "kube-system"
   timeout    = 600
 
@@ -93,6 +109,31 @@ resource "helm_release" "aws_lbc" {
 
   set {
     name  = "enableServiceMutatorWebhook"
+    value = "false"
+  }
+
+  # Chart 3.x defaults this to false, which mints a new webhook CA on every
+  # render while the running pod still serves the old one.
+  set {
+    name  = "keepTLSSecret"
+    value = "true"
+  }
+
+  # These default to on, and the controller exits if Gateway setup fails.
+  # Setting them explicitly also pins them: the controller's startup probe
+  # only adjusts gates that were left at their default.
+  set {
+    name  = "controllerConfig.featureGates.NLBGatewayAPI"
+    value = "false"
+  }
+
+  set {
+    name  = "controllerConfig.featureGates.ALBGatewayAPI"
+    value = "false"
+  }
+
+  set {
+    name  = "controllerConfig.featureGates.GatewayListenerSet"
     value = "false"
   }
 
@@ -135,6 +176,13 @@ resource "helm_release" "aws_lbc" {
     content {
       name  = "tolerations[0].effect"
       value = "NoSchedule"
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = length(fileset("${path.module}/files/lbc-crds", "*.yaml")) > 0
+      error_message = "files/lbc-crds is empty: the controller CRDs must be applied before the chart upgrades."
     }
   }
 }


### PR DESCRIPTION
### What is the feature/update/fix?

**Update: AWS Load Balancer Controller 3.5.0**

The AWS Load Balancer Controller on AWS racks moves from chart `1.7.2` to chart `3.5.0`, which installs controller `v3.5.0`. Upstream still maintains the v3 line.

The controller manages the rack's router Services. App ingresses are nginx or Contour class and are not involved. Racks installed before `3.18.0` have a router load balancer owned by the in-tree AWS cloud provider, which this controller never adopts, so nothing changes for those routers.

**Changes:**

| Area | Change |
|------|--------|
| Chart | `1.7.2` to `3.5.0` |
| IAM policy | Replaced with upstream's policy at `v3.5.0`, nine actions added and none removed |
| CRDs | The chart's four CRDs are vendored and applied with the chart, so their schema tracks the controller |
| Pinned values | `keepTLSSecret` pinned to `true`, and the three Gateway API feature gates set explicitly to `false` |

Two of the nine added IAM actions are required: without `elasticloadbalancing:DescribeListenerAttributes` the controller stops reconciling, and without `ec2:GetSecurityGroupsForVpc` it cannot create a load balancer. The remaining seven cover ALB rules, listener attributes, capacity reservations, IPAM pools, and route tables, none of which the routers use. The policy is applied before the new image starts.

Helm installs CRDs on first install and never updates them, so the four CRDs are applied directly, with server-side apply, and their schema tracks the controller that writes to them. They are never deleted, because deleting the TargetGroupBinding CRD would delete every TargetGroupBinding in the cluster. The chart's Gateway API CRDs are deliberately not installed.

`keepTLSSecret` defaults to `false` in chart 3.x, which regenerates the webhook CA on every render while the running pod still serves the old certificate. The ingress webhook fails closed and every deploy writes an Ingress, so it is pinned to `true`, which is the current behavior. The three Gateway API gates are on by default in v3; the controller turns them off itself only while the Gateway API CRDs are absent, and that check stops applying the first time anything installs those CRDs on the cluster, so all three are pinned rather than left to default.

**What does not change:**

- No load balancer, listener, target group, or security group is replaced. The name inputs are the same at both versions, and the routers set their load balancer name explicitly.
- Ownership tags are unchanged, so the new controller recognizes the load balancer the old one built.
- No rack parameter, CLI flag, API field, or Terraform variable changes. `nlb_security_group`, `deploy_extra_nlb`, `idle_timeout`, `proxy_protocol`, and `internal_router` behave as before.
- AWS only. The controller is not installed by the other cluster modules.

The upgrade changes two behaviors. `enableEndpointSlices` is on by default from v3, which has no effect here because the routers use instance targets. On Karpenter racks, draining nodes now leave the router target groups rather than staying registered until the Node object disappears.

---

### Why is this important?

The router is the shared path for every app on an AWS rack, and this controller provisions and reconciles the router load balancer. On a maintained release line, the controller keeps receiving upstream fixes and stays compatible with the AWS APIs it calls.

**Benefits:**

- **A maintained release line.** The controller tracks a version that upstream still ships fixes for.
- **CRD schema that matches the controller.** The vendored CRDs carry the fields this controller writes, so it stops rewriting fields on every reconcile pass.
- **The webhook certificate does not change.** Pinning `keepTLSSecret` keeps the webhook CA and the serving certificate matched across a chart render, so deploys keep working through the upgrade.
- **Explicit feature gates.** The Gateway API gates are set rather than inherited, so installing Gateway API CRDs on a cluster later does not silently turn three controller subsystems on.
- **No endpoint change.** The router load balancer, its DNS name, its listeners, and its target groups are the same objects after the upgrade.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this update.

No load balancer is replaced and no router endpoint changes. Chart values are additive across the two versions, so everything the rack sets still exists, and the controller's own arguments differ only by the feature gates flag. Nothing outside AWS racks is touched.

On a rollback, the chart, image, and IAM policy revert with the module in one apply. The CRDs stay, and that does not break the older controller: the newer schema only adds fields, its required set is no longer, the API versions are unchanged, there is no conversion webhook, and the older controller ignores fields it does not know.

One sequencing detail if you do roll back: the IAM policy narrows before the chart reverts, so the new image runs against the older policy for the length of the Helm step and logs permission errors until the older pod takes over. It clears on its own.

---

### Requirements

This update requires version `3.25.5` or later for the rack, and applies to AWS racks.

**Update the Rack:** Run `convox rack update 3.25.5 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
