### PR TITLE
add karpenter_ami_alias rack parameter

### DIFF
--- a/assets/provider/aws/params.yaml
+++ b/assets/provider/aws/params.yaml
@@ -640,6 +640,25 @@ Groups:
         allowedValues:
           - al2023
           - bottlerocket
+      - name: karpenter_ami_alias
+        optional: true
+        default: "null"
+        sideNote: Tracks the latest AL2023 AMI if not set
+        type: string
+        regex: ^al2023@(latest|v[0-9]{8})$
+        description: |
+          Pins the EKS-optimized AL2023 AMI on the Karpenter node pools. &l
+          &i e.g. &i al2023@v20260828 &l &l
+          Leave unset to track &i al2023@latest &i, which picks up each AMI as
+          AWS publishes it. &l &l A pool that already selects its own AMI keeps
+          it: &i ami_id &i on an &i additional_karpenter_nodepools_config &i
+          entry, or &i ec2NodeClass.amiSelectorTerms &i in &i karpenter_config
+          &i for the workload pool. A &i karpenter_node_os=bottlerocket &i
+          workload pool is pinned through &i karpenter_config &i as well. &l &l
+          The version must exist for the rack's Kubernetes version and for
+          every architecture the pools launch, or those pools cannot start
+          nodes. Clear or advance the pin before a Kubernetes version
+          upgrade. &l
       - name: karpenter_node_labels
         optional: true
         default: "null"

--- a/assets/provider/params_test.go
+++ b/assets/provider/params_test.go
@@ -204,6 +204,15 @@ func TestParamsYAML_RegexAcceptsValidInputs(t *testing.T) {
 			{"ECDHE-RSA-AES128-GCM-SHA256", true},
 			{"A:B:C", true},
 		},
+		// Karpenter AMI pin
+		"aws/karpenter_ami_alias": {
+			{"al2023@latest", true},
+			{"al2023@v20260828", true},
+			{"al2023@20260828", false},
+			{"al2023@v2026828", false},
+			{"bottlerocket@latest", false},
+			{"AL2023@latest", false},
+		},
 		// Syslog (all providers share)
 		"aws/syslog": {
 			{"tcp://host:514", true},

--- a/pkg/cli/rack.go
+++ b/pkg/cli/rack.go
@@ -72,7 +72,7 @@ var awsKnownParams = map[string]bool{
 	"imds_tags_enable": true, "internal_router": true, "contour_internal_tls": true,
 	"pod_imds_block_enabled": true, "network_policy_enable": true,
 	"internet_gateway_id": true, "k8s_version": true,
-	"karpenter_arch": true, "karpenter_auth_mode": true,
+	"karpenter_ami_alias": true, "karpenter_arch": true, "karpenter_auth_mode": true,
 	"karpenter_build_capacity_types": true, "karpenter_build_consolidate_after": true,
 	"karpenter_build_cpu_limit": true, "karpenter_build_instance_families": true,
 	"karpenter_build_disruption_budget_nodes": true,
@@ -263,6 +263,7 @@ var paramGroups = map[string]map[string]bool{
 	},
 	"karpenter": {
 		"additional_karpenter_nodepools_config":   true,
+		"karpenter_ami_alias":                     true,
 		"karpenter_arch":                          true,
 		"karpenter_auth_mode":                     true,
 		"karpenter_build_capacity_types":          true,
@@ -685,6 +686,7 @@ var clearableParams = map[string]bool{
 	// Router security group — clear means "use the rack-managed group"
 	"nlb_security_group": true,
 	// Optional overrides — clear means "use auto/default"
+	"karpenter_ami_alias":         true,
 	"build_node_type":             true,
 	"key_pair_name":               true,
 	"nginx_additional_config":     true,
@@ -1994,6 +1996,7 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 			"karpenter_build_memory_limit_gb", "karpenter_node_taints",
 			"karpenter_node_labels", "karpenter_build_node_labels",
 			"karpenter_build_imds_tokens", "karpenter_build_imds_hop_limit",
+			"karpenter_ami_alias",
 		}
 		for _, rk := range karpenterRevalidateKeys {
 			if _, inCall := params[rk]; !inCall {
@@ -2101,6 +2104,13 @@ func validateAndMutateParams(params map[string]string, provider string, currentP
 			if !budgetRe.MatchString(v) {
 				return fmt.Errorf("%s must be a node count or a percentage from 0%% to 100%% (e.g. 100%%)", bk)
 			}
+		}
+	}
+
+	amiAliasRe := regexp.MustCompile(`^al2023@(latest|v[0-9]{8})$`)
+	if v, ok := params["karpenter_ami_alias"]; ok && v != "" {
+		if !amiAliasRe.MatchString(v) {
+			return fmt.Errorf("karpenter_ami_alias pins AL2023 node pools and must be al2023@latest or al2023@vYYYYMMDD (e.g. al2023@v20260828)")
 		}
 	}
 

--- a/pkg/cli/rack_param_belt_test.go
+++ b/pkg/cli/rack_param_belt_test.go
@@ -493,3 +493,69 @@ func TestValidateAndMutateParams_PodSecurity(t *testing.T) {
 		}
 	}
 }
+
+// TestEC2NodeClassTemplateArgsComplete asserts both templatefile() calls for
+// the Karpenter EC2NodeClass template supply every name it references. CI runs
+// terraform validate with continue-on-error, so a missing key is silent.
+func TestEC2NodeClassTemplateArgsComplete(t *testing.T) {
+	const tplPath = "../../terraform/cluster/aws/templates/karpenter-ec2nodeclass.yaml.tpl"
+	const npPath = "../../terraform/cluster/aws/karpenter_nodepool.tf"
+
+	tpl := readTestFile(t, tplPath)
+
+	loopBound := map[string]bool{}
+	for _, m := range regexp.MustCompile(`%\{\s*for\s+([^}]+?)\s+in\s`).FindAllStringSubmatch(tpl, -1) {
+		for _, name := range strings.Split(m[1], ",") {
+			loopBound[strings.TrimSpace(name)] = true
+		}
+	}
+
+	want := map[string]bool{}
+	for _, re := range []*regexp.Regexp{
+		regexp.MustCompile(`\$\{\s*([a-zA-Z_][a-zA-Z0-9_]*)`),
+		regexp.MustCompile(`%\{\s*if\s+([a-zA-Z_][a-zA-Z0-9_]*)`),
+		regexp.MustCompile(`%\{\s*for\s+[^}]*?\bin\s+([a-zA-Z_][a-zA-Z0-9_]*)`),
+	} {
+		for _, m := range re.FindAllStringSubmatch(tpl, -1) {
+			if !loopBound[m[1]] {
+				want[m[1]] = true
+			}
+		}
+	}
+	if len(want) == 0 {
+		t.Fatalf("parsed no references out of %s", tplPath)
+	}
+
+	calls := regexp.MustCompile(`(?s)templatefile\("\$\{path\.module\}/templates/karpenter-ec2nodeclass\.yaml\.tpl",\s*\{(.*?)\n  \}\)`).
+		FindAllStringSubmatch(readTestFile(t, npPath), -1)
+	if len(calls) != 2 {
+		t.Fatalf("found %d templatefile calls for the EC2NodeClass template in %s; expected 2", len(calls), npPath)
+	}
+
+	argRe := regexp.MustCompile(`(?m)^\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*=`)
+	for i, call := range calls {
+		got := map[string]bool{}
+		for _, m := range argRe.FindAllStringSubmatch(call[1], -1) {
+			got[m[1]] = true
+		}
+		var missing []string
+		for name := range want {
+			if !got[name] {
+				missing = append(missing, name)
+			}
+		}
+		sort.Strings(missing)
+		if len(missing) > 0 {
+			t.Errorf("templatefile call %d in %s does not supply %v", i+1, npPath, missing)
+		}
+	}
+}
+
+func readTestFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}

--- a/pkg/cli/rack_validate_test.go
+++ b/pkg/cli/rack_validate_test.go
@@ -366,6 +366,41 @@ func TestValidateAndMutateParams_KarpenterNodeOS(t *testing.T) {
 	}
 }
 
+func TestValidateAndMutateParams_KarpenterAmiAlias(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"latest", "al2023@latest", false},
+		{"pinned version", "al2023@v20260828", false},
+		{"empty clears", "", false},
+		{"missing v prefix", "al2023@20260828", true},
+		{"short version", "al2023@v2026828", true},
+		{"bottlerocket family", "bottlerocket@latest", true},
+		{"uppercase family", "AL2023@latest", true},
+		{"trailing space", "al2023@latest ", true},
+		{"karpenter alias wildcard", "al2023@*", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := map[string]string{"karpenter_ami_alias": tt.value}
+			err := validateAndMutateParams(params, "aws", map[string]string{}, false)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("karpenter_ami_alias=%q: got err=%v, wantErr=%v", tt.value, err, tt.wantErr)
+			}
+		})
+	}
+
+	t.Run("stored value revalidated when karpenter is enabled", func(t *testing.T) {
+		params := map[string]string{"karpenter_enabled": "true"}
+		current := map[string]string{"karpenter_auth_mode": "true", "karpenter_ami_alias": "al2023@nope"}
+		if err := validateAndMutateParams(params, "aws", current, false); err == nil {
+			t.Error("expected the stored karpenter_ami_alias to be rejected")
+		}
+	})
+}
+
 func TestValidateAndMutateParams_WebhookSigningKey_AllProviders(t *testing.T) {
 	for _, provider := range []string{"aws", "gcp", "azure", "do", "metal", "local"} {
 		t.Run(provider, func(t *testing.T) {

--- a/pkg/rack/terraform.go
+++ b/pkg/rack/terraform.go
@@ -49,6 +49,7 @@ var preserveEmpty = map[string]bool{
 	"karpenter_node_taints":               true,
 	"karpenter_build_node_labels":         true,
 	"karpenter_build_imds_tokens":         true,
+	"karpenter_ami_alias":                 true,
 	"karpenter_instance_families":         true,
 	"karpenter_instance_sizes":            true,
 	"karpenter_build_instance_families":   true,

--- a/terraform/cluster/aws/karpenter_nodepool.tf
+++ b/terraform/cluster/aws/karpenter_nodepool.tf
@@ -6,6 +6,8 @@ locals {
 
   karpenter_is_bottlerocket = var.karpenter_node_os == "bottlerocket"
 
+  karpenter_effective_ami_alias = var.karpenter_ami_alias != "" ? var.karpenter_ami_alias : "al2023@latest"
+
   # Parse workload NodePool custom labels from "k1=v1,k2=v2" to map
   karpenter_workload_extra_labels = {
     for pair in compact(split(",", var.karpenter_node_labels)) :
@@ -177,7 +179,7 @@ locals {
   )
 
   # amiSelectorTerms: OS-aware default, still overridable
-  ec2_default_ami = local.karpenter_is_bottlerocket ? [{ alias = "bottlerocket@latest" }] : [{ alias = "al2023@latest" }]
+  ec2_default_ami = local.karpenter_is_bottlerocket ? [{ alias = "bottlerocket@latest" }] : [{ alias = local.karpenter_effective_ami_alias }]
   ec2_final_ami   = lookup(local.kc_ec2, "amiSelectorTerms", local.ec2_default_ami)
 
   # Optional fields from override only (no individual params for these)
@@ -320,6 +322,7 @@ resource "kubectl_manifest" "karpenter_ec2nodeclass_build" {
     imds_http_hop_limit        = local.build_imds_hop_limit
     extra_tags                 = var.tags
     ami_id                     = ""
+    ami_alias                  = local.karpenter_effective_ami_alias
   })
 
   wait = true
@@ -376,6 +379,7 @@ resource "kubectl_manifest" "karpenter_ec2nodeclass_additional" {
     imds_http_hop_limit        = var.imds_http_hop_limit
     extra_tags                 = var.tags
     ami_id                     = each.value.ami_id
+    ami_alias                  = local.karpenter_effective_ami_alias
   })
 
   wait = true

--- a/terraform/cluster/aws/templates/karpenter-ec2nodeclass.yaml.tpl
+++ b/terraform/cluster/aws/templates/karpenter-ec2nodeclass.yaml.tpl
@@ -16,7 +16,7 @@ spec:
     - id: ${ami_id}
 %{ else ~}
   amiSelectorTerms:
-    - alias: al2023@latest
+    - alias: ${ami_alias}
 %{ endif ~}
   blockDeviceMappings:
     - deviceName: /dev/xvda

--- a/terraform/cluster/aws/variables.tf
+++ b/terraform/cluster/aws/variables.tf
@@ -208,6 +208,11 @@ variable "karpenter_node_os" {
   default = "al2023"
 }
 
+variable "karpenter_ami_alias" {
+  type    = string
+  default = ""
+}
+
 variable "karpenter_node_labels" {
   type    = string
   default = ""

--- a/terraform/system/aws/main.tf
+++ b/terraform/system/aws/main.tf
@@ -153,6 +153,7 @@ module "cluster" {
   pod_imds_block_enabled                  = var.pod_imds_block_enabled
   network_policy_enable                   = var.network_policy_enable
   eks_access_entries                      = var.eks_access_entries == "true"
+  karpenter_ami_alias                     = var.karpenter_ami_alias
   karpenter_auth_mode                     = var.karpenter_auth_mode == "true"
   karpenter_enabled                       = var.karpenter_enabled == "true"
   karpenter_instance_families             = var.karpenter_instance_families

--- a/terraform/system/aws/telemetry.tf
+++ b/terraform/system/aws/telemetry.tf
@@ -73,6 +73,7 @@ locals {
     internal_router                           = var.internal_router
     internet_gateway_id                       = var.internet_gateway_id
     k8s_version                               = var.k8s_version
+    karpenter_ami_alias                       = var.karpenter_ami_alias
     karpenter_arch                            = var.karpenter_arch
     karpenter_auth_mode                       = var.karpenter_auth_mode
     karpenter_build_capacity_types            = var.karpenter_build_capacity_types
@@ -232,6 +233,7 @@ locals {
     internal_router                           = "false"
     internet_gateway_id                       = ""
     k8s_version                               = "1.35"
+    karpenter_ami_alias                       = ""
     karpenter_arch                            = ""
     karpenter_auth_mode                       = "false"
     karpenter_build_capacity_types            = "on-demand"

--- a/terraform/system/aws/variables.tf
+++ b/terraform/system/aws/variables.tf
@@ -363,6 +363,11 @@ variable "karpenter_node_os" {
   default = "al2023"
 }
 
+variable "karpenter_ami_alias" {
+  type    = string
+  default = ""
+}
+
 variable "karpenter_node_labels" {
   type    = string
   default = ""


### PR DESCRIPTION
### What is the feature/update/fix?

**Feature: `karpenter_ami_alias` Rack Parameter**

AWS racks running Karpenter have a new rack parameter, `karpenter_ami_alias`, that pins the EKS-optimized AL2023 AMI on every Karpenter node pool the rack renders: the workload pool, the build pool, and every pool in `additional_karpenter_nodepools_config`. It accepts `al2023@latest` or `al2023@vYYYYMMDD`. Unset, all three pools render `al2023@latest`, exactly as before.

**New Rack Parameters:**

| Parameter | Default | Description |
|-----------|---------|-------------|
| `karpenter_ami_alias` | unset, renders `al2023@latest` | Pins the AL2023 AMI on the workload, build and additional Karpenter node pools. `al2023@latest` or `al2023@vYYYYMMDD`. Clearable. AWS racks only. |

A pool that already selects its own AMI keeps it. Precedence per pool class:

| Pool | Renders |
|------|---------|
| workload | `karpenter_config.ec2NodeClass.amiSelectorTerms` if set, otherwise `karpenter_ami_alias`, otherwise `al2023@latest`. A `karpenter_node_os=bottlerocket` rack renders `bottlerocket@latest` here and ignores the parameter |
| additional | the pool's `ami_id` if set, otherwise `karpenter_ami_alias`, otherwise `al2023@latest` |
| build | `karpenter_ami_alias`, otherwise `al2023@latest` |

The build and additional pools are AL2023 regardless of `karpenter_node_os`, so on a Bottlerocket rack they take the pin and the workload pool does not.

The CLI validates the value against `^al2023@(latest|v[0-9]{8})$` and rejects anything else before the rack is touched:

```
ERROR: karpenter_ami_alias pins AL2023 node pools and must be al2023@latest or al2023@vYYYYMMDD (e.g. al2023@v20260828)
```

Only AL2023 aliases are accepted because the build and additional pools share one node class template written for AL2023, with a single `/dev/xvda` block device and `amiFamily: AL2023` when a pool selects an AMI by id, and a Bottlerocket alias rendered through it would produce nodes that do not boot.

---

### Why is this important?

`al2023@latest` moves whenever AWS publishes a new EKS-optimized AMI, and Karpenter re-resolves an alias on its own schedule, so a new AMI reaches a rack with no Terraform run and no operator action. Before this parameter the workload pool could be pinned through `karpenter_config.ec2NodeClass.amiSelectorTerms` and an additional pool through its `ami_id`, and the build pool had no pin. One parameter now pins all three.

**Benefits:**

- **One pin for every pool.** The workload, build and additional Karpenter pools follow the same AMI version from one parameter, and the build pool is pinnable for the first time.
- **Nothing changes until you set it.** An unset parameter renders `al2023@latest` at every pool, byte for byte what the rack rendered before.
- **Reversible.** Clearing the parameter returns every pool to `al2023@latest` on the next apply.
- **Rejected before the rack applies.** A value outside `al2023@latest` or `al2023@vYYYYMMDD` fails at the CLI, so a typo never reaches Terraform.
- **Existing overrides win.** A workload pool pinned through `karpenter_config` and an additional pool with its own `ami_id` keep what they have.

---

### How to use it?

Pin the rack to a published AL2023 version:

    $ convox rack params set karpenter_ami_alias=al2023@v20260828 -r rackName

The version is the `vYYYYMMDD` suffix of the EKS-optimized AL2023 AMI name, `amazon-eks-node-al2023-<arch>-<variant>-<k8s minor>-vYYYYMMDD`. To pin without replacing any node, use the version the pool's nodes already run, which is the suffix of the AMI name on a running node, rather than the newest published version.

Clear the pin to return to `al2023@latest`:

    $ convox rack params set karpenter_ami_alias= -r rackName

After a clear, `convox rack params` keeps listing `karpenter_ami_alias` with an empty value, as it does for every clearable parameter.

**What each value does to the nodes:**

| Value | Result |
|-------|--------|
| The version the nodes already run | No node is replaced. AMI selector terms are excluded from the node class drift hash, and Karpenter finds each running image inside the resolved set |
| A different published version | Every Karpenter pool drifts and Karpenter replaces its nodes, paced by each pool's disruption budget |
| A version AWS has not published for the rack's Kubernetes version, or for an architecture one of the pools launches | The apply completes, existing nodes keep running, and the affected pool cannot launch new nodes until the value is changed or cleared |
| Cleared | Every pool returns to `al2023@latest`. If that resolves to a different version than the pin, the pools drift |

The CLI checks the format only. It has no cluster or AWS credentials and cannot check that a version exists for the rack's Kubernetes version and every architecture and variant its pools launch. A Kubernetes version upgrade re-resolves the pin against the new version, so clear or advance the pin before one.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this feature.

The parameter is one additive string variable with an empty default. Unset, the workload, build and additional Karpenter pools render exactly what they rendered before. Static managed node groups, additional node groups, and the static build node group do not read it. Other providers reject the parameter as they reject every `karpenter_*` parameter, with `karpenter parameters are only supported for AWS racks`.

A rack downgraded to a version that does not declare the variable removes the parameter on that apply:

```
NOTICE: removing parameters not supported by version 3.25.5: karpenter_ami_alias
```

The pools re-render `al2023@latest` on that same apply, so a rack pinned to anything but the current latest replaces its Karpenter nodes then, paced by each pool's disruption budget.

---

### Requirements

| Side | Version | What it provides |
|------|---------|------------------|
| Rack | `3.25.6` or later | Declares `karpenter_ami_alias` and renders it into the workload, build and additional Karpenter node pools |
| CLI | `3.25.6` or later | Accepts the parameter in `convox rack params set`, validates the value, and allows clearing it |

An older CLI rejects the parameter as unknown unless `--force` is passed. A rack below `3.25.6` removes the parameter on its next apply with a `NOTICE` and keeps rendering `al2023@latest`. AWS racks only.

**Update the Rack:** Run `convox rack update 3.25.6 -r rackName` to update to this version.

**Update the CLI:** Run `sudo convox update` to get this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
