### PR TITLE
support efs on public subnet racks

### DIFF
--- a/terraform/cluster/aws/efs.tf
+++ b/terraform/cluster/aws/efs.tf
@@ -49,11 +49,16 @@ resource "aws_efs_file_system" "convox_efs" {
   tags             = local.tags
 }
 
+locals {
+  // keep existing mount targets in place on racks that have private subnets
+  efs_mount_subnets_ids = var.private || length(var.private_subnets_ids) > 0 ? local.private_subnets_ids : local.public_subnets_ids
+}
+
 resource "aws_efs_mount_target" "efs_mount" {
-  count = var.efs_csi_driver_enable ? length(local.private_subnets_ids) : 0
+  count = var.efs_csi_driver_enable ? length(local.efs_mount_subnets_ids) : 0
 
   file_system_id  = aws_efs_file_system.convox_efs[0].id
-  subnet_id       = local.private_subnets_ids[count.index]
+  subnet_id       = local.efs_mount_subnets_ids[count.index]
   security_groups = [aws_security_group.efs_security_group[0].id]
 }
 


### PR DESCRIPTION
### What is the feature/update/fix?

**Fix: EFS on AWS Racks Installed with `private=false`**

Enabling `efs_csi_driver_enable` on an AWS rack installed with `private=false` now creates EFS mount targets, one per availability zone, in the rack's public subnets. Previously that rack got the filesystem, the storage classes and `efs-pv-root` but no mount targets, so EFS volumes could not mount.

Mount targets go in the rack's private subnets when it has any, and in its public subnets when it has none. The expression checks the supplied private subnet list as well as the `private` flag because a `private=false` rack that supplied both `private_subnets_ids` and `public_subnets_ids` already has working mount targets in its private subnets, and `subnet_id` forces replacement on `aws_efs_mount_target`, so those are left where they are.

**Which racks change:**

| `private` | `private_subnets_ids` | `public_subnets_ids` | Before | After |
|---|---|---|---|---|
| `true` | | | 2 or 3 private subnets | unchanged |
| `false` | | | none | 2 or 3 public subnets |
| `true` | supplied | supplied | the supplied private subnets | unchanged |
| `false` | supplied | supplied | the supplied private subnets | unchanged |
| `false` | | supplied | none | the supplied public subnets |

On a rack whose subnets Convox created, the count is 2, or 3 with `high_availability`, the same on either path. On a rack that supplied its own subnets it follows the supplied list, and EFS allows one mount target per availability zone, so a supplied `public_subnets_ids` list has to cover distinct zones. An empty list on either side fails at install before EFS is involved, because the EKS cluster takes the public subnet list and the system node group indexes whichever list `private` selects.

Reachability is the same in either subnet type. The mount target security group rule sources the cluster security group, not a CIDR, and a mount target's network interface takes a private VPC address, so NFS port 2049 stays reachable only from the cluster.

`private` is install-only, so a rack cannot be moved between the two cases. A rack installed with `private=false` picks this up by updating and then setting the parameter:

    $ convox rack params set efs_csi_driver_enable=true -r rackName

---

### Why is this important?

EFS is the `ReadWriteMany` storage behind shared volumes on AWS racks, and a pod reaches it through a mount target in its own availability zone. Racks without private subnets now get one per zone.

**Benefits:**

- **EFS volumes mount on public racks.** A rack installed with `private=false` can enable EFS and run pods with EFS-backed volumes across nodes and zones.
- **Same layout as a private rack.** One mount target per availability zone, 2 or 3 with `high_availability`, the count the private path has always produced.
- **Existing mount targets stay put.** Racks with private subnets, including public racks that supplied their own, take the branch they always took, and no mount target is replaced.
- **Same network exposure.** Port 2049 on a mount target answers only to the cluster security group, in a public subnet as in a private one.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this fix.

The change can only add mount targets. The selection differs from the previous one only on racks with no private subnets, and those racks had no mount targets in state, so nothing existing is destroyed or moved. There is no new Terraform variable, and `efs_csi_driver_enable` is an existing parameter, so a downgrade removes no parameter. Racks with `efs_csi_driver_enable` unset see no plan change.

A rack that enables EFS on this version and then applies an earlier one has its mount targets destroyed. The filesystem, the CSI addon, the storage classes and the data survive, and the volumes mount again when the rack returns to `3.25.6` or later. Setting `efs_csi_driver_enable=false` deletes the filesystem and its contents and is not a remedy for that state.

---

### Requirements

This fix requires version `3.25.6` or later for the rack, and applies to AWS racks with `efs_csi_driver_enable=true`.

**Update the Rack:** Run `convox rack update 3.25.6 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
