### PR TITLE
deliver kubelet registry params on al2023

### DIFF
--- a/terraform/cluster/aws/files/custom_ami_userdata_al2023.sh
+++ b/terraform/cluster/aws/files/custom_ami_userdata_al2023.sh
@@ -17,6 +17,10 @@ spec:
     config:
       clusterDNS:
       - ${cluster_dns}
+%{ if kubelet_registry_pull_qps != 5 || kubelet_registry_burst != 10 ~}
+      registryPullQPS: ${kubelet_registry_pull_qps}
+      registryBurst: ${kubelet_registry_burst}
+%{ endif ~}
     maxPodsExpression: "((default_enis - 1) * (ips_per_eni - 1)) + 2"
     flags:
     - "--node-labels=${node_labels}"

--- a/terraform/cluster/aws/files/custom_user_data.sh
+++ b/terraform/cluster/aws/files/custom_user_data.sh
@@ -6,32 +6,23 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 
 #!/bin/bash
 echo "CONVOX MANAGED USER DATA SCRIPT"
-cat <<'SCRIPT' > /opt/modify_kubelet.sh
-#!/bin/bash
-
-# Install jq if not already installed
-yum install -y jq
-
-# Path to the kubelet configuration file
-KUBELET_CONFIG_FILE="/etc/kubernetes/kubelet/kubelet-config.json"
-
-# Modify the registryPullQPS and registryBurst parameters in the kubelet config file
-jq '.registryPullQPS = ${kubelet_registry_pull_qps} | .registryBurst = ${kubelet_registry_burst}' $KUBELET_CONFIG_FILE > /tmp/kubelet-config.json
-mv -f /tmp/kubelet-config.json $KUBELET_CONFIG_FILE
-
-# Reload the systemd daemon to apply the changes
-systemctl daemon-reload
-
-# Restart the kubelet service to apply the new configuration
-systemctl restart kubelet
-SCRIPT
-
-chmod +x /opt/modify_kubelet.sh
-/opt/modify_kubelet.sh
 
 echo "USER PROVIDED USER DATA SCRIPT"
 ${user_data}
 
 ${user_data_script_file}
 
+%{ if kubelet_registry_pull_qps != 5 || kubelet_registry_burst != 10 ~}
+--==MYBOUNDARY==
+Content-Type: application/node.eks.aws
+
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  kubelet:
+    config:
+      registryPullQPS: ${kubelet_registry_pull_qps}
+      registryBurst: ${kubelet_registry_burst}
+
+%{ endif ~}
 --==MYBOUNDARY==--

--- a/terraform/cluster/aws/karpenter_nodepool.tf
+++ b/terraform/cluster/aws/karpenter_nodepool.tf
@@ -180,8 +180,23 @@ locals {
   ec2_default_ami = local.karpenter_is_bottlerocket ? [{ alias = "bottlerocket@latest" }] : [{ alias = "al2023@latest" }]
   ec2_final_ami   = lookup(local.kc_ec2, "amiSelectorTerms", local.ec2_default_ami)
 
-  # Optional fields from override only (no individual params for these)
+  # userData: NodeConfig for the kubelet registry params. Skipped when karpenter_config picks
+  # the AMI, since a Bottlerocket class parses userData as TOML rather than YAML.
+  ec2_kubelet_nodeconfig = <<-EOT
+    apiVersion: node.eks.aws/v1alpha1
+    kind: NodeConfig
+    spec:
+      kubelet:
+        config:
+          registryPullQPS: ${local.kubelet_registry_pull_qps_effective}
+          registryBurst: ${local.kubelet_registry_burst_effective}
+  EOT
+
+  ec2_kubelet_user_data = local.kubelet_registry_set ? local.ec2_kubelet_nodeconfig : ""
+
+  # Params first, then override, so karpenter_config wins on any key it sets
   ec2_optional_fields = merge(
+    !local.karpenter_is_bottlerocket && lookup(local.kc_ec2, "amiSelectorTerms", null) == null && local.ec2_kubelet_user_data != "" ? { userData = local.ec2_kubelet_user_data } : {},
     lookup(local.kc_ec2, "userData", null) != null ? { userData = local.kc_ec2["userData"] } : {},
     lookup(local.kc_ec2, "detailedMonitoring", null) != null ? { detailedMonitoring = local.kc_ec2["detailedMonitoring"] } : {},
     lookup(local.kc_ec2, "associatePublicIPAddress", null) != null ? { associatePublicIPAddress = local.kc_ec2["associatePublicIPAddress"] } : {},
@@ -320,6 +335,7 @@ resource "kubectl_manifest" "karpenter_ec2nodeclass_build" {
     imds_http_hop_limit        = local.build_imds_hop_limit
     extra_tags                 = var.tags
     ami_id                     = ""
+    kubelet_user_data          = local.ec2_kubelet_user_data
   })
 
   wait = true
@@ -376,6 +392,7 @@ resource "kubectl_manifest" "karpenter_ec2nodeclass_additional" {
     imds_http_hop_limit        = var.imds_http_hop_limit
     extra_tags                 = var.tags
     ami_id                     = each.value.ami_id
+    kubelet_user_data          = local.ec2_kubelet_user_data
   })
 
   wait = true

--- a/terraform/cluster/aws/main.tf
+++ b/terraform/cluster/aws/main.tf
@@ -557,9 +557,9 @@ resource "aws_launch_template" "cluster" {
     }
   }
 
-  user_data = var.user_data_url != "" || var.user_data != "" || var.kubelet_registry_pull_qps != 5 || var.kubelet_registry_burst != 10 ? base64encode(templatefile("${path.module}/files/custom_user_data.sh", {
-    kubelet_registry_pull_qps = var.kubelet_registry_pull_qps
-    kubelet_registry_burst    = var.kubelet_registry_burst
+  user_data = var.user_data_url != "" || var.user_data != "" || local.kubelet_registry_set ? base64encode(templatefile("${path.module}/files/custom_user_data.sh", {
+    kubelet_registry_pull_qps = local.kubelet_registry_pull_qps_effective
+    kubelet_registry_burst    = local.kubelet_registry_burst_effective
     user_data_script_file     = var.user_data_url != "" ? data.http.user_data_content[0].response_body : ""
     user_data                 = var.user_data
   })) : ""
@@ -594,6 +594,8 @@ resource "aws_launch_template" "cluster-build" {
       tags          = local.tags
     }
   }
+
+  user_data = local.kubelet_registry_user_data != "" ? base64encode(local.kubelet_registry_user_data) : null
 
   key_name = var.key_pair_name != "" ? var.key_pair_name : null
 }

--- a/terraform/cluster/aws/node_groups.tf
+++ b/terraform/cluster/aws/node_groups.tf
@@ -1,10 +1,26 @@
 
 locals {
-  launch_template_user_data_raw = var.user_data_url != "" || var.user_data != "" || var.kubelet_registry_pull_qps != 5 || var.kubelet_registry_burst != 10 ? templatefile("${path.module}/files/custom_user_data.sh", {
-    kubelet_registry_pull_qps = var.kubelet_registry_pull_qps
-    kubelet_registry_burst    = var.kubelet_registry_burst
+  launch_template_user_data_raw = var.user_data_url != "" || var.user_data != "" || local.kubelet_registry_set ? templatefile("${path.module}/files/custom_user_data.sh", {
+    kubelet_registry_pull_qps = local.kubelet_registry_pull_qps_effective
+    kubelet_registry_burst    = local.kubelet_registry_burst_effective
     user_data_script_file     = var.user_data_url != "" ? data.http.user_data_content[0].response_body : ""
     user_data                 = var.user_data
+  }) : ""
+
+  # Values outside int32 make kubelet exit, and a zero burst admits no pull at all. Zero QPS is
+  # kubelet's own "no limit", which is why only the burst floor is 1.
+  kubelet_registry_pull_qps_effective = min(2147483647, floor(max(0, var.kubelet_registry_pull_qps)))
+  kubelet_registry_burst_effective    = min(2147483647, floor(max(1, var.kubelet_registry_burst)))
+
+  # Compare the clamped values, so this can never disagree with the gate inside the templates,
+  # which see the clamped values and nothing else.
+  kubelet_registry_set = local.kubelet_registry_pull_qps_effective != 5 || local.kubelet_registry_burst_effective != 10
+
+  kubelet_registry_user_data = local.kubelet_registry_set ? templatefile("${path.module}/files/custom_user_data.sh", {
+    kubelet_registry_pull_qps = local.kubelet_registry_pull_qps_effective
+    kubelet_registry_burst    = local.kubelet_registry_burst_effective
+    user_data_script_file     = ""
+    user_data                 = ""
   }) : ""
 
   kube_dns_ip = cidrhost(aws_eks_cluster.cluster.kubernetes_network_config[0].service_ipv4_cidr, 10)
@@ -181,14 +197,18 @@ resource "aws_launch_template" "cluster_additional" {
     }
   }
 
-  user_data = random_id.additional_node_groups[each.key].keepers.ami_id == null ? null : base64encode(templatefile("${path.module}/files/custom_ami_userdata_al2023.sh", {
-    api_server_endpoint = aws_eks_cluster.cluster.endpoint,
-    api_server_ca       = aws_eks_cluster.cluster.certificate_authority[0].data,
-    name                = aws_eks_cluster.cluster.name,
-    cidr                = var.cidr,
-    cluster_dns         = local.kube_dns_ip,
-    node_labels         = "eks.amazonaws.com/nodegroup=${var.name}-additional-${each.key}-${random_id.additional_node_groups[each.key].hex}",
-    user_data           = local.launch_template_user_data_raw,
+  user_data = random_id.additional_node_groups[each.key].keepers.ami_id == null ? (
+    local.kubelet_registry_user_data != "" ? base64encode(local.kubelet_registry_user_data) : null
+    ) : base64encode(templatefile("${path.module}/files/custom_ami_userdata_al2023.sh", {
+      api_server_endpoint       = aws_eks_cluster.cluster.endpoint,
+      api_server_ca             = aws_eks_cluster.cluster.certificate_authority[0].data,
+      name                      = aws_eks_cluster.cluster.name,
+      cidr                      = var.cidr,
+      cluster_dns               = local.kube_dns_ip,
+      node_labels               = "eks.amazonaws.com/nodegroup=${var.name}-additional-${each.key}-${random_id.additional_node_groups[each.key].hex}",
+      user_data                 = local.launch_template_user_data_raw,
+      kubelet_registry_pull_qps = local.kubelet_registry_pull_qps_effective,
+      kubelet_registry_burst    = local.kubelet_registry_burst_effective,
   }))
   key_name = var.key_pair_name != "" ? var.key_pair_name : null
 }
@@ -318,14 +338,18 @@ resource "aws_launch_template" "build_additional" {
     instance_metadata_tags      = var.imds_tags_enable ? "enabled" : "disabled"
   }
 
-  user_data = random_id.build_node_additional[each.key].keepers.ami_id == null ? null : base64encode(templatefile("${path.module}/files/custom_ami_userdata_al2023.sh", {
-    api_server_endpoint = aws_eks_cluster.cluster.endpoint,
-    api_server_ca       = aws_eks_cluster.cluster.certificate_authority[0].data,
-    name                = aws_eks_cluster.cluster.name,
-    cidr                = var.cidr,
-    cluster_dns         = local.kube_dns_ip,
-    node_labels         = "eks.amazonaws.com/nodegroup=${var.name}-build-additional-${each.key}-${random_id.build_node_additional[each.key].hex}",
-    user_data           = "",
+  user_data = random_id.build_node_additional[each.key].keepers.ami_id == null ? (
+    local.kubelet_registry_user_data != "" ? base64encode(local.kubelet_registry_user_data) : null
+    ) : base64encode(templatefile("${path.module}/files/custom_ami_userdata_al2023.sh", {
+      api_server_endpoint       = aws_eks_cluster.cluster.endpoint,
+      api_server_ca             = aws_eks_cluster.cluster.certificate_authority[0].data,
+      name                      = aws_eks_cluster.cluster.name,
+      cidr                      = var.cidr,
+      cluster_dns               = local.kube_dns_ip,
+      node_labels               = "eks.amazonaws.com/nodegroup=${var.name}-build-additional-${each.key}-${random_id.build_node_additional[each.key].hex}",
+      user_data                 = "",
+      kubelet_registry_pull_qps = local.kubelet_registry_pull_qps_effective,
+      kubelet_registry_burst    = local.kubelet_registry_burst_effective,
   }))
 
   dynamic "tag_specifications" {

--- a/terraform/cluster/aws/templates/karpenter-ec2nodeclass.yaml.tpl
+++ b/terraform/cluster/aws/templates/karpenter-ec2nodeclass.yaml.tpl
@@ -18,6 +18,10 @@ spec:
   amiSelectorTerms:
     - alias: al2023@latest
 %{ endif ~}
+%{ if kubelet_user_data != "" ~}
+  userData: |
+    ${indent(4, chomp(kubelet_user_data))}
+%{ endif ~}
   blockDeviceMappings:
     - deviceName: /dev/xvda
       ebs:


### PR DESCRIPTION
### What is the feature/update/fix?

**Fix: `kubelet_registry_pull_qps` and `kubelet_registry_burst` on AL2023 Nodes**

The AWS rack parameters `kubelet_registry_pull_qps` and `kubelet_registry_burst` now reach every node the rack launches: the main system node group, the static build node group, additional and additional build node groups on either the EKS AMI or a custom `ami_id`, and every Karpenter pool. The previous delivery path edited the kubelet configuration file that Amazon Linux 2 writes, and the Karpenter node classes had none, so on AL2023 nodes the stored values did not reach kubelet.

Both values are delivered as one NodeConfig document, which nodeadm merges into the kubelet configuration when the node boots. With the parameters set to `20` and `40` the document is:

```yaml
apiVersion: node.eks.aws/v1alpha1
kind: NodeConfig
spec:
  kubelet:
    config:
      registryPullQPS: 20
      registryBurst: 40
```

Managed node groups receive it as an `application/node.eks.aws` part of the launch template user data. Karpenter node classes receive it as `spec.userData` on the EC2NodeClass. The EC2NodeClass `spec.kubelet` field does not accept these two keys, so user data is the delivery path on both sides.

**Delivery by node class:**

| Node class | Before | After |
|------------|--------|-------|
| Main system node group | Amazon Linux 2 script in the launch template | shell script part plus a NodeConfig part |
| Static build node group | no user data | shell script part plus a NodeConfig part |
| Additional node groups on the EKS AMI | no user data | shell script part plus a NodeConfig part |
| Additional and additional build groups with a custom `ami_id` | NodeConfig without these keys | both keys added to the existing NodeConfig |
| Karpenter workload pool | no `userData` | NodeConfig as `spec.userData` |
| Karpenter build pool | no `userData` | NodeConfig as `spec.userData` |
| Karpenter additional pools | no `userData` | NodeConfig as `spec.userData` |

Values are clamped before rendering. `kubelet_registry_pull_qps` is floored at `0` and `kubelet_registry_burst` at `1`, both are capped at `2147483647`, and a non-integer is rounded down. The floors differ because `0` QPS is kubelet's own no-limit setting while a burst of `0` admits no pulls at all. `kubelet_registry_pull_qps=0` turns the limiter off. Raising the values does not remove the burst limit itself: a cold node that starts more distinct image pulls than the burst still sees the transient `pull QPS exceeded` message, and the pulls retry.

    $ convox rack params set kubelet_registry_pull_qps=20 kubelet_registry_burst=40 -r rackName

**What recycles on this update:**

| Rack configuration | Recycles |
|--------------------|----------|
| All four of `kubelet_registry_pull_qps`, `kubelet_registry_burst`, `user_data`, `user_data_url` at default | nothing |
| Either registry parameter off default, Karpenter disabled | every managed node group |
| Either registry parameter off default, Karpenter enabled | every managed node group and every Karpenter pool |
| `user_data` or `user_data_url` set, registry parameters at default | the main system group and every additional group with a custom `ami_id` |

`node_max_unavailable_percentage` defaults to `0`, so managed node groups recycle one node at a time. Raising it speeds up the system and additional node groups only; the static build group and additional build groups recycle one node at a time regardless. Raise it, and `terraform_update_timeout` (default `2h`), before taking the roll on a large rack. Karpenter replacements are paced by each pool's disruption budget, which defaults to `10%`. Schedule the update in a maintenance window on affected racks.

**`user_data` and `user_data_url`:**

Operator content runs at the same position and the same cloud-init stage as before, inside the same `text/x-shellscript` part. The Amazon Linux 2 block that ran ahead of it is gone, and with it `yum install -y jq` (`jq` ships in the EKS AL2023 AMI), `systemctl daemon-reload`, and `systemctl restart kubelet`. A script that assumed kubelet was already running when it started sees a different state on AL2023, where nodeadm starts kubelet after user data has run. The NodeConfig part is placed last in the document, and nodeadm merges NodeConfig parts in order with the later value winning per key, so a NodeConfig in operator content cannot override the rack setting.

---

### Why is this important?

When a node with many services or a large deploy hits `pull QPS exceeded`, pods sit in a pull backoff while the rest of the rack is idle. These two parameters exist to raise that limit, and they now take effect on the nodes the rack runs today.

**Benefits:**

- **Set values take effect.** A value set with `convox rack params set` is the value kubelet runs with on every node class, including the Karpenter pools.
- **One document, every node class.** Managed node groups and Karpenter pools receive the same NodeConfig, so a rack that mixes them gets one behavior.
- **Values kubelet accepts.** Negative, fractional, and out-of-range values are clamped to something kubelet starts with, so a typo does not stop a node from joining.
- **Operator user data keeps running.** Scripts delivered through `user_data` and `user_data_url` run where they always ran and cannot be shadowed by the rack's own NodeConfig.
- **No churn at defaults.** A rack with all four parameters at default renders the same launch templates and node classes as before and recycles nothing.

---

### Does it have a breaking change?

**No breaking changes** are introduced with this fix.

No parameter is added or renamed, no Terraform variable is added, and there is no CLI, API, or manifest change. Other providers are untouched. Bottlerocket workload pools (`karpenter_node_os=bottlerocket`) take TOML settings rather than a NodeConfig and do not read these parameters. A `karpenter_config.ec2NodeClass` that supplies its own `userData` keeps that value, and one that supplies `amiSelectorTerms` suppresses the rack's NodeConfig because the node OS is then chosen by the operator.

Racks with either registry parameter set, or with `user_data` or `user_data_url` set, recycle nodes on this update as described in the table above. The one behavior change inside operator user data is the removed Amazon Linux 2 block; a `user_data` script that relied on `systemctl restart kubelet` having run ahead of it should not assume kubelet is up.

Downgrading is symmetric. No new Terraform variable is involved. Applying an earlier version removes the NodeConfig from each Karpenter node class and re-renders the previous launch templates, which recycles the same nodes once more.

---

### Requirements

This fix requires version `3.25.6` or later for the rack, and applies to AWS racks. Racks with either parameter set, or with `user_data` or `user_data_url` set, recycle nodes on this update; see the table above.

**Update the Rack:** Run `convox rack update 3.25.6 -r rackName` to update to this version.

_Note that your rack must already be on at least version `3.24.0` before performing this update._

_If you're unfamiliar with v3 rack versioning, we recommend reviewing the documentation on [Updating a Rack](https://docs.convox.com/management/cli-rack-management/) before applying any updates._
