### PR TITLE
keep terraform parseable on legacy rack binaries

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -82,6 +82,33 @@ jobs:
             (cd "$dir" && tflint --config "$(git rev-parse --show-toplevel)/.tflint.hcl")
           done
 
+  terraform-fleet-floor:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: terraform fleet floor
+        run: |
+          set +e
+          hits=$(grep -rnE --include='*.tf' --include='*.tpl' --include='*.sh' --exclude-dir=.terraform \
+            -e '(^|[^A-Za-z0-9_])(alltrue|anytrue|endswith|ephemeralasnull|issensitive|nonsensitive|one|optional|plantimestamp|sensitive|startswith|strcontains|templatestring|textdecodebase64|textencodebase64|timecmp)\(' \
+            -e '^(check|import|moved|removed)[[:space:]]*[{"]' \
+            -e '(^|[^A-Za-z0-9_])(precondition|postcondition)[[:space:]]*\{' \
+            -e '(^|[^A-Za-z0-9_])replace_triggered_by[[:space:]]*=' \
+            -e '(^[[:space:]]*|\{[[:space:]]*)(sensitive|nullable)[[:space:]]*=' \
+            terraform)
+          rc=$?
+          set -e
+          if [ "$rc" -eq 0 ]; then
+            printf '%s\n' "$hits"
+            echo "Terraform construct above the fleet floor. A rack keeps the binary it was installed with, so terraform/ must stay parseable on the oldest binary in the fleet."
+            exit 1
+          fi
+          if [ "$rc" -ne 1 ]; then
+            echo "fleet floor scan failed: grep exited $rc"
+            exit 1
+          fi
+
   terraform-security:
     runs-on: ubuntu-22.04
     steps:

--- a/terraform/api/k8s/main.tf
+++ b/terraform/api/k8s/main.tf
@@ -518,7 +518,7 @@ resource "kubernetes_service" "api" {
 locals {
   ingress_annotations = var.router_type == "contour" ? {
     for k, v in var.annotations : k => v
-    if !startswith(k, "cert-manager.io/")
+    if length(regexall("^cert-manager\\.io/", k)) == 0
   } : var.annotations
 }
 

--- a/terraform/cluster/aws/lbc.tf
+++ b/terraform/cluster/aws/lbc.tf
@@ -178,11 +178,4 @@ resource "helm_release" "aws_lbc" {
       value = "NoSchedule"
     }
   }
-
-  lifecycle {
-    precondition {
-      condition     = length(fileset("${path.module}/files/lbc-crds", "*.yaml")) > 0
-      error_message = "files/lbc-crds is empty: the controller CRDs must be applied before the chart upgrades."
-    }
-  }
 }


### PR DESCRIPTION
### What is the feature/update/fix?

**Fix: Rack Updates on Racks Pinned to an Older Terraform Binary**

An AWS rack whose Terraform state records a binary older than `1.2.0` can update to `3.25.6`. The `3.25.5` module tree used a `lifecycle` precondition, which needs Terraform 1.2, so on those racks `terraform init` stopped while decoding the configuration, before any module or provider was downloaded, and `3.25.5` could not be applied:

```
Error: Unsupported block type

  on .terraform/modules/system/terraform/cluster/aws/lbc.tf line 183, in resource "helm_release" "aws_lbc":
 183:     precondition {

Blocks of type "precondition" are not expected here.
```

On a Console-managed rack the Terraform binary that runs a rack update is chosen from the version recorded in that rack's own state, and Terraform writes its version back into state on every apply, so the rack keeps the binary it was installed with. A self-managed rack runs whichever `terraform` is first on PATH where `convox rack update` runs.

**Changes:**

| File | Change |
|------|--------|
| `terraform/cluster/aws/lbc.tf` | The `lifecycle` precondition on `helm_release.aws_lbc` is removed |
| `terraform/api/k8s/main.tf` | `startswith()` is replaced with an equivalent `regexall()` prefix test |

CRD ordering does not depend on the removed precondition. `helm_release.aws_lbc` already lists `kubectl_manifest.lbc_crds` in its `depends_on`, so the controller CRDs are applied before the chart exactly as before. The precondition only asserted that the CRD files committed with the module exist.

`startswith()` needs Terraform 1.3 and is reached only when `router_type=contour`, where it drops the `cert-manager.io/` annotations from the API ingress; on those racks it failed at plan. The `regexall()` form drops the same annotations.

**CI check.** A new `terraform-fleet-floor` job in the lint workflow fails a pull request that adds a Terraform construct newer than the oldest binary a rack can be running. It scans `*.tf`, `*.tpl`, and `*.sh` files under `terraform/` on a plain checkout, with no Terraform tooling, against the pattern list in `.github/fleet-floor-patterns`. The forms it rejects:

| Form | Constructs |
|------|------------|
| Function call | `alltrue`, `anytrue`, `endswith`, `ephemeralasnull`, `issensitive`, `nonsensitive`, `one`, `optional`, `plantimestamp`, `sensitive`, `startswith`, `strcontains`, `templatestring`, `textdecodebase64`, `textencodebase64`, `timecmp` |
| Top-level block | `check`, `import`, `moved`, `removed` |
| Nested block | `precondition`, `postcondition` |
| Lifecycle argument | `replace_triggered_by` |
| Variable argument | `sensitive`, `nullable` |

`sum()`, `try()`, and `can()` evaluate on the oldest binary in use and are deliberately not listed.

**Terraform versions.** Behavior by binary on the `3.25.6` tree rooted at `terraform/system/aws`:

| Binary | Result |
|--------|--------|
| `0.13.2` | init and validate complete |
| `1.1.9` | init and validate complete |
| `1.2.0` | fails on a module `count` and `for_each` limitation of that release, on `3.25.4` and `3.25.5` as well; not a usable version for this tree |
| `1.2.9` | init completes |
| `1.5.2` | init completes |

---

### Why is this important?

A Console-managed rack installed with a `0.13` or `1.1` binary still runs that binary on every update. Those racks can now reach the current release without changing the binary, and CI rejects a newer construct in the module tree, so a later release cannot reintroduce one.

**Benefits:**

- **Every AWS rack can reach `3.25.6`.** A rack whose state records a binary below `1.2.0` updates from `3.25.4` directly to `3.25.6`.
- **No binary change.** The update runs under the rack's existing Terraform binary, and the state keeps recording that binary afterwards.
- **Same controller behavior.** The AWS Load Balancer Controller chart, its CRDs, and the order they apply in are unchanged.
- **Checked in CI.** A construct newer than the oldest binary in use fails the pull request that introduces it, before it reaches a release.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this fix.

No Terraform variable is added or removed, no resource changes, and state is untouched in either direction. A rack on `3.25.4` with such a binary updates directly to `3.25.6`, skipping `3.25.5`.

Downgrading such a rack to `3.25.5` returns it to the same `terraform init` failure. `3.25.4` still applies, so a downgrade from `3.25.6` on one of these racks goes to `3.25.4`, not `3.25.5`.

`helm_release.aws_lbc` exists only in the AWS cluster module. `terraform/api/k8s` is shared by every provider, but `router_type` is declared only on the AWS path and defaults to `nginx`, so the API ingress annotations on GCP, Azure, DigitalOcean, Metal, and Local are `var.annotations` unchanged, before and after.

---

### Requirements

This fix requires version `3.25.6` or later for the rack, and applies to AWS racks. A rack currently on `3.25.4` updates directly to `3.25.6`. The change is in the rack's Terraform modules, so no CLI update is required.

**Update the Rack:** Run `convox rack update 3.25.6 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
