### PR TITLE
validate whitelist and guard against rack lockout

### DIFF
--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"regexp"
 	"sort"
@@ -1613,6 +1614,63 @@ func validateNodePoolRemoval(params, currentParams map[string]string, force bool
 	return nil
 }
 
+func validateWhitelist(params map[string]string, force bool) error {
+	v, ok := params["whitelist"]
+	if !ok {
+		return nil
+	}
+
+	var entries []string
+	open := false
+
+	for _, e := range strings.Split(v, ",") {
+		e = strings.TrimSpace(e)
+		if e == "" {
+			continue
+		}
+
+		_, n, err := net.ParseCIDR(e)
+		if err != nil {
+			return fmt.Errorf("param 'whitelist' entry %q is not a valid cidr range", e)
+		}
+
+		if n.IP.To4() == nil {
+			return fmt.Errorf("param 'whitelist' entry %q is not an ipv4 cidr range, the rack router is ipv4 only", e)
+		}
+
+		if n.String() == "0.0.0.0/0" {
+			open = true
+		}
+
+		// AWS canonicalizes a security group CIDR on write and the controller compares
+		// the raw string, so a non-canonical entry never matches on the next reconcile.
+		entries = append(entries, n.String())
+	}
+
+	if len(entries) == 0 {
+		return fmt.Errorf("param 'whitelist' requires at least one cidr range")
+	}
+
+	params["whitelist"] = strings.Join(entries, ",")
+
+	if open {
+		return nil
+	}
+
+	if !force {
+		return fmt.Errorf("param 'whitelist' does not include 0.0.0.0/0\n" +
+			"  The rack router serves the rack API, so this blocks every client outside\n" +
+			"  these ranges, including Convox Console. A Console-managed rack that blocks\n" +
+			"  Console cannot be updated through Convox again without editing the load\n" +
+			"  balancer rules in your cloud provider.\n" +
+			"  Re-run with --force to proceed")
+	}
+
+	fmt.Fprintf(os.Stderr, "WARNING: whitelist does not include 0.0.0.0/0. Clients outside these ranges, including Convox Console, can no longer reach this rack.\n")
+
+	return nil
+}
+
 func validateAndMutateParams(params map[string]string, provider string, currentParams map[string]string, force bool) error {
 	// Install-only params — these define infrastructure that cannot be changed
 	// after rack creation without catastrophic consequences (network recreation,
@@ -2629,6 +2687,10 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 				return fmt.Errorf("%s: must contain only letters, digits, and underscore (got %q)", k, v)
 			}
 		}
+	}
+
+	if err := validateWhitelist(params, force); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/cli/rack_validate_test.go
+++ b/pkg/cli/rack_validate_test.go
@@ -1131,3 +1131,237 @@ func TestValidateAndMutateParams_DeployFastFail(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateAndMutateParams_Whitelist(t *testing.T) {
+	const (
+		warning      = "WARNING: whitelist does not include 0.0.0.0/0. Clients outside these ranges, including Convox Console, can no longer reach this rack."
+		warningStart = "WARNING: whitelist"
+	)
+
+	for _, tc := range []struct {
+		name     string
+		params   map[string]string
+		current  map[string]string
+		provider string
+		force    bool
+		err      string
+		notErr   string
+		want     string
+		absent   bool
+		warn     bool
+	}{
+		{
+			name:   "open value accepted unchanged",
+			params: map[string]string{"whitelist": "0.0.0.0/0"},
+			want:   "0.0.0.0/0",
+		},
+		{
+			name:   "restricted value refused",
+			params: map[string]string{"whitelist": "10.0.0.0/8"},
+			err:    "does not include 0.0.0.0/0",
+		},
+		{
+			name:   "restricted value refusal names force",
+			params: map[string]string{"whitelist": "10.0.0.0/8"},
+			err:    "--force",
+		},
+		{
+			name:   "restricted value refusal explains the consequence",
+			params: map[string]string{"whitelist": "10.0.0.0/8"},
+			err:    "balancer rules in your cloud provider",
+		},
+		{
+			name:   "restricted value accepted with force",
+			params: map[string]string{"whitelist": "10.0.0.0/8"},
+			force:  true,
+			want:   "10.0.0.0/8",
+			warn:   true,
+		},
+		{
+			name:   "restricted range alongside the default route",
+			params: map[string]string{"whitelist": "10.0.0.0/8,0.0.0.0/0"},
+			want:   "10.0.0.0/8,0.0.0.0/0",
+		},
+		{
+			name:   "surrounding whitespace trimmed",
+			params: map[string]string{"whitelist": "0.0.0.0/0, 10.0.0.0/8"},
+			want:   "0.0.0.0/0,10.0.0.0/8",
+		},
+		{
+			name:   "padded mask counts as the default route",
+			params: map[string]string{"whitelist": "0.0.0.0/00"},
+			want:   "0.0.0.0/0",
+		},
+		{
+			name:   "host address with a zero prefix is the default route",
+			params: map[string]string{"whitelist": "1.2.3.4/0"},
+			want:   "0.0.0.0/0",
+		},
+		{
+			name:   "ipv4 mapped default route",
+			params: map[string]string{"whitelist": "::ffff:0.0.0.0/96"},
+			want:   "0.0.0.0/0",
+		},
+		{
+			name:   "host bits canonicalized",
+			params: map[string]string{"whitelist": "10.0.0.1/8"},
+			force:  true,
+			want:   "10.0.0.0/8",
+			warn:   true,
+		},
+		{
+			name:   "prefix out of range",
+			params: map[string]string{"whitelist": "10.0.0.0/33"},
+			err:    "not a valid cidr range",
+		},
+		{
+			name:   "prefix out of range is not forceable",
+			params: map[string]string{"whitelist": "10.0.0.0/33"},
+			force:  true,
+			err:    "not a valid cidr range",
+		},
+		{
+			name:   "not a cidr at all",
+			params: map[string]string{"whitelist": "not-a-cidr"},
+			err:    "not a valid cidr range",
+		},
+		{
+			name:   "bare address without a mask",
+			params: map[string]string{"whitelist": "1.2.3.4"},
+			err:    "not a valid cidr range",
+		},
+		{
+			name:   "trailing comma dropped",
+			params: map[string]string{"whitelist": "0.0.0.0/0,"},
+			want:   "0.0.0.0/0",
+		},
+		{
+			name:   "only separators",
+			params: map[string]string{"whitelist": ","},
+			err:    "requires at least one cidr range",
+		},
+		{
+			name:   "ipv6 range refused",
+			params: map[string]string{"whitelist": "::/0"},
+			err:    "not an ipv4 cidr range",
+		},
+		{
+			name:   "ipv6 range is not forceable",
+			params: map[string]string{"whitelist": "::/0"},
+			force:  true,
+			err:    "not an ipv4 cidr range",
+		},
+		{
+			name:   "ipv6 range refused alongside the default route",
+			params: map[string]string{"whitelist": "0.0.0.0/0,::/0"},
+			err:    "not an ipv4 cidr range",
+		},
+		{
+			name:   "ipv4 mapped range accepted",
+			params: map[string]string{"whitelist": "::ffff:10.0.0.0/104"},
+			force:  true,
+			want:   "10.0.0.0/8",
+			warn:   true,
+		},
+		{
+			name:     "refused on gcp",
+			params:   map[string]string{"whitelist": "10.0.0.0/8"},
+			provider: "gcp",
+			err:      "does not include 0.0.0.0/0",
+		},
+		{
+			name:     "refused on metal",
+			params:   map[string]string{"whitelist": "10.0.0.0/8"},
+			provider: "metal",
+			err:      "does not include 0.0.0.0/0",
+		},
+		{
+			name:     "refused when the provider has no known param map",
+			params:   map[string]string{"whitelist": "10.0.0.0/8"},
+			provider: "unknown",
+			err:      "does not include 0.0.0.0/0",
+		},
+		{
+			name:    "unrelated param on a restricted rack",
+			params:  map[string]string{"node_disk": "50"},
+			current: map[string]string{"whitelist": "10.0.0.0/8"},
+		},
+		{
+			name:   "unrelated param does not invent the key",
+			params: map[string]string{"node_disk": "50"},
+			absent: true,
+		},
+		{
+			name:   "empty value keeps the existing message",
+			params: map[string]string{"whitelist": ""},
+			err:    "requires an explicit value",
+			notErr: "cidr",
+		},
+		{
+			name:   "whitespace value keeps the existing message",
+			params: map[string]string{"whitelist": "   "},
+			err:    "requires an explicit value",
+			notErr: "cidr",
+		},
+		{
+			name:    "v2 rack on a known provider skips validation",
+			params:  map[string]string{"whitelist": "10.0.0.0/8"},
+			current: map[string]string{"HighAvailability": "true"},
+		},
+		{
+			name:     "local rack reports the unknown key first",
+			params:   map[string]string{"whitelist": "10.0.0.0/8"},
+			provider: "local",
+			err:      "unknown parameter",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := tc.provider
+			if provider == "" {
+				provider = "aws"
+			}
+
+			current := tc.current
+			if current == nil {
+				current = map[string]string{}
+			}
+
+			var err error
+
+			out := captureStderr(t, func() {
+				err = validateAndMutateParams(tc.params, provider, current, tc.force)
+			})
+
+			switch {
+			case tc.err == "" && err != nil:
+				t.Fatalf("unexpected error: %v", err)
+			case tc.err != "" && err == nil:
+				t.Fatalf("expected error containing %q, got nil", tc.err)
+			case tc.err != "" && !strings.Contains(err.Error(), tc.err):
+				t.Fatalf("error %q should contain %q", err.Error(), tc.err)
+			}
+
+			if tc.notErr != "" && err != nil && strings.Contains(err.Error(), tc.notErr) {
+				t.Errorf("error %q should not contain %q", err.Error(), tc.notErr)
+			}
+
+			if tc.want != "" && tc.params["whitelist"] != tc.want {
+				t.Errorf("whitelist = %q, want %q", tc.params["whitelist"], tc.want)
+			}
+
+			if tc.absent {
+				if _, ok := tc.params["whitelist"]; ok {
+					t.Errorf("whitelist key was added to a call that did not set it")
+				}
+			}
+
+			if tc.warn && !strings.Contains(out, warning) {
+				t.Errorf("expected stderr to contain %q, got %q", warning, out)
+			}
+
+			if !tc.warn && strings.Contains(out, warningStart) {
+				t.Errorf("unexpected whitelist warning on stderr: %q", out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What is the feature/update/fix?

**Update: `whitelist` Rack Parameter Validation**

`convox rack params set whitelist=<value>` now validates each entry as an IPv4 CIDR range, stores the list in canonical form, and refuses a list that does not include `0.0.0.0/0` unless `--force` is passed. The value is applied to `spec.loadBalancerSourceRanges` on the rack router Service on AWS, GCP, Azure, DigitalOcean and Metal racks, so a list that excludes Convox Console's address ranges cuts Console off from the rack, and a Console-managed rack in that state cannot be updated through Convox again without editing the load balancer rules in the cloud provider.

**What the check accepts:**

| Value | Result | Message |
|-------|--------|---------|
| Contains the IPv4 default route `0.0.0.0/0` | Accepted | |
| Every entry is a valid IPv4 CIDR, none is the default route | Refused, `--force` overrides and prints a warning | `param 'whitelist' does not include 0.0.0.0/0`, full text below |
| Any entry is not a valid CIDR | Refused, `--force` does not override | `param 'whitelist' entry "10.0.0.0/33" is not a valid cidr range` |
| Any entry is IPv6 | Refused, `--force` does not override | `param 'whitelist' entry "::/0" is not an ipv4 cidr range, the rack router is ipv4 only` |
| No entry survives, such as `whitelist=,` | Refused | `param 'whitelist' requires at least one cidr range` |

`--force` does not override the CIDR and IPv6 rules because nothing downstream accepts those values: the Kubernetes apiserver rejects a malformed range, and the AWS Load Balancer Controller rejects an IPv6 range for an IPv4 load balancer.

The refusal:

```
ERROR: param 'whitelist' does not include 0.0.0.0/0
  The rack router serves the rack API, so this blocks every client outside
  these ranges, including Convox Console. A Console-managed rack that blocks
  Console cannot be updated through Convox again without editing the load
  balancer rules in your cloud provider.
  Re-run with --force to proceed
```

With `--force`, the value is sent and this is printed to stderr:

```
WARNING: whitelist does not include 0.0.0.0/0. Clients outside these ranges, including Convox Console, can no longer reach this rack.
```

**Canonical storage.** Entries are trimmed, empty entries from a doubled or trailing comma are dropped, and each range is stored in its masked form, so `0.0.0.0/0, 10.0.0.1/8` is stored as `0.0.0.0/0,10.0.0.0/8`. AWS reports a security group CIDR in masked form and the controller compares strings, so a stored `10.0.0.1/8` would never match the `10.0.0.0/8` AWS reports back.

---

### Why is this important?

The rack router serves the rack API as well as app traffic, so the source ranges on its Service decide who can reach the rack at all. A typo or a list that leaves out a needed range now fails on the command line, before anything is sent, instead of on the next reconcile.

**Benefits:**

- **Malformed values fail on the command line.** An entry that is not a CIDR, or is IPv6, is refused with the offending entry named, rather than reaching Kubernetes.
- **A restricted list is a deliberate choice.** A list without `0.0.0.0/0` needs `--force`, and the warning names what the list cuts off.
- **The stored value matches what the cloud provider reports.** Masked, trimmed entries mean the controller's string comparison matches on every reconcile.
- **Any rack version.** The check runs in the CLI, so it applies to every rack that has the parameter, on any rack version.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this update.

A value that contains `0.0.0.0/0`, which is the parameter's default, is accepted as before. A list of valid IPv4 ranges without it now needs `--force`, an existing flag on `convox rack params set`. A malformed or IPv6 entry is now refused by the CLI; it did not produce a working configuration before.

---

### Requirements

This update requires the `convox` CLI at version `3.25.6` or later. It ships in the CLI rather than in the rack, so it applies to a rack on any version. The check runs when the parameter is set with `convox rack params set`; a value already stored on a rack is not re-validated by later updates. It runs in the `convox` CLI, so it applies to Console-managed and self-managed racks alike.

**Update the CLI:** Run `sudo convox update` to get this version.

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
