### PR TITLE
support TCP_UDP protocol on balancer ports

### DIFF
--- a/pkg/manifest/balancer.go
+++ b/pkg/manifest/balancer.go
@@ -2,6 +2,12 @@ package manifest
 
 import "strings"
 
+const (
+	BalancerProtocolTcp    = "TCP"
+	BalancerProtocolTcpUdp = "TCP_UDP"
+	BalancerProtocolUdp    = "UDP"
+)
+
 type Balancer struct {
 	Name string `yaml:"-"`
 

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -790,7 +790,7 @@ func TestManifestValidate(t *testing.T) {
 		"balancer charlie annotation noequalssign must be in key=value format",
 		"balancer charlie port 3000 has unsupported protocol SCTP",
 		"balancer delta has UDP ports and no TCP port, set service.beta.kubernetes.io/aws-load-balancer-healthcheck-port in annotations",
-		"balancer echo declares port 53 more than once, TCP and UDP on the same port number is not supported",
+		"balancer echo declares port 53 more than once, use protocol: TCP_UDP on a single entry to serve both protocols on one port number",
 		"resource name 1resource invalid, must contain only lowercase alphanumeric and dashes",
 		"service deployment-invalid-low deployment minimum can not be less than 0",
 		"service deployment-invalid-low deployment maximum can not be less than 100",

--- a/pkg/manifest/validate.go
+++ b/pkg/manifest/validate.go
@@ -83,16 +83,27 @@ func (m *Manifest) validateBalancers() []error {
 
 		for _, p := range b.Ports {
 			switch p.Protocol {
-			case "UDP":
+			case BalancerProtocolUdp:
 				udp = true
-			case "", "TCP":
+			case "", BalancerProtocolTcp:
 				tcp = true
+			case BalancerProtocolTcpUdp:
+				tcp = true
+				udp = true
+
+				if !b.AwsLoadBalancerController {
+					errs = append(errs, fmt.Errorf("balancer %s port %d uses protocol TCP_UDP, which requires awsLoadBalancerController: true", b.Name, p.Source))
+				}
+
+				if p.Target == 0 {
+					errs = append(errs, fmt.Errorf("balancer %s port %d uses protocol TCP_UDP and must set a target port", b.Name, p.Source))
+				}
 			default:
 				errs = append(errs, fmt.Errorf("balancer %s port %d has unsupported protocol %s", b.Name, p.Source, p.Protocol))
 			}
 
 			if b.AwsLoadBalancerController && seen[p.Source] {
-				errs = append(errs, fmt.Errorf("balancer %s declares port %d more than once, TCP and UDP on the same port number is not supported", b.Name, p.Source))
+				errs = append(errs, fmt.Errorf("balancer %s declares port %d more than once, use protocol: TCP_UDP on a single entry to serve both protocols on one port number", b.Name, p.Source))
 			}
 
 			seen[p.Source] = true

--- a/pkg/manifest/validate_test.go
+++ b/pkg/manifest/validate_test.go
@@ -1,0 +1,165 @@
+package manifest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func balancerManifest(b *Balancer) *Manifest {
+	return &Manifest{
+		Balancers: Balancers{*b},
+		Services:  Services{{Name: "web"}},
+	}
+}
+
+func balancerErrors(t *testing.T, b *Balancer) []string {
+	t.Helper()
+
+	var ss []string
+
+	for _, err := range balancerManifest(b).validateBalancers() {
+		ss = append(ss, err.Error())
+	}
+
+	return ss
+}
+
+func TestValidateBalancersTcpUdp(t *testing.T) {
+	for _, c := range []struct {
+		name     string
+		balancer Balancer
+		errs     []string
+	}{
+		{
+			name: "accepted with the controller flag",
+			balancer: Balancer{
+				Name:                      "dns",
+				Service:                   "web",
+				AwsLoadBalancerController: true,
+				Ports:                     BalancerPorts{{Source: 53, Protocol: BalancerProtocolTcpUdp, Target: 5300}},
+			},
+		},
+		{
+			name: "rejected without the controller flag",
+			balancer: Balancer{
+				Name:    "dns",
+				Service: "web",
+				Ports:   BalancerPorts{{Source: 53, Protocol: BalancerProtocolTcpUdp, Target: 5300}},
+			},
+			errs: []string{"balancer dns port 53 uses protocol TCP_UDP, which requires awsLoadBalancerController: true"},
+		},
+		{
+			name: "rejected with no target port",
+			balancer: Balancer{
+				Name:                      "dns",
+				Service:                   "web",
+				AwsLoadBalancerController: true,
+				Ports:                     BalancerPorts{{Source: 53, Protocol: BalancerProtocolTcpUdp}},
+			},
+			errs: []string{"balancer dns port 53 uses protocol TCP_UDP and must set a target port"},
+		},
+		{
+			name: "both rules fire together",
+			balancer: Balancer{
+				Name:    "dns",
+				Service: "web",
+				Ports:   BalancerPorts{{Source: 53, Protocol: BalancerProtocolTcpUdp}},
+			},
+			errs: []string{
+				"balancer dns port 53 uses protocol TCP_UDP, which requires awsLoadBalancerController: true",
+				"balancer dns port 53 uses protocol TCP_UDP and must set a target port",
+			},
+		},
+		{
+			name: "the udp only health check rule stays quiet",
+			balancer: Balancer{
+				Name:                      "dns",
+				Service:                   "web",
+				AwsLoadBalancerController: true,
+				Ports: BalancerPorts{
+					{Source: 53, Protocol: BalancerProtocolTcpUdp, Target: 5300},
+					{Source: 514, Protocol: BalancerProtocolUdp, Target: 5140},
+				},
+			},
+		},
+		{
+			name: "the udp only health check rule still fires",
+			balancer: Balancer{
+				Name:                      "syslog",
+				Service:                   "web",
+				AwsLoadBalancerController: true,
+				Ports:                     BalancerPorts{{Source: 514, Protocol: BalancerProtocolUdp, Target: 5140}},
+			},
+			errs: []string{"balancer syslog has UDP ports and no TCP port, set service.beta.kubernetes.io/aws-load-balancer-healthcheck-port in annotations"},
+		},
+		{
+			name: "an unrelated protocol is still rejected",
+			balancer: Balancer{
+				Name:                      "sctp",
+				Service:                   "web",
+				AwsLoadBalancerController: true,
+				Ports:                     BalancerPorts{{Source: 3000, Protocol: "SCTP", Target: 3001}},
+			},
+			errs: []string{"balancer sctp port 3000 has unsupported protocol SCTP"},
+		},
+		{
+			name: "a repeated source port points at the new value",
+			balancer: Balancer{
+				Name:                      "dns",
+				Service:                   "web",
+				AwsLoadBalancerController: true,
+				Ports: BalancerPorts{
+					{Source: 53, Protocol: BalancerProtocolTcp, Target: 5300},
+					{Source: 53, Protocol: BalancerProtocolUdp, Target: 5300},
+				},
+			},
+			errs: []string{"balancer dns declares port 53 more than once, use protocol: TCP_UDP on a single entry to serve both protocols on one port number"},
+		},
+		{
+			name: "a repeated source port on a legacy balancer is still allowed",
+			balancer: Balancer{
+				Name:    "legacy",
+				Service: "web",
+				Ports: BalancerPorts{
+					{Source: 8000, Protocol: BalancerProtocolTcp, Target: 8001},
+					{Source: 8000, Protocol: BalancerProtocolTcp, Target: 8002},
+				},
+			},
+		},
+		{
+			name: "an empty protocol is still a tcp port",
+			balancer: Balancer{
+				Name:                      "mixed",
+				Service:                   "web",
+				AwsLoadBalancerController: true,
+				Ports: BalancerPorts{
+					{Source: 7000, Target: 7001},
+					{Source: 514, Protocol: BalancerProtocolUdp, Target: 5140},
+				},
+			},
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.errs, balancerErrors(t, &c.balancer))
+		})
+	}
+}
+
+func TestValidateBalancersTcpUdpLowercase(t *testing.T) {
+	m, err := Load([]byte(`balancers:
+  dns:
+    awsLoadBalancerController: true
+    ports:
+      53:
+        protocol: tcp_udp
+        port: 5300
+    service: web
+services:
+  web:
+    build: .
+`), map[string]string{})
+	require.NoError(t, err)
+	require.Equal(t, BalancerProtocolTcpUdp, m.Balancers[0].Ports[0].Protocol)
+	require.Empty(t, m.validateBalancers())
+}

--- a/provider/k8s/balancer_ownership_test.go
+++ b/provider/k8s/balancer_ownership_test.go
@@ -36,7 +36,7 @@ services:
     port: 5000
 `
 
-func createBalancerService(t *testing.T, kk *fake.Clientset, ns, name, lbType string, ingress bool) {
+func createBalancerService(t *testing.T, kk *fake.Clientset, ns, name, lbType string, ingress bool, ports ...ac.ServicePort) {
 	t.Helper()
 
 	s := &ac.Service{
@@ -45,6 +45,7 @@ func createBalancerService(t *testing.T, kk *fake.Clientset, ns, name, lbType st
 			Namespace:   ns,
 			Annotations: map[string]string{"service.beta.kubernetes.io/aws-load-balancer-type": lbType},
 		},
+		Spec: ac.ServiceSpec{Ports: ports},
 	}
 
 	if ingress {

--- a/provider/k8s/balancer_render_test.go
+++ b/provider/k8s/balancer_render_test.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/convox/convox/pkg/manifest"
@@ -85,6 +86,7 @@ func TestRenderBalancerControllerTcpOnly(t *testing.T) {
 	})
 
 	require.NotContains(t, out, "aws-load-balancer-healthcheck")
+	require.NotContains(t, out, "enable-tcp-udp-listener")
 }
 
 func TestRenderBalancerControllerSchemeOverride(t *testing.T) {
@@ -122,4 +124,164 @@ func TestRenderBalancerControllerRequiresAws(t *testing.T) {
 	}, nil)
 
 	require.EqualError(t, err, "balancer alpha: awsLoadBalancerController is only supported on AWS racks")
+}
+
+func balancerRenderedPorts(t *testing.T, out string) string {
+	t.Helper()
+
+	i := strings.Index(out, "\n  ports:\n")
+	j := strings.Index(out, "\n  selector:\n")
+	require.NotEqual(t, -1, i)
+	require.NotEqual(t, -1, j)
+
+	return out[i+1 : j+1]
+}
+
+func TestRenderBalancerControllerPortsGolden(t *testing.T) {
+	out := renderBalancer(t, "aws", &manifest.Balancer{
+		Name:                      "alpha",
+		Service:                   "web",
+		AwsLoadBalancerController: true,
+		Ports: manifest.BalancerPorts{
+			{Source: 5000, Protocol: "TCP", Target: 5001},
+			{Source: 7000, Target: 7001},
+			{Source: 6000, Protocol: "UDP", Target: 6001},
+		},
+	})
+
+	require.Equal(t, `  ports:
+  - name: "5000"
+    port: 5000
+    protocol: TCP
+    targetPort: 5001
+  - name: "7000"
+    port: 7000
+    protocol: null
+    targetPort: 7001
+  - name: "6000"
+    port: 6000
+    protocol: UDP
+    targetPort: 6001
+`, balancerRenderedPorts(t, out))
+}
+
+func TestRenderBalancerControllerTcpUdpGolden(t *testing.T) {
+	out := renderBalancer(t, "aws", &manifest.Balancer{
+		Name:                      "dns",
+		Service:                   "resolver",
+		AwsLoadBalancerController: true,
+		Ports: manifest.BalancerPorts{
+			{Source: 5353, Protocol: manifest.BalancerProtocolTcpUdp, Target: 5300},
+			{Source: 8080, Protocol: "TCP", Target: 8080},
+		},
+	})
+
+	require.Equal(t, `  ports:
+  - name: 5353-tcp
+    port: 5353
+    protocol: TCP
+    targetPort: 5300
+  - name: 5353-udp
+    port: 5353
+    protocol: UDP
+    targetPort: 5300
+  - name: "8080"
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+`, balancerRenderedPorts(t, out))
+	require.Contains(t, out, "service.beta.kubernetes.io/aws-load-balancer-enable-tcp-udp-listener: \"true\"\n")
+	require.NotContains(t, out, "aws-load-balancer-healthcheck")
+}
+
+func TestRenderBalancerControllerTcpUdpKeepsGeneratedListenerAnnotation(t *testing.T) {
+	out := renderBalancer(t, "aws", &manifest.Balancer{
+		Name:                      "dns",
+		Service:                   "resolver",
+		AwsLoadBalancerController: true,
+		Annotations:               manifest.BalancerAnnotations{"service.beta.kubernetes.io/aws-load-balancer-enable-tcp-udp-listener=false"},
+		Ports:                     manifest.BalancerPorts{{Source: 5353, Protocol: manifest.BalancerProtocolTcpUdp, Target: 5300}},
+	})
+
+	require.Contains(t, out, "service.beta.kubernetes.io/aws-load-balancer-enable-tcp-udp-listener: \"true\"\n")
+	require.NotContains(t, out, "enable-tcp-udp-listener: \"false\"")
+}
+
+func TestRenderBalancerTcpUdpRequiresController(t *testing.T) {
+	_, err := balancerRenderProvider("aws").releaseTemplateBalancer(&structs.App{Name: "app1"}, &structs.Release{Id: "release1"}, manifest.Balancer{
+		Name:    "dns",
+		Service: "resolver",
+		Ports:   manifest.BalancerPorts{{Source: 5353, Protocol: manifest.BalancerProtocolTcpUdp, Target: 5300}},
+	}, nil)
+
+	require.EqualError(t, err, "balancer dns: protocol TCP_UDP requires awsLoadBalancerController: true, update convox.yml and build again")
+}
+
+func TestBalancerRenderPorts(t *testing.T) {
+	ports, tcpUdp := balancerRenderPorts(manifest.BalancerPorts{
+		{Source: 5000, Protocol: "TCP", Target: 5001},
+		{Source: 7000, Target: 7001},
+		{Source: 5353, Protocol: manifest.BalancerProtocolTcpUdp, Target: 5300},
+	})
+
+	require.True(t, tcpUdp)
+	require.Equal(t, []balancerRenderPort{
+		{Name: "5000", Source: 5000, Protocol: "TCP", Target: 5001},
+		{Name: "7000", Source: 7000, Protocol: "", Target: 7001},
+		{Name: "5353-tcp", Source: 5353, Protocol: "TCP", Target: 5300},
+		{Name: "5353-udp", Source: 5353, Protocol: "UDP", Target: 5300},
+	}, ports)
+
+	ports, tcpUdp = balancerRenderPorts(manifest.BalancerPorts{{Source: 5000, Protocol: "TCP", Target: 5001}})
+
+	require.False(t, tcpUdp)
+	require.Equal(t, []balancerRenderPort{{Name: "5000", Source: 5000, Protocol: "TCP", Target: 5001}}, ports)
+}
+
+func TestBalancerHealthCheckPortTcpUdp(t *testing.T) {
+	for _, c := range []struct {
+		name  string
+		ports manifest.BalancerPorts
+		want  int
+	}{
+		{
+			name:  "a pair alone needs no annotation",
+			ports: manifest.BalancerPorts{{Source: 5353, Protocol: manifest.BalancerProtocolTcpUdp, Target: 5300}},
+		},
+		{
+			name: "a pair beside a tcp port needs no annotation",
+			ports: manifest.BalancerPorts{
+				{Source: 8080, Protocol: "TCP", Target: 8080},
+				{Source: 5353, Protocol: manifest.BalancerProtocolTcpUdp, Target: 5300},
+			},
+		},
+		{
+			name: "a pair beside a udp port probes the pair",
+			ports: manifest.BalancerPorts{
+				{Source: 5353, Protocol: manifest.BalancerProtocolTcpUdp, Target: 5300},
+				{Source: 514, Protocol: "UDP", Target: 5140},
+			},
+			want: 5300,
+		},
+		{
+			name: "a udp port before a pair still probes the pair",
+			ports: manifest.BalancerPorts{
+				{Source: 514, Protocol: "UDP", Target: 5140},
+				{Source: 5353, Protocol: manifest.BalancerProtocolTcpUdp, Target: 5300},
+			},
+			want: 5300,
+		},
+		{
+			name:  "udp only is unchanged",
+			ports: manifest.BalancerPorts{{Source: 514, Protocol: "UDP", Target: 5140}},
+		},
+		{
+			name:  "tcp only is unchanged",
+			ports: manifest.BalancerPorts{{Source: 5000, Protocol: "TCP", Target: 5001}},
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			require.Equal(t, c.want, balancerHealthCheckPort(c.ports))
+		})
+	}
 }

--- a/provider/k8s/balancer_stability_test.go
+++ b/provider/k8s/balancer_stability_test.go
@@ -1,0 +1,259 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	"github.com/convox/convox/pkg/manifest"
+	"github.com/convox/convox/pkg/structs"
+	"github.com/stretchr/testify/require"
+	ac "k8s.io/api/core/v1"
+	kerr "k8s.io/apimachinery/pkg/api/errors"
+	am "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	ktesting "k8s.io/client-go/testing"
+)
+
+const balancerFreezeError = "balancer dns: TCP and UDP on one port number can only be set up on a new balancer, and its ports cannot be changed afterwards. It is currently serving 5353/TCP->5300, 5353/UDP->5300. Restore this balancer's previous ports in convox.yml to deploy it again, or replace it: add a second balancer with the ports you want and move traffic to it, or remove this one, deploy, then add it back. Replacing it gives a new address"
+
+func livePort(name string, port, target int32, protocol ac.Protocol) ac.ServicePort {
+	return ac.ServicePort{Name: name, Port: port, Protocol: protocol, TargetPort: intstr.FromInt32(target)}
+}
+
+func livePair() []ac.ServicePort {
+	return []ac.ServicePort{
+		livePort("5353-tcp", 5353, 5300, ac.ProtocolTCP),
+		livePort("5353-udp", 5353, 5300, ac.ProtocolUDP),
+	}
+}
+
+func tcpUdpBalancer(ports manifest.BalancerPorts) manifest.Balancer {
+	return manifest.Balancer{Name: "dns", Service: "resolver", AwsLoadBalancerController: true, Ports: ports}
+}
+
+func TestValidateBalancerPortStability(t *testing.T) {
+	pair := manifest.BalancerPorts{{Source: 5353, Protocol: manifest.BalancerProtocolTcpUdp, Target: 5300}}
+
+	for _, c := range []struct {
+		name      string
+		provider  string
+		balancers manifest.Balancers
+		live      []ac.ServicePort
+		noService bool
+		noRead    bool
+		err       string
+	}{
+		{
+			name:      "a non aws rack never reads",
+			noRead:    true,
+			provider:  "test",
+			balancers: manifest.Balancers{tcpUdpBalancer(manifest.BalancerPorts{{Source: 5353, Protocol: manifest.BalancerProtocolTcpUdp, Target: 5400}})},
+			live:      livePair(),
+		},
+		{
+			name:      "dropping the controller flag off a live pair is refused",
+			provider:  "aws",
+			balancers: manifest.Balancers{{Name: "dns", Service: "resolver", Ports: manifest.BalancerPorts{{Source: 5353, Protocol: "TCP", Target: 5300}}}},
+			live:      livePair(),
+			err:       balancerFreezeError,
+		},
+		{
+			name:      "a balancer without the controller flag and no live pair is left alone",
+			provider:  "aws",
+			balancers: manifest.Balancers{{Name: "dns", Service: "resolver", Ports: manifest.BalancerPorts{{Source: 8000, Protocol: "TCP", Target: 9001}}}},
+			live:      []ac.ServicePort{livePort("8000", 8000, 8001, ac.ProtocolTCP)},
+		},
+		{
+			name:      "removing the balancer from the manifest never reads",
+			noRead:    true,
+			provider:  "aws",
+			balancers: manifest.Balancers{},
+			live:      livePair(),
+		},
+		{
+			name:      "a manifest naming only another balancer never reads this one",
+			noRead:    true,
+			provider:  "aws",
+			balancers: manifest.Balancers{{Name: "other", Service: "resolver", AwsLoadBalancerController: true, Ports: manifest.BalancerPorts{{Source: 5353, Protocol: manifest.BalancerProtocolTcpUdp, Target: 5400}}}},
+			live:      livePair(),
+		},
+		{
+			name:      "a balancer with no live service is the create path",
+			provider:  "aws",
+			balancers: manifest.Balancers{tcpUdpBalancer(pair)},
+			noService: true,
+		},
+		{
+			name:      "an unchanged pair is the steady state",
+			provider:  "aws",
+			balancers: manifest.Balancers{tcpUdpBalancer(pair)},
+			live:      livePair(),
+		},
+		{
+			name:     "an unchanged pair beside a long form port with no protocol or target",
+			provider: "aws",
+			balancers: manifest.Balancers{tcpUdpBalancer(manifest.BalancerPorts{
+				{Source: 5353, Protocol: manifest.BalancerProtocolTcpUdp, Target: 5300},
+				{Source: 8080},
+			})},
+			live: append(livePair(), livePort("8080", 8080, 8080, ac.ProtocolTCP)),
+		},
+		{
+			name:      "no mixed pair on either side is today's behavior",
+			provider:  "aws",
+			balancers: manifest.Balancers{tcpUdpBalancer(manifest.BalancerPorts{{Source: 8000, Protocol: "TCP", Target: 9000}})},
+			live:      []ac.ServicePort{livePort("8000", 8000, 8001, ac.ProtocolTCP)},
+		},
+		{
+			name:     "a same protocol repeat is not a pair",
+			provider: "aws",
+			balancers: manifest.Balancers{tcpUdpBalancer(manifest.BalancerPorts{
+				{Source: 8000, Protocol: "TCP", Target: 8001},
+				{Source: 8000, Protocol: "TCP", Target: 8002},
+			})},
+			live: []ac.ServicePort{livePort("8000", 8000, 8001, ac.ProtocolTCP)},
+		},
+		{
+			name:     "a skipped balancer does not stop the check",
+			provider: "aws",
+			balancers: manifest.Balancers{
+				{Name: "unflagged", Service: "resolver", Ports: manifest.BalancerPorts{{Source: 8000, Protocol: "TCP", Target: 8001}}},
+				{Name: "new", Service: "resolver", AwsLoadBalancerController: true, Ports: pair},
+				tcpUdpBalancer(manifest.BalancerPorts{{Source: 5353, Protocol: manifest.BalancerProtocolTcpUdp, Target: 5400}}),
+			},
+			live: livePair(),
+			err:  balancerFreezeError,
+		},
+		{
+			name:      "a target port edit is refused",
+			provider:  "aws",
+			balancers: manifest.Balancers{tcpUdpBalancer(manifest.BalancerPorts{{Source: 5353, Protocol: manifest.BalancerProtocolTcpUdp, Target: 5400}})},
+			live:      livePair(),
+			err:       balancerFreezeError,
+		},
+		{
+			name:      "dropping to a single protocol is refused",
+			provider:  "aws",
+			balancers: manifest.Balancers{tcpUdpBalancer(manifest.BalancerPorts{{Source: 5353, Protocol: "UDP", Target: 5300}})},
+			live:      livePair(),
+			err:       balancerFreezeError,
+		},
+		{
+			name:     "adding a port is refused",
+			provider: "aws",
+			balancers: manifest.Balancers{tcpUdpBalancer(manifest.BalancerPorts{
+				{Source: 5353, Protocol: manifest.BalancerProtocolTcpUdp, Target: 5300},
+				{Source: 9090, Protocol: "TCP", Target: 9090},
+			})},
+			live: livePair(),
+			err:  balancerFreezeError,
+		},
+		{
+			name:      "removing a port is refused",
+			provider:  "aws",
+			balancers: manifest.Balancers{tcpUdpBalancer(pair)},
+			live:      append(livePair(), livePort("9090", 9090, 9090, ac.ProtocolTCP)),
+			err:       "balancer dns: TCP and UDP on one port number can only be set up on a new balancer, and its ports cannot be changed afterwards. It is currently serving 5353/TCP->5300, 5353/UDP->5300, 9090/TCP->9090. Restore this balancer's previous ports in convox.yml to deploy it again, or replace it: add a second balancer with the ports you want and move traffic to it, or remove this one, deploy, then add it back. Replacing it gives a new address",
+		},
+		{
+			name:     "a reorder is refused while a pair is present",
+			provider: "aws",
+			balancers: manifest.Balancers{tcpUdpBalancer(manifest.BalancerPorts{
+				{Source: 8080, Protocol: "TCP", Target: 8080},
+				{Source: 5353, Protocol: manifest.BalancerProtocolTcpUdp, Target: 5300},
+			})},
+			live: append(livePair(), livePort("8080", 8080, 8080, ac.ProtocolTCP)),
+			err:  "balancer dns: TCP and UDP on one port number can only be set up on a new balancer, and its ports cannot be changed afterwards. It is currently serving 5353/TCP->5300, 5353/UDP->5300, 8080/TCP->8080. Restore this balancer's previous ports in convox.yml to deploy it again, or replace it: add a second balancer with the ports you want and move traffic to it, or remove this one, deploy, then add it back. Replacing it gives a new address",
+		},
+		{
+			name:     "a reorder is allowed with no pair present",
+			provider: "aws",
+			balancers: manifest.Balancers{tcpUdpBalancer(manifest.BalancerPorts{
+				{Source: 8080, Protocol: "TCP", Target: 8080},
+				{Source: 9090, Protocol: "TCP", Target: 9090},
+			})},
+			live: []ac.ServicePort{
+				livePort("9090", 9090, 9090, ac.ProtocolTCP),
+				livePort("8080", 8080, 8080, ac.ProtocolTCP),
+			},
+		},
+		{
+			name:      "adding a pair to a live single port balancer is refused",
+			provider:  "aws",
+			balancers: manifest.Balancers{tcpUdpBalancer(pair)},
+			live:      []ac.ServicePort{livePort("5353", 5353, 5300, ac.ProtocolTCP)},
+			err:       "balancer dns: TCP and UDP on one port number can only be set up on a new balancer, and its ports cannot be changed afterwards. It is currently serving 5353/TCP->5300. Restore this balancer's previous ports in convox.yml to deploy it again, or replace it: add a second balancer with the ports you want and move traffic to it, or remove this one, deploy, then add it back. Replacing it gives a new address",
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			p, kk, _ := minimalProvider(t)
+			p.Provider = c.provider
+
+			if !c.noService {
+				createBalancerService(t, kk, p.AppNamespace("app1"), "dns", "external", true, c.live...)
+			}
+
+			kk.ClearActions()
+
+			err := p.validateBalancerPortStability("app1", c.balancers)
+
+			if c.err == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, c.err)
+			}
+
+			if c.noRead {
+				for _, a := range kk.Actions() {
+					g, ok := a.(ktesting.GetAction)
+					require.True(t, ok)
+					require.NotEqual(t, "balancer-dns", g.GetName())
+				}
+			}
+		})
+	}
+}
+
+func TestValidateBalancerPortStabilityApiError(t *testing.T) {
+	p, kk, _ := minimalProvider(t)
+	p.Provider = "aws"
+
+	kk.PrependReactor("get", "services", func(_ ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, kerr.NewInternalError(context.DeadlineExceeded)
+	})
+
+	err := p.validateBalancerPortStability("app1", manifest.Balancers{tcpUdpBalancer(manifest.BalancerPorts{{Source: 5353, Protocol: manifest.BalancerProtocolTcpUdp, Target: 5300}})})
+	require.ErrorContains(t, err, "Internal error occurred")
+}
+
+const balancerFreezeManifest = `balancers:
+  dns:
+    service: web
+    awsLoadBalancerController: true
+    ports:
+      5353:
+        protocol: TCP_UDP
+        port: 5400
+services:
+  web:
+    build: .
+`
+
+func TestReleasePromoteRejectsBalancerPortChange(t *testing.T) {
+	t.Setenv("TEST", "true")
+
+	p, kk, kc := minimalProvider(t)
+	p.Provider = "aws"
+
+	_, err := kk.CoreV1().Namespaces().Create(context.TODO(), &ac.Namespace{ObjectMeta: am.ObjectMeta{Name: p.Namespace}}, am.CreateOptions{})
+	require.NoError(t, err)
+	require.NoError(t, p.Initialize(structs.ProviderOptions{}))
+
+	createAppNamespace(t, kk, "rack1", "app1")
+	createBuild(t, kc, "rack1-app1", "build1")
+	createRelease(t, kc, "rack1-app1", "rel1", balancerFreezeManifest)
+	createBalancerService(t, kk, p.AppNamespace("app1"), "dns", "external", true, livePair()...)
+
+	require.EqualError(t, p.ReleasePromote("app1", "rel1", structs.ReleasePromoteOptions{}), balancerFreezeError)
+}

--- a/provider/k8s/release.go
+++ b/provider/k8s/release.go
@@ -165,6 +165,10 @@ func (p *Provider) ReleasePromote(app, id string, opts structs.ReleasePromoteOpt
 			return errors.WithStack(err)
 		}
 
+		if err := p.validateBalancerPortStability(app, m.Balancers); err != nil {
+			return errors.WithStack(err)
+		}
+
 		progressDeadlines, crashRestartLimits, maxProgressDeadline = p.fastFailStateForPromote(m.Services)
 
 		if a.Release != "" && a.Release != id {
@@ -533,6 +537,12 @@ func (p *Provider) releaseTemplateBalancer(a *structs.App, r *structs.Release, b
 		return nil, structs.ErrBadRequest("balancer %s: awsLoadBalancerController is only supported on AWS racks", b.Name)
 	}
 
+	ports, tcpUdp := balancerRenderPorts(b.Ports)
+
+	if tcpUdp && !b.AwsLoadBalancerController {
+		return nil, structs.ErrBadRequest("balancer %s: protocol TCP_UDP requires awsLoadBalancerController: true, update convox.yml and build again", b.Name)
+	}
+
 	annotations := b.AnnotationsMap()
 
 	params := map[string]interface{}{
@@ -540,9 +550,11 @@ func (p *Provider) releaseTemplateBalancer(a *structs.App, r *structs.Release, b
 		"Balancer":        b,
 		"HealthCheckPort": balancerHealthCheckPort(b.Ports),
 		"Namespace":       p.AppNamespace(a.Name),
+		"Ports":           ports,
 		"Release":         r,
 		"Labels":          lbs,
 		"Scheme":          balancerScheme(annotations),
+		"TcpUdp":          tcpUdp,
 	}
 
 	data, err := p.RenderTemplate("app/balancer", params)
@@ -573,6 +585,146 @@ func balancerHealthCheckPort(ports manifest.BalancerPorts) int {
 	}
 
 	return target
+}
+
+type balancerRenderPort struct {
+	Name     string
+	Source   int
+	Protocol string
+	Target   int
+}
+
+func balancerRenderPorts(ports manifest.BalancerPorts) ([]balancerRenderPort, bool) {
+	rps := []balancerRenderPort{}
+	tcpUdp := false
+
+	for _, p := range ports {
+		if p.Protocol == manifest.BalancerProtocolTcpUdp {
+			tcpUdp = true
+
+			rps = append(rps,
+				balancerRenderPort{Name: fmt.Sprintf("%d-tcp", p.Source), Source: p.Source, Protocol: manifest.BalancerProtocolTcp, Target: p.Target},
+				balancerRenderPort{Name: fmt.Sprintf("%d-udp", p.Source), Source: p.Source, Protocol: manifest.BalancerProtocolUdp, Target: p.Target},
+			)
+
+			continue
+		}
+
+		rps = append(rps, balancerRenderPort{Name: strconv.Itoa(p.Source), Source: p.Source, Protocol: p.Protocol, Target: p.Target})
+	}
+
+	return rps, tcpUdp
+}
+
+type balancerPortKey struct {
+	Source   int
+	Protocol string
+	Target   int
+}
+
+func balancerRenderedKeys(ports []balancerRenderPort) []balancerPortKey {
+	ks := make([]balancerPortKey, len(ports))
+
+	for i, p := range ports {
+		k := balancerPortKey{Source: p.Source, Protocol: p.Protocol, Target: p.Target}
+
+		if k.Protocol == "" {
+			k.Protocol = manifest.BalancerProtocolTcp
+		}
+
+		if k.Target == 0 {
+			k.Target = k.Source
+		}
+
+		ks[i] = k
+	}
+
+	return ks
+}
+
+func balancerLiveKeys(ports []v1.ServicePort) []balancerPortKey {
+	ks := make([]balancerPortKey, len(ports))
+
+	for i, p := range ports {
+		ks[i] = balancerPortKey{Source: int(p.Port), Protocol: string(p.Protocol), Target: p.TargetPort.IntValue()}
+	}
+
+	return ks
+}
+
+func balancerMixedPair(ks []balancerPortKey) bool {
+	seen := map[int]string{}
+
+	for _, k := range ks {
+		if protocol, ok := seen[k.Source]; ok && protocol != k.Protocol {
+			return true
+		}
+
+		seen[k.Source] = k.Protocol
+	}
+
+	return false
+}
+
+func balancerPortKeysEqual(a, b []balancerPortKey) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func balancerPortKeysDescription(ks []balancerPortKey) string {
+	ss := make([]string, len(ks))
+
+	for i, k := range ks {
+		ss[i] = fmt.Sprintf("%d/%s->%d", k.Source, k.Protocol, k.Target)
+	}
+
+	return strings.Join(ss, ", ")
+}
+
+func (p *Provider) validateBalancerPortStability(app string, bs manifest.Balancers) error {
+	if p.Provider != "aws" {
+		return nil
+	}
+
+	for _, b := range bs {
+		s, err := p.Cluster.CoreV1().Services(p.AppNamespace(app)).Get(context.TODO(), fmt.Sprintf("balancer-%s", b.Name), am.GetOptions{})
+		if kerr.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		rendered, _ := balancerRenderPorts(b.Ports)
+
+		want := balancerRenderedKeys(rendered)
+		have := balancerLiveKeys(s.Spec.Ports)
+
+		if !b.AwsLoadBalancerController && !balancerMixedPair(have) {
+			continue
+		}
+
+		if !balancerMixedPair(want) && !balancerMixedPair(have) {
+			continue
+		}
+
+		if balancerPortKeysEqual(want, have) {
+			continue
+		}
+
+		return structs.ErrBadRequest("balancer %s: TCP and UDP on one port number can only be set up on a new balancer, and its ports cannot be changed afterwards. It is currently serving %s. Restore this balancer's previous ports in convox.yml to deploy it again, or replace it: add a second balancer with the ports you want and move traffic to it, or remove this one, deploy, then add it back. Replacing it gives a new address", b.Name, balancerPortKeysDescription(have))
+	}
+
+	return nil
 }
 
 func balancerScheme(annotations map[string]string) string {

--- a/provider/k8s/template/app/balancer.yml.tmpl
+++ b/provider/k8s/template/app/balancer.yml.tmpl
@@ -21,6 +21,9 @@ metadata:
     {{ range keyValue .Annotations }}
     {{.Key}}: "{{ quoteEscape .Value}}"
     {{ end }}
+    {{ if and .Balancer.AwsLoadBalancerController .TcpUdp }}
+    service.beta.kubernetes.io/aws-load-balancer-enable-tcp-udp-listener: "true"
+    {{ end }}
   labels:
     balancer: {{.Balancer.Name}}
     service: {{.Balancer.Service}}
@@ -41,8 +44,8 @@ spec:
     service: {{.Balancer.Service}}
     type: service
   ports:
-    {{ range .Balancer.Ports }}
-    - name: "{{.Source}}"
+    {{ range .Ports }}
+    - name: "{{.Name}}"
       port: {{.Source}}
       protocol: {{.Protocol}}
       targetPort: {{.Target}}


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: TCP and UDP on One Balancer Port with `protocol: TCP_UDP`**

A custom balancer with `awsLoadBalancerController: true` can now serve TCP and UDP on the same port number. Setting `protocol: TCP_UDP` on one port entry provisions one AWS `TCP_UDP` listener and one `TCP_UDP` target group for that port, so a DNS resolver, a game server, or a QUIC endpoint answers both protocols at one address and one port. This extends the `awsLoadBalancerController` attribute added in #1096 (`3.25.5`), which allowed TCP and UDP on one balancer but only on different port numbers.

**New Port Protocol Value:**

| Value | Type | Default | Effect | Scope |
|-------|------|---------|--------|-------|
| `balancers.<name>.ports.<n>.protocol: TCP_UDP` | string | `TCP` | Serves both protocols on source port `<n>` through one AWS `TCP_UDP` listener and one `TCP_UDP` target group | AWS racks, balancers with `awsLoadBalancerController: true` |

`TCP_UDP` is the AWS listener protocol name. The value is case-insensitive, so `tcp_udp` works too. It is only available in the long form of a port entry, and the entry must set `port:`.

```yaml
balancers:
  dns:
    service: resolver
    awsLoadBalancerController: true
    ports:
      53:
        protocol: TCP_UDP
        port: 5300
services:
  resolver:
    build: .
```

The service needs no `port:` of its own. The balancer selects the service's pods directly with a numeric target port, and adding `port:` to the service would render an HTTP readiness probe against the health path, which a DNS listener cannot answer.

One manifest entry renders two ports on the balancer Service, and the controller builds the listener from that Service:

```yaml
spec:
  ports:
  - name: 53-tcp
    port: 53
    protocol: TCP
    targetPort: 5300
  - name: 53-udp
    port: 53
    protocol: UDP
    targetPort: 5300
```

A balancer with a `TCP_UDP` port also carries this annotation, which opts that one balancer into the controller's `TCP_UDP` listener support without any rack change. It is written after the balancer's own `annotations:` and cannot be overridden:

```yaml
service.beta.kubernetes.io/aws-load-balancer-enable-tcp-udp-listener: "true"
```

No health check annotations are emitted for a `TCP_UDP` balancer. The controller's default is a TCP probe on each target group's own traffic port, and a `TCP_UDP` target group accepts TCP on that port. When the balancer also has a plain `UDP` port, the health check annotations from #1096 are emitted as before, aimed at the target port of the first non-UDP port.

A balancer `whitelist:` applies to both protocols. The controller writes a `tcp` and a `udp` security group rule per CIDR for a `TCP_UDP` port, and the backend rule allows both on the target port.

**The port list is fixed once a pair is live.** Kubernetes merges Service ports by port number alone, so editing a Service that carries two ports at one number can report success while dropping or misdirecting one of them. A promote is refused when it would change the ports of a balancer already serving a TCP and UDP pair on one number, including a change of target port, protocol, port order, or the addition or removal of a port; when it would drop `awsLoadBalancerController: true` while a pair is live; and when it would add a `TCP_UDP` port to a balancer that already has a load balancer. A pair is set up on a new balancer only. Shown with example values, the promote fails with:

```
balancer dns: TCP and UDP on one port number can only be set up on a new balancer, and its ports cannot be changed afterwards. It is currently serving 53/TCP->5300, 53/UDP->5300. Restore this balancer's previous ports in convox.yml to deploy it again, or replace it: add a second balancer with the ports you want and move traffic to it, or remove this one, deploy, then add it back. Replacing it gives a new address
```

`--force` does not override the refusal. Removing the balancer block entirely is never refused, and that is the way to change a live pair: remove the block, deploy, then add it back with the new ports. A replaced balancer gets a new address. Only the offending promote fails; the app keeps its last successful release, and `convox apps params set` and `convox apps update` keep working.

**Rejected at build:**

| Manifest | Error |
|----------|-------|
| `protocol: TCP_UDP` on a balancer without `awsLoadBalancerController: true` | `balancer <name> port <n> uses protocol TCP_UDP, which requires awsLoadBalancerController: true` |
| `protocol: TCP_UDP` with no `port:` | `balancer <name> port <n> uses protocol TCP_UDP and must set a target port` |
| the same `ports:` key twice on a balancer with `awsLoadBalancerController: true` | `balancer <name> declares port <n> more than once, use protocol: TCP_UDP on a single entry to serve both protocols on one port number` |

An interpolated protocol, such as `protocol: ${LB_PROTO}`, is not seen by the build-time check until it is rendered. If it resolves to `TCP_UDP` on a balancer without the attribute, the promote is refused before anything is applied with `balancer <name>: protocol TCP_UDP requires awsLoadBalancerController: true, update convox.yml and build again`.

---

### Why is this important?

Protocols that run on one well-known port over both TCP and UDP, such as DNS on 53, could only be served on a Convox balancer by splitting them across two port numbers or two balancers, which clients do not expect. One entry in `convox.yml` now gives both protocols one address and one port.

**Benefits:**

- **One port, both protocols.** A single balancer port serves TCP and UDP through one AWS listener and one target group.
- **One manifest line.** `protocol: TCP_UDP` on the port entry is the whole configuration. No rack parameter, annotation, or Terraform change is needed.
- **Health checks work by default.** A `TCP_UDP` target group takes the controller's default TCP probe, so no health check annotation is required.
- **Live balancers are protected.** A change that would corrupt a live TCP and UDP pair is refused at promote, the message says how to replace the balancer, and the load balancer is untouched.

---

### How to use it?

Add a new balancer block with `awsLoadBalancerController: true` and `protocol: TCP_UDP` on the port entry, with a target `port:`, then deploy. A `TCP_UDP` port cannot be added to a balancer that already has an address:

```yaml
balancers:
  dns:
    service: resolver
    awsLoadBalancerController: true
    ports:
      53:
        protocol: TCP_UDP
        port: 5300
services:
  resolver:
    build: .
```

    $ convox deploy -a my-app -r rackName
    $ convox balancers -a my-app -r rackName

Do not give the service a `port:`. `convox api get /apps/my-app/balancers` reports two entries for port 53, one `TCP` and one `UDP`, both targeting 5300, because the live Service carries two ports.

To change the ports of a balancer that is already serving a pair, remove its block from `convox.yml`, deploy, add it back with the new ports, and deploy again. The balancer comes back with a new address. Alternatively, add a second balancer with the ports you want, move traffic to it, then remove the first.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this feature.

Every existing balancer renders byte for byte as before. `TCP_UDP` cannot appear in a manifest built before this version, a port with any other protocol renders one Service port named by its number as it did, and no balancer created before this version can have a live Service with two ports at one number. Same-protocol duplicate ports on a balancer without `awsLoadBalancerController: true` are not affected by the promote check in either direction. There is no Terraform variable, rack parameter, API, SDK, or CLI change.

**Downgrade:**

| Rack rolled back to | With a `TCP_UDP` manifest | Where it surfaces |
|---------------------|---------------------------|-------------------|
| `3.25.5`, rebuild | `balancer <name> port <n> has unsupported protocol TCP_UDP` | build |
| `3.25.5`, promote or `convox apps params set` of a release built on `3.25.6` | the Kubernetes API server rejects the protocol value, until a new build | apply |
| `3.25.4` or earlier, either path | the same API server rejection | apply |
| `3.25.5`, a `TCP_UDP` balancer live and no deploy | nothing, both versions install controller chart `3.5.0` | nowhere |
| below `3.25.5`, a `TCP_UDP` balancer live and no deploy | the controller chart reverts to `1.7.2`, which has no `TCP_UDP` support, and one protocol stops being served with no error or event | nowhere |

Remove a `TCP_UDP` balancer before taking a rack below `3.25.5`. If a rack is taken below it with one live, upgrading back to `3.25.5` or later restores chart `3.5.0`, the controller rebuilds the `TCP_UDP` listener and target group from the same Service, and the load balancer keeps its name and address throughout, because the Service is never deleted. Every other row is a single rejected write that leaves the live Service and its load balancer untouched.

---

### Requirements

This feature requires version `3.25.6` or later for the rack, and applies to AWS racks. The balancer must set `awsLoadBalancerController: true`, which is available since `3.25.5`.

**Update the Rack:** Run `convox rack update 3.25.6 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
